### PR TITLE
docs: defer M5 until Storybook custom-control API matures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfun
 
 ## Current milestone
 
-`Current: M5 — Token-aware color control`
+`Current: M6 — Doc blocks` (M5 deferred — see `docs/decisions.md`)
 
 Update this line when a milestone closes. See the matching GitHub milestones for per-issue state.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -12,6 +12,22 @@ Append-only ADR-lite log. Entries capture tactical choices made during execution
 
 ---
 
+## 2026-04-17 — Defer M5 (token-aware color control) until after M6
+
+**Context:** M5's plan exit criterion is a \`swatchbook-color\` argType that writes \`var(--…)\` directly to the story's args via \`updateArgs\`. Storybook 10 has no first-class API for registering new control types in the Controls panel — the paths available are:
+- Preset-colors on the built-in color picker (writes the raw color, not a var reference).
+- Decorator-based picker above the story (not in the Args panel; works around `useArgs` quirks).
+- Full custom Controls panel replacement (fights Storybook's panel ordering and is fragile across upstream updates).
+
+**Decision:** Defer M5 to after M6. Reasons:
+- M6's \`TokenDetail\` block and the Tokens panel we shipped in M4 already cover the "browse + pick a token" UX for authors.
+- Investing build time in a custom control that the upstream may soon supersede is poor ROI now.
+- Tracked as issue #68. M5 milestone stays open on GitHub; its two seed issues (#26, #27) closed as "not planned".
+
+**Rationale:** The plan isn't a contract; deferring a milestone when the cost/benefit flips is the governance process working. M6 ships the higher-value surface.
+
+---
+
 ## 2026-04-17 — Modernize `tsconfig.base.json` for TS 6
 
 **Context:** TS 6 changed several defaults (`strict`, `module: esnext`, `target` = current-year floating, `noUncheckedSideEffectImports: true`, `libReplacement: false`) and added new strictness flags. Our base config was carrying TS 5-era boilerplate that's now redundant or outdated.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -484,7 +484,7 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 **Exit:** Panel lists every token from `tokens-reference`; `useToken('color.sys.surface.default')` returns the resolved value with autocomplete; theme switch updates the value.
 **Demo:** Story uses `useToken` and renders its return value as text; Tokens panel search filters down to a single result.
 
-### M5 — Token-aware color control
+### M5 — Token-aware color control ⏸ Deferred
 **Goal:** Replace Storybook's default color picker for color-typed args.
 **Work:**
 - `swatchbook-color` argType: searchable popover of color tokens (swatch + path + resolved), writes `var(--…)` directly to args via `updateArgs`.
@@ -492,6 +492,8 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 
 **Exit:** Selecting a token writes `var(--sb-color-…)` to args; component re-renders with that value; Args tab is honest (shows exactly what the component receives).
 **Demo:** Pick a token from the popover → both the rendered component and the Args panel update.
+
+**Status (deferred):** Storybook 10 has no first-class API for registering new control types; the workable paths (preset-colors / decorator / custom panel) each compromise on the plan's "writes `var(--…)` to args" exit criterion. M6's `TokenDetail` block and the existing Tokens panel cover the "pick a token" UX well enough in the meantime. Revisit after M6 lands, once we see how the blocks shake out and whether Storybook's upstream story on custom controls has evolved. See `docs/decisions.md` entry.
 
 ### M6 — Doc blocks
 **Goal:** Rich MDX documentation of tokens.


### PR DESCRIPTION
**Milestone:** M5 — Token-aware color control

**Closes:** Closes #68

**Plan impact:** update included + decisions.md entry

## Summary

M5's plan exit criterion — \`swatchbook-color\` argType writing \`var(--…)\` directly to args — needs a first-class custom-control registration point Storybook 10 doesn't expose. All three workable paths (preset-colors / decorator / custom panel) compromise the criterion. M6's \`TokenDetail\` block plus the M4 Tokens panel already cover the "browse + pick a token" UX.

### Changes

- \`docs/plan.md\` → M5 heading gets a \`⏸ Deferred\` tag; a Status block captures the why and the return condition.
- \`CLAUDE.md\` → Current marker flipped to \`M6 — Doc blocks\`.
- \`docs/decisions.md\` → new entry with the context, the three paths considered, and the rationale.

### GitHub mirror (already done via API)

- #26 and #27 closed as \"not planned\", comment links to #68.
- #68 remains open as the resume tracker; this PR closes it on merge.
- M5 milestone stays open for when we return to it.

## Test plan

- [x] \`pnpm turbo run lint format:check typecheck test build\` → 19/19 green.