### PR TITLE
ci: add Playwright→GHCR mirror workflow

### DIFF
--- a/.github/workflows/mirror-playwright.yml
+++ b/.github/workflows/mirror-playwright.yml
@@ -1,0 +1,51 @@
+name: Mirror Playwright image
+
+# Mirrors mcr.microsoft.com/playwright:<tag> to GHCR so CI can pull from
+# the same network edge as the runner (~3-5s vs ~27s). Trigger manually
+# after bumping the playwright version in apps/storybook/package.json;
+# then update .github/workflows/ci.yml's container tag to match.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Playwright image tag (e.g. v1.59.1-noble). Must match apps/storybook/node_modules/playwright version + image base."
+        required: true
+        default: v1.59.1-noble
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull upstream image
+        run: docker pull mcr.microsoft.com/playwright:${{ inputs.tag }}
+
+      - name: Re-tag for GHCR
+        run: |
+          src="mcr.microsoft.com/playwright:${{ inputs.tag }}"
+          dst="ghcr.io/${{ github.repository }}/playwright:${{ inputs.tag }}"
+          docker tag "$src" "$dst"
+          echo "dst=$dst" >> "$GITHUB_ENV"
+
+      - name: Push to GHCR
+        run: docker push "$dst"
+
+      - name: Summary
+        run: |
+          echo "### Mirrored" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Source: \`mcr.microsoft.com/playwright:${{ inputs.tag }}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Destination: \`$dst\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Update \`.github/workflows/ci.yml\`'s \`container.image\` to the destination tag, and \`CLAUDE.md\`'s CI Playwright image bullet to match." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Refs #87

## Summary

Part one of the two-PR swap. Adds \`.github/workflows/mirror-playwright.yml\` — a manually-triggered workflow (\`workflow_dispatch\`) that pulls \`mcr.microsoft.com/playwright:<tag>\` and re-pushes it to \`ghcr.io/<repo>/playwright:<tag>\`. Needs \`packages: write\` on the job token (declared).

CI still points at MCR in this PR — the follow-up swaps \`ci.yml\` once the first mirror run has populated GHCR.

## Post-merge procedure

1. Run the \`Mirror Playwright image\` workflow manually (Actions → Run workflow). Default input tag is \`v1.59.1-noble\`.
2. Verify the tag appears under the repo's Packages.
3. Open the follow-up PR swapping \`ci.yml\`'s container tag + CLAUDE.md's bullet.

## On Playwright upgrades

Same four-step procedure (bump playwright → dispatch mirror → verify → update \`ci.yml\`).

Milestone: _(none — CI hygiene)_
Plan impact: none

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck\` green
- [ ] Post-merge: manually dispatch the workflow and verify the image pushes to GHCR