### PR TITLE
chore: close M0–M4 milestones, require issue-first on PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 <!-- Required for every PR. See docs/plan.md → "Plan governance". -->
 
-**Milestone:** <!-- e.g. M2 — Baseline Storybook app -->
+**Milestone:** <!-- e.g. M5 — Token-aware color control -->
+
+**Closes:** <!-- Closes #N / Refs #N — every PR links an issue. Open one first if it doesn't exist (`gh issue create --milestone "Mx — …"`). -->
 
 **Plan impact:** <!-- none | update included | decisions.md entry -->
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,16 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
     strategy:
       matrix:
         node: [24]

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,66 @@
+name: PR lint
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    name: Conventional Commits title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            test
+            ci
+            refactor
+            perf
+            build
+            revert
+          scopes: |
+            core
+            addon
+            blocks
+            tokens-reference
+            tokens-starter
+            storybook
+            ci
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject "{subject}" must start with a lowercase letter.
+          # Fail if the title has no type prefix.
+          wip: false
+
+  linked-issue:
+    name: Linked issue
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Require Closes / Fixes / Refs #N in body
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [ -z "$BODY" ]; then
+            echo "::error::PR body is empty. Every PR links an issue via 'Closes #N' (or 'Fixes' / 'Resolves')."
+            exit 1
+          fi
+          if echo "$BODY" | grep -qiE '(close[sd]?|fix(e[sd])?|resolve[sd]?|refs?) #[0-9]+'; then
+            echo "Linked-issue reference found."
+            exit 0
+          fi
+          echo "::error::PR body must link an issue — include 'Closes #N', 'Fixes #N', 'Resolves #N', or 'Refs #N'. Open one first if needed: gh issue create --milestone \"Mx — …\" --title \"…\""
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfun
 
 ## Current milestone
 
-`Current: M0 — Foundation`
+`Current: M5 — Token-aware color control`
 
 Update this line when a milestone closes. See the matching GitHub milestones for per-issue state.
 
@@ -70,5 +70,6 @@ claude
 
 - Plan body edits → same PR as the change they reflect.
 - Tactical choices that don't change design intent → append to `docs/decisions.md`.
-- PR template (`.github/pull_request_template.md`) requires `Milestone:` and `Plan impact:` lines — don't remove them.
+- PR template (`.github/pull_request_template.md`) requires `Milestone:`, `Closes:`, and `Plan impact:` lines — don't remove them.
+- Every PR links an existing GitHub issue. File one first if needed: `gh issue create --milestone "Mx — …" --title "…"`. Merging the PR auto-closes the issue; milestones close automatically when the last issue is done.
 - **PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)**: `<type>(<scope>): <description>`. Types: `feat` / `fix` / `chore` / `docs` / `test` / `ci` / `refactor` / `perf` / `build` / `revert`. Scope is a package slug (`core`, `addon`, `blocks`, `tokens-reference`, `tokens-starter`, `storybook`, `ci`) or omitted. Milestone goes in the PR body, never the title — squash-merge lands the title on `main`.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -407,6 +407,7 @@ All work after the M0 scaffold commit flows through PRs. Direct pushes to `main`
   - ❌ `M3: addon preset + virtual module`
   - ❌ `Update addon`
 - Body follows the PR template verbatim. Link related milestone issues with `Closes #N` / `Refs #N`.
+- **Issue-first, always.** Every PR ties to an open GitHub issue under the relevant milestone. If one doesn't exist for the work you're about to start, file it first (`gh issue create --milestone "Mx — …" --title "…"`). The PR body's `Closes #N` line auto-closes the issue on merge; milestones then close themselves when their last issue is done. Chore/infra PRs that don't map to an M-issue still open a tracking issue for the trail.
 - **Merge strategy:** squash-merge by default. Preserve commits only when the history is genuinely useful to future readers.
 - **No self-merge by automation.** Claude (or any agent) opens PRs; the human reviewer merges. This keeps the governance human-in-the-loop.
 - **Branch protection** on `main` is the repo owner's call — the discipline above holds either way, but enabling protection rules (require PR, require status checks, restrict pushes) in GitHub settings makes it enforced rather than norm-based.
@@ -428,7 +429,7 @@ Two mechanisms:
 
 Each milestone has a single measurable demo step. Progress is tracked by which milestones are green.
 
-### M0 — Foundation
+### M0 — Foundation ✅
 **Goal:** Empty but fully wired monorepo; scope of core is confirmed; governance in place.
 **Work:**
 - Spike: read `@terrazzo/parser` API + source; prototype loading a small DTCG file; verify alias chains, multi-file merge, composite emission, diagnostic surface. Produce `docs/terrazzo-notes.md`.
