### PR TITLE
feat(blocks): add DimensionScale block

### DIFF
--- a/.changeset/dimension-scale-block.md
+++ b/.changeset/dimension-scale-block.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+Add `DimensionScale` block: renders dimension tokens (`space.*`, `radius.*`, `size.*`, or any `$type: 'dimension'`) as visible bars sized to the token's actual value. Three visualization kinds — `'length'` (horizontal bar, default), `'radius'` (sample square with the token applied as `border-radius`), `'size'` (square box sized to the token). Bars wider than 480px are capped with a visible marker so extreme tokens don't break the layout. Sorted ascending by computed pixel value; ties broken by path.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfun
 
 ## Current milestone
 
-`Current: DTCG spec convergence` — see `docs/decisions.md` for the deferrals (color control, tokens-starter) carried into this phase.
+`Current: DTCG comprehension visualizations` — every token type earns a block that makes its value legible. Five sibling issues seeded (#108–#113). First pickup: #108 DimensionScale.
 
 Update this line when a milestone closes. See the matching GitHub milestones for per-issue state.
 

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -1,5 +1,6 @@
 import {
   ColorPalette,
+  DimensionScale,
   TokenDetail,
   TokenTable,
   TypographyScale,
@@ -67,6 +68,25 @@ export const TokenTableRenders = meta.story({
     expect(headerTexts).toEqual(expect.arrayContaining(['Path', 'Type', 'Value']));
     const rows = canvasElement.querySelectorAll('tbody tr');
     expect(rows.length, 'table must render at least one row').toBeGreaterThan(0);
+  },
+});
+
+/**
+ * `DimensionScale` must render one bar per dimension token, and each bar's
+ * rendered width must reflect the underlying cssVar (i.e. non-zero for
+ * tokens with a non-zero value — space.sys.md is 12px).
+ */
+export const DimensionScaleRenders = meta.story({
+  render: () => <DimensionScale filter='space.sys.*' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'div[aria-hidden="true"]');
+    const bars = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    expect(bars.length, 'DimensionScale must render at least one bar').toBeGreaterThan(0);
+    const nonZeroWidths = bars.map((bar) => bar.getBoundingClientRect().width).filter((w) => w > 0);
+    expect(
+      nonZeroWidths.length,
+      'at least one bar must resolve to a non-zero width',
+    ).toBeGreaterThan(0);
   },
 });
 

