### PR TITLE
chore(addon,blocks): kill dts build warnings

### DIFF
--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -46,7 +46,7 @@
     "supportedFrameworks": ["react"]
   },
   "scripts": {
-    "build": "tsdown src/index.ts src/preset.ts src/preview.tsx src/manager.tsx src/hooks/index.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src",
     "format": "oxfmt -c ../../.oxfmtrc.json src",

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -25,12 +25,6 @@ export interface TokenInfo {
   description?: string;
 }
 
-interface ResolvedToken {
-  $value?: unknown;
-  $type?: string;
-  $description?: string;
-}
-
 function makeCssVar(path: string, prefix: string): string {
   const tail = path.replaceAll('.', '-');
   return prefix ? `var(--${prefix}-${tail})` : `var(--${tail})`;
@@ -51,7 +45,7 @@ function makeCssVar(path: string, prefix: string): string {
 export function useToken(path: TokenPath): TokenInfo {
   const contextTheme = useActiveTheme();
   const themeName = contextTheme || (defaultTheme ?? '');
-  const tokens = (themesResolved[themeName] ?? {}) as Record<string, ResolvedToken>;
+  const tokens = themesResolved[themeName] ?? {};
   const token = tokens[path];
   const info: TokenInfo = {
     value: token?.$value,

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -2,10 +2,10 @@ import type { Decorator, Preview } from '@storybook/react-vite';
 import { useEffect } from 'react';
 import { addons } from 'storybook/preview-api';
 import {
-  css as generatedCss,
+  css,
   cssVarPrefix,
   defaultTheme,
-  diagnostics as generatedDiagnostics,
+  diagnostics,
   themes,
   themesResolved,
   themingMode,
@@ -19,21 +19,9 @@ import {
 } from '#/constants.ts';
 import { ThemeContext } from '#/theme-context.ts';
 
-interface ThemeEntry {
-  name: string;
-  input: Record<string, string>;
-  sources: string[];
-}
-
-const typedThemes = themes as ThemeEntry[];
-const typedCss = generatedCss as string;
-const typedDefaultTheme = defaultTheme as string | null;
-const typedPrefix = (cssVarPrefix ?? '') as string;
-const typedMode = themingMode as 'layered' | 'resolver' | 'manifest';
-
 /** CSS var name with the active prefix applied. */
 function v(name: string): string {
-  return typedPrefix ? `--${typedPrefix}-${name}` : `--${name}`;
+  return cssVarPrefix ? `--${cssVarPrefix}-${name}` : `--${name}`;
 }
 
 /**
@@ -50,7 +38,7 @@ html, body {
   margin: 0;
 }
 `;
-  const text = `${typedCss}\n${bodyRules}`;
+  const text = `${css}\n${bodyRules}`;
   let style = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
   if (!style) {
     style = document.createElement('style');
@@ -74,12 +62,12 @@ function setRootTheme(theme: string): void {
 function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(INIT_EVENT, {
-    themes: typedThemes,
-    defaultTheme: typedDefaultTheme,
-    mode: typedMode,
+    themes,
+    defaultTheme,
+    mode: themingMode,
     themesResolved,
-    diagnostics: generatedDiagnostics,
-    cssVarPrefix: typedPrefix,
+    diagnostics,
+    cssVarPrefix,
   });
 }
 
@@ -88,7 +76,7 @@ const themedDecorator: Decorator = (Story, context) => {
   const parameterTheme = (context.parameters as Record<string, Record<string, unknown>>)[
     PARAM_KEY
   ]?.['theme'];
-  const theme = (parameterTheme ?? globalTheme ?? typedDefaultTheme ?? 'Light') as string;
+  const theme = (parameterTheme ?? globalTheme ?? defaultTheme ?? 'Light') as string;
 
   useEffect(() => {
     ensureStylesheet();
@@ -128,5 +116,5 @@ export const globalTypes: NonNullable<Preview['globalTypes']> = {
 };
 
 export const initialGlobals: NonNullable<Preview['initialGlobals']> = {
-  [GLOBAL_KEY]: typedDefaultTheme ?? typedThemes[0]?.name ?? 'Light',
+  [GLOBAL_KEY]: defaultTheme ?? themes[0]?.name ?? 'Light',
 };

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -1,9 +1,8 @@
 /**
  * Typed shape of the addon's `virtual:swatchbook/tokens` module. The runtime
- * payload is produced by the addon's Vite plugin (`swatchbookTokensPlugin`)
+ * payload is produced by this package's Vite plugin (`swatchbookTokensPlugin`)
  * and JSON-serialized, so this declaration describes the plain-data shape
- * consumers read back — a narrow subset of Terrazzo's `TokenNormalized`
- * plus core's `Theme` and `Diagnostic`.
+ * consumers read back.
  */
 declare module 'virtual:swatchbook/tokens' {
   interface VirtualTheme {

--- a/packages/addon/tsdown.config.ts
+++ b/packages/addon/tsdown.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: [
+    'src/index.ts',
+    'src/preset.ts',
+    'src/preview.tsx',
+    'src/manager.tsx',
+    'src/hooks/index.ts',
+  ],
+  format: 'esm',
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  external: [/^vite($|\/)/, /^@storybook\//, 'storybook', 'react', 'react-dom'],
+});

--- a/packages/addon/tsdown.config.ts
+++ b/packages/addon/tsdown.config.ts
@@ -12,5 +12,14 @@ export default defineConfig({
   dts: true,
   clean: true,
   sourcemap: true,
-  external: [/^vite($|\/)/, /^@storybook\//, 'storybook', 'react', 'react-dom'],
+  deps: {
+    neverBundle: [
+      /^vite($|\/)/,
+      /^@storybook\//,
+      /^virtual:/,
+      'storybook',
+      'react',
+      'react-dom',
+    ],
+  },
 });

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -25,7 +25,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src",
     "format": "oxfmt -c ../../.oxfmtrc.json src",

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -7,17 +7,14 @@ import {
   themingMode,
 } from 'virtual:swatchbook/tokens';
 
-interface ResolvedToken {
-  $type?: string;
-  $value?: unknown;
-  $description?: string;
-}
+type VirtualTokens = typeof themesResolved;
+type ResolvedTokens = VirtualTokens[string];
 
 export interface ProjectData {
   activeTheme: string;
-  themes: readonly { name: string; input: Record<string, string>; sources: string[] }[];
-  resolved: Record<string, ResolvedToken>;
-  themesResolved: Record<string, Record<string, ResolvedToken>>;
+  themes: typeof themes;
+  resolved: ResolvedTokens;
+  themesResolved: VirtualTokens;
   cssVarPrefix: string;
   mode: 'layered' | 'resolver' | 'manifest';
 }
@@ -30,12 +27,11 @@ export interface ProjectData {
 export function useProject(): ProjectData {
   const contextTheme = useActiveTheme();
   const activeTheme = contextTheme || (defaultTheme ?? themes[0]?.name ?? '');
-  const resolvedMap = themesResolved as Record<string, Record<string, ResolvedToken>>;
   return {
     activeTheme,
     themes,
-    themesResolved: resolvedMap,
-    resolved: resolvedMap[activeTheme] ?? {},
+    themesResolved,
+    resolved: themesResolved[activeTheme] ?? {},
     cssVarPrefix,
     mode: themingMode,
   };

--- a/packages/blocks/tsdown.config.ts
+++ b/packages/blocks/tsdown.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: 'esm',
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  deps: {
+    neverBundle: [/^@storybook\//, /^virtual:/, 'storybook', 'react', 'react-dom'],
+  },
+});


### PR DESCRIPTION
Closes #74, #75

## Summary

- Silence ~175 rolldown dts warnings (`MISSING_EXPORT`, `IMPORT_IS_UNDEFINED`, `UNRESOLVED_IMPORT`) from the addon + blocks builds. Warnings: 175 → 0.
- Introduce typed ambient declarations for `virtual:swatchbook/tokens` in both packages, replacing runtime `as` casts with real types.

## What changed

1. **Externalize framework packages in dts** — `vite`, `@storybook/*`, `storybook`, `react`, `react-dom` move to `deps.neverBundle` so tsdown's dts bundler stops inlining their type graphs. Root cause: they sat in devDependencies, so rolldown inlined them, walking into postcss's `.d.mts` / `.d.ts` export mismatch and react-docgen-typescript's named imports from typescript's `export = ts` namespace. TS resolves both via its synthetic namespace bridge; rolldown's dts bundler doesn't.
2. **Type `virtual:swatchbook/tokens`** — `packages/addon/src/virtual.d.ts` and `packages/blocks/src/virtual.d.ts` ambient-declare the module with narrow shapes matching the plugin's JSON-serialized payload. Blocks stays self-contained (no core runtime dep). This kills the `as ThemeEntry[]` / `as Record<string, ResolvedToken>` casts in `preview.tsx`, `use-token.ts`, `use-project.ts`.
3. **Externalize the virtual module** — `/^virtual:/` in `deps.neverBundle` silences the "Could not resolve 'virtual:swatchbook/tokens'" warning at package-build time; the module is only ever provided by the addon's Vite plugin at Storybook runtime.
4. **Per-package `tsdown.config.ts`** — build scripts simplify to `tsdown`. Also migrate `external` → `deps.neverBundle` (former is deprecated).

Milestone: M6 — Doc blocks
Plan impact: none

## Test plan

- [x] `pnpm turbo run typecheck build lint --force` green across all tasks
- [x] `pnpm turbo run build --force` produces zero warnings (previously ~175)
- [x] Emitted `dist/preset.d.mts` references vite shallowly: `import { InlineConfig } from "vite"`