### PR TITLE
test(core): share loaded Project across tests via beforeAll

### DIFF
--- a/packages/core/test/css.test.ts
+++ b/packages/core/test/css.test.ts
@@ -1,12 +1,13 @@
 import { dirname } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { manifestPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
 import { projectCss } from '#/emit';
 import { loadProject } from '#/load';
+import type { Project } from '#/types';
 
 const fixtureCwd = dirname(tokensDir);
 
-async function loadWithPrefix(prefix: string | undefined) {
+async function loadWithPrefix(prefix: string | undefined): Promise<Project> {
   return loadProject(
     {
       tokens: ['tokens/**/*.json'],
@@ -18,50 +19,38 @@ async function loadWithPrefix(prefix: string | undefined) {
   );
 }
 
-describe('projectCss — structure', () => {
-  it('emits one [data-theme] block per theme', async () => {
-    const project = await loadWithPrefix('sb');
-    const css = projectCss(project);
+describe('projectCss — with sb prefix', () => {
+  let project: Project;
+  let css: string;
+
+  beforeAll(async () => {
+    project = await loadWithPrefix('sb');
+    css = projectCss(project);
+  }, 30_000);
+
+  it('emits one [data-theme] block per theme', () => {
     for (const theme of project.themes) {
       expect(css).toContain(`[data-theme="${theme.name}"]`);
     }
   });
 
-  it('terminates with a trailing newline', async () => {
-    const project = await loadWithPrefix('sb');
-    expect(projectCss(project).endsWith('\n')).toBe(true);
+  it('terminates with a trailing newline', () => {
+    expect(css.endsWith('\n')).toBe(true);
   });
-});
 
-describe('projectCss — prefix', () => {
-  it('applies the prefix to variable names', async () => {
-    const project = await loadWithPrefix('sb');
-    const css = projectCss(project);
+  it('applies the prefix to variable names', () => {
     expect(css).toContain('--sb-color-sys-surface-default:');
     expect(css).not.toMatch(/^\s*--color-sys-surface-default:/m);
   });
 
-  it('applies the prefix to aliased var(…) references inside values', async () => {
-    const project = await loadWithPrefix('sb');
-    const css = projectCss(project);
+  it('applies the prefix to aliased var(…) references inside values', () => {
     // cmp.button.bg aliases color.sys.accent.bg; both sides of the reference should carry the prefix
     const line = css.split('\n').find((l) => l.includes('--sb-cmp-button-bg:'));
     expect(line).toBeDefined();
     expect(line).toMatch(/var\(--sb-color-sys-accent-bg\)/);
   });
 
-  it('omits the leading dash when prefix is empty', async () => {
-    const project = await loadWithPrefix('');
-    const css = projectCss(project);
-    expect(css).toContain('--color-sys-surface-default:');
-    expect(css).not.toContain('---color-sys-surface-default:');
-  });
-});
-
-describe('projectCss — DTCG type coverage', () => {
-  it('emits every primitive + composite type covered by the fixture', async () => {
-    const project = await loadWithPrefix('sb');
-    const css = projectCss(project);
+  it('emits every primitive + composite type covered by the fixture', () => {
     // color (primitive) — Terrazzo emits modern rgb() with percentage channels
     expect(css).toMatch(/--sb-color-ref-blue-500:\s*rgb\(/i);
     // dimension — 4px
@@ -85,12 +74,8 @@ describe('projectCss — DTCG type coverage', () => {
     // transition — composite
     expect(css).toMatch(/--sb-motion-sys-enter/);
   });
-});
 
-describe('projectCss — theme override consistency', () => {
-  it('sparse overrides in Dark theme flip the surface but keep size scale identical', async () => {
-    const project = await loadWithPrefix('sb');
-    const css = projectCss(project);
+  it('sparse overrides in Dark theme flip the surface but keep size scale identical', () => {
     const lightBlock = extractBlock(css, 'Light');
     const darkBlock = extractBlock(css, 'Dark');
     expect(lightBlock).toBeTruthy();
@@ -102,6 +87,15 @@ describe('projectCss — theme override consistency', () => {
     const lightSurface = grep(lightBlock, '--sb-color-sys-surface-default:');
     const darkSurface = grep(darkBlock, '--sb-color-sys-surface-default:');
     expect(lightSurface).not.toEqual(darkSurface);
+  });
+});
+
+describe('projectCss — empty prefix', () => {
+  it('omits the leading dash when prefix is empty', async () => {
+    const project = await loadWithPrefix('');
+    const css = projectCss(project);
+    expect(css).toContain('--color-sys-surface-default:');
+    expect(css).not.toContain('---color-sys-surface-default:');
   });
 });
 

--- a/packages/core/test/equivalence.test.ts
+++ b/packages/core/test/equivalence.test.ts
@@ -1,7 +1,8 @@
 import { dirname } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import { manifestPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
 import { loadProject, resolveTheme } from '#/load';
+import type { Project } from '#/types';
 
 /**
  * The plan's "three-way equivalence" promise is that the same logical
@@ -22,8 +23,11 @@ const LAYER_SETS = {
 };
 
 describe('layered ≡ manifest for shared compositions', () => {
-  it.each(['Light', 'Dark'])('%s resolves identically in both modes', async (themeName) => {
-    const [layered, manifest] = await Promise.all([
+  let layered: Project;
+  let manifest: Project;
+
+  beforeAll(async () => {
+    [layered, manifest] = await Promise.all([
       loadProject(
         {
           tokens: ['tokens/**/*.json'],
@@ -40,16 +44,14 @@ describe('layered ≡ manifest for shared compositions', () => {
         },
         fixtureCwd,
       ),
-      loadProject(
-        { tokens: ['tokens/**/*.json'], manifest: manifestPath },
-        fixtureCwd,
-      ),
+      loadProject({ tokens: ['tokens/**/*.json'], manifest: manifestPath }, fixtureCwd),
     ]);
+  }, 30_000);
 
+  it.each(['Light', 'Dark'])('%s resolves identically in both modes', (themeName) => {
     const layeredTokens = resolveTheme(layered, themeName).tokens;
     const manifestTokens = resolveTheme(manifest, themeName).tokens;
 
-    // Compare resolved values for every sys-layer token that both produce.
     const sysKeys = Object.keys(layeredTokens).filter((k) => k.includes('.sys.'));
     expect(sysKeys.length).toBeGreaterThan(20);
 

--- a/packages/core/test/load.test.ts
+++ b/packages/core/test/load.test.ts
@@ -1,20 +1,26 @@
 import { dirname, resolve } from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 import {
   manifestPath,
   resolverPath,
   tokensDir,
 } from '@unpunnyfuns/swatchbook-tokens-reference';
 import { loadProject, resolveTheme } from '#/load';
+import type { Project } from '#/types';
 
 const fixtureCwd = dirname(tokensDir);
 
 describe('loadProject — manifest mode', () => {
-  it('loads all 5 named compositions from the Tokens Studio manifest', async () => {
-    const project = await loadProject(
+  let project: Project;
+
+  beforeAll(async () => {
+    project = await loadProject(
       { tokens: ['tokens/**/*.json'], manifest: manifestPath, default: 'Light' },
       fixtureCwd,
     );
+  }, 30_000);
+
+  it('loads all 5 named compositions from the Tokens Studio manifest', () => {
     expect(project.themes.map((t) => t.name)).toEqual([
       'Light',
       'Dark',
@@ -25,22 +31,14 @@ describe('loadProject — manifest mode', () => {
     expect(Object.keys(project.graph).length).toBeGreaterThan(100);
   });
 
-  it('resolves deep alias chains (cmp → sys → ref)', async () => {
-    const project = await loadProject(
-      { tokens: ['tokens/**/*.json'], manifest: manifestPath, default: 'Light' },
-      fixtureCwd,
-    );
+  it('resolves deep alias chains (cmp → sys → ref)', () => {
     const light = resolveTheme(project, 'Light').tokens;
     const buttonBg = light['cmp.button.bg'];
     expect(buttonBg).toBeDefined();
     expect(buttonBg?.$type).toBe('color');
   });
 
-  it('produces different surface values for Light vs Dark', async () => {
-    const project = await loadProject(
-      { tokens: ['tokens/**/*.json'], manifest: manifestPath, default: 'Light' },
-      fixtureCwd,
-    );
+  it('produces different surface values for Light vs Dark', () => {
     const light = resolveTheme(project, 'Light').tokens['color.sys.surface.default'];
     const dark = resolveTheme(project, 'Dark').tokens['color.sys.surface.default'];
     expect(light).toBeDefined();
@@ -48,11 +46,7 @@ describe('loadProject — manifest mode', () => {
     expect(JSON.stringify(light?.$value)).not.toEqual(JSON.stringify(dark?.$value));
   });
 
-  it('throws on unknown theme name', async () => {
-    const project = await loadProject(
-      { tokens: ['tokens/**/*.json'], manifest: manifestPath, default: 'Light' },
-      fixtureCwd,
-    );
+  it('throws on unknown theme name', () => {
     expect(() => resolveTheme(project, 'Nope')).toThrow(/unknown theme/i);
   });
 });


### PR DESCRIPTION
Closes #100

## Summary

Each test in core's suite was re-running \`loadProject\` (full DTCG parse + Terrazzo normalize) even when configs were identical. On cold GHA runners this was pushing the equivalence test past vitest's 5s default. Refactoring to \`beforeAll\` fixtures cuts total core-test time from ~4s → ~1.3s locally and gives wide margin against the default, so no \`testTimeout\` bump is needed.

### Per file

- \`equivalence.test.ts\` — load layered + manifest once in \`beforeAll\`, reuse across both theme-name cases (previously one pair per case).
- \`css.test.ts\` — the six-test \`sb\`-prefix block now shares a single loaded project; the empty-prefix test stays in its own describe since its config differs.
- \`load.test.ts\` — four manifest-mode invariants share one project; resolver-mode and layered-mode tests keep their standalone loads (one per config shape, nothing to share).

Each \`beforeAll\` carries a 30s safety timeout purely for the one-time setup on a cold CI runner.

Milestone: _(none — hygiene)_
Plan impact: none

## Test plan

- [x] \`pnpm turbo run test --force --filter=@unpunnyfuns/swatchbook-core\` — 24 tests, 1.34s total (was ~4s)
- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` green