### PR TITLE
docs: per-package READMEs

### DIFF
--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,8 +1,6 @@
 # @unpunnyfuns/swatchbook-addon
 
-Storybook addon for DTCG design tokens. Wires a virtual token module into the preview, injects a per-theme stylesheet, and adds a theme switcher to the toolbar.
-
-> M3 preview wiring: toolbar comes from the addon's `globalTypes`. The full manager UI (rich toolbar chips + Tokens/Diagnostics panel) arrives in the next PR.
+Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview over a virtual module, renders a theme switcher in the toolbar and a browser + diagnostics panel, and ships a `useToken()` hook with typed paths.
 
 ## Install
 
@@ -10,14 +8,18 @@ Storybook addon for DTCG design tokens. Wires a virtual token module into the pr
 pnpm add -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
+Peer requirements: `storybook@^10.3`, `react` / `react-dom` 18+.
+
 ## Register
 
-```ts
-// .storybook/main.ts
-import type { StorybookConfig } from '@storybook/react-vite';
+`.storybook/main.ts` — CSF Next:
 
-const config: StorybookConfig = {
-  stories: ['../src/**/*.stories.@(ts|tsx)'],
+```ts
+import { defineMain } from '@storybook/react-vite/node';
+
+export default defineMain({
+  stories: ['../src/**/*.stories.@(ts|tsx)', '../src/**/*.mdx'],
+  framework: '@storybook/react-vite',
   addons: [
     {
       name: '@unpunnyfuns/swatchbook-addon',
@@ -26,25 +28,64 @@ const config: StorybookConfig = {
       },
     },
   ],
-  framework: '@storybook/react-vite',
-};
+});
+```
 
-export default config;
+`.storybook/preview.ts` — opt the preview into the addon's annotations (decorator, globalTypes, initialGlobals):
+
+```ts
+import { definePreview } from '@storybook/react-vite';
+import swatchbookAddon from '@unpunnyfuns/swatchbook-addon';
+
+export default definePreview({
+  addons: [swatchbookAddon()],
+});
 ```
 
 ## Options
 
-| Option       | Type                    | What                                                     |
-| ------------ | ----------------------- | -------------------------------------------------------- |
-| `config`     | `Config`                | Inline swatchbook config. Mutually exclusive with below. |
-| `configPath` | `string`                | Path to a config module relative to `.storybook/`.       |
+| Option       | Type     | What                                                              |
+| ------------ | -------- | ----------------------------------------------------------------- |
+| `config`     | `Config` | Inline swatchbook config. Mutually exclusive with `configPath`.   |
+| `configPath` | `string` | Path to a config module relative to `.storybook/`. Loaded via jiti so `.ts` / `.mts` / `.js` / `.mjs` all work. |
 
-Config files can be `.ts` / `.mts` / `.js` / `.mjs` — loaded via [jiti](https://github.com/unjs/jiti).
+## `useToken`
+
+```ts
+import { useToken } from '@unpunnyfuns/swatchbook-addon/hooks';
+
+function Card() {
+  const bg = useToken('color.sys.surface.default');
+  const radius = useToken('radius.sys.lg');
+  return (
+    <div style={{ background: bg.cssVar, borderRadius: radius.cssVar }}>
+      {bg.description}
+    </div>
+  );
+}
+```
+
+Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across themes; `value` flips with the active theme. Paths autocomplete from the generated `.swatchbook/tokens.d.ts` once the addon has run against your project.
 
 ## Per-story overrides
 
 ```ts
-export const DarkOnly: Story = {
+export const AlwaysDark = meta.story({
   parameters: { swatchbook: { theme: 'Dark' } },
-};
+});
 ```
+
+Any valid theme name — including stacked compositions like `'Light · Brand A'` — is accepted.
+
+## Do / don't
+
+- ✅ Use `useToken` for typed lookups when you need the resolved value at runtime (aria labels, conditional rendering, …).
+- ✅ Prefer `var(--…)` in CSS; `useToken().cssVar` gives you the right string programmatically.
+- ❌ Don't import from `virtual:swatchbook/tokens` directly in consumer code. Go through `useToken` / the panel / the doc blocks so the API stays stable if we change the virtual module's shape.
+- ❌ Don't combine `parameters.swatchbook.theme` *and* the toolbar for the same story — the parameter wins and the toolbar change won't stick.
+
+## See also
+
+- [`@unpunnyfuns/swatchbook-core`](../core) — the loader this addon wraps. Consume directly if you need DTCG processing outside Storybook.
+- [`@unpunnyfuns/swatchbook-blocks`](../blocks) — MDX doc blocks that build on this addon's virtual module.
+- [Project README](../../README.md) — the full install + wiring flow.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,6 +1,6 @@
 # @unpunnyfuns/swatchbook-blocks
 
-Storybook MDX doc blocks for DTCG design tokens. Drop-in React components for rendering token documentation inside `.mdx` pages or standard React stories.
+Storybook MDX doc blocks for DTCG design tokens. Drop-in React components for rendering token documentation inside `.mdx` pages or standard React stories. Self-mount the addon's CSS and react to the toolbar theme switcher; work inside the docs container even though story decorators don't.
 
 ## Install
 
@@ -8,30 +8,55 @@ Storybook MDX doc blocks for DTCG design tokens. Drop-in React components for re
 pnpm add @unpunnyfuns/swatchbook-blocks
 ```
 
