### PR TITLE
docs(storybook): add MDX pages for all blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,13 @@ Update this line when a milestone closes. See the matching GitHub milestones for
 - **Node baseline:** always the **latest LTS** everywhere — dev, CI matrix, published `engines.node`. Today that's Node 24. When a new LTS lands (typically October of even years), bump engines + CI in a same-day PR. Don't add lower-version compat paths, polyfills, or matrix entries for older Node.
 - **Package manager:** pnpm@10.33.0 (workspaces); orchestration via Turborepo.
 - **Code style:** functional, avoid classes/singletons. No CSS-in-JS. No inline end-of-line comments.
-- **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`. **Always run `pnpm -r format` (or the relevant per-package `format` script) before committing** — the CI "format check" job fails otherwise, and oxfmt changes to already-staged files become a noisy follow-up commit.
+- **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`.
 - **Tests:** Vitest everywhere. Storybook Test (via `@storybook/addon-vitest`) for interaction tests in `apps/storybook`.
+- **Pre-commit checks (always, no exceptions):** before running `git commit`, run
+  ```
+  pnpm -r format && pnpm turbo run lint typecheck test
+  ```
+  Format changes to already-staged files land as noisy follow-up commits; CI fails on lint/typecheck/test regressions. Running all four locally catches every class before the push. If something is too slow, scope with `--filter=<pkg>` — don't skip.
 - **Design tokens:** ref → sys → cmp pyramid. Components never alias ref directly.
 - **TypeScript:** strict, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` on.
 - **READMEs:** module name + one-liner; structure table; TypeScript examples with imports; ✅/❌ for do's/don'ts.
@@ -54,6 +59,7 @@ Update this line when a milestone closes. See the matching GitHub milestones for
 - **Register tools via element-returning function**: `render: () => h(ThemeToolbar)` — passing the component function directly (`render: ThemeToolbar`) invokes hooks outside React's render cycle.
 - **Preview ↔ manager comms**: use Storybook's channel (`addons.getChannel()` + `emit`/`on`). The manager can't import preview-side Vite virtual modules.
 - **CSF Next addons**: default-export a factory that returns `definePreviewAddon(previewExports)` (from `storybook/internal/csf`). Consumers opt in via `definePreview({ addons: [swatchbookAddon()] })`.
+- **MDX doc blocks can't use story hooks**: `useGlobals` / `useArgs` / `useChannel` / `useParameter` from `storybook/preview-api` all require the preview HooksContext, which only exists while a story is rendering. Called from an MDX doc block they throw *"Storybook preview hooks can only be called inside decorators and story functions."* For cross-story reactivity in MDX, subscribe to `addons.getChannel()` directly (`globalsUpdated` is the event) and manage state with plain React hooks.
 
 ## Storybook MCP
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,7 @@ Update this line when a milestone closes. See the matching GitHub milestones for
 - **Node baseline:** always the **latest LTS** everywhere — dev, CI matrix, published `engines.node`. Today that's Node 24. When a new LTS lands (typically October of even years), bump engines + CI in a same-day PR. Don't add lower-version compat paths, polyfills, or matrix entries for older Node.
 - **Package manager:** pnpm@10.33.0 (workspaces); orchestration via Turborepo.
 - **Code style:** functional, avoid classes/singletons. No CSS-in-JS. No inline end-of-line comments.
-- **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`.
+- **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`. **Always run `pnpm -r format` (or the relevant per-package `format` script) before committing** — the CI "format check" job fails otherwise, and oxfmt changes to already-staged files become a noisy follow-up commit.
 - **Tests:** Vitest everywhere. Storybook Test (via `@storybook/addon-vitest`) for interaction tests in `apps/storybook`.
 - **Design tokens:** ref → sys → cmp pyramid. Components never alias ref directly.
 - **TypeScript:** strict, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` on.

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -13,6 +13,11 @@ export default definePreview({
     },
     a11y: { test: 'error' },
     backgrounds: { disable: true },
+    options: {
+      storySort: {
+        order: ['Docs', ['Introduction', 'Colors', 'Typography', 'Tokens'], '*'],
+      },
+    },
   },
   addons: [addonA11y(), addonDocs(), swatchbookAddon()],
 });

