### PR TITLE
M1: three-way theme normalization + loadProject

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { defineSwatchbookConfig } from '#/config';
+export { loadProject, resolveTheme } from '#/load';
 
 export type {
   Config,
@@ -8,4 +9,5 @@ export type {
   ResolvedTheme,
   Theme,
   ThemeConfig,
+  TokenMap,
 } from '#/types';

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,0 +1,37 @@
+import { BufferedLogger, toDiagnostics } from '#/diagnostics';
+import { normalizeThemes } from '#/themes/normalize';
+import type { Config, Project, ResolvedTheme } from '#/types';
+
+/**
+ * Load a swatchbook project from a config. Themes are eagerly resolved,
+ * so downstream consumers can call `resolveTheme(project, name)` or read
+ * `project.themesResolved[name]` directly without further I/O.
+ *
+ * The `cwd` defaults to `process.cwd()`. All relative paths in `config`
+ * (token globs, `resolver`, `manifest`, theme layer globs) resolve
+ * against this directory.
+ */
+export async function loadProject(config: Config, cwd: string = process.cwd()): Promise<Project> {
+  const logger = new BufferedLogger({ level: 'warn' });
+  const normalized = await normalizeThemes(config, cwd, logger);
+
+  const graph = normalized.resolved[normalized.defaultThemeName] ?? {};
+
+  return {
+    config,
+    themes: normalized.themes,
+    themesResolved: normalized.resolved,
+    graph,
+    diagnostics: toDiagnostics(logger),
+  };
+}
+
+/** Fetch the resolved tokens for a named theme. Throws if the name is unknown. */
+export function resolveTheme(project: Project, name: string): ResolvedTheme {
+  const tokens = project.themesResolved[name];
+  if (!tokens) {
+    const known = project.themes.map((t) => t.name).join(', ');
+    throw new Error(`swatchbook: unknown theme "${name}". Known: ${known || '(none)'}`);
+  }
+  return { name, tokens };
+}

--- a/packages/core/src/themes/layered.ts
+++ b/packages/core/src/themes/layered.ts
@@ -1,0 +1,90 @@
+import { glob } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { isAbsolute, resolve as resolvePath } from 'node:path';
+import { defineConfig as defineTerrazzoConfig, parse } from '@terrazzo/parser';
+import type { Theme, ThemeConfig, TokenMap } from '#/types';
+import type { BufferedLogger } from '#/diagnostics';
+
+export interface LayeredLoadResult {
+  themes: Theme[];
+  resolved: Record<string, TokenMap>;
+  defaultThemeName: string;
+}
+
+/**
+ * Realize themes from an explicit `themes: ThemeConfig[]` config.
+ * Each theme's `layers` glob list is parsed independently; aliases across
+ * layers resolve because Terrazzo sees them in a single `parse` call.
+ */
+export async function loadLayeredThemes(
+  themeConfigs: ThemeConfig[],
+  cwd: string,
+  logger: BufferedLogger,
+  explicitDefault?: string,
+): Promise<LayeredLoadResult> {
+  if (themeConfigs.length === 0) {
+    throw new Error('swatchbook: `themes` is set but empty.');
+  }
+
+  const themes: Theme[] = [];
+  const resolved: Record<string, TokenMap> = {};
+
+  const cwdUrl = pathToFileURL(`${cwd}/`);
+  const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
+
+  for (const themeConfig of themeConfigs) {
+    const files = await expandLayers(themeConfig.layers, cwd);
+    const inputs = await Promise.all(
+      files.map(async (filename) => ({
+        filename: pathToFileURL(filename),
+        src: await readFile(filename, 'utf8'),
+      })),
+    );
+
+    const result = await parse(inputs, {
+      logger,
+      config: terrazzoConfig,
+      resolveAliases: true,
+      continueOnError: true,
+    });
+
+    resolved[themeConfig.name] = result.tokens;
+    themes.push({
+      name: themeConfig.name,
+      input: { theme: themeConfig.name },
+      sources: files,
+    });
+  }
+
+  const defaultThemeName =
+    explicitDefault && resolved[explicitDefault] ? explicitDefault : (themes[0]?.name ?? '');
+
+  return { themes, resolved, defaultThemeName };
+}
+
+/** Expand an ordered list of glob patterns into an ordered list of files. */
+async function expandLayers(patterns: string[], cwd: string): Promise<string[]> {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const pattern of patterns) {
+    const absolute = isAbsolute(pattern) ? pattern : resolvePath(cwd, pattern);
+    for await (const match of glob(pattern, { cwd })) {
+      const full = isAbsolute(match) ? match : resolvePath(cwd, match);
+      if (!seen.has(full)) {
+        seen.add(full);
+        out.push(full);
+      }
+    }
+    // If the pattern had no glob characters and didn't expand, treat as a literal path.
+    if (!hasGlobChars(pattern) && !seen.has(absolute)) {
+      seen.add(absolute);
+      out.push(absolute);
+    }
+  }
+  return out;
+}
+
+function hasGlobChars(p: string): boolean {
+  return /[*?[\]{}]/.test(p);
+}

