### PR TITLE
chore: latest deps policy, TS 6, Node 24 LTS baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [20, 22]
+        node: [24]
     steps:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 10.18.1
           run_install: false
 
       - uses: actions/setup-node@v4
@@ -39,10 +38,8 @@ jobs:
 
       - name: Build Storybook
         run: pnpm turbo run build:storybook
-        if: matrix.node == '22'
 
       - uses: actions/upload-artifact@v4
-        if: matrix.node == '22'
         with:
           name: storybook-static
           path: apps/storybook/storybook-static

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,9 @@ Update this line when a milestone closes. See the matching GitHub milestones for
 
 ## Project conventions
 
-- **Package manager:** pnpm@10.18.1 (workspaces); orchestration via Turborepo.
+- **Latest deps policy:** always pin the latest stable major/minor of every third-party dependency unless a concrete blocker is documented in `docs/decisions.md`. When adding a dep, check `npm view <pkg> version` and use that. Default to eager upgrades — we'd rather hit new-version friction early than accumulate a drift debt.
+- **Node baseline:** always the **latest LTS** everywhere — dev, CI matrix, published `engines.node`. Today that's Node 24. When a new LTS lands (typically October of even years), bump engines + CI in a same-day PR. Don't add lower-version compat paths, polyfills, or matrix entries for older Node.
+- **Package manager:** pnpm@10.33.0 (workspaces); orchestration via Turborepo.
 - **Code style:** functional, avoid classes/singletons. No CSS-in-JS. No inline end-of-line comments.
 - **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`.
 - **Tests:** Vitest everywhere. Storybook Test (via `@storybook/addon-vitest`) for interaction tests in `apps/storybook`.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -12,6 +12,19 @@ Append-only ADR-lite log. Entries capture tactical choices made during execution
 
 ---
 
+## 2026-04-17 — Latest deps policy + TS 6 + pnpm 10.33 + Node 24 minimum
+
+**Context:** Repo starts with modern defaults; no legacy to carry. Prefer eager upgrades over drift.
+
+**Decision:**
+- Always pin the latest stable major/minor of every third-party dep unless a concrete blocker is logged here.
+- Node baseline is the **latest LTS**, not a fixed version. Today that's Node 24 (active LTS). When a new LTS lands (roughly every October in even years), update `engines.node`, CI matrix, and this decisions entry in the same PR. Never add compat paths or CI entries for older Node.
+- Immediate upgrades: `typescript` → `^6.0.0`, `turbo` → `^2.9.0`, `packageManager` → `pnpm@10.33.0`. CI matrix collapsed to `[24]`. Policy captured in `CLAUDE.md` → "Project conventions" so future sessions inherit it.
+
+**Rationale:** Hitting version-change friction early is cheaper than deferred upgrades across a maturing codebase. No compatibility shims, no `>=` ranges wider than semver requires, no testing against Node versions we don't support.
+
+---
+
 ## 2026-04-17 — Core's public helper is `defineSwatchbookConfig`, not `defineConfig`
 
 **Context:** `@terrazzo/parser` exports its own `defineConfig`. Consumers of `@unpunnyfuns/swatchbook-core` often also import from `@terrazzo/parser` (advanced use cases), so colliding names would force aliasing at every import site.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -348,7 +348,7 @@ Root `package.json` currently uses `"@unpunnyfuns/swatchbook"`. Rename to neutra
 
 GitHub Actions pipeline (`.github/workflows/ci.yml`):
 
-- Matrix: Node 20 + 22 (Storybook 10.3+ baseline).
+- Matrix: latest Node LTS only (Node 24 today; bump with each LTS). See `docs/decisions.md`.
 - Cache: pnpm store, Turbo local cache, Playwright browsers.
 - Steps: `pnpm install --frozen-lockfile` → `pnpm turbo run lint typecheck test build test:storybook`.
 - Storybook static build (`turbo run build:storybook`) uploaded as artifact; deploy step deferred.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "Storybook addon + doc blocks for DTCG design tokens",
   "private": true,
   "license": "MIT",
-  "packageManager": "pnpm@10.18.1",
+  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "engines": {
+    "node": ">=24.0.0"
+  },
   "scripts": {
     "build": "turbo run build",
     "test": "turbo run test",
@@ -17,7 +20,7 @@
     "dev": "turbo run storybook"
   },
   "devDependencies": {
-    "turbo": "^2.3.0",
-    "typescript": "^5.6.0"
+    "turbo": "^2.9.0",
+    "typescript": "^6.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     devDependencies:
       turbo:
-        specifier: ^2.3.0
+        specifier: ^2.9.0
         version: 2.9.6
       typescript:
-        specifier: ^5.6.0
-        version: 5.9.3
+        specifier: ^6.0.0
+        version: 6.0.3
 
 packages:
 
@@ -51,8 +51,8 @@ packages:
     resolution: {integrity: sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg==}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -85,4 +85,4 @@ snapshots:
       '@turbo/windows-64': 2.9.6
       '@turbo/windows-arm64': 2.9.6
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}


### PR DESCRIPTION
**Milestone:** none (governance / infra)

**Plan impact:** update included + decisions.md entry

## Summary

- Establishes two policies in `CLAUDE.md`:
  - **Latest deps:** always pin the latest stable major/minor of every third-party dep.
  - **Node baseline:** always the latest LTS (Node 24 today), bumped same-day when a new LTS lands.
- Immediate upgrades: `typescript@^6.0.0`, `turbo@^2.9.0`, `pnpm@10.33.0` (corepack-pinned), added `engines.node: ">=24.0.0"`.
- CI matrix collapsed to `[24]`.
- `docs/plan.md` CI section updated; `docs/decisions.md` entry logs the rationale.

## Test plan

- [x] `pnpm install` clean on the bumped packageManager and TS 6.
- [x] `pnpm turbo run lint typecheck` still succeeds (no-op on empty packages).
- [ ] CI runs green on Node 24 after merge.