-Requires `@unpunnyfuns/swatchbook-addon` to be registered in your Storybook config — the blocks consume its virtual token module and theme context.
+Requires `@unpunnyfuns/swatchbook-addon` to be registered in your Storybook config — the blocks consume its virtual token module.
 
 ## Blocks
 
-| Block              | What                                                             |
-| ------------------ | ---------------------------------------------------------------- |
-| `TokenTable`       | Columnar listing of tokens, filterable by path glob and `$type`. |
-| `ColorPalette`     | Swatch grid grouped by sub-path, optionally scoped to a group.   |
-| `TypographyScale`  | Each typography token rendered as a sample line using its value. |
-| `TokenDetail`      | Full per-token detail — type, description, per-theme values.     |
+| Block              | What                                                                |
+| ------------------ | ------------------------------------------------------------------- |
+| `TokenTable`       | Searchable table of tokens, filterable by path glob and `$type`.    |
+| `ColorPalette`     | Swatch grid grouped by sub-path (`groupBy` controls depth).         |
+| `TypographyScale`  | Each typography token rendered as a sample line using its own value.|
+| `TokenDetail`      | Single-token inspector — type, value, alias chain, per-theme table. |
+
+Shared: every block accepts a `caption` override and renders against the addon's `var(--<prefix>-…)` output.
 
 ## MDX example
 
 ```mdx
-import { TokenTable, ColorPalette } from '@unpunnyfuns/swatchbook-blocks';
+import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
 # Color tokens
 
-<ColorPalette group="color.sys" />
+<ColorPalette filter="color.sys.*" groupBy={3} />
 
 ## Every color token
 
-<TokenTable type="color" />
+<TokenTable filter="color.sys.*" type="color" />
+
+## Inspect one
+
+<TokenDetail path="color.sys.accent.bg" />
 ```
 
