### PR TITLE
docs: icebox tokens-starter past v0.1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfun
 
 ## Current milestone
 
-`Current: M8 — Public starter + documentation` (M5 deferred — see `docs/decisions.md`)
+`Current: M8 — Public documentation` (M5 deferred, M8 starter iceboxed — see `docs/decisions.md`)
 
 Update this line when a milestone closes. See the matching GitHub milestones for per-issue state.
 

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -140,3 +140,15 @@ Dropped (TS 6 handles by default): `strict`, `module`, `target`, `esModuleIntero
 **Decision:** Apps and peer ranges pin `storybook@^10.3.5` and `@storybook/addon-vitest@^10.3.5`. The MCP addon is `@storybook/addon-mcp@^0.6.0`.
 
 **Rationale:** Latest matching the plan's "MCP support requires 10.3" gate.
+
+---
+
+## 2026-04-17 — Iceboxed `@unpunnyfuns/swatchbook-tokens` starter past v0.1.0
+
+**Context:** M8's original scope bundled three items: root README (#39), per-package READMEs (#38), and fleshing out `packages/tokens-starter` (#37) into a publishable slim pyramid with prebuilt CSS/JSON/types. The starter was positioned as a low-friction entry point — `pnpm add @unpunnyfuns/swatchbook-tokens` → import CSS → done.
+
+**Decision:** Drop #37 from M8. The starter stays in the repo as a build-pipeline smoke test for core, but isn't a v0.1.0 release blocker. Issue #37 de-milestoned (kept open, unassigned).
+
+**Rationale:** Consumers in the primary target audience (design-system teams) bring their own tokens — that's the whole point. The starter is "nice to have for tiny projects", not core value. Shipping it well means curating a defensible tasteful palette, which is effort that competes with getting the addon + blocks out the door. Revisit post-v0.1.0 once there's real signal for whether a starter is wanted at all.
+
+**Plan impact:** `docs/plan.md` → M8 renamed from "Public starter + documentation" to "Public documentation". Starter work explicitly noted as deferred in the M8 body.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -514,15 +514,16 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 **Exit:** `turbo run test:storybook` green in CI.
 **Demo:** CI run shows a green Storybook Test job with the expected number of passing tests.
 
-### M8 — Public starter + documentation
-**Goal:** A consumer can install swatchbook from npm and use it.
+### M8 — Public documentation
+**Goal:** A consumer can install swatchbook from npm and find their way.
 **Work:**
-- Flesh out `packages/tokens-starter`: slim ref + sys + 2 themes; prebuilt `dist/themes/*.json`, `dist/css/*.css`, `dist/index.{js,d.ts}`.
+- Root README: install flow, MCP startup order, link to each package. _(done in #92)_
 - READMEs per package (module name + one-liner, structure table, TS examples, ✅/❌ do's/don'ts).
-- Root README: install flow, MCP startup order, link to each package.
 
-**Exit:** `npm pack --dry-run` on each published package lists the expected files; cold `pnpm add` install in a throwaway repo works and CSS renders.
-**Demo:** `pnpm dlx create-vite demo && cd demo && pnpm add @unpunnyfuns/swatchbook-tokens` → import CSS → demo renders styled.
+**Exit:** `npm pack --dry-run` on each published package lists the expected files; cold `pnpm add` install in a throwaway repo works against a hand-rolled tokens folder.
+**Demo:** README flow copy-pasted into a fresh Vite+Storybook app — addon loads, panel lists tokens, theme switcher works.
+
+**Deferred:** Fleshing out `@unpunnyfuns/swatchbook-tokens` (slim pyramid + prebuilt CSS/JSON/types) — see `docs/decisions.md`. Consumers bring their own tokens for v0.1.0; the starter package is post-v0.1.0 polish, not a release blocker.
 
 ### M9 — v0.1.0 release
 **Goal:** First public release under `@unpunnyfuns`.


### PR DESCRIPTION
Refs #37

## Summary

- \`docs/plan.md\`: M8 renamed from "Public starter + documentation" → "Public documentation". Starter flesh-out explicitly noted as deferred post-v0.1.0 in the M8 body.
- \`docs/decisions.md\`: new ADR-lite entry with the *why* — consumers in our primary target audience bring their own tokens; curating a defensible starter palette is post-release polish that competes with getting the addon + blocks out the door.
- \`CLAUDE.md\`: Current-milestone line picks up the rename and notes the icebox alongside the M5 deferral.
- GitHub side (done out-of-band): issue #37 de-milestoned and commented; milestone #9 renamed via the API.

Milestone: M8 — Public documentation
Plan impact: update included

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck\` green (docs-only but ran for hygiene)
- [ ] docs/plan.md M8 section reads cleanly on GitHub preview