--- a/apps/storybook/src/stories/DimensionScale.stories.tsx
+++ b/apps/storybook/src/stories/DimensionScale.stories.tsx
@@ -1,0 +1,18 @@
+import { DimensionScale } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/DimensionScale',
+  component: DimensionScale,
+  argTypes: {
+    filter: { control: 'text' },
+    kind: { control: 'select', options: ['length', 'radius', 'size'] },
+  },
+});
+
+export default meta;
+
+export const SpaceSystem = meta.story({ args: { filter: 'space.sys.*' } });
+export const RadiusSystem = meta.story({ args: { filter: 'radius.sys.*', kind: 'radius' } });
+export const SizeReferencePx = meta.story({ args: { filter: 'size.ref.*', kind: 'size' } });
+export const All = meta.story();

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -1,0 +1,213 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export type DimensionKind = 'length' | 'radius' | 'size';
+
+export interface DimensionScaleProps {
+  /**
+   * Token-path filter. Defaults to every `dimension` token. Use e.g.
+   * `"space.sys.*"` to scope to the spacing scale.
+   */
+  filter?: string;
+  /**
+   * Visualization kind:
+   * - `'length'` (default): horizontal bar whose width equals the token's dimension.
+   * - `'radius'`: 56×56 square with the token applied as `border-radius`.
+   * - `'size'`: a square sized to the token's dimension.
+   */
+  kind?: DimensionKind;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const MAX_RENDER_PX = 480;
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
+    gap: 16,
+    alignItems: 'center',
+    padding: '10px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  specs: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+  visualCell: {
+    display: 'flex',
+    alignItems: 'center',
+    minWidth: 0,
+  } satisfies CSSProperties,
+  bar: {
+    height: 14,
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+    borderRadius: 2,
+    minWidth: 1,
+  } satisfies CSSProperties,
+  radiusSample: {
+    width: 56,
+    height: 56,
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',
+  } satisfies CSSProperties,
+  sizeSample: {
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',
+    minWidth: 1,
+    minHeight: 1,
+  } satisfies CSSProperties,
+  cssVar: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    opacity: 0.7,
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+  cap: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 10,
+    opacity: 0.6,
+    marginLeft: 6,
+  } satisfies CSSProperties,
+};
+
+interface Row {
+  path: string;
+  cssVar: string;
+  displayValue: string;
+  pxValue: number;
+  capped: boolean;
+}
+
+/**
+ * Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
+ * purpose of ordering and deciding whether to cap the rendered bar. Returns
+ * `NaN` for units we can't reasonably approximate (ex / ch / %), which the
+ * caller treats as "render at cssVar but don't cap or sort numerically".
+ */
+function toPixels(raw: unknown): number {
+  if (raw == null || typeof raw !== 'object') return Number.NaN;
+  const v = raw as { value?: unknown; unit?: unknown };
+  if (typeof v.value !== 'number' || typeof v.unit !== 'string') return Number.NaN;
+  switch (v.unit) {
+    case 'px':
+      return v.value;
+    case 'rem':
+    case 'em':
+      return v.value * 16;
+    default:
+      return Number.NaN;
+  }
+}
+
+export function DimensionScale({
+  filter = 'dimension',
+  kind = 'length',
+  caption,
+}: DimensionScaleProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo(() => {
+    const collected: Row[] = [];
+    for (const [path, token] of Object.entries(resolved)) {
+      if (token.$type !== 'dimension') continue;
+      if (!globMatch(path, filter)) continue;
+      const pxValue = toPixels(token.$value);
+      collected.push({
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        displayValue: formatValue(token.$value),
+        pxValue,
+        capped: Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX,
+      });
+    }
+    collected.sort((a, b) => {
+      if (Number.isFinite(a.pxValue) && Number.isFinite(b.pxValue)) return a.pxValue - b.pxValue;
+      return a.path.localeCompare(b.path);
+    });
+    return collected;
+  }, [resolved, filter, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} dimension${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.empty}>No dimension tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            <span style={styles.specs}>{row.displayValue}</span>
+          </div>
+          <div style={styles.visualCell}>
+            {renderVisual(row, kind)}
+            {row.capped && <span style={styles.cap}>capped at {MAX_RENDER_PX}px</span>}
+          </div>
+          <span style={styles.cssVar}>{row.cssVar}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function renderVisual(row: Row, kind: DimensionKind): ReactElement {
+  const cappedValue = row.capped ? `${MAX_RENDER_PX}px` : row.cssVar;
+  switch (kind) {
+    case 'radius':
+      return <div style={{ ...styles.radiusSample, borderRadius: row.cssVar }} aria-hidden />;
+    case 'size':
+      return (
+        <div
+          style={{ ...styles.sizeSample, width: cappedValue, height: cappedValue }}
+          aria-hidden
+        />
+      );
+    case 'length':
+    default:
+      return <div style={{ ...styles.bar, width: cappedValue }} aria-hidden />;
+  }
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,4 +1,5 @@
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
+export { DimensionScale, type DimensionKind, type DimensionScaleProps } from '#/DimensionScale.tsx';
 export { TokenDetail, type TokenDetailProps } from '#/TokenDetail.tsx';
 export { TokenTable, type TokenTableProps } from '#/TokenTable.tsx';
 export { TypographyScale, type TypographyScaleProps } from '#/TypographyScale.tsx';


### PR DESCRIPTION
Closes #108

## Summary

First deliverable in the DTCG comprehension visualizations milestone. A new MDX doc block that renders dimension tokens as visible bars sized to the token's actual value — so "is \`space.sys.md\` twice \`space.sys.sm\`?" is legible at a glance without mental math.

### Shape

\`\`\`tsx
<DimensionScale filter="space.sys.*" />                  // horizontal bars
<DimensionScale filter="radius.sys.*" kind="radius" />   // rounded-corner samples
<DimensionScale filter="size.ref.*" kind="size" />       // square boxes
\`\`\`

Three visualization kinds (\`'length'\` default, \`'radius'\`, \`'size'\`). Rows sort ascending by computed pixel value; ties broken by path. Bars > 480px cap with a visible marker so extreme values don't break the layout. Only \`px\` / \`rem\` / \`em\` units are coerced to pixels for ordering and capping; other units render at the cssVar and fall back to path-order.

### Tests

- Display stories under \`Blocks/DimensionScale\` exercise space / radius / size variants.
- \`Tests/BlockAssertions\` gains a \`DimensionScaleRenders\` play-fn that asserts at least one rendered bar has non-zero \`getBoundingClientRect\` width.
- 42/42 storybook interaction tests pass locally.

### Housekeeping

- \`CLAUDE.md\` Current-milestone line advances to *DTCG comprehension visualizations*; remaining sibling issues (#109–#113) noted.
- \`.changeset/dimension-scale-block.md\` — \`minor\` on \`@unpunnyfuns/swatchbook-blocks\`. Release stays postponed but the changeset accumulates for whenever we unpause.

Milestone: DTCG comprehension visualizations
Plan impact: none

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test build --force\` green (17/17 tasks)
- [x] \`pnpm turbo run test:storybook --force\` green (42/42 tests)