### PR TITLE
ci: pull Playwright image from GHCR mirror

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,13 @@ jobs:
     # Pin to match apps/storybook/node_modules/playwright version. Bump in
     # the same PR as a Playwright upgrade — ships chromium + all system
     # deps pre-installed, so we skip `apt-get install` entirely.
+    # GHCR mirror of mcr.microsoft.com/playwright:v1.59.1-noble, maintained by
+    # .github/workflows/mirror-playwright.yml. GHCR pulls are ~3-5s on GHA
+    # runners vs ~27s from MCR. On Playwright bump: update the version in
+    # apps/storybook/package.json, dispatch the mirror workflow with the new
+    # tag, then update this line + the CLAUDE.md bullet.
     container:
-      image: mcr.microsoft.com/playwright:v1.59.1-noble
+      image: ghcr.io/${{ github.repository }}/playwright:v1.59.1-noble
     env:
       # The image pre-installs chromium to /ms-playwright, but GH Actions
       # overrides $HOME to /github/home inside containers so Playwright's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Update this line when a milestone closes. See the matching GitHub milestones for
   ```
   The leading slash in `#/` lands cleanly because Node 24.14+ supports `#/`-prefixed subpaths. TypeScript (5.4+), Vite, and Vitest all honor `package.json#imports` natively — no `tsconfig#paths`, no `resolve.alias`. Don't add them.
 - **Node baseline:** always the **latest LTS** everywhere — dev, CI matrix, published `engines.node`. Today that's Node 24. When a new LTS lands (typically October of even years), bump engines + CI in a same-day PR. Don't add lower-version compat paths, polyfills, or matrix entries for older Node.
-- **CI Playwright image:** CI runs inside `mcr.microsoft.com/playwright:vX.Y.Z-noble` (pinned in `.github/workflows/ci.yml`) so chromium + system deps are pre-installed and no `apt-get install` runs. When upgrading `playwright`, bump the image tag in the same PR to match the new version.
+- **CI Playwright image:** CI runs inside a GHCR mirror of the Playwright image, pinned in `.github/workflows/ci.yml` as `ghcr.io/<repo>/playwright:vX.Y.Z-noble`. Chromium + system deps come pre-installed; GHCR pulls are ~3-5s on GHA runners vs ~27s from MCR. The mirror is maintained by `.github/workflows/mirror-playwright.yml` (manual dispatch). **On Playwright upgrade:** (1) bump `playwright` in `apps/storybook/package.json`; (2) dispatch the Mirror Playwright workflow with the new tag; (3) verify the new tag under repo Packages; (4) update the `container.image` tag in `ci.yml` + this bullet in the same PR.
 - **Package manager:** pnpm@10.33.0 (workspaces); orchestration via Turborepo.
 - **Code style:** functional, avoid classes/singletons. No CSS-in-JS. No inline end-of-line comments.
 - **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`.


### PR DESCRIPTION
Closes #87

## Summary

Swap the CI job's container from \`mcr.microsoft.com/playwright:v1.59.1-noble\` to \`ghcr.io/\${{ github.repository }}/playwright:v1.59.1-noble\`, populated by the mirror workflow added in #88.

Expected: each CI run saves ~20-25s on the image pull because GHCR pulls share GHA's network edge (~3-5s steady-state vs ~27s from MCR).

CLAUDE.md bullet updated with the upgrade procedure (bump playwright → dispatch mirror → verify package → update \`ci.yml\` + bullet).

Milestone: _(none — CI hygiene)_
Plan impact: none

## Test plan

- [ ] This PR's own CI run passes with the GHCR image (image is already mirrored)
- [ ] Wall-clock shorter than the last main run's CI
- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` green locally