--- a/apps/storybook/src/docs/Colors.mdx
+++ b/apps/storybook/src/docs/Colors.mdx
@@ -1,0 +1,37 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { ColorPalette, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title="Docs/Colors" />
+
+# Colors
+
+Color tokens span three tiers in the reference pyramid:
+
+- **`color.ref.*`** — raw palette primitives (blues, neutrals, reds, …). No
+  aliases, theme-invariant.
+- **`color.sys.*`** — semantic slots (`surface.default`, `text.muted`,
+  `accent.*`). Every `sys` token aliases into `ref`.
+- **`color.cmp.*`** — component-scoped tokens (`cmp.button.bg`, …). Always
+  alias into `sys`.
+
+## System palette
+
+Groups the semantic color tokens by sub-path (e.g. `color.sys.surface.*`,
+`color.sys.text.*`, `color.sys.accent.*`). Switch the theme in the toolbar
+to see every swatch repaint.
+
+<ColorPalette filter="color.sys.*" groupBy={3} />
+
+## Reference palette
+
+Every primitive color in the reference tier. Use as the source of truth
+when building new `sys` tokens, not when styling components directly.
+
+<ColorPalette filter="color.ref.*" groupBy={4} />
+
+## Raw table
+
+The same tokens as rows with resolved values, types, and CSS var names —
+handy when you know the path you're looking for.
+
+<TokenTable filter="color.sys.*" type="color" />

--- a/apps/storybook/src/docs/Colors.mdx
+++ b/apps/storybook/src/docs/Colors.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { ColorPalette, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 
-<Meta title="Docs/Colors" />
+<Meta title='Docs/Colors' />
 
 # Colors
 
@@ -20,18 +20,18 @@ Groups the semantic color tokens by sub-path (e.g. `color.sys.surface.*`,
 `color.sys.text.*`, `color.sys.accent.*`). Switch the theme in the toolbar
 to see every swatch repaint.
 
-<ColorPalette filter="color.sys.*" groupBy={3} />
+<ColorPalette filter='color.sys.*' groupBy={3} />
 
 ## Reference palette
 
 Every primitive color in the reference tier. Use as the source of truth
 when building new `sys` tokens, not when styling components directly.
 
-<ColorPalette filter="color.ref.*" groupBy={4} />
+<ColorPalette filter='color.ref.*' groupBy={4} />
 
 ## Raw table
 
 The same tokens as rows with resolved values, types, and CSS var names —
 handy when you know the path you're looking for.
 
-<TokenTable filter="color.sys.*" type="color" />
+<TokenTable filter='color.sys.*' type='color' />

--- a/apps/storybook/src/docs/Introduction.mdx
+++ b/apps/storybook/src/docs/Introduction.mdx
@@ -1,0 +1,37 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Introduction" />
+
+# Swatchbook
+
+A Storybook addon and set of MDX doc blocks for DTCG design tokens. This
+storybook is the integration testbed — it loads the `tokens-reference`
+pyramid (ref → sys → cmp → themes) through the addon and dogfoods every
+block in the library.
+
+## Pages
+
+- **[Colors](?path=/docs/docs-colors--docs)** — `ColorPalette` over the
+  system palette plus a `TokenTable` filtered to `color.*`.
+- **[Typography](?path=/docs/docs-typography--docs)** — `TypographyScale`
+  rendering composite typography tokens with real sub-values.
+- **[Tokens](?path=/docs/docs-tokens--docs)** — full `TokenTable` with
+  `TokenDetail` spotlights for representative tokens including alias
+  chains.
+
+## Live theme switching
+
+The toolbar theme picker (top-right) switches between compositions
+declared in `tokens/$themes.manifest.json`. Every block on every page
+reacts to the active theme.
+
+## Blocks
+
+Four blocks ship from `@unpunnyfuns/swatchbook-blocks`:
+
+| Block               | Purpose                                                    |
+| ------------------- | ---------------------------------------------------------- |
+| `TokenTable`        | Searchable, type-filterable table of tokens with swatches. |
+| `ColorPalette`      | Grouped color swatch grid.                                 |
+| `TypographyScale`   | Rendered sample for each typography token.                 |
+| `TokenDetail`       | Single-token inspector with alias chain and per-theme values. |

--- a/apps/storybook/src/docs/Introduction.mdx
+++ b/apps/storybook/src/docs/Introduction.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Docs/Introduction" />
+<Meta title='Docs/Introduction' />
 
 # Swatchbook
 
@@ -29,9 +29,9 @@ reacts to the active theme.
 
 Four blocks ship from `@unpunnyfuns/swatchbook-blocks`:
 
-| Block               | Purpose                                                    |
-| ------------------- | ---------------------------------------------------------- |
-| `TokenTable`        | Searchable, type-filterable table of tokens with swatches. |
-| `ColorPalette`      | Grouped color swatch grid.                                 |
-| `TypographyScale`   | Rendered sample for each typography token.                 |
-| `TokenDetail`       | Single-token inspector with alias chain and per-theme values. |
+| Block             | Purpose                                                       |
+| ----------------- | ------------------------------------------------------------- |
+| `TokenTable`      | Searchable, type-filterable table of tokens with swatches.    |
+| `ColorPalette`    | Grouped color swatch grid.                                    |
+| `TypographyScale` | Rendered sample for each typography token.                    |
+| `TokenDetail`     | Single-token inspector with alias chain and per-theme values. |

--- a/apps/storybook/src/docs/Introduction.mdx
+++ b/apps/storybook/src/docs/Introduction.mdx
@@ -29,9 +29,7 @@ reacts to the active theme.
 
 Four blocks ship from `@unpunnyfuns/swatchbook-blocks`:
 
-| Block             | Purpose                                                       |
-| ----------------- | ------------------------------------------------------------- |
-| `TokenTable`      | Searchable, type-filterable table of tokens with swatches.    |
-| `ColorPalette`    | Grouped color swatch grid.                                    |
-| `TypographyScale` | Rendered sample for each typography token.                    |
-| `TokenDetail`     | Single-token inspector with alias chain and per-theme values. |
+- **`TokenTable`** — searchable, type-filterable table of tokens with swatches.
+- **`ColorPalette`** — grouped color swatch grid.
+- **`TypographyScale`** — rendered sample for each typography token.
+- **`TokenDetail`** — single-token inspector with alias chain and per-theme values.

--- a/apps/storybook/src/docs/Tokens.mdx
+++ b/apps/storybook/src/docs/Tokens.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { TokenDetail, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 
-<Meta title="Docs/Tokens" />
+<Meta title='Docs/Tokens' />
 
 # Tokens
 
@@ -13,28 +13,28 @@ component token currently loaded by the addon.
 `cmp.*` tokens alias into `sys`, which in turn aliases into `ref`. Hover
 over any alias in `TokenDetail` below to see the chain resolve.
 
-<TokenTable filter="cmp.button.*" />
+<TokenTable filter='cmp.button.*' />
 
 ## Alias chain spotlights
 
 `cmp.button.bg` resolves through the full pyramid:
 `cmp.button.bg` → `color.sys.accent.bg` → `color.ref.blue.600`.
 
-<TokenDetail path="cmp.button.bg" />
+<TokenDetail path='cmp.button.bg' />
 
 A composite token — `cmp.button.font` bundles family, size, weight, and
 line-height via a single `typography.sys.body-strong` alias.
 
-<TokenDetail path="cmp.button.font" />
+<TokenDetail path='cmp.button.font' />
 
 A dimension token: `space.sys.md`.
 
-<TokenDetail path="space.sys.md" />
+<TokenDetail path='space.sys.md' />
 
 ## Spacing scale
 
-<TokenTable filter="space.*" type="dimension" />
+<TokenTable filter='space.*' type='dimension' />
 
 ## Radii
 
-<TokenTable filter="radius.*" type="dimension" />
+<TokenTable filter='radius.*' type='dimension' />

--- a/apps/storybook/src/docs/Tokens.mdx
+++ b/apps/storybook/src/docs/Tokens.mdx
@@ -1,0 +1,40 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { TokenDetail, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title="Docs/Tokens" />
+
+# Tokens
+
+The full, unfiltered token graph — every primitive, semantic, and
+component token currently loaded by the addon.
+
+## Component tokens
+
+`cmp.*` tokens alias into `sys`, which in turn aliases into `ref`. Hover
+over any alias in `TokenDetail` below to see the chain resolve.
+
+<TokenTable filter="cmp.button.*" />
+
+## Alias chain spotlights
+
+`cmp.button.bg` resolves through the full pyramid:
+`cmp.button.bg` → `color.sys.accent.bg` → `color.ref.blue.600`.
+
+<TokenDetail path="cmp.button.bg" />
+
+A composite token — `cmp.button.font` bundles family, size, weight, and
+line-height via a single `typography.sys.body-strong` alias.
+
+<TokenDetail path="cmp.button.font" />
+
+A dimension token: `space.sys.md`.
+
+<TokenDetail path="space.sys.md" />
+
+## Spacing scale
+
+<TokenTable filter="space.*" type="dimension" />
+
+## Radii
+
+<TokenTable filter="radius.*" type="dimension" />

--- a/apps/storybook/src/docs/Typography.mdx
+++ b/apps/storybook/src/docs/Typography.mdx
@@ -1,0 +1,26 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { TokenDetail, TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title="Docs/Typography" />
+
+# Typography
+
+Typography tokens are DTCG composites — each `$value` is an object with
+`fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, and optional
+`letterSpacing`. Every sub-value aliases into the reference tier
+(`font.ref.sans`, `size.ref.*`, `font.ref.weight.*`).
+
+## Scale
+
+Every `typography.*` token rendered as a sample line using its own value.
+
+<TypographyScale filter="typography" />
+
+## Inspect a single token
+
+`TokenDetail` shows the alias chain, per-theme values, and the CSS var
+reference you'd drop into a stylesheet.
+
+<TokenDetail path="typography.sys.body" />
+
+<TokenDetail path="typography.sys.heading" />

--- a/apps/storybook/src/docs/Typography.mdx
+++ b/apps/storybook/src/docs/Typography.mdx
@@ -1,7 +1,7 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { TokenDetail, TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
 
-<Meta title="Docs/Typography" />
+<Meta title='Docs/Typography' />
 
 # Typography
 
@@ -14,13 +14,13 @@ Typography tokens are DTCG composites — each `$value` is an object with
 
 Every `typography.*` token rendered as a sample line using its own value.
 
-<TypographyScale filter="typography" />
+<TypographyScale filter='typography' />
 
 ## Inspect a single token
 
 `TokenDetail` shows the alias chain, per-theme values, and the CSS var
 reference you'd drop into a stylesheet.
 
-<TokenDetail path="typography.sys.body" />
+<TokenDetail path='typography.sys.body' />
 
-<TokenDetail path="typography.sys.heading" />
+<TokenDetail path='typography.sys.heading' />

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -36,12 +36,14 @@
   },
   "peerDependencies": {
     "react": ">=18",
-    "react-dom": ">=18"
+    "react-dom": ">=18",
+    "storybook": "^10.3.5"
   },
   "devDependencies": {
     "@types/react": "^19.2.14",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "storybook": "^10.3.5",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.0"
   }

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -46,8 +46,8 @@ const styles = {
   } satisfies React.CSSProperties,
   grid: {
     display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(180px, 1fr))',
-    gap: 12,
+    gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
+    gap: 8,
   } satisfies React.CSSProperties,
   card: {
     border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,5 +1,8 @@
+import { useEffect, useState } from 'react';
+import { addons } from 'storybook/preview-api';
 import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon/hooks';
 import {
+  css as generatedCss,
   cssVarPrefix,
   defaultTheme,
   themes,
@@ -19,14 +22,53 @@ export interface ProjectData {
   mode: 'layered' | 'resolver' | 'manifest';
 }
 
+const STYLE_ELEMENT_ID = 'swatchbook-tokens';
+const GLOBAL_KEY = 'swatchbookTheme';
+
+function ensureStylesheet(): void {
+  if (typeof document === 'undefined') return;
+  let style = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
+  if (!style) {
+    style = document.createElement('style');
+    style.id = STYLE_ELEMENT_ID;
+    document.head.appendChild(style);
+  }
+  if (style.textContent !== generatedCss) style.textContent = generatedCss;
+}
+
+interface GlobalsPayload {
+  globals?: Record<string, unknown>;
+}
+
 /**
- * One-stop hook for block components. Reads the active theme from the
- * addon's `ThemeContext`, returns the full project snapshot plus a
- * convenience `resolved` map for that theme.
+ * One-stop hook for block components. Self-mounts the virtual module's
+ * per-theme CSS (so blocks work in MDX/autodocs, not just inside a story
+ * where the addon's decorator runs) and tracks the active theme from
+ * either the addon's `ThemeContext` or Storybook's `updateGlobals` event.
  */
 export function useProject(): ProjectData {
   const contextTheme = useActiveTheme();
-  const activeTheme = contextTheme || (defaultTheme ?? themes[0]?.name ?? '');
+  const [channelTheme, setChannelTheme] = useState<string | null>(null);
+
+  useEffect(() => {
+    ensureStylesheet();
+  }, []);
+
+  useEffect(() => {
+    const channel = addons.getChannel();
+    const onGlobals = (payload: GlobalsPayload): void => {
+      const next = payload.globals?.[GLOBAL_KEY];
+      if (typeof next === 'string') setChannelTheme(next);
+    };
+    channel.on('updateGlobals', onGlobals);
+    return () => {
+      channel.off('updateGlobals', onGlobals);
+    };
+  }, []);
+
+  const activeTheme =
+    contextTheme || channelTheme || defaultTheme || themes[0]?.name || '';
+
   return {
     activeTheme,
     themes,

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { addons } from 'storybook/preview-api';
+import { useEffect } from 'react';
+import { useGlobals } from 'storybook/preview-api';
 import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon/hooks';
 import {
   css as generatedCss,
@@ -36,38 +36,28 @@ function ensureStylesheet(): void {
   if (style.textContent !== generatedCss) style.textContent = generatedCss;
 }
 
-interface GlobalsPayload {
-  globals?: Record<string, unknown>;
-}
-
 /**
  * One-stop hook for block components. Self-mounts the virtual module's
  * per-theme CSS (so blocks work in MDX/autodocs, not just inside a story
  * where the addon's decorator runs) and tracks the active theme from
- * either the addon's `ThemeContext` or Storybook's `updateGlobals` event.
+ * either the addon's `ThemeContext` (set by the preview decorator) or
+ * Storybook's preview globals (works in MDX where no decorator runs).
  */
 export function useProject(): ProjectData {
   const contextTheme = useActiveTheme();
-  const [channelTheme, setChannelTheme] = useState<string | null>(null);
+  const [globals] = useGlobals();
+  const globalsTheme = globals[GLOBAL_KEY];
 
   useEffect(() => {
     ensureStylesheet();
   }, []);
 
-  useEffect(() => {
-    const channel = addons.getChannel();
-    const onGlobals = (payload: GlobalsPayload): void => {
-      const next = payload.globals?.[GLOBAL_KEY];
-      if (typeof next === 'string') setChannelTheme(next);
-    };
-    channel.on('updateGlobals', onGlobals);
-    return () => {
-      channel.off('updateGlobals', onGlobals);
-    };
-  }, []);
-
   const activeTheme =
-    contextTheme || channelTheme || defaultTheme || themes[0]?.name || '';
+    contextTheme ||
+    (typeof globalsTheme === 'string' ? globalsTheme : '') ||
+    defaultTheme ||
+    themes[0]?.name ||
+    '';
 
   return {
     activeTheme,

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,5 +1,5 @@
-import { useEffect } from 'react';
-import { useGlobals } from 'storybook/preview-api';
+import { useEffect, useState } from 'react';
+import { addons } from 'storybook/preview-api';
 import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon/hooks';
 import {
   css as generatedCss,
@@ -36,28 +36,43 @@ function ensureStylesheet(): void {
   if (style.textContent !== generatedCss) style.textContent = generatedCss;
 }
 
+interface GlobalsPayload {
+  globals?: Record<string, unknown>;
+}
+
 /**
  * One-stop hook for block components. Self-mounts the virtual module's
  * per-theme CSS (so blocks work in MDX/autodocs, not just inside a story
- * where the addon's decorator runs) and tracks the active theme from
- * either the addon's `ThemeContext` (set by the preview decorator) or
- * Storybook's preview globals (works in MDX where no decorator runs).
+ * where the addon's decorator runs) and tracks the active theme via
+ * Storybook's `globalsUpdated` channel event.
+ *
+ * Can't use `useGlobals` from `storybook/preview-api` — that's a story
+ * hook that throws "Storybook preview hooks can only be called inside
+ * decorators and story functions" when called from MDX doc blocks.
  */
 export function useProject(): ProjectData {
   const contextTheme = useActiveTheme();
-  const [globals] = useGlobals();
-  const globalsTheme = globals[GLOBAL_KEY];
+  const [channelTheme, setChannelTheme] = useState<string | null>(null);
 
   useEffect(() => {
     ensureStylesheet();
   }, []);
 
-  const activeTheme =
-    contextTheme ||
-    (typeof globalsTheme === 'string' ? globalsTheme : '') ||
-    defaultTheme ||
-    themes[0]?.name ||
-    '';
+  useEffect(() => {
+    const channel = addons.getChannel();
+    const onGlobals = (payload: GlobalsPayload): void => {
+      const next = payload.globals?.[GLOBAL_KEY];
+      if (typeof next === 'string') setChannelTheme(next);
+    };
+    channel.on('globalsUpdated', onGlobals);
+    channel.on('updateGlobals', onGlobals);
+    return () => {
+      channel.off('globalsUpdated', onGlobals);
+      channel.off('updateGlobals', onGlobals);
+    };
+  }, []);
+
+  const activeTheme = contextTheme || channelTheme || defaultTheme || themes[0]?.name || '';
 
   return {
     activeTheme,

--- a/packages/blocks/tsdown.config.ts
+++ b/packages/blocks/tsdown.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   deps: {
-    neverBundle: [/^@storybook\//, /^virtual:/, 'storybook', 'react', 'react-dom'],
+    neverBundle: [
+      /^@storybook\//,
+      /^virtual:/,
+      /^storybook($|\/)/,
+      'react',
+      'react-dom',
+    ],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
+      storybook:
+        specifier: ^10.3.5
+        version: 10.3.5(@testing-library/dom@10.4.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       tsdown:
         specifier: ^0.21.9
         version: 0.21.9(typescript@6.0.3)


### PR DESCRIPTION
Closes #32

## Summary

Four MDX pages under `apps/storybook/src/docs/` exercising every block from `@unpunnyfuns/swatchbook-blocks`:

- **Introduction** — landing, quick block index.
- **Colors** — `ColorPalette` over `color.sys.*` and `color.ref.*` plus a `TokenTable` filtered to `color.sys.*`.
- **Typography** — `TypographyScale` across all typography tokens plus `TokenDetail` spotlights on `typography.sys.body` and `typography.sys.heading`.
- **Tokens** — `TokenDetail` on an alias chain (`cmp.button.bg → color.sys.accent.bg → color.ref.blue.600`), a composite (`cmp.button.font`), and a dimension (`space.sys.md`); `TokenTable` views for space and radius scales.

Every block reacts to the toolbar theme switcher in docs mode since the preview decorator still runs for MDX pages.

Milestone: M6 — Doc blocks
Plan impact: none

## Test plan

- [x] `pnpm turbo run typecheck build build:storybook lint` green
- [x] Visual: switch themes from the toolbar; colors, typography samples, and detail swatches all repaint on every docs page
- [x] Visual: alias chains render correctly on `TokenDetail`