### PR TITLE
feat(blocks): token detail block

### DIFF
--- a/apps/storybook/src/stories/TokenDetail.stories.tsx
+++ b/apps/storybook/src/stories/TokenDetail.stories.tsx
@@ -1,0 +1,20 @@
+import { TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail',
+  component: TokenDetail,
+  argTypes: {
+    path: { control: 'text' },
+    heading: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const SysSurface = meta.story({ args: { path: 'color.sys.surface.default' } });
+export const SysAccent = meta.story({ args: { path: 'color.sys.text.accent' } });
+export const ButtonBg = meta.story({ args: { path: 'cmp.button.bg' } });
+export const SpaceMd = meta.story({ args: { path: 'space.sys.md' } });
+export const TypographyBody = meta.story({ args: { path: 'typography.sys.body' } });
+export const Missing = meta.story({ args: { path: 'color.does.not.exist' } });

--- a/apps/storybook/src/stories/TypographyScale.stories.tsx
+++ b/apps/storybook/src/stories/TypographyScale.stories.tsx
@@ -4,7 +4,6 @@ import preview from '../../.storybook/preview.tsx';
 const meta = preview.meta({
   title: 'Blocks/TypographyScale',
   component: TypographyScale,
-  tags: ['autodocs'],
   argTypes: {
     filter: { control: 'text' },
     sample: { control: 'text' },

--- a/apps/storybook/src/stories/TypographyScale.stories.tsx
+++ b/apps/storybook/src/stories/TypographyScale.stories.tsx
@@ -1,0 +1,20 @@
+import { TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TypographyScale',
+  component: TypographyScale,
+  tags: ['autodocs'],
+  argTypes: {
+    filter: { control: 'text' },
+    sample: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const All = meta.story();
+export const HeadingOnly = meta.story({ args: { filter: 'typography.sys.heading' } });
+export const Pangram = meta.story({
+  args: { sample: 'Sphinx of black quartz, judge my vow — 0123456789' },
+});

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -1,0 +1,207 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { formatValue, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface TokenDetailProps {
+  /** Full dot-path of the token to inspect. */
+  path: string;
+  /** Override the heading. Defaults to the path. */
+  heading?: string;
+}
+
+interface DetailToken {
+  $type?: string;
+  $value?: unknown;
+  $description?: string;
+  aliasOf?: string;
+  aliasChain?: string[];
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 16,
+    borderRadius: 6,
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  heading: {
+    margin: 0,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 16,
+  } satisfies CSSProperties,
+  subline: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    margin: '4px 0 12px',
+    fontSize: 12,
+    opacity: 0.8,
+  } satisfies CSSProperties,
+  typePill: {
+    display: 'inline-block',
+    padding: '2px 6px',
+    borderRadius: 4,
+    fontSize: 10,
+    letterSpacing: 0.5,
+    textTransform: 'uppercase',
+    background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.15))',
+  } satisfies CSSProperties,
+  description: {
+    margin: '0 0 12px',
+    opacity: 0.85,
+  } satisfies CSSProperties,
+  sectionHeader: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    opacity: 0.6,
+    margin: '12px 0 6px',
+  } satisfies CSSProperties,
+  chain: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: 6,
+    alignItems: 'center',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+  } satisfies CSSProperties,
+  chainNode: {
+    padding: '2px 6px',
+    borderRadius: 4,
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  arrow: {
+    opacity: 0.5,
+  } satisfies CSSProperties,
+  themeTable: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    tableLayout: 'fixed',
+    fontSize: 12,
+  } satisfies CSSProperties,
+  themeRow: {
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+  } satisfies CSSProperties,
+  themeCell: {
+    padding: '6px 8px',
+    verticalAlign: 'middle',
+  } satisfies CSSProperties,
+  swatch: {
+    display: 'inline-block',
+    width: 14,
+    height: 14,
+    verticalAlign: 'middle',
+    marginRight: 6,
+    borderRadius: 3,
+    border: '1px solid var(--sb-color-sys-border-default, rgba(0,0,0,0.1))',
+  } satisfies CSSProperties,
+  snippet: {
+    display: 'block',
+    padding: '8px 10px',
+    borderRadius: 4,
+    background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.1))',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    whiteSpace: 'pre',
+    overflow: 'auto',
+  } satisfies CSSProperties,
+  missing: {
+    padding: 12,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+};
+
+export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
+  const { activeTheme, themesResolved, resolved, cssVarPrefix } = useProject();
+
+  const token = resolved[path] as DetailToken | undefined;
+  const cssVar = makeCssVar(path, cssVarPrefix);
+
+  const chain = useMemo<string[]>(() => {
+    if (!token) return [];
+    if (Array.isArray(token.aliasChain) && token.aliasChain.length > 0) {
+      return [path, ...token.aliasChain];
+    }
+    if (typeof token.aliasOf === 'string') return [path, token.aliasOf];
+    return [path];
+  }, [token, path]);
+
+  if (!token) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.missing}>
+          Token <code>{path}</code> not found in theme <strong>{activeTheme}</strong>.
+        </div>
+      </div>
+    );
+  }
+
+  const isColor = token.$type === 'color';
+  const value = formatValue(token.$value);
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <h3 style={styles.heading}>{heading ?? path}</h3>
+      <div style={styles.subline}>
+        {token.$type && <span style={styles.typePill}>{token.$type}</span>}
+        <span>{cssVar}</span>
+      </div>
+      {token.$description && <p style={styles.description}>{token.$description}</p>}
+
+      <div style={styles.sectionHeader}>Resolved value · {activeTheme}</div>
+      <div style={styles.chain}>
+        {isColor && <span style={{ ...styles.swatch, background: cssVar }} aria-hidden />}
+        <span>{value}</span>
+      </div>
+
+      {chain.length > 1 && (
+        <>
+          <div style={styles.sectionHeader}>Alias chain</div>
+          <div style={styles.chain}>
+            {chain.map((step, i) => (
+              <span key={step} style={styles.chain}>
+                <span style={styles.chainNode}>{step}</span>
+                {i < chain.length - 1 && <span style={styles.arrow}>→</span>}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+
+      <div style={styles.sectionHeader}>Per-theme values</div>
+      <table style={styles.themeTable}>
+        <tbody>
+          {Object.entries(themesResolved).map(([themeName, tokens]) => {
+            const t = tokens[path] as DetailToken | undefined;
+            const themeValue = t ? formatValue(t.$value) : '—';
+            return (
+              <tr key={themeName} style={styles.themeRow}>
+                <td style={{ ...styles.themeCell, width: '30%' }}>{themeName}</td>
+                <td style={styles.themeCell}>
+                  {isColor && t && (
+                    <span
+                      style={{
+                        ...styles.swatch,
+                        background: cssVar,
+                      }}
+                      data-theme={themeName}
+                      aria-hidden
+                    />
+                  )}
+                  {themeValue}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+
+      <div style={styles.sectionHeader}>Usage</div>
+      <code style={styles.snippet}>{`color: ${cssVar};`}</code>
+    </div>
+  );
+}

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -128,14 +128,14 @@ export function TypographyScale({
 
   if (rows.length === 0) {
     return (
-      <div style={styles.wrapper}>
+      <div data-theme={activeTheme} style={styles.wrapper}>
         <div style={styles.empty}>No typography tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div style={styles.wrapper}>
+    <div data-theme={activeTheme} style={styles.wrapper}>
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -92,7 +92,11 @@ function buildRow(path: string, composite: Record<string, unknown>): Row {
   if (lineHeight) sampleStyle.lineHeight = lineHeight;
   if (letterSpacing) sampleStyle.letterSpacing = letterSpacing;
 
-  const parts = [fontSize, fontWeight ? `w${fontWeight}` : undefined, lineHeight ? `lh ${lineHeight}` : undefined]
+  const parts = [
+    fontSize,
+    fontWeight ? `w${fontWeight}` : undefined,
+    lineHeight ? `lh ${lineHeight}` : undefined,
+  ]
     .filter(Boolean)
     .join(' · ');
 

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -18,6 +18,9 @@ const styles = {
   wrapper: {
     fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
     color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
   } satisfies CSSProperties,
   caption: {
     padding: '4px 0 12px',

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -1,0 +1,148 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { globMatch, useProject } from '#/internal/use-project.ts';
+
+export interface TypographyScaleProps {
+  /**
+   * Token-path filter. Defaults to every `typography` token. Use e.g.
+   * `"typography.sys.*"` to scope to the semantic layer.
+   */
+  filter?: string;
+  /** Override the sample text rendered for each token. */
+  sample?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 1fr',
+    gap: 16,
+    alignItems: 'baseline',
+    padding: '14px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+  } satisfies CSSProperties,
+  specs: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface Row {
+  path: string;
+  sampleStyle: CSSProperties;
+  specs: string;
+}
+
+function asDimension(raw: unknown): string | undefined {
+  if (raw == null) return undefined;
+  if (typeof raw === 'string' || typeof raw === 'number') return String(raw);
+  if (typeof raw === 'object') {
+    const v = raw as Record<string, unknown>;
+    if ('value' in v && 'unit' in v) return `${String(v['value'])}${String(v['unit'])}`;
+  }
+  return undefined;
+}
+
+function asFontFamily(raw: unknown): string | undefined {
+  if (typeof raw === 'string') return raw;
+  if (Array.isArray(raw)) return raw.map(String).join(', ');
+  return undefined;
+}
+
+function buildRow(path: string, composite: Record<string, unknown>): Row {
+  const fontFamily = asFontFamily(composite['fontFamily']);
+  const fontSize = asDimension(composite['fontSize']);
+  const fontWeight = composite['fontWeight'] == null ? undefined : String(composite['fontWeight']);
+  const lineHeight = composite['lineHeight'] == null ? undefined : String(composite['lineHeight']);
+  const letterSpacing = asDimension(composite['letterSpacing']);
+
+  const sampleStyle: CSSProperties = {};
+  if (fontFamily) sampleStyle.fontFamily = fontFamily;
+  if (fontSize) sampleStyle.fontSize = fontSize;
+  if (fontWeight) sampleStyle.fontWeight = fontWeight as CSSProperties['fontWeight'];
+  if (lineHeight) sampleStyle.lineHeight = lineHeight;
+  if (letterSpacing) sampleStyle.letterSpacing = letterSpacing;
+
+  const parts = [fontSize, fontWeight ? `w${fontWeight}` : undefined, lineHeight ? `lh ${lineHeight}` : undefined]
+    .filter(Boolean)
+    .join(' · ');
+
+  return { path, sampleStyle, specs: parts };
+}
+
+export function TypographyScale({
+  filter = 'typography',
+  sample = 'The quick brown fox jumps over the lazy dog.',
+  caption,
+}: TypographyScaleProps): ReactElement {
+  const { resolved, activeTheme } = useProject();
+
+  const rows = useMemo<Row[]>(() => {
+    return Object.entries(resolved)
+      .filter(([path, token]) => {
+        if (token.$type !== 'typography') return false;
+        return globMatch(path, filter);
+      })
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([path, token]) => {
+        const value = token.$value;
+        if (!value || typeof value !== 'object') {
+          return { path, sampleStyle: {}, specs: '' };
+        }
+        return buildRow(path, value as Record<string, unknown>);
+      });
+  }, [resolved, filter]);
+
+  const captionText =
+    caption ??
+    `${rows.length} typography token${rows.length === 1 ? '' : 's'}${filter && filter !== 'typography' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div style={styles.wrapper}>
+        <div style={styles.empty}>No typography tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            {row.specs && <span style={styles.specs}>{row.specs}</span>}
+          </div>
+          <div style={row.sampleStyle}>{sample}</div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,2 +1,3 @@
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
 export { TokenTable, type TokenTableProps } from '#/TokenTable.tsx';
+export { TypographyScale, type TypographyScaleProps } from '#/TypographyScale.tsx';

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,3 +1,4 @@
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
+export { TokenDetail, type TokenDetailProps } from '#/TokenDetail.tsx';
 export { TokenTable, type TokenTableProps } from '#/TokenTable.tsx';
 export { TypographyScale, type TypographyScaleProps } from '#/TypographyScale.tsx';


### PR DESCRIPTION
Closes #31

## Summary

Fourth M6 doc block — per-token inspector.

Given a token `path`, renders:
- Heading + `$type` pill + CSS var reference.
- `$description` when present.
- Resolved value for the active theme (with inline swatch for colors).
- Alias chain as linked nodes (`a → b → c`), from Terrazzo's `aliasChain`.
- Per-theme value table — each row scopes `data-theme` on its swatch so every row shows its theme's actual color at once.
- Usage snippet (`color: var(--sb-…);`) ready to copy.
- "Not found" state when the path doesn't resolve in the active theme.

Stacked on #72.

**Milestone:** M6 — Doc blocks
**Plan impact:** none

## Test plan
- [x] `pnpm turbo run lint typecheck build` (blocks + storybook)
- [ ] Visual: each demo story renders; alias chain + per-theme table react to theme switch