### PR TITLE
chore: forbid explicit any outside tests

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -8,9 +8,17 @@
   },
   "rules": {
     "no-unused-vars": "warn",
-    "typescript/no-explicit-any": "warn",
+    "typescript/no-explicit-any": "error",
     "react/react-in-jsx-scope": "off",
     "import/no-unassigned-import": "off"
   },
+  "overrides": [
+    {
+      "files": ["**/*.test.*", "**/*.spec.*", "**/test/**", "**/*.stories.*"],
+      "rules": {
+        "typescript/no-explicit-any": "off"
+      }
+    }
+  ],
   "ignorePatterns": ["dist", "storybook-static", "coverage", ".turbo", ".swatchbook", "node_modules"]
 }


### PR DESCRIPTION
Closes #77

## Summary

- Promote \`typescript/no-explicit-any\` from \`"warn"\` to \`"error"\` in \`.oxlintrc.json\`. CI already ran lint with \`--deny-warnings\` so behaviour is unchanged, but the config now matches intent and stays strict if the flag is ever dropped.
- Add an oxlint \`overrides\` block turning the rule off for \`**/*.test.*\`, \`**/*.spec.*\`, \`**/test/**\`, \`**/*.stories.*\` — mocking stubs and interaction-test helpers need the escape hatch.

\`noImplicitAny\` is already on via \`strict: true\` in \`tsconfig.base.json\` (landed earlier). Combined with this PR, \`#77\` is fully closed.

Probe verified: \`const x: any\` in \`src/\` now errors; same line in \`test/\` passes.

Milestone: _(none — repo hygiene)_
Plan impact: none

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test --force\` green across all 16 tasks
- [x] Manual probe: \`src/__probe.ts\` with explicit \`any\` → 1 lint error; same file under \`test/\` → 0 errors