### PR TITLE
feat(addon): custom toolbar tool with composition chips + source badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ apps/storybook/src/generated
 .vscode
 .idea
 
+# Claude Code session state
+.claude
+
 # Logs
 *.log
 npm-debug.log*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,13 @@ Update this line when a milestone closes. See the matching GitHub milestones for
 
 `.claude/skills/dtcg-tokens/SKILL.md` — reference card for the DTCG 2025.10 spec. Loads automatically when working on token files; consult it before writing or editing `.tokens.json` / `.dtcg.json` content.
 
+## Storybook addon gotchas
+
+- **Manager bundle**: use `React.createElement` (or a local `h` alias), **not JSX**. Storybook's manager page runs React 18 and doesn't expose `react/jsx-runtime`'s React-19 dispatcher — JSX in manager code crashes with *"Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')"*. Preview code is fine with JSX (runs on the consumer's React).
+- **Register tools via element-returning function**: `render: () => h(ThemeToolbar)` — passing the component function directly (`render: ThemeToolbar`) invokes hooks outside React's render cycle.
+- **Preview ↔ manager comms**: use Storybook's channel (`addons.getChannel()` + `emit`/`on`). The manager can't import preview-side Vite virtual modules.
+- **CSF Next addons**: default-export a factory that returns `definePreviewAddon(previewExports)` (from `storybook/internal/csf`). Consumers opt in via `definePreview({ addons: [swatchbookAddon()] })`.
+
 ## Storybook MCP
 
 `apps/storybook` runs an MCP server via `@storybook/addon-mcp` at `http://localhost:6006/mcp`. The MCP endpoint only exists while Storybook is running — start it in one terminal before using MCP tools in another.

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,12 +1,12 @@
+import { defineMain } from '@storybook/react-vite/node';
 import { dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { StorybookConfig } from '@storybook/react-vite';
 
 function pkg(name: string): string {
   return dirname(fileURLToPath(import.meta.resolve(`${name}/package.json`)));
 }
 
-const config: StorybookConfig = {
+export default defineMain({
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
   addons: [
     pkg('@chromatic-com/storybook'),
@@ -22,6 +22,4 @@ const config: StorybookConfig = {
     },
   ],
   framework: pkg('@storybook/react-vite'),
-};
-
-export default config;
+});

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,11 +1,8 @@
-import type { Preview } from '@storybook/react-vite';
+import addonDocs from '@storybook/addon-docs';
+import addonA11y from '@storybook/addon-a11y';
+import { definePreview } from '@storybook/react-vite';
 
-/**
- * Swatchbook's preview decorator + theme toolbar come from
- * `@unpunnyfuns/swatchbook-addon` (registered in main.ts). This file carries
- * only app-level parameters.
- */
-const preview: Preview = {
+export default definePreview({
   parameters: {
     controls: {
       matchers: {
@@ -16,6 +13,6 @@ const preview: Preview = {
     a11y: { test: 'error' },
     backgrounds: { disable: true },
   },
-};
 
-export default preview;
+  addons: [addonA11y(), addonDocs()],
+});

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,6 +1,7 @@
-import addonDocs from '@storybook/addon-docs';
 import addonA11y from '@storybook/addon-a11y';
+import addonDocs from '@storybook/addon-docs';
 import { definePreview } from '@storybook/react-vite';
+import swatchbookAddon from '@unpunnyfuns/swatchbook-addon';
 
 export default definePreview({
   parameters: {
@@ -13,6 +14,5 @@ export default definePreview({
     a11y: { test: 'error' },
     backgrounds: { disable: true },
   },
-
-  addons: [addonA11y(), addonDocs()],
+  addons: [addonA11y(), addonDocs(), swatchbookAddon()],
 });

--- a/apps/storybook/src/stories/Button.stories.tsx
+++ b/apps/storybook/src/stories/Button.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import preview from '../../.storybook/preview';
 import { Button } from '../components/Button';
 
-const meta = {
+const meta = preview.meta({
   title: 'Components/Button',
   component: Button,
   tags: ['autodocs'],
@@ -9,10 +9,7 @@ const meta = {
     variant: { control: 'select', options: ['primary', 'ghost'] },
   },
   args: { children: 'Save changes' },
-} satisfies Meta<typeof Button>;
+});
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Primary: Story = { args: { variant: 'primary' } };
-export const Ghost: Story = { args: { variant: 'ghost' } };
+export const Primary = meta.story({ args: { variant: 'primary' } });
+export const Ghost = meta.story({ args: { variant: 'ghost' } });

--- a/apps/storybook/src/stories/Card.stories.tsx
+++ b/apps/storybook/src/stories/Card.stories.tsx
@@ -1,7 +1,7 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import preview from '../../.storybook/preview';
 import { Card } from '../components/Card';
 
-const meta = {
+const meta = preview.meta({
   title: 'Components/Card',
   component: Card,
   tags: ['autodocs'],
@@ -10,10 +10,7 @@ const meta = {
     children:
       'Every surface, border, radius, and shadow on this card resolves through swatchbook-core from the reference DTCG pyramid.',
   },
-} satisfies Meta<typeof Card>;
+});
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {};
-export const Untitled: Story = { args: { title: undefined } };
+export const Default = meta.story();
+export const Untitled = meta.story({ args: { title: undefined } });

--- a/apps/storybook/src/stories/Input.stories.tsx
+++ b/apps/storybook/src/stories/Input.stories.tsx
@@ -1,18 +1,15 @@
-import type { Meta, StoryObj } from '@storybook/react-vite';
+import preview from '../../.storybook/preview';
 import { Input } from '../components/Input';
 
-const meta = {
+const meta = preview.meta({
   title: 'Components/Input',
   component: Input,
   tags: ['autodocs'],
   args: { placeholder: 'Type a theme name…' },
-} satisfies Meta<typeof Input>;
+});
 
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-export const Default: Story = {};
-export const Disabled: Story = {
+export const Default = meta.story();
+export const Disabled = meta.story({
   args: { disabled: true, defaultValue: 'Disabled input' },
-};
-export const Invalid: Story = { args: { invalid: true, defaultValue: 'not-a-theme' } };
+});
+export const Invalid = meta.story({ args: { invalid: true, defaultValue: 'not-a-theme' } });

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -21,6 +21,10 @@
       "types": "./dist/preview.d.mts",
       "import": "./dist/preview.mjs"
     },
+    "./manager": {
+      "types": "./dist/manager.d.mts",
+      "import": "./dist/manager.mjs"
+    },
     "./package.json": "./package.json"
   },
   "imports": {
@@ -39,7 +43,7 @@
     "supportedFrameworks": ["react"]
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/preset.ts src/preview.tsx --format esm --dts --clean --sourcemap",
+    "build": "tsdown src/index.ts src/preset.ts src/preview.tsx src/manager.tsx --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src",
     "format": "oxfmt -c ../../.oxfmtrc.json src",

--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -1,4 +1,5 @@
 export const ADDON_ID = 'swatchbook';
+export const TOOL_ID = `${ADDON_ID}/theme-switcher`;
 export const PARAM_KEY = 'swatchbook';
 export const GLOBAL_KEY = 'swatchbookTheme';
 
@@ -7,3 +8,6 @@ export const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;
 
 export const DATA_THEME_ATTR = 'data-theme';
 export const STYLE_ELEMENT_ID = 'swatchbook-tokens';
+
+/** Channel event: preview → manager, carries theme list + mode. */
+export const INIT_EVENT = 'swatchbook/init';

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -1,2 +1,14 @@
+import { definePreviewAddon } from 'storybook/internal/csf';
+import * as previewExports from './preview';
+
 export { ADDON_ID, GLOBAL_KEY, PARAM_KEY, VIRTUAL_MODULE_ID } from '#/constants';
 export type { AddonOptions } from '#/options';
+
+/**
+ * CSF Next factory. Consumers call this inside
+ * `definePreview({ addons: [swatchbookAddon()] })` so the preview annotations
+ * (decorator, globalTypes, initialGlobals) are added to the preview bundle.
+ */
+export default function swatchbookAddon(): ReturnType<typeof definePreviewAddon> {
+  return definePreviewAddon(previewExports);
+}

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -1,0 +1,160 @@
+import React, { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { IconButton, TooltipLinkList, WithTooltip } from 'storybook/internal/components';
+import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
+import { ADDON_ID, GLOBAL_KEY, INIT_EVENT, TOOL_ID } from '#/constants';
+
+/**
+ * Use explicit `React.createElement` rather than JSX so the manager bundle
+ * doesn't take a hard dependency on `react/jsx-runtime`. Storybook's manager
+ * page injects its own React as a runtime global; `react/jsx-runtime` isn't
+ * always part of that exposure, which breaks JSX with
+ * "Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')".
+ * Mirrors the pattern `@storybook/addon-a11y` uses in its manager.
+ */
+const h = React.createElement;
+
+interface ThemeEntry {
+  name: string;
+  input: Record<string, string>;
+  sources: string[];
+}
+
+type ThemingMode = 'layered' | 'resolver' | 'manifest';
+
+interface InitPayload {
+  themes: ThemeEntry[];
+  defaultTheme: string | null;
+  mode: ThemingMode;
+}
+
+const modeBadge: Record<ThemingMode, string> = {
+  layered: 'layered',
+  resolver: 'DTCG resolver',
+  manifest: '$themes manifest',
+};
+
+const EMPTY_THEMES: ThemeEntry[] = [];
+
+/** Split a resolver permutation like `{ appearance: 'light', brand: 'a' }` into display chips. */
+function chipsFor(theme: ThemeEntry): string[] {
+  const entries = Object.entries(theme.input);
+  // Layered / manifest modes use a single-key { theme: name } — the name itself is the chip.
+  if (entries.length === 1 && entries[0]?.[0] === 'theme') return [];
+  return entries.map(([key, value]) => `${key}: ${value}`);
+}
+
+function ThemeIcon(): ReactElement {
+  return h(
+    'svg',
+    { width: 14, height: 14, viewBox: '0 0 14 14', 'aria-hidden': true },
+    h('circle', { cx: 7, cy: 7, r: 6, fill: 'currentColor', opacity: 0.15 }),
+    h('path', {
+      d: 'M7 1a6 6 0 0 0 0 12 3 3 0 0 0 0-6 3 3 0 0 1 0-6Z',
+      fill: 'currentColor',
+    }),
+  );
+}
+
+function ThemeToolbar(): ReactElement {
+  const [globals, updateGlobals] = useGlobals();
+  const api = useStorybookApi();
+  const [payload, setPayload] = useState<InitPayload | null>(null);
+
+  useEffect(() => {
+    const channel = addons.getChannel();
+    const onInit = (next: InitPayload): void => setPayload(next);
+    channel.on(INIT_EVENT, onInit);
+    return () => {
+      channel.off(INIT_EVENT, onInit);
+    };
+  }, []);
+
+  const themes = payload?.themes ?? EMPTY_THEMES;
+  const active =
+    (globals[GLOBAL_KEY] as string | undefined) ?? payload?.defaultTheme ?? themes[0]?.name ?? '';
+
+  const selectTheme = useMemo(
+    () =>
+      (name: string): void => {
+        updateGlobals({ [GLOBAL_KEY]: name });
+      },
+    [updateGlobals],
+  );
+
+  useEffect(() => {
+    if (themes.length === 0) return;
+    api.setAddonShortcut(ADDON_ID, {
+      label: 'Cycle swatchbook theme',
+      defaultShortcut: ['alt', 'T'],
+      actionName: 'cycleTheme',
+      showInMenu: true,
+      action: () => {
+        const idx = themes.findIndex((t) => t.name === active);
+        const next = themes[(idx + 1) % themes.length];
+        if (next) selectTheme(next.name);
+      },
+    });
+  }, [api, themes, active, selectTheme]);
+
+  if (themes.length === 0) {
+    return h(
+      IconButton,
+      { key: TOOL_ID, title: 'Swatchbook theme (loading…)', disabled: true },
+      h(ThemeIcon),
+      h('span', { style: { marginLeft: 6, opacity: 0.6 } }, '—'),
+    );
+  }
+
+  const tooltip = ({ onHide }: { onHide: () => void }): ReactElement =>
+    h(
+      'div',
+      { style: { minWidth: 220 } },
+      h(
+        'div',
+        {
+          style: {
+            padding: '8px 12px',
+            fontSize: 11,
+            textTransform: 'uppercase',
+            letterSpacing: 0.5,
+            opacity: 0.6,
+          },
+        },
+        `Theme${payload?.mode ? ` — ${modeBadge[payload.mode]}` : ''}`,
+      ),
+      h(TooltipLinkList, {
+        links: themes.map((theme) => ({
+          id: theme.name,
+          title: theme.name,
+          right: chipsFor(theme).join(' · ') || undefined,
+          active: theme.name === active,
+          onClick: () => {
+            selectTheme(theme.name);
+            onHide();
+          },
+        })),
+      }),
+    );
+
+  return h(WithTooltip, {
+    placement: 'bottom',
+    trigger: 'click',
+    closeOnOutsideClick: true,
+    tooltip,
+    children: h(
+      IconButton,
+      { key: TOOL_ID, title: 'Swatchbook theme' },
+      h(ThemeIcon),
+      h('span', { style: { marginLeft: 6 } }, active),
+    ),
+  });
+}
+
+addons.register(ADDON_ID, () => {
+  addons.add(TOOL_ID, {
+    type: types.TOOL,
+    title: 'Swatchbook theme',
+    match: ({ viewMode, tabId }) => !tabId && (viewMode === 'story' || viewMode === 'docs'),
+    render: () => h(ThemeToolbar),
+  });
+});

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -1,5 +1,5 @@
 import { dirname, isAbsolute, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Config } from '@unpunnyfuns/swatchbook-core';
 import { createJiti } from 'jiti';
 import type { InlineConfig } from 'vite';
@@ -26,6 +26,12 @@ export async function viteFinal(
   plugins.push(swatchbookTokensPlugin({ config, cwd }));
 
   return { ...viteConfig, plugins };
+}
+
+/** Storybook appends this module into the manager bundle so our toolbar tool registers. */
+export function managerEntries(entry: string[] = []): string[] {
+  const managerUrl = import.meta.resolve('@unpunnyfuns/swatchbook-addon/manager');
+  return [...entry, fileURLToPath(managerUrl)];
 }
 
 async function resolveConfig(options: PresetOptions): Promise<{ config: Config; cwd: string }> {

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -1,5 +1,5 @@
 import { dirname, isAbsolute, resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Config } from '@unpunnyfuns/swatchbook-core';
 import { createJiti } from 'jiti';
 import type { InlineConfig } from 'vite';
@@ -26,6 +26,16 @@ export async function viteFinal(
   plugins.push(swatchbookTokensPlugin({ config, cwd }));
 
   return { ...viteConfig, plugins };
+}
+
+/**
+ * Append our preview entry so the decorator + globalTypes ship in the
+ * preview bundle even under CSF Next's `definePreview` pattern, where
+ * consumers don't directly register non-factory addon annotations.
+ */
+export function previewAnnotations(entry: string[] = []): string[] {
+  const previewUrl = import.meta.resolve('@unpunnyfuns/swatchbook-addon/preview');
+  return [...entry, fileURLToPath(previewUrl)];
 }
 
 async function resolveConfig(options: PresetOptions): Promise<{ config: Config; cwd: string }> {

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -1,5 +1,5 @@
 import { dirname, isAbsolute, resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { pathToFileURL } from 'node:url';
 import type { Config } from '@unpunnyfuns/swatchbook-core';
 import { createJiti } from 'jiti';
 import type { InlineConfig } from 'vite';
@@ -26,16 +26,6 @@ export async function viteFinal(
   plugins.push(swatchbookTokensPlugin({ config, cwd }));
 
   return { ...viteConfig, plugins };
-}
-
-/**
- * Append our preview entry so the decorator + globalTypes ship in the
- * preview bundle even under CSF Next's `definePreview` pattern, where
- * consumers don't directly register non-factory addon annotations.
- */
-export function previewAnnotations(entry: string[] = []): string[] {
-  const previewUrl = import.meta.resolve('@unpunnyfuns/swatchbook-addon/preview');
-  return [...entry, fileURLToPath(previewUrl)];
 }
 
 async function resolveConfig(options: PresetOptions): Promise<{ config: Config; cwd: string }> {

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -1,16 +1,26 @@
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { useEffect } from 'react';
-import { css as generatedCss, cssVarPrefix, defaultTheme, themes } from 'virtual:swatchbook/tokens';
-import { DATA_THEME_ATTR, GLOBAL_KEY, PARAM_KEY, STYLE_ELEMENT_ID } from '#/constants';
+import { addons } from 'storybook/preview-api';
+import {
+  css as generatedCss,
+  cssVarPrefix,
+  defaultTheme,
+  themes,
+  themingMode,
+} from 'virtual:swatchbook/tokens';
+import { DATA_THEME_ATTR, GLOBAL_KEY, INIT_EVENT, PARAM_KEY, STYLE_ELEMENT_ID } from '#/constants';
 
 interface ThemeEntry {
   name: string;
+  input: Record<string, string>;
+  sources: string[];
 }
 
 const typedThemes = themes as ThemeEntry[];
 const typedCss = generatedCss as string;
 const typedDefaultTheme = defaultTheme as string | null;
 const typedPrefix = (cssVarPrefix ?? '') as string;
+const typedMode = themingMode as 'layered' | 'resolver' | 'manifest';
 
 /** CSS var name with the active prefix applied. */
 function v(name: string): string {
@@ -47,6 +57,20 @@ function setRootTheme(theme: string): void {
   document.documentElement.setAttribute(DATA_THEME_ATTR, theme);
 }
 
+/**
+ * Emit themes to the manager over Storybook's channel so the toolbar tool
+ * (in the manager bundle, which can't import our virtual module) gets the
+ * theme list, default, and mode.
+ */
+function broadcastThemes(): void {
+  const channel = addons.getChannel();
+  channel.emit(INIT_EVENT, {
+    themes: typedThemes,
+    defaultTheme: typedDefaultTheme,
+    mode: typedMode,
+  });
+}
+
 const themedDecorator: Decorator = (Story, context) => {
   const globalTheme = (context.globals as Record<string, unknown>)[GLOBAL_KEY];
   const parameterTheme = (context.parameters as Record<string, Record<string, unknown>>)[
@@ -56,6 +80,7 @@ const themedDecorator: Decorator = (Story, context) => {
 
   useEffect(() => {
     ensureStylesheet();
+    broadcastThemes();
   }, []);
 
   useEffect(() => {
@@ -84,12 +109,7 @@ export const decorators: NonNullable<Preview['decorators']> = [themedDecorator];
 export const globalTypes: NonNullable<Preview['globalTypes']> = {
   [GLOBAL_KEY]: {
     name: 'Theme',
-    description: 'Active swatchbook theme.',
-    toolbar: {
-      icon: 'paintbrush',
-      items: typedThemes.map((t) => ({ value: t.name, title: t.name })),
-      dynamicTitle: true,
-    },
+    description: 'Active swatchbook theme. UI lives in the manager toolbar tool.',
   },
 };
 

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -1,6 +1,5 @@
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { useEffect } from 'react';
-// @ts-expect-error — virtual module resolved by the Vite plugin at preview build time
 import { css as generatedCss, cssVarPrefix, defaultTheme, themes } from 'virtual:swatchbook/tokens';
 import { DATA_THEME_ATTR, GLOBAL_KEY, PARAM_KEY, STYLE_ELEMENT_ID } from '#/constants';
 
@@ -48,7 +47,7 @@ function setRootTheme(theme: string): void {
   document.documentElement.setAttribute(DATA_THEME_ATTR, theme);
 }
 
-const decorator: Decorator = (Story, context) => {
+const themedDecorator: Decorator = (Story, context) => {
   const globalTheme = (context.globals as Record<string, unknown>)[GLOBAL_KEY];
   const parameterTheme = (context.parameters as Record<string, Record<string, unknown>>)[
     PARAM_KEY
@@ -76,20 +75,24 @@ const decorator: Decorator = (Story, context) => {
   );
 };
 
-const preview: Preview = {
-  decorators: [decorator],
-  globalTypes: {
-    [GLOBAL_KEY]: {
-      name: 'Theme',
-      description: 'Active swatchbook theme.',
-      toolbar: {
-        icon: 'paintbrush',
-        items: typedThemes.map((t) => ({ value: t.name, title: t.name })),
-        dynamicTitle: true,
-      },
+/**
+ * Named exports consumed by `definePreviewAddon(previewExports)` in the
+ * addon's CSF Next factory (`src/index.ts`).
+ */
+export const decorators: NonNullable<Preview['decorators']> = [themedDecorator];
+
+export const globalTypes: NonNullable<Preview['globalTypes']> = {
+  [GLOBAL_KEY]: {
+    name: 'Theme',
+    description: 'Active swatchbook theme.',
+    toolbar: {
+      icon: 'paintbrush',
+      items: typedThemes.map((t) => ({ value: t.name, title: t.name })),
+      dynamicTitle: true,
     },
   },
-  initialGlobals: { [GLOBAL_KEY]: typedDefaultTheme ?? typedThemes[0]?.name ?? 'Light' },
 };
 
-export default preview;
+export const initialGlobals: NonNullable<Preview['initialGlobals']> = {
+  [GLOBAL_KEY]: typedDefaultTheme ?? typedThemes[0]?.name ?? 'Light',
+};

--- a/packages/addon/src/virtual/module.d.ts
+++ b/packages/addon/src/virtual/module.d.ts
@@ -1,0 +1,22 @@
+/**
+ * Type declarations for the virtual module served by our Vite plugin.
+ * The real module is generated at preview build time — these shapes mirror
+ * what `swatchbookTokensPlugin` emits in `packages/addon/src/virtual/plugin.ts`.
+ */
+declare module 'virtual:swatchbook/tokens' {
+  import type { TokenMap } from '@unpunnyfuns/swatchbook-core';
+
+  export interface VirtualTheme {
+    name: string;
+    input: Record<string, string>;
+    sources: string[];
+  }
+
+  export const themes: VirtualTheme[];
+  export const defaultTheme: string | null;
+  export const themesResolved: Record<string, TokenMap>;
+  export const diagnostics: unknown[];
+  export const css: string;
+  export const cssVarPrefix: string;
+  export const themingMode: 'layered' | 'resolver' | 'manifest';
+}

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,5 +1,5 @@
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
-import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { loadProject, projectCss, resolveThemingMode } from '@unpunnyfuns/swatchbook-core';
 import type { Plugin } from 'vite';
 import { RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from '#/constants';
 
@@ -39,6 +39,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
     load(id) {
       if (id !== RESOLVED_VIRTUAL_MODULE_ID) return null;
       if (!project) return 'export default null;';
+      const mode = resolveThemingMode(config);
       // Emit a typed ESM module. Values are JSON-stringified for stability.
       return [
         `/* swatchbook virtual module — generated */`,
@@ -48,6 +49,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
         `export const diagnostics = ${JSON.stringify(project.diagnostics)};`,
         `export const css = ${JSON.stringify(css)};`,
         `export const cssVarPrefix = ${JSON.stringify(config.cssVarPrefix ?? '')};`,
+        `export const themingMode = ${JSON.stringify(mode)};`,
       ].join('\n');
     },
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { defineSwatchbookConfig } from '#/config';
+export { defineSwatchbookConfig, resolveThemingMode } from '#/config';
 export { loadProject, resolveTheme } from '#/load';
 export { projectCss, emitTypes } from '#/emit';
 export { emitCss, type EmitCssOptions } from '#/css';


### PR DESCRIPTION
**Milestone:** M3 — Addon runtime

**Plan impact:** none

## Summary

Second M3 PR — replaces the plain \`globalTypes\` dropdown from #57 with a rich Storybook manager **TOOL**. Closes out M3's toolbar UI work.

### Wiring

- New \`./manager\` export from \`@unpunnyfuns/swatchbook-addon\`; tsdown bundles \`src/manager.tsx\` → \`dist/manager.mjs\`.
- \`preset.ts\` exports \`managerEntries()\` so Storybook picks up the tool.
- \`constants\`: \`TOOL_ID\`, \`INIT_EVENT\` channel topic.
- Virtual module exposes \`themingMode\` (\`'layered' | 'resolver' | 'manifest'\`) so the UI can render a provenance badge.
- New \`src/virtual/module.d.ts\` declares the virtual module's exports — drops the \`@ts-expect-error\` on the preview-side import.

### Channel comms

The manager bundle runs in Storybook's chrome and can't import \`virtual:swatchbook/tokens\`. The **preview broadcasts** the theme list, default, and mode over Storybook's channel on first mount (\`INIT_EVENT = 'swatchbook/init'\`). Manager listens, renders.

### UX

- Active theme shown in the toolbar button.
- Click → popover with one entry per theme:
  - **Composition chips** for resolver mode: \`"appearance: light · brand: a"\`.
  - Layered / manifest modes show just the name.
- Popover header shows the **theming-mode badge**: \`Theme — DTCG resolver\`, etc.
- \`alt+T\` keyboard shortcut cycles themes.
- Loading state while the channel hasn't delivered the list yet.

### Preview trim

Drops \`globalTypes.toolbar.items\` — the custom tool owns the UI. \`initialGlobals\` + the global-type description stay so Storybook knows the global exists.

Also exports \`resolveThemingMode\` from \`@unpunnyfuns/swatchbook-core\` for the addon's virtual module.

## Test plan

- [x] \`pnpm turbo run lint format:check typecheck test build\` → 19/19 green.
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-storybook build:storybook\` succeeds with the new manager entry.
- [ ] Visit \`http://localhost:6006\`: toolbar shows the custom tool (not the default globals dropdown), clicking opens a popover with all 5 themes + chips + badge, \`alt+T\` cycles.