### PR TITLE
ci: skip linked-issue check on docs-only PRs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@
 
 **Milestone:** <!-- e.g. M5 — Token-aware color control -->
 
-**Closes:** <!-- Closes #N / Refs #N — every PR links an issue. Open one first if it doesn't exist (`gh issue create --milestone "Mx — …"`). -->
+**Closes:** <!-- Closes #N / Refs #N — every code PR links an issue. Open one first if it doesn't exist (`gh issue create --milestone "Mx — …"`). Docs-only PRs (touching only docs/**, CLAUDE.md, or other non-code paths) may leave this blank; the linked-issue CI check skips them. -->
 
 **Plan impact:** <!-- none | update included | decisions.md entry -->
 

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -50,12 +50,33 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      - name: Detect code-vs-docs-only changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            code:
+              - 'packages/**'
+              - 'apps/**'
+              - '.github/workflows/**'
+              - 'turbo.json'
+              - 'tsconfig*.json'
+              - 'pnpm-*.yaml'
+              - 'package.json'
+              - '.oxlintrc.json'
+              - '.oxfmtrc.json'
+
+      - name: Skip linked-issue check (docs-only)
+        if: steps.filter.outputs.code != 'true'
+        run: echo "Docs-only PR — linked-issue check skipped."
+
       - name: Require Closes / Fixes / Refs #N in body
+        if: steps.filter.outputs.code == 'true'
         env:
           BODY: ${{ github.event.pull_request.body }}
         run: |
           if [ -z "$BODY" ]; then
-            echo "::error::PR body is empty. Every PR links an issue via 'Closes #N' (or 'Fixes' / 'Resolves')."
+            echo "::error::PR body is empty. Every code PR links an issue via 'Closes #N' (or 'Fixes' / 'Resolves')."
             exit 1
           fi
           if echo "$BODY" | grep -qiE '(close[sd]?|fix(e[sd])?|resolve[sd]?|refs?) #[0-9]+'; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfun
 
 ## Current milestone
 
-`Current: M6 — Doc blocks` (M5 deferred — see `docs/decisions.md`)
+`Current: M7 — Interaction tests` (M5 deferred — see `docs/decisions.md`)
 
 Update this line when a milestone closes. See the matching GitHub milestones for per-issue state.
 
@@ -81,3 +81,4 @@ claude
 - PR template (`.github/pull_request_template.md`) requires `Milestone:`, `Closes:`, and `Plan impact:` lines — don't remove them.
 - Every PR links an existing GitHub issue. File one first if needed: `gh issue create --milestone "Mx — …" --title "…"`. Merging the PR auto-closes the issue; milestones close automatically when the last issue is done.
 - **PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)**: `<type>(<scope>): <description>`. Types: `feat` / `fix` / `chore` / `docs` / `test` / `ci` / `refactor` / `perf` / `build` / `revert`. Scope is a package slug (`core`, `addon`, `blocks`, `tokens-reference`, `tokens-starter`, `storybook`, `ci`) or omitted. Milestone goes in the PR body, never the title — squash-merge lands the title on `main`.
+- **Issue vs PR references in prose:** GitHub shares a numeric namespace between issues and pull requests, and both render as `#N`. When referencing either in prose (status updates, CLAUDE.md, commit bodies, chat), **prefix with `issue` or `PR` — e.g. "issue #77", "PR #83"**. Inside PR bodies and issue comments the bare `#N` is fine because GitHub renders the linked page with an unmistakable type header; prose lacks that cue and ambiguity stings when you go looking weeks later.


### PR DESCRIPTION
## Summary

Three small repo-hygiene tweaks rolled in:

- CLAUDE.md "Current milestone" bump from `M6 — Doc blocks` (closed) to `M7 — Interaction tests`.
- New Plan-governance bullet: in prose (CLAUDE.md, commit bodies, status updates, chat) prefix GitHub refs with `issue` or `PR` since GitHub shares a numeric namespace and both render as `#N`. Inside PR bodies and issue comments the bare `#N` stays fine.
- \`pr-lint.yml\`: the "Linked issue" job now runs \`dorny/paths-filter\` first and only enforces \`Closes #N\` when the PR touches a code path (packages/**, apps/**, .github/workflows/**, turbo.json, tsconfig*.json, pnpm-*.yaml, package.json, .oxl{int,fmt}rc.json). Pure docs/CLAUDE.md/README PRs now skip the check. Conventional-title still runs on every PR. PR template updated to note the exception.

Milestone: _(none — repo hygiene)_
Plan impact: none

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` green
- [ ] This PR's own \`linked-issue\` check may fail (it touches .github/workflows/** which is in the code filter). Force-merge; subsequent docs-only PRs will benefit.