### PR TITLE
feat(addon): Tokens + Diagnostics panels

### DIFF
--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -1,5 +1,8 @@
 export const ADDON_ID = 'swatchbook';
 export const TOOL_ID = `${ADDON_ID}/theme-switcher`;
+export const PANEL_ID = `${ADDON_ID}/panel`;
+export const PANEL_TOKENS_TAB = `${ADDON_ID}/tokens`;
+export const PANEL_DIAGNOSTICS_TAB = `${ADDON_ID}/diagnostics`;
 export const PARAM_KEY = 'swatchbook';
 export const GLOBAL_KEY = 'swatchbookTheme';
 

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -1,7 +1,15 @@
 import React, { useEffect, useMemo, useState, type ReactElement } from 'react';
 import { IconButton, TooltipLinkList, WithTooltip } from 'storybook/internal/components';
 import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
-import { ADDON_ID, GLOBAL_KEY, INIT_EVENT, TOOL_ID } from '#/constants.ts';
+import {
+  ADDON_ID,
+  GLOBAL_KEY,
+  INIT_EVENT,
+  PANEL_DIAGNOSTICS_TAB,
+  PANEL_TOKENS_TAB,
+  TOOL_ID,
+} from '#/constants.ts';
+import { DiagnosticsPanel, TokensPanel } from '#/panel.tsx';
 
 /**
  * Use explicit `React.createElement` rather than JSX so the manager bundle
@@ -156,5 +164,19 @@ addons.register(ADDON_ID, () => {
     title: 'Swatchbook theme',
     match: ({ viewMode, tabId }) => !tabId && (viewMode === 'story' || viewMode === 'docs'),
     render: () => h(ThemeToolbar),
+  });
+
+  addons.add(PANEL_TOKENS_TAB, {
+    type: types.PANEL,
+    title: 'Swatchbook tokens',
+    match: ({ viewMode }) => viewMode === 'story',
+    render: ({ active }) => h(TokensPanel, { active: !!active }),
+  });
+
+  addons.add(PANEL_DIAGNOSTICS_TAB, {
+    type: types.PANEL,
+    title: 'Swatchbook diagnostics',
+    match: ({ viewMode }) => viewMode === 'story',
+    render: ({ active }) => h(DiagnosticsPanel, { active: !!active }),
   });
 });

--- a/packages/addon/src/panel.tsx
+++ b/packages/addon/src/panel.tsx
@@ -1,0 +1,302 @@
+import React, { useEffect, useMemo, useState, type ReactElement } from 'react';
+import { addons, useGlobals } from 'storybook/manager-api';
+import { Placeholder, ScrollArea } from 'storybook/internal/components';
+import { GLOBAL_KEY, INIT_EVENT } from '#/constants.ts';
+
+/** `React.createElement` alias so the manager bundle avoids `react/jsx-runtime`. */
+const h = React.createElement;
+
+interface VirtualToken {
+  id: string;
+  $type?: string;
+  $value?: unknown;
+  $description?: string;
+}
+
+interface VirtualTheme {
+  name: string;
+  input: Record<string, string>;
+  sources: string[];
+}
+
+type ThemingMode = 'layered' | 'resolver' | 'manifest';
+
+type DiagnosticSeverity = 'error' | 'warn' | 'info';
+
+interface VirtualDiagnostic {
+  severity: DiagnosticSeverity;
+  group: string;
+  message: string;
+  filename?: string;
+  line?: number;
+  column?: number;
+}
+
+interface InitPayload {
+  themes: VirtualTheme[];
+  defaultTheme: string | null;
+  mode: ThemingMode;
+  themesResolved: Record<string, Record<string, VirtualToken>>;
+  diagnostics: VirtualDiagnostic[];
+  cssVarPrefix: string;
+}
+
+function usePayload(): InitPayload | null {
+  const [payload, setPayload] = useState<InitPayload | null>(null);
+  useEffect(() => {
+    const channel = addons.getChannel();
+    const onInit = (next: InitPayload): void => setPayload(next);
+    channel.on(INIT_EVENT, onInit);
+    return () => {
+      channel.off(INIT_EVENT, onInit);
+    };
+  }, []);
+  return payload;
+}
+
+function makeCssVar(path: string, prefix: string): string {
+  const tail = path.replaceAll('.', '-');
+  return prefix ? `--${prefix}-${tail}` : `--${tail}`;
+}
+
+async function copy(text: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    /* clipboard access denied — no fallback, the user can read the var name from the row */
+  }
+}
+
+/** Format a token `$value` into a short display string. */
+function formatValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  if (typeof value === 'object') {
+    const v = value as Record<string, unknown>;
+    // Color with hex
+    if (typeof v['hex'] === 'string') return v['hex'] as string;
+    // Dimension / duration { value, unit }
+    if ('value' in v && 'unit' in v) return `${String(v['value'])}${String(v['unit'])}`;
+    // Fallback: JSON-ish single line
+    return JSON.stringify(value).slice(0, 80);
+  }
+  return String(value);
+}
+
+const rowStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '1fr auto',
+  gap: 12,
+  padding: '6px 12px',
+  fontSize: 12,
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
+  borderBottom: '1px solid rgba(128,128,128,0.12)',
+  cursor: 'pointer',
+};
+
+const pathStyle: React.CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis' };
+const valueStyle: React.CSSProperties = { opacity: 0.7, whiteSpace: 'nowrap' };
+const groupHeaderStyle: React.CSSProperties = {
+  padding: '8px 12px',
+  fontSize: 10,
+  textTransform: 'uppercase',
+  letterSpacing: 0.5,
+  opacity: 0.6,
+  position: 'sticky',
+  top: 0,
+  background: 'inherit',
+};
+const searchBarStyle: React.CSSProperties = {
+  padding: '8px 12px',
+  borderBottom: '1px solid rgba(128,128,128,0.2)',
+};
+const searchInputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '4px 8px',
+  fontSize: 12,
+  border: '1px solid rgba(128,128,128,0.3)',
+  borderRadius: 4,
+  background: 'transparent',
+  color: 'inherit',
+};
+
+function groupByType(tokens: Record<string, VirtualToken>): Map<string, VirtualToken[]> {
+  const groups = new Map<string, VirtualToken[]>();
+  for (const [path, token] of Object.entries(tokens)) {
+    const type = token.$type ?? 'unknown';
+    const arr = groups.get(type) ?? [];
+    arr.push({ ...token, id: path });
+    groups.set(type, arr);
+  }
+  // Sort groups by name, tokens within each group by path.
+  return new Map(
+    [...groups.entries()]
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([k, v]) => [k, v.toSorted((a, b) => a.id.localeCompare(b.id))]),
+  );
+}
+
+interface PanelProps {
+  active: boolean;
+}
+
+export function TokensPanel({ active }: PanelProps): ReactElement | null {
+  const payload = usePayload();
+  const [globals] = useGlobals();
+  const [query, setQuery] = useState('');
+
+  const themeName = (globals[GLOBAL_KEY] as string | undefined) ?? payload?.defaultTheme ?? '';
+  const prefix = payload?.cssVarPrefix ?? '';
+  const tokens = useMemo(() => payload?.themesResolved[themeName] ?? {}, [payload, themeName]);
+  const tokenCount = Object.keys(tokens).length;
+
+  const grouped = useMemo(() => groupByType(tokens), [tokens]);
+  const lowerQuery = query.toLowerCase();
+  const filtered = useMemo(() => {
+    if (!lowerQuery) return grouped;
+    const out = new Map<string, VirtualToken[]>();
+    for (const [type, list] of grouped) {
+      const matches = list.filter((t) => t.id.toLowerCase().includes(lowerQuery));
+      if (matches.length > 0) out.set(type, matches);
+    }
+    return out;
+  }, [grouped, lowerQuery]);
+
+  if (!active) return null;
+
+  if (!payload) {
+    return h(Placeholder, null, 'Waiting for swatchbook preview…');
+  }
+
+  const totalMatches = [...filtered.values()].reduce((n, l) => n + l.length, 0);
+
+  return h(
+    'div',
+    { style: { display: 'flex', flexDirection: 'column', height: '100%' } },
+    h(
+      'div',
+      { style: searchBarStyle },
+      h('input', {
+        style: searchInputStyle,
+        type: 'search',
+        placeholder: `Search ${tokenCount} tokens in ${themeName}…`,
+        value: query,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value),
+      }),
+    ),
+    h(
+      ScrollArea,
+      { vertical: true },
+      totalMatches === 0
+        ? h(Placeholder, null, 'No tokens match this filter.')
+        : [...filtered.entries()].map(([type, list]) =>
+            h(
+              'section',
+              { key: type },
+              h('header', { style: groupHeaderStyle }, type, ` · ${list.length}`),
+              list.map((token) => {
+                const cssVar = makeCssVar(token.id, prefix);
+                return h(
+                  'button',
+                  {
+                    key: token.id,
+                    type: 'button',
+                    style: rowStyle,
+                    title: `Click to copy var(${cssVar})`,
+                    onClick: () => void copy(`var(${cssVar})`),
+                  },
+                  h('span', { style: pathStyle }, token.id),
+                  h('span', { style: valueStyle }, formatValue(token.$value)),
+                );
+              }),
+            ),
+          ),
+    ),
+  );
+}
+
+const severityStyle: Record<DiagnosticSeverity, React.CSSProperties> = {
+  error: { color: '#d64545' },
+  warn: { color: '#b08900' },
+  info: { opacity: 0.6 },
+};
+
+const severityLabel: Record<DiagnosticSeverity, string> = {
+  error: 'ERROR',
+  warn: 'WARN',
+  info: 'INFO',
+};
+
+const diagnosticRowStyle: React.CSSProperties = {
+  display: 'grid',
+  gridTemplateColumns: '60px 1fr',
+  gap: 12,
+  padding: '8px 12px',
+  fontSize: 12,
+  borderBottom: '1px solid rgba(128,128,128,0.12)',
+};
+
+export function DiagnosticsPanel({ active }: PanelProps): ReactElement | null {
+  const payload = usePayload();
+
+  if (!active) return null;
+
+  if (!payload) {
+    return h(Placeholder, null, 'Waiting for swatchbook preview…');
+  }
+
+  const counts = payload.diagnostics.reduce(
+    (acc, d) => {
+      acc[d.severity] = (acc[d.severity] ?? 0) + 1;
+      return acc;
+    },
+    { error: 0, warn: 0, info: 0 } as Record<DiagnosticSeverity, number>,
+  );
+
+  if (payload.diagnostics.length === 0) {
+    return h(
+      Placeholder,
+      null,
+      h('strong', null, 'All clear ✓'),
+      h('span', { style: { display: 'block', marginTop: 8, opacity: 0.7 } }, 'No diagnostics.'),
+    );
+  }
+
+  return h(
+    'div',
+    { style: { display: 'flex', flexDirection: 'column', height: '100%' } },
+    h(
+      'header',
+      { style: { ...searchBarStyle, display: 'flex', gap: 16, fontSize: 11 } },
+      h('span', severityStyle.error, `${counts.error} errors`),
+      h('span', severityStyle.warn, `${counts.warn} warnings`),
+      h('span', severityStyle.info, `${counts.info} info`),
+    ),
+    h(
+      ScrollArea,
+      { vertical: true },
+      payload.diagnostics.map((d, i) =>
+        h(
+          'div',
+          { key: `${d.group}-${i}`, style: diagnosticRowStyle },
+          h(
+            'span',
+            { style: { ...severityStyle[d.severity], fontWeight: 600, fontSize: 10 } },
+            severityLabel[d.severity],
+          ),
+          h(
+            'div',
+            null,
+            h('div', null, d.message),
+            (d.filename || d.group) &&
+              h(
+                'div',
+                { style: { opacity: 0.5, fontSize: 10, marginTop: 4 } },
+                [d.group, d.filename, d.line ? `:${d.line}` : ''].filter(Boolean).join(' · '),
+              ),
+          ),
+        ),
+      ),
+    ),
+  );
+}

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -5,7 +5,9 @@ import {
   css as generatedCss,
   cssVarPrefix,
   defaultTheme,
+  diagnostics as generatedDiagnostics,
   themes,
+  themesResolved,
   themingMode,
 } from 'virtual:swatchbook/tokens';
 import {
@@ -64,16 +66,19 @@ function setRootTheme(theme: string): void {
 }
 
 /**
- * Emit themes to the manager over Storybook's channel so the toolbar tool
- * (in the manager bundle, which can't import our virtual module) gets the
- * theme list, default, and mode.
+ * Emit the full virtual-module payload to the manager over Storybook's
+ * channel so the toolbar + panel (which run in the manager bundle and
+ * can't import our virtual module) can render from it.
  */
-function broadcastThemes(): void {
+function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(INIT_EVENT, {
     themes: typedThemes,
     defaultTheme: typedDefaultTheme,
     mode: typedMode,
+    themesResolved,
+    diagnostics: generatedDiagnostics,
+    cssVarPrefix: typedPrefix,
   });
 }
 
@@ -86,7 +91,7 @@ const themedDecorator: Decorator = (Story, context) => {
 
   useEffect(() => {
     ensureStylesheet();
-    broadcastThemes();
+    broadcastInit();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
**Milestone:** M4 — Token browsing + typed hook

**Plan impact:** none

**Depends on #62** — branched from \`chore/explicit-ts-extensions\`. Review order: merge #62 first, then this one (will rebase on main once #62 lands).

## Summary

Two Storybook addon panels backed by the preview→manager channel.

- **Swatchbook tokens** — grouped by \`\$type\`, searchable by path, click copies \`var(--sb-…)\` to clipboard. Short-form value column (hex, \`value+unit\`). Reactive to theme global.
- **Swatchbook diagnostics** — severity counters up top, flat list with origin group + filename + line. Empty state is the \`All clear ✓\` placeholder the plan asks for.

## Channel payload

\`broadcastInit()\` replaces \`broadcastThemes()\` — payload now carries \`themesResolved\`, \`diagnostics\`, and \`cssVarPrefix\` on top of the existing \`themes\`/\`defaultTheme\`/\`mode\`. Manager bundle can't import the virtual module, so this is the only way it gets that data.

## Code

- \`packages/addon/src/panel.tsx\` hosts both panel components + a shared \`usePayload()\` hook.
- \`manager.tsx\` registers two \`types.PANEL\` entries.
- All manager code stays on \`React.createElement\` — not JSX — per the manager-bundle gotcha in CLAUDE.md.

## Test plan

- [x] \`pnpm turbo run lint format:check typecheck test build\` → 19/19 green.
- [x] In Storybook: **Swatchbook tokens** tab shows ~147 entries grouped by type, search narrows, click copies the right \`var(--sb-…)\`.
- [x] **Swatchbook diagnostics** tab shows counts + list from the reference fixture's deprecation warnings.