--- a/packages/core/src/themes/manifest.ts
+++ b/packages/core/src/themes/manifest.ts
@@ -1,0 +1,71 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
+import type { Theme, ThemeConfig, TokenMap } from '#/types';
+import type { BufferedLogger } from '#/diagnostics';
+import { loadLayeredThemes } from '#/themes/layered';
+
+interface ManifestEntry {
+  name: string;
+  selectedTokenSets: Record<string, 'enabled' | 'source' | 'disabled'>;
+}
+
+interface ManifestFile {
+  $themes: ManifestEntry[];
+}
+
+/**
+ * Realize themes from a Tokens Studio `$themes` manifest.
+ *
+ * Each manifest entry is converted into an explicit layered theme, then
+ * handed off to `loadLayeredThemes`. Files marked `enabled` or `source`
+ * are included as layers in declaration order; `disabled` entries are
+ * skipped. The `enabled` / `source` distinction doesn't affect token
+ * resolution — it matters at emit time and is tracked separately by
+ * the emitter (which sees the manifest via the project config).
+ */
+export async function loadManifestThemes(
+  manifestPath: string,
+  cwd: string,
+  logger: BufferedLogger,
+  explicitDefault?: string,
+): Promise<{
+  themes: Theme[];
+  resolved: Record<string, TokenMap>;
+  defaultThemeName: string;
+  sourceOnlyFiles: Set<string>;
+}> {
+  const absolute = isAbsolute(manifestPath) ? manifestPath : resolvePath(cwd, manifestPath);
+  const raw = await readFile(absolute, 'utf8');
+  const manifest = JSON.parse(raw) as ManifestFile;
+
+  if (!Array.isArray(manifest.$themes) || manifest.$themes.length === 0) {
+    throw new Error(`swatchbook: manifest at ${absolute} has no \`$themes\` entries.`);
+  }
+
+  const manifestDir = dirname(absolute);
+  const sourceOnlyFiles = new Set<string>();
+
+  const themeConfigs: ThemeConfig[] = manifest.$themes.map((entry) => {
+    const layers: string[] = [];
+    for (const [key, state] of Object.entries(entry.selectedTokenSets)) {
+      if (state === 'disabled') continue;
+      const layerPath = resolveManifestLayer(key, manifestDir);
+      layers.push(layerPath);
+      if (state === 'source') sourceOnlyFiles.add(layerPath);
+    }
+    return { name: entry.name, layers };
+  });
+
+  const layered = await loadLayeredThemes(themeConfigs, cwd, logger, explicitDefault);
+  return { ...layered, sourceOnlyFiles };
+}
+
+/**
+ * Tokens Studio keys are file stems without the `.json` extension
+ * (e.g. `sys/color` → `sys/color.json`). Resolve relative to the
+ * manifest's directory.
+ */
+function resolveManifestLayer(key: string, manifestDir: string): string {
+  const withExt = key.endsWith('.json') ? key : `${key}.json`;
+  return isAbsolute(withExt) ? withExt : resolvePath(manifestDir, withExt);
+}

--- a/packages/core/src/themes/normalize.ts
+++ b/packages/core/src/themes/normalize.ts
@@ -1,0 +1,48 @@
+import type { Config, Theme, TokenMap } from '#/types';
+import type { BufferedLogger } from '#/diagnostics';
+import { resolveThemingMode } from '#/config';
+import { loadLayeredThemes } from '#/themes/layered';
+import { loadManifestThemes } from '#/themes/manifest';
+import { loadResolverThemes } from '#/themes/resolver';
+
+export interface NormalizedThemes {
+  themes: Theme[];
+  resolved: Record<string, TokenMap>;
+  defaultThemeName: string;
+  /** Files loaded as `source`-only (manifest mode). Emission filters these out. */
+  sourceOnlyFiles: Set<string>;
+}
+
+/**
+ * Dispatch to the appropriate theming loader based on what the config
+ * specifies. All three paths produce the same downstream shape.
+ */
+export async function normalizeThemes(
+  config: Config,
+  cwd: string,
+  logger: BufferedLogger,
+): Promise<NormalizedThemes> {
+  const mode = resolveThemingMode(config);
+
+  switch (mode) {
+    case 'layered': {
+      const r = await loadLayeredThemes(config.themes ?? [], cwd, logger, config.default);
+      return { ...r, sourceOnlyFiles: new Set() };
+    }
+    case 'manifest': {
+      if (!config.manifest) throw new Error('unreachable: manifest mode without manifest path');
+      return loadManifestThemes(config.manifest, cwd, logger, config.default);
+    }
+    case 'resolver': {
+      if (!config.resolver) throw new Error('unreachable: resolver mode without resolver path');
+      const r = await loadResolverThemes(
+        config.resolver,
+        config.tokens,
+        cwd,
+        logger,
+        config.default,
+      );
+      return { ...r, sourceOnlyFiles: new Set() };
+    }
+  }
+}

