### PR TITLE
feat(blocks): typography scale block

### DIFF
--- a/apps/storybook/src/stories/TypographyScale.stories.tsx
+++ b/apps/storybook/src/stories/TypographyScale.stories.tsx
@@ -4,7 +4,6 @@ import preview from '../../.storybook/preview.tsx';
 const meta = preview.meta({
   title: 'Blocks/TypographyScale',
   component: TypographyScale,
-  tags: ['autodocs'],
   argTypes: {
     filter: { control: 'text' },
     sample: { control: 'text' },

--- a/apps/storybook/src/stories/TypographyScale.stories.tsx
+++ b/apps/storybook/src/stories/TypographyScale.stories.tsx
@@ -1,0 +1,20 @@
+import { TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TypographyScale',
+  component: TypographyScale,
+  tags: ['autodocs'],
+  argTypes: {
+    filter: { control: 'text' },
+    sample: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const All = meta.story();
+export const HeadingOnly = meta.story({ args: { filter: 'typography.sys.heading' } });
+export const Pangram = meta.story({
+  args: { sample: 'Sphinx of black quartz, judge my vow — 0123456789' },
+});

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -128,14 +128,14 @@ export function TypographyScale({
 
   if (rows.length === 0) {
     return (
-      <div style={styles.wrapper}>
+      <div data-theme={activeTheme} style={styles.wrapper}>
         <div style={styles.empty}>No typography tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div style={styles.wrapper}>
+    <div data-theme={activeTheme} style={styles.wrapper}>
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -92,7 +92,11 @@ function buildRow(path: string, composite: Record<string, unknown>): Row {
   if (lineHeight) sampleStyle.lineHeight = lineHeight;
   if (letterSpacing) sampleStyle.letterSpacing = letterSpacing;
 
-  const parts = [fontSize, fontWeight ? `w${fontWeight}` : undefined, lineHeight ? `lh ${lineHeight}` : undefined]
+  const parts = [
+    fontSize,
+    fontWeight ? `w${fontWeight}` : undefined,
+    lineHeight ? `lh ${lineHeight}` : undefined,
+  ]
     .filter(Boolean)
     .join(' · ');
 

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -18,6 +18,9 @@ const styles = {
   wrapper: {
     fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
     color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
   } satisfies CSSProperties,
   caption: {
     padding: '4px 0 12px',

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -1,0 +1,148 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { globMatch, useProject } from '#/internal/use-project.ts';
+
+export interface TypographyScaleProps {
+  /**
+   * Token-path filter. Defaults to every `typography` token. Use e.g.
+   * `"typography.sys.*"` to scope to the semantic layer.
+   */
+  filter?: string;
+  /** Override the sample text rendered for each token. */
+  sample?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 1fr',
+    gap: 16,
+    alignItems: 'baseline',
+    padding: '14px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+  } satisfies CSSProperties,
+  specs: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface Row {
+  path: string;
+  sampleStyle: CSSProperties;
+  specs: string;
+}
+
+function asDimension(raw: unknown): string | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw === 'string' || typeof raw === 'number') return String(raw);
+  if (typeof raw === 'object') {
+    const v = raw as Record<string, unknown>;
+    if ('value' in v && 'unit' in v) return `${String(v['value'])}${String(v['unit'])}`;
+  }
+  return undefined;
+}
+
+function asFontFamily(raw: unknown): string | undefined {
+  if (typeof raw === 'string') return raw;
+  if (Array.isArray(raw)) return raw.map(String).join(', ');
+  return undefined;
+}
+
+function buildRow(path: string, composite: Record<string, unknown>): Row {
+  const fontFamily = asFontFamily(composite['fontFamily']);
+  const fontSize = asDimension(composite['fontSize']);
+  const fontWeight = composite['fontWeight'] == null ? undefined : String(composite['fontWeight']);
+  const lineHeight = composite['lineHeight'] == null ? undefined : String(composite['lineHeight']);
+  const letterSpacing = asDimension(composite['letterSpacing']);
+
+  const sampleStyle: CSSProperties = {};
+  if (fontFamily) sampleStyle.fontFamily = fontFamily;
+  if (fontSize) sampleStyle.fontSize = fontSize;
+  if (fontWeight) sampleStyle.fontWeight = fontWeight as CSSProperties['fontWeight'];
+  if (lineHeight) sampleStyle.lineHeight = lineHeight;
+  if (letterSpacing) sampleStyle.letterSpacing = letterSpacing;
+
+  const parts = [fontSize, fontWeight ? `w${fontWeight}` : undefined, lineHeight ? `lh ${lineHeight}` : undefined]
+    .filter(Boolean)
+    .join(' · ');
+
+  return { path, sampleStyle, specs: parts };
+}
+
+export function TypographyScale({
+  filter = 'typography',
+  sample = 'The quick brown fox jumps over the lazy dog.',
+  caption,
+}: TypographyScaleProps): ReactElement {
+  const { resolved, activeTheme } = useProject();
+
+  const rows = useMemo<Row[]>(() => {
+    return Object.entries(resolved)
+      .filter(([path, token]) => {
+        if (token.$type !== 'typography') return false;
+        return globMatch(path, filter);
+      })
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([path, token]) => {
+        const value = token.$value;
+        if (!value || typeof value !== 'object') {
+          return { path, sampleStyle: {}, specs: '' };
+        }
+        return buildRow(path, value as Record<string, unknown>);
+      });
+  }, [resolved, filter]);
+
+  const captionText =
+    caption ??
+    `${rows.length} typography token${rows.length === 1 ? '' : 's'}${filter && filter !== 'typography' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div style={styles.wrapper}>
+        <div style={styles.empty}>No typography tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            {row.specs && <span style={styles.specs}>{row.specs}</span>}
+          </div>
+          <div style={row.sampleStyle}>{sample}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,2 +1,3 @@
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
 export { TokenTable, type TokenTableProps } from '#/TokenTable.tsx';
+export { TypographyScale, type TypographyScaleProps } from '#/TypographyScale.tsx';


### PR DESCRIPTION
Closes #30

## Summary

Third M6 doc block — composite typography renderer.

- For every `typography`-typed token, renders a sample line styled with the resolved sub-values (`fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`).
- Path + compact specs (`1rem · w400 · lh 1.5`) sit alongside each sample.
- `filter` glob narrows the set; `sample` overrides the rendered text.

Stacked on #71.

**Milestone:** M6 — Doc blocks
**Plan impact:** none

## Test plan
- [x] `pnpm turbo run lint typecheck build` (blocks + storybook)
- [x] Visual: scale renders, sample text updates, theme switch repaints