-✅ Blocks react to the active swatchbook theme — switching in the toolbar updates resolved values live.
-❌ Blocks can't run outside Storybook's preview/docs iframe — they rely on the addon's virtual token module.
+## Props
+
+```ts
+<TokenTable filter="color.sys.*" type="color" />
+<ColorPalette filter="color.sys.*" groupBy={3} />
+<TypographyScale filter="typography" sample="The quick brown fox" />
+<TokenDetail path="cmp.button.bg" />
+```
+
+## Do / don't
+
+- ✅ React to the active swatchbook theme — switching in the toolbar updates resolved values live, even on MDX docs pages.
+- ✅ Compose multiple blocks per MDX page — each mounts independently.
+- ❌ Don't run outside Storybook's preview/docs iframe — blocks rely on the addon's virtual token module.
+- ❌ Don't use `useGlobals` / `useArgs` from `storybook/preview-api` inside custom blocks you write — those are story-only hooks and throw in docs context. Subscribe to `addons.getChannel()` directly for globals reactivity.
+
+## See also
+
+- [`@unpunnyfuns/swatchbook-addon`](../addon) — required peer. Registers the virtual module and the toolbar.
+- [`@unpunnyfuns/swatchbook-core`](../core) — underlying loader.
+- [Project README](../../README.md) — install + wiring flow for the whole toolchain.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,88 @@
+# @unpunnyfuns/swatchbook-core
+
+Framework-free DTCG loader. Parses token files (via Terrazzo), resolves aliases, composes themes through any of three idioms — explicit layers, DTCG 2025.10 resolvers, or Tokens Studio `$themes` manifests — and emits CSS variables + TypeScript types. All three inputs normalize to the same internal shape; a core unit test pins byte-identical output across them.
+
+## Install
+
+```sh
+pnpm add @unpunnyfuns/swatchbook-core
+```
+
+## Public API
+
+| Export | Purpose |
+| --- | --- |
+| `defineSwatchbookConfig(config)` | Identity helper for a typed `swatchbook.config.ts`. |
+| `loadProject(config, cwd?)` | Parse + normalize — returns `Project { themes, themesResolved, graph, diagnostics, … }`. |
+| `resolveTheme(project, name)` | Pick a single composed theme out of a project. |
+| `emitCss(project, options?)` | Concatenated stylesheet, one `[data-theme="…"]` block per theme. |
+| `projectCss(project)` | Same as `emitCss` with project defaults applied. |
+| `emitTypes(project)` | TypeScript source declaring the token-path union + `SwatchbookTokenMap`. |
+| `resolveThemingMode(config)` | `'layered' | 'resolver' | 'manifest'` — which branch the config activates. |
+| Types | `Config`, `Theme`, `ThemeConfig`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
+
+## Minimal config
+
+```ts
+import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
+
+export default defineSwatchbookConfig({
+  tokens: ['tokens/**/*.json'],
+  manifest: 'tokens/$themes.manifest.json', // or `themes:` / `resolver:` — pick one
+  default: 'Light',
+  cssVarPrefix: 'sb',
+});
+```
+
+## Load + emit
+
+```ts
+import { loadProject, projectCss, emitTypes } from '@unpunnyfuns/swatchbook-core';
+
+const project = await loadProject(config, process.cwd());
+
+const css = projectCss(project);
+const dts = emitTypes(project);
+```
+
+`project.diagnostics` is always populated — severity is `'error' | 'warn' | 'info'`. The addon surfaces these in its Diagnostics panel; your own pipeline can inspect / `throw` on `severity === 'error'` as fits.
+
+## Three theming idioms, one shape
+
+```ts
+// A — explicit layers
+defineSwatchbookConfig({
+  tokens: ['tokens/**/*.json'],
+  themes: [
+    { name: 'Light', layers: ['ref/**', 'sys/**', 'cmp/**', 'themes/light.json'] },
+    { name: 'Dark',  layers: ['ref/**', 'sys/**', 'cmp/**', 'themes/dark.json'] },
+  ],
+});
+
+// B — DTCG 2025.10 resolver
+defineSwatchbookConfig({
+  tokens: ['tokens/**/*.json'],
+  resolver: 'tokens/resolver.json',
+});
+
+// C — Tokens Studio manifest
+defineSwatchbookConfig({
+  tokens: ['tokens/**/*.json'],
+  manifest: 'tokens/$themes.manifest.json',
+});
+```
+
+Mixing is an error surfaced during `loadProject`.
+
+## Do / don't
+
+- ✅ Use this package at build time — Node, scripts, SSR, storybook presets. It has no DOM or React dependency.
+- ✅ Treat `emitCss` output as the source of truth for CSS vars; don't parallel-hand-write them.
+- ❌ Don't import from `@terrazzo/parser` directly unless you need features core doesn't expose. Stay on the core surface so upgrades don't churn your code.
+- ❌ Don't ship the `Project` object to the browser — it's node-parsed and carries full raw-AST references. Use `emitCss` / `emitTypes` / `themesResolved` projections instead.
+
+## See also
+
+- [`@unpunnyfuns/swatchbook-addon`](../addon) — the Storybook wrapper. Uses `loadProject` at startup, exposes results over a virtual module.
+- [`@unpunnyfuns/swatchbook-blocks`](../blocks) — React doc blocks consumed from MDX.
+- [Project README](../../README.md) — install + wiring flow for the whole toolchain.

--- a/packages/tokens-starter/README.md
+++ b/packages/tokens-starter/README.md
@@ -2,6 +2,8 @@
 
 Minimal DTCG design-token starter set. Drop in for a working baseline; fork and extend.
 
+> **Status:** iceboxed past v0.1.0 — see `docs/decisions.md` (2026-04-17 entry). The package currently exists as a build-pipeline smoke test for `@unpunnyfuns/swatchbook-core`, not a public starter. Pin from npm at your own risk until v0.1.0 ships; the shape below is the intent, not yet a contract.
+
 ## Install
 
 ```sh


### PR DESCRIPTION
Closes #38

## Summary

Touches four READMEs so each published package has a consistent shell (module name + one-liner + structure table + TypeScript examples + do/don't + see-also cross-links), matching CLAUDE.md's README convention.

- **\`packages/core/README.md\`** — new. Public-API table, minimal \`defineSwatchbookConfig\` example, load + emit snippet, three theming idioms, do/don't, cross-links.
- **\`packages/addon/README.md\`** — overhauled. Dropped the stale "M3 preview wiring" note and the old \`StorybookConfig\` example; replaced with SB10 CSF Next (\`defineMain\` + \`definePreview({ addons: [swatchbookAddon()] })\`). Added \`useToken\` example, per-story override, do/don't, see-also.
- **\`packages/blocks/README.md\`** — updated. Fixed prop names (\`ColorPalette\` takes \`filter\`/\`groupBy\`, not \`group\`). Added \`TokenDetail\` example. Do/don't calls out the MDX-hooks gotcha (\`useGlobals\`/\`useArgs\` throw in docs context). Cross-linked.
- **\`packages/tokens-starter/README.md\`** — added a "iceboxed past v0.1.0" banner pointing at \`docs/decisions.md\` so anyone landing from npm knows the shape isn't yet a contract.

Milestone: M8 — Public documentation
Plan impact: none

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck\` green
- [ ] Each README renders cleanly on GitHub preview