### PR TITLE
chore(ci): bump GH Actions to latest majors (Node 24 runtimes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,19 @@ jobs:
       matrix:
         node: [24]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         with:
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
 
       - name: Cache Turbo
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .turbo
           key: turbo-${{ matrix.node }}-${{ github.sha }}
@@ -39,7 +39,7 @@ jobs:
       - name: Build Storybook
         run: pnpm turbo run build:storybook
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: storybook-static
           path: apps/storybook/storybook-static

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -12,6 +12,16 @@ Append-only ADR-lite log. Entries capture tactical choices made during execution
 
 ---
 
+## 2026-04-17 — Bump GH Actions to latest majors (Node 24 runtimes)
+
+**Context:** GitHub deprecated Node 20 runtimes for JavaScript actions (forced migration 2026-06-02, removal 2026-09-16). The v4 lineup we used on M0 scaffold was flagged at first CI run.
+
+**Decision:** Pin the latest major of every action: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/cache@v5`, `actions/upload-artifact@v7`, `pnpm/action-setup@v5`. All use Node 24 natively.
+
+**Rationale:** Falls out of the "latest deps" policy; no env-var workaround needed.
+
+---
+
 ## 2026-04-17 — Latest deps policy + TS 6 + pnpm 10.33 + Node 24 minimum
 
 **Context:** Repo starts with modern defaults; no legacy to carry. Prefer eager upgrades over drift.


### PR DESCRIPTION
**Milestone:** none (infra)

**Plan impact:** decisions.md entry

## Summary

CI on PR #44 flagged Node 20 runtime deprecation for our action pins. All five actions have newer majors available on Node 24:

- `actions/checkout` v4 → **v6**
- `actions/setup-node` v4 → **v6**
- `actions/cache` v4 → **v5**
- `actions/upload-artifact` v4 → **v7**
- `pnpm/action-setup` v4 → **v5**

Logged in `docs/decisions.md`. No env-var workaround needed.

## Test plan

- [ ] CI completes without the Node 20 deprecation warning.
- [ ] All steps still green on the empty scaffold.