--- a/packages/core/src/themes/resolver.ts
+++ b/packages/core/src/themes/resolver.ts
@@ -1,0 +1,93 @@
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, resolve as resolvePath } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { defineConfig as defineTerrazzoConfig, loadResolver, parse } from '@terrazzo/parser';
+import type { Theme, TokenMap } from '#/types';
+import type { BufferedLogger } from '#/diagnostics';
+import { collectGlobbedFiles } from '#/themes/util';
+
+export interface ResolverLoadResult {
+  themes: Theme[];
+  resolved: Record<string, TokenMap>;
+  defaultThemeName: string;
+}
+
+/**
+ * Realize themes from a DTCG 2025.10 native resolver file.
+ *
+ * Terrazzo's `loadResolver` scans the provided input list for a resolver
+ * document, normalizes it, then lets us enumerate permutations via
+ * `resolver.listPermutations()` and realize each with `resolver.apply()`.
+ */
+export async function loadResolverThemes(
+  resolverPath: string,
+  tokenGlobs: string[],
+  cwd: string,
+  logger: BufferedLogger,
+  explicitDefault?: string,
+): Promise<ResolverLoadResult> {
+  const absolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
+  const cwdUrl = pathToFileURL(`${cwd}/`);
+  const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
+
+  const tokenFiles = await collectGlobbedFiles(tokenGlobs, cwd);
+
+  // `loadResolver` expects the resolver file alone as input and fetches
+  // referenced token files via `req`. Passing tokens up front triggers
+  // "Resolver must be the only input" errors.
+  const resolverInput = {
+    filename: pathToFileURL(absolute),
+    src: await readFile(absolute, 'utf8'),
+  };
+
+  const req = async (url: URL): Promise<string> => {
+    const filename = url.protocol === 'file:' ? fileURLToPath(url) : url.toString();
+    return readFile(filename, 'utf8');
+  };
+
+  const loaded = await loadResolver([resolverInput], {
+    config: terrazzoConfig,
+    logger,
+    req,
+  });
+
+  if (!loaded.resolver) {
+    // Fall back to plain parse; no resolver found.
+    const tokenInputs = await Promise.all(
+      tokenFiles.map(async (filename) => ({
+        filename: pathToFileURL(filename),
+        src: await readFile(filename, 'utf8'),
+      })),
+    );
+    const parsed = await parse(tokenInputs, {
+      logger,
+      config: terrazzoConfig,
+      resolveAliases: true,
+      continueOnError: true,
+    });
+    const name = explicitDefault ?? 'default';
+    return {
+      themes: [{ name, input: { theme: name }, sources: tokenFiles }],
+      resolved: { [name]: parsed.tokens },
+      defaultThemeName: name,
+    };
+  }
+
+  const { resolver } = loaded;
+  const permutations = resolver.listPermutations();
+
+  const themes: Theme[] = [];
+  const resolved: Record<string, TokenMap> = {};
+
+  for (const input of permutations) {
+    const id = resolver.getPermutationID(input);
+    const tokens = resolver.apply(input);
+    themes.push({ name: id, input: { ...input }, sources: [] });
+    resolved[id] = tokens;
+  }
+
+  const defaultThemeName =
+    explicitDefault && resolved[explicitDefault] ? explicitDefault : (themes[0]?.name ?? '');
+
+  return { themes, resolved, defaultThemeName };
+}

