### PR TITLE
chore(core): clear oxlint warnings, fail CI on any future one

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "build": "tsdown src/index.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint -c ../../.oxlintrc.json src",
+    "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src",
     "format": "oxfmt -c ../../.oxfmtrc.json src",
     "format:check": "oxfmt --check -c ../../.oxfmtrc.json src"
   },

--- a/packages/core/src/themes/layered.ts
+++ b/packages/core/src/themes/layered.ts
@@ -1,4 +1,4 @@
-import { glob } from 'node:fs/promises';
+import { globSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
 import { pathToFileURL } from 'node:url';
 import { isAbsolute, resolve as resolvePath } from 'node:path';
@@ -27,34 +27,39 @@ export async function loadLayeredThemes(
     throw new Error('swatchbook: `themes` is set but empty.');
   }
 
-  const themes: Theme[] = [];
-  const resolved: Record<string, TokenMap> = {};
-
   const cwdUrl = pathToFileURL(`${cwd}/`);
   const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
 
-  for (const themeConfig of themeConfigs) {
-    const files = await expandLayers(themeConfig.layers, cwd);
-    const inputs = await Promise.all(
-      files.map(async (filename) => ({
-        filename: pathToFileURL(filename),
-        src: await readFile(filename, 'utf8'),
-      })),
-    );
+  const entries = await Promise.all(
+    themeConfigs.map(async (themeConfig) => {
+      const files = expandLayers(themeConfig.layers, cwd);
+      const inputs = await Promise.all(
+        files.map(async (filename) => ({
+          filename: pathToFileURL(filename),
+          src: await readFile(filename, 'utf8'),
+        })),
+      );
+      const result = await parse(inputs, {
+        logger,
+        config: terrazzoConfig,
+        resolveAliases: true,
+        continueOnError: true,
+      });
+      return {
+        theme: {
+          name: themeConfig.name,
+          input: { theme: themeConfig.name },
+          sources: files,
+        } satisfies Theme,
+        tokens: result.tokens,
+      };
+    }),
+  );
 
-    const result = await parse(inputs, {
-      logger,
-      config: terrazzoConfig,
-      resolveAliases: true,
-      continueOnError: true,
-    });
-
-    resolved[themeConfig.name] = result.tokens;
-    themes.push({
-      name: themeConfig.name,
-      input: { theme: themeConfig.name },
-      sources: files,
-    });
+  const themes: Theme[] = entries.map((e) => e.theme);
+  const resolved: Record<string, TokenMap> = {};
+  for (const { theme, tokens } of entries) {
+    resolved[theme.name] = tokens;
   }
 
   const defaultThemeName =
@@ -64,12 +69,12 @@ export async function loadLayeredThemes(
 }
 
 /** Expand an ordered list of glob patterns into an ordered list of files. */
-async function expandLayers(patterns: string[], cwd: string): Promise<string[]> {
+function expandLayers(patterns: string[], cwd: string): string[] {
   const seen = new Set<string>();
   const out: string[] = [];
   for (const pattern of patterns) {
     const absolute = isAbsolute(pattern) ? pattern : resolvePath(cwd, pattern);
-    for await (const match of glob(pattern, { cwd })) {
+    for (const match of globSync(pattern, { cwd })) {
       const full = isAbsolute(match) ? match : resolvePath(cwd, match);
       if (!seen.has(full)) {
         seen.add(full);

--- a/packages/core/src/themes/util.ts
+++ b/packages/core/src/themes/util.ts
@@ -1,14 +1,14 @@
-import { glob } from 'node:fs/promises';
+import { globSync } from 'node:fs';
 import { isAbsolute, resolve as resolvePath } from 'node:path';
 
 /** Expand globs relative to cwd, returning deduplicated absolute paths in sorted order. */
-export async function collectGlobbedFiles(patterns: string[], cwd: string): Promise<string[]> {
+export function collectGlobbedFiles(patterns: string[], cwd: string): string[] {
   const seen = new Set<string>();
   for (const pattern of patterns) {
-    for await (const match of glob(pattern, { cwd })) {
+    for (const match of globSync(pattern, { cwd })) {
       const absolute = isAbsolute(match) ? match : resolvePath(cwd, match);
       seen.add(absolute);
     }
   }
-  return [...seen].sort();
+  return [...seen].toSorted();
 }

--- a/packages/tokens-reference/package.json
+++ b/packages/tokens-reference/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint -c ../../.oxlintrc.json src",
+    "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src",
     "format": "oxfmt -c ../../.oxfmtrc.json src",
     "format:check": "oxfmt --check -c ../../.oxfmtrc.json src"
   },


### PR DESCRIPTION
**Milestone:** none (infra)

**Plan impact:** none

## Summary

Warnings had accumulated from code merged before the quality gates PR (#49). Cleaning them up and tightening lint so new ones can't slip through.

- `themes/util.ts` + `themes/layered.ts`: swap the async `for await (glob(...))` iteration for synchronous `globSync` (Node 24 native). Removes 6 `no-await-in-loop` warnings.
- `loadLayeredThemes`: parallelize per-theme loading via `Promise.all` since each theme's parse is independent.
- Add `--deny-warnings` to the oxlint script in every package. Any future warning is now a build break, not a quiet nag.

## Test plan

- [x] `pnpm turbo run lint format:check typecheck build` → 7/7 green, 0 warnings.
- [x] `oxlint --deny-warnings` verified: removed a known line, lint exits non-zero.