### PR TITLE
feat(blocks): scaffold @unpunnyfuns/swatchbook-blocks + TokenTable

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -35,6 +35,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@unpunnyfuns/swatchbook-addon": "workspace:*",
+    "@unpunnyfuns/swatchbook-blocks": "workspace:*",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
     "@unpunnyfuns/swatchbook-tokens-reference": "workspace:*",
     "@vitejs/plugin-react": "^6.0.1",

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -1,0 +1,36 @@
+import { TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenTable',
+  component: TokenTable,
+  tags: ['autodocs'],
+  argTypes: {
+    filter: { control: 'text' },
+    type: {
+      control: 'select',
+      options: [
+        undefined,
+        'color',
+        'dimension',
+        'fontFamily',
+        'fontWeight',
+        'duration',
+        'cubicBezier',
+        'typography',
+        'shadow',
+        'border',
+        'transition',
+      ],
+    },
+    showVar: { control: 'boolean' },
+  },
+});
+
+export default meta;
+
+export const All = meta.story();
+export const ColorsOnly = meta.story({ args: { type: 'color' } });
+export const SysColors = meta.story({ args: { filter: 'color.sys.*' } });
+export const ComponentButton = meta.story({ args: { filter: 'cmp.button.*' } });
+export const DimensionsOnly = meta.story({ args: { type: 'dimension' } });

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -4,7 +4,6 @@ import preview from '../../.storybook/preview.tsx';
 const meta = preview.meta({
   title: 'Blocks/TokenTable',
   component: TokenTable,
-  tags: ['autodocs'],
   argTypes: {
     filter: { control: 'text' },
     type: {

--- a/packages/addon/src/hooks/index.ts
+++ b/packages/addon/src/hooks/index.ts
@@ -4,3 +4,4 @@ export {
   type TokenInfo,
   type TokenPath,
 } from '#/hooks/use-token.ts';
+export { useActiveTheme } from '#/theme-context.ts';

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,0 +1,37 @@
+# @unpunnyfuns/swatchbook-blocks
+
+Storybook MDX doc blocks for DTCG design tokens. Drop-in React components for rendering token documentation inside `.mdx` pages or standard React stories.
+
+## Install
+
+```sh
+pnpm add @unpunnyfuns/swatchbook-blocks
+```
+
+Requires `@unpunnyfuns/swatchbook-addon` to be registered in your Storybook config — the blocks consume its virtual token module and theme context.
+
+## Blocks
+
+| Block              | What                                                             |
+| ------------------ | ---------------------------------------------------------------- |
+| `TokenTable`       | Columnar listing of tokens, filterable by path glob and `$type`. |
+| `ColorPalette`     | Swatch grid grouped by sub-path, optionally scoped to a group.   |
+| `TypographyScale`  | Each typography token rendered as a sample line using its value. |
+| `TokenDetail`      | Full per-token detail — type, description, per-theme values.     |
+
+## MDX example
+
+```mdx
+import { TokenTable, ColorPalette } from '@unpunnyfuns/swatchbook-blocks';
+
+# Color tokens
+
+<ColorPalette group="color.sys" />
+
+## Every color token
+
+<TokenTable type="color" />
+```
+
+✅ Blocks react to the active swatchbook theme — switching in the toolbar updates resolved values live.
+❌ Blocks can't run outside Storybook's preview/docs iframe — they rely on the addon's virtual token module.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@unpunnyfuns/swatchbook-blocks",
+  "version": "0.0.0",
+  "description": "Storybook MDX doc blocks for DTCG design tokens — TokenTable, ColorPalette, TypographyScale, TokenDetail.",
+  "type": "module",
+  "engines": {
+    "node": ">=24.14.0"
+  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "imports": {
+    "#/*": "./src/*"
+  },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown src/index.ts --format esm --dts --clean --sourcemap",
+    "typecheck": "tsc --noEmit",
+    "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src",
+    "format": "oxfmt -c ../../.oxfmtrc.json src",
+    "format:check": "oxfmt --check -c ../../.oxfmtrc.json src"
+  },
+  "dependencies": {
+    "@unpunnyfuns/swatchbook-addon": "workspace:*"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tsdown": "^0.21.9",
+    "typescript": "^6.0.0"
+  }
+}

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -21,6 +21,9 @@ const styles = {
     fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
     fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
     color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
   } satisfies React.CSSProperties,
   caption: {
     captionSide: 'top',

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,0 +1,165 @@
+import type { ReactElement } from 'react';
+import { useMemo } from 'react';
+import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface TokenTableProps {
+  /**
+   * Token-path filter. `"color.sys.*"` matches every `color.sys.…` token;
+   * omit to include everything. Combines with `type` (both must match).
+   */
+  filter?: string;
+  /** Restrict to one DTCG `$type`. */
+  type?: string;
+  /** Show the CSS variable reference column. Defaults to `true`. */
+  showVar?: boolean;
+  /** Override the table caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+  } satisfies React.CSSProperties,
+  caption: {
+    captionSide: 'top',
+    textAlign: 'left',
+    padding: '8px 0',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies React.CSSProperties,
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    tableLayout: 'fixed',
+  } satisfies React.CSSProperties,
+  th: {
+    textAlign: 'left',
+    padding: '8px 12px',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    opacity: 0.6,
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',
+  } satisfies React.CSSProperties,
+  td: {
+    padding: '8px 12px',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    verticalAlign: 'top',
+  } satisfies React.CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+  } satisfies React.CSSProperties,
+  typePill: {
+    display: 'inline-block',
+    padding: '2px 6px',
+    borderRadius: 4,
+    fontSize: 10,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.15))',
+  } satisfies React.CSSProperties,
+  value: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    opacity: 0.85,
+    wordBreak: 'break-all',
+  } satisfies React.CSSProperties,
+  swatch: {
+    display: 'inline-block',
+    width: 14,
+    height: 14,
+    verticalAlign: 'middle',
+    marginRight: 6,
+    borderRadius: 3,
+    border: '1px solid var(--sb-color-sys-border-default, rgba(0,0,0,0.1))',
+  } satisfies React.CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies React.CSSProperties,
+};
+
+export function TokenTable({
+  filter,
+  type,
+  showVar = true,
+  caption,
+}: TokenTableProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo(() => {
+    const entries = Object.entries(resolved)
+      .filter(([path, token]) => {
+        if (!globMatch(path, filter)) return false;
+        if (type && token.$type !== type) return false;
+        return true;
+      })
+      .toSorted(([a], [b]) => a.localeCompare(b));
+    return entries.map(([path, token]) => ({
+      path,
+      type: token.$type ?? '',
+      value: formatValue(token.$value),
+      description: token.$description ?? '',
+      cssVar: makeCssVar(path, cssVarPrefix),
+      isColor: token.$type === 'color',
+    }));
+  }, [resolved, filter, type, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} token${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''}${type ? ` · $type=${type}` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div style={styles.wrapper}>
+        <div style={styles.empty}>No tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      <table style={styles.table}>
+        <caption style={styles.caption}>{captionText}</caption>
+        <colgroup>
+          <col style={{ width: '30%' }} />
+          <col style={{ width: '8%' }} />
+          <col style={{ width: showVar ? '28%' : '40%' }} />
+          {showVar && <col style={{ width: '24%' }} />}
+          <col />
+        </colgroup>
+        <thead>
+          <tr>
+            <th style={styles.th}>Path</th>
+            <th style={styles.th}>Type</th>
+            <th style={styles.th}>Value</th>
+            {showVar && <th style={styles.th}>CSS var</th>}
+            <th style={styles.th}>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.path}>
+              <td style={{ ...styles.td, ...styles.path }}>{row.path}</td>
+              <td style={styles.td}>
+                {row.type && <span style={styles.typePill}>{row.type}</span>}
+              </td>
+              <td style={{ ...styles.td, ...styles.value }}>
+                {row.isColor && (
+                  <span style={{ ...styles.swatch, background: row.cssVar }} aria-hidden />
+                )}
+                {row.value}
+              </td>
+              {showVar && <td style={{ ...styles.td, ...styles.value }}>{row.cssVar}</td>}
+              <td style={styles.td}>{row.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -118,14 +118,14 @@ export function TokenTable({
 
   if (rows.length === 0) {
     return (
-      <div style={styles.wrapper}>
+      <div data-theme={activeTheme} style={styles.wrapper}>
         <div style={styles.empty}>No tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div style={styles.wrapper}>
+    <div data-theme={activeTheme} style={styles.wrapper}>
       <table style={styles.table}>
         <caption style={styles.caption}>{captionText}</caption>
         <colgroup>

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,0 +1,1 @@
+export { TokenTable, type TokenTableProps } from '#/TokenTable.tsx';

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,0 +1,68 @@
+import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon/hooks';
+import {
+  cssVarPrefix,
+  defaultTheme,
+  themes,
+  themesResolved,
+  themingMode,
+} from 'virtual:swatchbook/tokens';
+
+interface ResolvedToken {
+  $type?: string;
+  $value?: unknown;
+  $description?: string;
+}
+
+export interface ProjectData {
+  activeTheme: string;
+  themes: readonly { name: string; input: Record<string, string>; sources: string[] }[];
+  resolved: Record<string, ResolvedToken>;
+  themesResolved: Record<string, Record<string, ResolvedToken>>;
+  cssVarPrefix: string;
+  mode: 'layered' | 'resolver' | 'manifest';
+}
+
+/**
+ * One-stop hook for block components. Reads the active theme from the
+ * addon's `ThemeContext`, returns the full project snapshot plus a
+ * convenience `resolved` map for that theme.
+ */
+export function useProject(): ProjectData {
+  const contextTheme = useActiveTheme();
+  const activeTheme = contextTheme || (defaultTheme ?? themes[0]?.name ?? '');
+  const resolvedMap = themesResolved as Record<string, Record<string, ResolvedToken>>;
+  return {
+    activeTheme,
+    themes,
+    themesResolved: resolvedMap,
+    resolved: resolvedMap[activeTheme] ?? {},
+    cssVarPrefix,
+    mode: themingMode,
+  };
+}
+
+export function makeCssVar(path: string, prefix: string): string {
+  const tail = path.replaceAll('.', '-');
+  return prefix ? `var(--${prefix}-${tail})` : `var(--${tail})`;
+}
+
+export function globMatch(path: string, glob: string | undefined): boolean {
+  if (!glob) return true;
+  if (glob === '*' || glob === '**') return true;
+  // Accept simple `prefix.*` patterns plus exact matches.
+  if (glob.endsWith('.*')) return path.startsWith(`${glob.slice(0, -2)}.`);
+  if (glob.endsWith('**')) return path.startsWith(glob.slice(0, -2));
+  return path === glob || path.startsWith(`${glob}.`);
+}
+
+export function formatValue(value: unknown): string {
+  if (value == null) return '';
+  if (typeof value === 'string' || typeof value === 'number') return String(value);
+  if (typeof value === 'object') {
+    const v = value as Record<string, unknown>;
+    if (typeof v['hex'] === 'string') return v['hex'] as string;
+    if ('value' in v && 'unit' in v) return `${String(v['value'])}${String(v['unit'])}`;
+    return JSON.stringify(value).slice(0, 120);
+  }
+  return String(value);
+}

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Re-declaration of the addon's virtual token module so the blocks package
+ * typechecks in isolation. The runtime module is provided by the addon's
+ * Vite plugin when Storybook is running.
+ */
+declare module 'virtual:swatchbook/tokens' {
+  interface VirtualTheme {
+    name: string;
+    input: Record<string, string>;
+    sources: string[];
+  }
+  interface ResolvedToken {
+    $type?: string;
+    $value?: unknown;
+    $description?: string;
+  }
+
+  export const themes: VirtualTheme[];
+  export const defaultTheme: string | null;
+  export const themesResolved: Record<string, Record<string, ResolvedToken>>;
+  export const diagnostics: unknown[];
+  export const css: string;
+  export const cssVarPrefix: string;
+  export const themingMode: 'layered' | 'resolver' | 'manifest';
+}

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": []
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@unpunnyfuns/swatchbook-addon':
         specifier: workspace:*
         version: link:../../packages/addon
+      '@unpunnyfuns/swatchbook-blocks':
+        specifier: workspace:*
+        version: link:../../packages/blocks
       '@unpunnyfuns/swatchbook-core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -130,6 +133,28 @@ importers:
       vite:
         specifier: ^8.0.4
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)
+
+  packages/blocks:
+    dependencies:
+      '@unpunnyfuns/swatchbook-addon':
+        specifier: workspace:*
+        version: link:../addon
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      react:
+        specifier: ^19.2.4
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.5(react@19.2.5)
+      tsdown:
+        specifier: ^0.21.9
+        version: 0.21.9(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
 
   packages/core:
     dependencies:


### PR DESCRIPTION
## Summary

Scaffolds the new public `@unpunnyfuns/swatchbook-blocks` package and ships the first of four planned doc blocks.

- New package: ESM-only, `#/` subpath imports, tsdown build, peer-deps on React 18+.
- `TokenTable` — filter by glob and/or DTCG `$type`, optional CSS-var column, inline swatch for color tokens.
- Shared `useProject()` hook + helpers (`makeCssVar`, `globMatch`, `formatValue`) under `src/internal/` — to be reused by the remaining blocks.
- Re-exports `useActiveTheme` from `@unpunnyfuns/swatchbook-addon/hooks` so blocks react to the toolbar.
- Demo stories in `apps/storybook` (All / ColorsOnly / SysColors / ComponentButton / DimensionsOnly).

Includes follow-up fixes landed on this branch: wrapper paints its own theme surface, `data-theme={activeTheme}` on the block wrapper so the CSS-var scope is self-contained, and `tags: ['autodocs']` dropped from the block's stories (autodocs doesn't propagate theme scope reliably).

Remaining M6 work tracked separately: ColorPalette (#29), TypographyScale (#30), TokenDetail (#31), MDX pages (#32).

**Milestone:** M6 — Doc blocks
**Closes:** Closes #28
**Plan impact:** none

## Test plan
- [x] `pnpm turbo run lint typecheck test build`
- [ ] Visual: TokenTable stories render in Storybook and react to theme switch