@@ -441,7 +442,7 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 **Exit:** `pnpm install && pnpm turbo run lint typecheck` green on empty packages. CI runs on PR. Terrazzo note committed.
 **Demo:** CI badge green on the scaffold commit.
 
-### M1 — Core (`@unpunnyfuns/swatchbook-core`)
+### M1 — Core (`@unpunnyfuns/swatchbook-core`) ✅
 **Goal:** DTCG loading + three-way theming + CSS/types emission, fully tested.
 **Work:**
 - Author `packages/tokens-reference`: ref/sys/cmp/themes + `$themes.manifest.json` + `resolver.json`.
@@ -452,7 +453,7 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 **Exit:** `turbo run test --filter core` green; `turbo run build --filter tokens-starter` produces `dist/css/light.css` and `dist/tokens.d.ts`.
 **Demo:** `cat packages/tokens-starter/dist/css/light.css` shows expected CSS vars.
 
-### M2 — Baseline Storybook app
+### M2 — Baseline Storybook app ✅
 **Goal:** `apps/storybook` builds and renders demo components styled by real tokens — no swatchbook addon yet.
 **Work:**
 - Scaffold `apps/storybook` on the pinned Storybook version with React-Vite.
@@ -463,7 +464,7 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 **Exit:** `turbo run storybook` serves the app; `turbo run build:storybook` produces `storybook-static/`.
 **Demo:** Visit `http://localhost:6006` — Button/Card/Input stories render fully themed.
 
-### M3 — Addon runtime
+### M3 — Addon runtime ✅
 **Goal:** Live theme switching in Storybook driven by the swatchbook addon.
 **Work:**
 - `@unpunnyfuns/swatchbook-addon`: preset + Vite virtual module (`virtual:swatchbook/tokens`) + HMR + preview decorator.
@@ -473,7 +474,7 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 **Exit:** Toolbar dropdown changes `data-theme`, CSS vars repaint. Editing a token file in `tokens-reference` hot-reloads the preview with new values.
 **Demo:** Pick "Dark · Brand A" in toolbar → demo components reflect the stacked composition instantly.
 
-### M4 — Token browsing + typed hook
+### M4 — Token browsing + typed hook ✅
 **Goal:** Authors can introspect tokens and read them from JS with full types.
 **Work:**
 - Panel: **Tokens** tab (searchable, grouped by `$type`, click → copy `var(--…)`) + **Diagnostics** tab (error/warn/info, green OK badge when empty).


### PR DESCRIPTION
**Milestone:** none (governance)

**Closes:** Closes #66

**Plan impact:** update included

## Summary

Three things, all aimed at keeping the GitHub mirror and the repo in sync automatically.

### GitHub mirror (already done via API)

- Closed 17 open issues under M1–M4 (work landed in merged PRs).
- Closed milestones #1 (M0), #2 (M1), #3 (M2), #4 (M3), #5 (M4). M6+ remain open.

### In-repo governance

- `CLAUDE.md` — Current marker flipped to `M5 — Token-aware color control`. Governance section adds two bullets: required template lines and issue-first workflow.
- `docs/plan.md` — ✅ next to M0–M4 headings, "Issue-first, always" bullet in Branch & PR workflow.
- `.github/pull_request_template.md` — new `**Closes:**` line between `Milestone:` and `Plan impact:`.

### Mechanical enforcement

- `.github/workflows/pr-lint.yml` (new) — two jobs run on every PR open/edit:
  - **Conventional Commits title** via `amannn/action-semantic-pull-request@v5`. Types locked to our set; scope optional.
  - **Linked issue** — custom step that greps the PR body for `Closes` / `Fixes` / `Resolves` / `Refs #N` and fails if none.

### Workflow permissions hardening

- `.github/workflows/ci.yml` — added explicit top-level `permissions: { contents: read, actions: write }` (least privilege; `actions: write` covers the Turbo + Playwright cache saves and the Storybook artifact upload).
- `pr-lint.yml` ships with explicit `permissions: { pull-requests: read }` (only reads the PR payload; sets check status via default job result).

## Notes on native enforcement

The "Required linked issues" Ruleset option isn't available on all GitHub tiers (GHEC-gated in practice). The `pr-lint` workflow is the cross-tier substitute.

## Test plan

- [x] `pnpm turbo run lint format:check typecheck test build` → 19/19 green.
- [x] This PR dogfoods the new rule — filed #66 first, body links `Closes #66`, title matches the Conventional-Commits pattern the workflow enforces.