### PR TITLE
ci: run job in Playwright container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # Pin to match apps/storybook/node_modules/playwright version. Bump in
+    # the same PR as a Playwright upgrade — ships chromium + all system
+    # deps pre-installed, so we skip `apt-get install` entirely.
+    container:
+      image: mcr.microsoft.com/playwright:v1.59.1-noble
     permissions:
       contents: read
       actions: write
@@ -40,27 +45,6 @@ jobs:
             turbo-${{ matrix.node }}-
 
       - run: pnpm install --frozen-lockfile
-
-      - name: Resolve Playwright version
-        id: playwright
-        run: |
-          version=$(node -p "require('./apps/storybook/node_modules/playwright/package.json').version")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: playwright-cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}
-
-      - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: pnpm --filter @unpunnyfuns/swatchbook-storybook exec playwright install --with-deps chromium
-
-      - name: Install Playwright system deps on cache hit
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: pnpm --filter @unpunnyfuns/swatchbook-storybook exec playwright install-deps chromium
 
       - run: pnpm turbo run lint format:check typecheck test build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: Trust workspace inside container
+        # Runner UID differs from checkout owner inside containers, which
+        # makes git refuse to read the repo ("dubious ownership"). Turbo
+        # uses git status for its dirty hash; we tell git to trust the
+        # workspace path to silence the warning and restore reliable
+        # cache keys.
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - uses: pnpm/action-setup@v5
         with:
           run_install: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,12 @@ jobs:
     # deps pre-installed, so we skip `apt-get install` entirely.
     container:
       image: mcr.microsoft.com/playwright:v1.59.1-noble
+    env:
+      # The image pre-installs chromium to /ms-playwright, but GH Actions
+      # overrides $HOME to /github/home inside containers so Playwright's
+      # default lookup ($HOME/.cache/ms-playwright) misses. Point it at
+      # the image's install dir explicitly.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
     permissions:
       contents: read
       actions: write

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ Update this line when a milestone closes. See the matching GitHub milestones for
   ```
   The leading slash in `#/` lands cleanly because Node 24.14+ supports `#/`-prefixed subpaths. TypeScript (5.4+), Vite, and Vitest all honor `package.json#imports` natively — no `tsconfig#paths`, no `resolve.alias`. Don't add them.
 - **Node baseline:** always the **latest LTS** everywhere — dev, CI matrix, published `engines.node`. Today that's Node 24. When a new LTS lands (typically October of even years), bump engines + CI in a same-day PR. Don't add lower-version compat paths, polyfills, or matrix entries for older Node.
+- **CI Playwright image:** CI runs inside `mcr.microsoft.com/playwright:vX.Y.Z-noble` (pinned in `.github/workflows/ci.yml`) so chromium + system deps are pre-installed and no `apt-get install` runs. When upgrading `playwright`, bump the image tag in the same PR to match the new version.
 - **Package manager:** pnpm@10.33.0 (workspaces); orchestration via Turborepo.
 - **Code style:** functional, avoid classes/singletons. No CSS-in-JS. No inline end-of-line comments.
 - **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`.

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
     include: ['test/**/*.test.ts'],
     environment: 'node',
     reporters: ['default'],
+    // DTCG parse + Terrazzo normalize + CSS emit take ~800ms per
+    // loadProject locally; in the GH Actions Playwright container they
+    // can creep past vitest's 5s default. 30s gives ample headroom
+    // without masking real regressions.
+    testTimeout: 30_000,
   },
 });

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -5,10 +5,5 @@ export default defineConfig({
     include: ['test/**/*.test.ts'],
     environment: 'node',
     reporters: ['default'],
-    // DTCG parse + Terrazzo normalize + CSS emit take ~800ms per
-    // loadProject locally; in the GH Actions Playwright container they
-    // can creep past vitest's 5s default. 30s gives ample headroom
-    // without masking real regressions.
-    testTimeout: 30_000,
   },
 });

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,8 @@
     "test:storybook": {
       "dependsOn": ["^build"],
       "inputs": ["src/**", "tokens/**", ".storybook/**", "vitest.config.*", "vitest.setup.*"],
-      "outputs": []
+      "outputs": [],
+      "passThroughEnv": ["PLAYWRIGHT_BROWSERS_PATH"]
     },
     "lint": {
       "inputs": ["src/**", "$TURBO_ROOT$/.oxlintrc.json"],


### PR DESCRIPTION
Closes #82

## Summary

- Pin CI to \`mcr.microsoft.com/playwright:v1.59.1-noble\` so chromium + all system deps are pre-installed.
- Drop four now-redundant steps: resolve version, cache \`~/.cache/ms-playwright\`, \`playwright install --with-deps\` on miss, \`playwright install-deps\` on hit.
- Note in \`CLAUDE.md\` that the image tag must be bumped in the same PR as any \`playwright\` upgrade.

Expected impact: eliminates the ~20–40s \`apt-get install\` slice of each CI run — roughly 40% of wall-clock on cold runs.

Milestone: _(none — CI hygiene)_
Plan impact: none

## Test plan

- [x] This PR's CI run passes — \`lint\`, \`format:check\`, \`typecheck\`, \`test\`, \`build\`, \`test:storybook\`, \`build:storybook\` all green inside the container.
- [x] Playwright-driven \`test:storybook\` actually launches a browser (confirms the container's chromium is reachable).
- [x] CI wall-clock is measurably shorter than recent main runs.