### PR TITLE
docs: formalize PR-based workflow

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -32,6 +32,16 @@ Append-only ADR-lite log. Entries capture tactical choices made during execution
 
 ---
 
+## 2026-04-17 — PR-based workflow from M1 onward
+
+**Context:** M0 scaffold was committed directly to `main` to bootstrap the repo. From M1 onward we want the governance rules (plan diff alongside invalidating changes, PR template, decisions log) to have a clear mechanical enforcement point.
+
+**Decision:** Every change after `076c970` flows through a PR. Branch names carry a milestone slug (`m1/…`, `docs/…`, `chore/…`). PRs squash-merge by default. Claude opens PRs, never self-merges — the human reviewer merges. Captured in `docs/plan.md` → "Plan governance" → "Branch & PR workflow".
+
+**Rationale:** Makes "any PR that invalidates the plan must include the plan diff" a reviewable event, not an honor-system norm.
+
+---
+
 ## 2026-04-17 — Pinned `storybook@10.3.5` and `@storybook/addon-mcp@0.6.0`
 
 **Context:** Plan required Storybook 10.3+ for MCP support. Latest-stable check during M0 spike.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -394,6 +394,16 @@ The plan is the **design doc**; GitHub milestones/issues are the **tracker**. Do
 - One issue per "Work" bullet under each milestone. Each issue links back to the relevant `docs/plan.md` section anchor.
 - Root README carries a one-line `Current: Mx — <goal>` status that updates when a milestone closes.
 
+### Branch & PR workflow
+
+All work after the M0 scaffold commit flows through PRs. Direct pushes to `main` are reserved for the initial scaffold only.
+
+- **Branch per logical chunk**, not per tiny issue. Typical M1 cut: `m1/tokens-reference`, `m1/core-impl`, `m1/core-tests`, `m1/tokens-starter-skel`. Branch names start with the milestone slug (`m1/…`, `docs/…`, `chore/…`).
+- **PR title:** `Mx: <what>`. Body follows the PR template verbatim. Link related milestone issues with `Closes #N` / `Refs #N`.
+- **Merge strategy:** squash-merge by default. Preserve commits only when the history is genuinely useful to future readers.
+- **No self-merge by automation.** Claude (or any agent) opens PRs; the human reviewer merges. This keeps the governance human-in-the-loop.
+- **Branch protection** on `main` is the repo owner's call — the discipline above holds either way, but enabling protection rules (require PR, require status checks, restrict pushes) in GitHub settings makes it enforced rather than norm-based.
+
 ### Keeping the plan honest
 
 Two mechanisms:


### PR DESCRIPTION
**Milestone:** none (governance)

**Plan impact:** update included

## Summary

- Adds a "Branch & PR workflow" subsection under Plan governance in `docs/plan.md` covering branch naming, PR title convention, squash-merge default, and the no-self-merge rule.
- Logs the switch from the M0 direct-push bootstrap in `docs/decisions.md`.
- First PR of the new workflow — dogfoods the process we're documenting.

## Test plan

- [ ] Plan diff reads cleanly and the rules match how we intend to work.
- [x] Decisions log entry is dated and references the plan section.