### PR TITLE
chore: enable tsconfig strict mode

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,6 +5,7 @@
     "lib": ["ES2025", "DOM", "DOM.Iterable", "DOM.AsyncIterable"],
     "jsx": "react-jsx",
 
+    "strict": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitOverride": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Closes #78

## Summary

- Add `"strict": true` to `tsconfig.base.json`. All strict sub-flags now on: `strictNullChecks`, `noImplicitAny`, `strictFunctionTypes`, `strictBindCallApply`, `strictPropertyInitialization`, `noImplicitThis`, `alwaysStrict`, `useUnknownInCatchVariables`.
- Codebase was already strict-compliant — `pnpm turbo run typecheck --force` reports zero errors across all 9 tasks. Pure config flip.
- Activates `exactOptionalPropertyTypes`, which was a no-op without `strictNullChecks`. Verified it now bites: `{ a?: string }` + `{ a: undefined }` → `TS2375`.

Milestone: M6 — Doc blocks
Plan impact: none

## Test plan

- [x] `pnpm turbo run typecheck --force` green across 9 tasks
- [x] `exactOptionalPropertyTypes` probe produces `TS2375` as expected