--- a/packages/core/src/themes/util.ts
+++ b/packages/core/src/themes/util.ts
@@ -1,0 +1,14 @@
+import { glob } from 'node:fs/promises';
+import { isAbsolute, resolve as resolvePath } from 'node:path';
+
+/** Expand globs relative to cwd, returning deduplicated absolute paths in sorted order. */
+export async function collectGlobbedFiles(patterns: string[], cwd: string): Promise<string[]> {
+  const seen = new Set<string>();
+  for (const pattern of patterns) {
+    for await (const match of glob(pattern, { cwd })) {
+      const absolute = isAbsolute(match) ? match : resolvePath(cwd, match);
+      seen.add(absolute);
+    }
+  }
+  return [...seen].sort();
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,13 +1,17 @@
-import type { Resolver, TokenNormalized } from '@terrazzo/parser';
+import type { TokenNormalized } from '@terrazzo/parser';
 
-/**
- * A single theme composition — the permutation input that hits Terrazzo's
- * `resolver.apply()` to realize its tokens.
- */
+export type TokenMap = Record<string, TokenNormalized>;
+
+/** A single theme composition. */
 export interface Theme {
   name: string;
-  /** Resolver input (e.g. `{ appearance: 'light', brand: 'a' }`). */
+  /**
+   * For DTCG-resolver mode: the resolver input (e.g. `{ appearance: 'light', brand: 'a' }`).
+   * For layered / manifest modes: mirrors `{ theme: name }` for a uniform shape.
+   */
   input: Record<string, string>;
+  /** Ordered layer file paths used to build this theme. Empty for resolver mode. */
+  sources: string[];
 }
 
 /**
@@ -49,21 +53,20 @@ export interface Diagnostic {
 }
 
 /**
- * Loaded swatchbook project — the shape every downstream consumer (addon
- * preset, block renderer, CSS emitter) works against.
+ * Loaded swatchbook project. Themes are eagerly resolved at load time; use
+ * `resolveTheme(project, name)` to fetch one.
  */
 export interface Project {
   config: Config;
-  /** Themes normalized from whichever theming input the config used. */
   themes: Theme[];
-  /** Terrazzo resolver. Use `resolver.apply(theme.input)` to realize tokens. */
-  resolver: Resolver;
-  /** Base (pre-resolution) token set. */
-  graph: Record<string, TokenNormalized>;
+  /** Eagerly-resolved tokens per theme, keyed by `theme.name`. */
+  themesResolved: Record<string, TokenMap>;
+  /** Default theme's resolved tokens — convenience for global views. */
+  graph: TokenMap;
   diagnostics: Diagnostic[];
 }
 
 export interface ResolvedTheme {
   name: string;
-  tokens: Record<string, TokenNormalized>;
+  tokens: TokenMap;
 }


### PR DESCRIPTION
**Milestone:** M1 — Core (@unpunnyfuns/swatchbook-core)

**Plan impact:** none

## Summary

Second of three M1 PRs for core. Lands the theming layer:

- `loadProject(config, cwd?)` and `resolveTheme(project, name)` as the public entry points.
- `themes/layered.ts` — explicit `{ name, layers: [] }` compositions; each theme's layer globs parsed in a single Terrazzo pass so aliases resolve across files.
- `themes/manifest.ts` — Tokens Studio `$themes` convention; each entry's `selectedTokenSets` becomes a layered theme. `source`-only files are tracked on the result so the emitter (next PR) can filter them at CSS-emit time.
- `themes/resolver.ts` — DTCG 2025.10 native resolver via Terrazzo's `loadResolver` + `Resolver.listPermutations`. The resolver file is the sole input to `loadResolver`; referenced token files are fetched lazily via a `req` callback that reads from disk.
- `themes/normalize.ts` — dispatcher unifying all three paths into `{ themes, resolved, defaultThemeName, sourceOnlyFiles }`.

Themes are **eagerly resolved** at load time (`Project.themesResolved`). `resolveTheme` reads from the map synchronously. Dropped `resolver: Resolver` from `Project`'s public shape since downstream consumers don't need Terrazzo's resolver directly — the realized `TokenMap` is what the emitter, panel, and blocks will actually use.

Verified manually against `@unpunnyfuns/swatchbook-tokens-reference`:
- **manifest** → 5 themes (Light, Dark, Light · Brand A, Dark · Brand A, High Contrast)
- **resolver** → 6 permutations (3 appearance × 2 brand)
- **layered** → 2 themes (Light, Dark) from an explicit layer list

All three produce a 147-token graph. Semantics differ slightly: manifest enumerates 5 curated compositions, resolver enumerates the full cross-product (6). That's inherent to each model; the three-way equivalence test in the tests PR will compare like-with-like.

Follow-up PRs: CSS emission + `emitTypes`, then Vitest unit tests.

Refs #13.

## Test plan

- [x] `pnpm turbo run typecheck` green.
- [x] `pnpm turbo run build` emits `dist/index.{mjs,d.mts}`.
- [x] Smoke test against `tokens-reference` loads all three modes without throwing.