### PR TITLE
feat(blocks): add ShadowPreview and BorderPreview blocks

### DIFF
--- a/.changeset/shadow-border-preview-blocks.md
+++ b/.changeset/shadow-border-preview-blocks.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+Add `ShadowPreview` and `BorderPreview` blocks. Each renders its composite tokens by applying them to a sample element, so the visual effect is legible — not just the sub-value string. Sub-values (offset, blur, spread, color for shadows; width, style, color for borders) appear next to the sample as a breakdown. `ShadowPreview` handles layered shadows (DTCG shadow values can be arrays) with a per-layer breakdown.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -1,6 +1,8 @@
 import {
+  BorderPreview,
   ColorPalette,
   DimensionScale,
+  ShadowPreview,
   TokenDetail,
   TokenTable,
   TypographyScale,
@@ -86,6 +88,46 @@ export const DimensionScaleRenders = meta.story({
     expect(
       nonZeroWidths.length,
       'at least one bar must resolve to a non-zero width',
+    ).toBeGreaterThan(0);
+  },
+});
+
+/**
+ * `ShadowPreview` must render a sample with a non-empty `box-shadow`
+ * computed style for at least one shadow token.
+ */
+export const ShadowPreviewRenders = meta.story({
+  render: () => <ShadowPreview filter='shadow.sys.*' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'div[aria-hidden="true"]');
+    const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const withShadow = samples.filter((el) => {
+      const bs = getComputedStyle(el).boxShadow;
+      return bs && bs !== 'none';
+    });
+    expect(
+      withShadow.length,
+      'at least one sample must resolve to a non-none box-shadow',
+    ).toBeGreaterThan(0);
+  },
+});
+
+/**
+ * `BorderPreview` must render a sample whose computed `border-style` is not
+ * `none` for at least one border token.
+ */
+export const BorderPreviewRenders = meta.story({
+  render: () => <BorderPreview filter='border.sys.*' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'div[aria-hidden="true"]');
+    const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const withBorder = samples.filter((el) => {
+      const style = getComputedStyle(el).borderTopStyle;
+      return style && style !== 'none';
+    });
+    expect(
+      withBorder.length,
+      'at least one sample must resolve to a non-none border-style',
     ).toBeGreaterThan(0);
   },
 });

--- a/apps/storybook/src/stories/BorderPreview.stories.tsx
+++ b/apps/storybook/src/stories/BorderPreview.stories.tsx
@@ -1,0 +1,15 @@
+import { BorderPreview } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/BorderPreview',
+  component: BorderPreview,
+  argTypes: {
+    filter: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const SystemBorders = meta.story({ args: { filter: 'border.sys.*' } });
+export const All = meta.story();

--- a/apps/storybook/src/stories/ShadowPreview.stories.tsx
+++ b/apps/storybook/src/stories/ShadowPreview.stories.tsx
@@ -1,0 +1,15 @@
+import { ShadowPreview } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/ShadowPreview',
+  component: ShadowPreview,
+  argTypes: {
+    filter: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const SystemShadows = meta.story({ args: { filter: 'shadow.sys.*' } });
+export const All = meta.story();

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -1,0 +1,177 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface BorderPreviewProps {
+  /**
+   * Token-path filter. Defaults to every `border` token. Use e.g.
+   * `"border.sys.*"` to scope to the semantic layer.
+   */
+  filter?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 140px 1fr',
+    gap: 16,
+    alignItems: 'center',
+    padding: '14px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  cssVar: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+  sampleCell: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  } satisfies CSSProperties,
+  sample: {
+    width: 120,
+    height: 56,
+    background: 'var(--sb-color-sys-surface-raised, transparent)',
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  breakdown: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr',
+    columnGap: 12,
+    rowGap: 2,
+  } satisfies CSSProperties,
+  breakdownKey: {
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface BorderValue {
+  color?: unknown;
+  width?: unknown;
+  style?: unknown;
+}
+
+interface Row {
+  path: string;
+  cssVar: string;
+  value: BorderValue;
+}
+
+function formatDimension(raw: unknown): string {
+  if (raw == null) return '—';
+  if (typeof raw === 'number') return String(raw);
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') {
+    const v = raw as { value?: unknown; unit?: unknown };
+    if (typeof v.value === 'number' && typeof v.unit === 'string') {
+      return `${v.value}${v.unit}`;
+    }
+  }
+  return JSON.stringify(raw);
+}
+
+function formatColor(raw: unknown): string {
+  if (raw == null) return '—';
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') {
+    const v = raw as { components?: unknown; alpha?: unknown; colorSpace?: unknown };
+    if (Array.isArray(v.components) && typeof v.colorSpace === 'string') {
+      const parts = v.components.map((c) => (typeof c === 'number' ? c.toFixed(3) : String(c)));
+      const alpha = typeof v.alpha === 'number' && v.alpha !== 1 ? `, ${v.alpha}` : '';
+      return `${v.colorSpace}(${parts.join(' ')}${alpha})`;
+    }
+  }
+  return JSON.stringify(raw);
+}
+
+export function BorderPreview({ filter = 'border', caption }: BorderPreviewProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo(() => {
+    const collected: Row[] = [];
+    for (const [path, token] of Object.entries(resolved)) {
+      if (token.$type !== 'border') continue;
+      if (!globMatch(path, filter)) continue;
+      collected.push({
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        value: (token.$value ?? {}) as BorderValue,
+      });
+    }
+    collected.sort((a, b) => a.path.localeCompare(b.path));
+    return collected;
+  }, [resolved, filter, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} border${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.empty}>No border tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            <span style={styles.cssVar}>{row.cssVar}</span>
+          </div>
+          <div style={styles.sampleCell}>
+            <div style={{ ...styles.sample, border: row.cssVar }} aria-hidden />
+          </div>
+          <div style={styles.breakdown}>
+            <span style={styles.breakdownKey}>width</span>
+            <span>{formatDimension(row.value.width)}</span>
+            <span style={styles.breakdownKey}>style</span>
+            <span>{row.value.style != null ? String(row.value.style) : '—'}</span>
+            <span style={styles.breakdownKey}>color</span>
+            <span>{formatColor(row.value.color)}</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -1,0 +1,242 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface ShadowPreviewProps {
+  /**
+   * Token-path filter. Defaults to every `shadow` token. Use e.g.
+   * `"shadow.sys.*"` to scope to the semantic layer.
+   */
+  filter?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 140px 1fr',
+    gap: 16,
+    alignItems: 'center',
+    padding: '16px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  cssVar: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+  sampleCell: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 96,
+  } satisfies CSSProperties,
+  sample: {
+    width: 120,
+    height: 56,
+    background: 'var(--sb-color-sys-surface-raised, #fff)',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  breakdown: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr',
+    columnGap: 12,
+    rowGap: 2,
+  } satisfies CSSProperties,
+  breakdownKey: {
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  layerHeader: {
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+    marginTop: 6,
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface ShadowLayer {
+  color?: unknown;
+  offsetX?: unknown;
+  offsetY?: unknown;
+  blur?: unknown;
+  spread?: unknown;
+  inset?: unknown;
+}
+
+interface Row {
+  path: string;
+  cssVar: string;
+  layers: ShadowLayer[];
+}
+
+function formatDimension(raw: unknown): string {
+  if (raw == null) return '—';
+  if (typeof raw === 'number') return String(raw);
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') {
+    const v = raw as { value?: unknown; unit?: unknown };
+    if (typeof v.value === 'number' && typeof v.unit === 'string') {
+      return `${v.value}${v.unit}`;
+    }
+  }
+  return JSON.stringify(raw);
+}
+
+function formatColor(raw: unknown): string {
+  if (raw == null) return '—';
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') {
+    const v = raw as { components?: unknown; alpha?: unknown; colorSpace?: unknown };
+    if (Array.isArray(v.components) && typeof v.colorSpace === 'string') {
+      const parts = v.components.map((c) => (typeof c === 'number' ? c.toFixed(3) : String(c)));
+      const alpha = typeof v.alpha === 'number' && v.alpha !== 1 ? `, ${v.alpha}` : '';
+      return `${v.colorSpace}(${parts.join(' ')}${alpha})`;
+    }
+  }
+  return JSON.stringify(raw);
+}
+
+function asLayers(raw: unknown): ShadowLayer[] {
+  if (Array.isArray(raw)) return raw as ShadowLayer[];
+  if (raw && typeof raw === 'object') return [raw as ShadowLayer];
+  return [];
+}
+
+function layerKey(path: string, layer: ShadowLayer, fallback: number): string {
+  const off = `${formatDimension(layer.offsetX)},${formatDimension(layer.offsetY)}`;
+  const blur = formatDimension(layer.blur);
+  const spread = formatDimension(layer.spread);
+  return `${path}|${off}|${blur}|${spread}|${fallback}`;
+}
+
+export function ShadowPreview({ filter = 'shadow', caption }: ShadowPreviewProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo(() => {
+    const collected: Row[] = [];
+    for (const [path, token] of Object.entries(resolved)) {
+      if (token.$type !== 'shadow') continue;
+      if (!globMatch(path, filter)) continue;
+      collected.push({
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        layers: asLayers(token.$value),
+      });
+    }
+    collected.sort((a, b) => a.path.localeCompare(b.path));
+    return collected;
+  }, [resolved, filter, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} shadow${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.empty}>No shadow tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            <span style={styles.cssVar}>{row.cssVar}</span>
+          </div>
+          <div style={styles.sampleCell}>
+            <div style={{ ...styles.sample, boxShadow: row.cssVar }} aria-hidden />
+          </div>
+          <div style={styles.breakdown}>
+            {row.layers.length === 1
+              ? renderLayer(row.layers[0])
+              : row.layers.map((layer, i) => (
+                  <Layer
+                    key={layerKey(row.path, layer, i)}
+                    layer={layer}
+                    index={i}
+                    total={row.layers.length}
+                  />
+                ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function renderLayer(layer: ShadowLayer | undefined): ReactElement[] {
+  if (!layer) return [];
+  const entries: [string, string][] = [
+    ['offset', `${formatDimension(layer.offsetX)} ${formatDimension(layer.offsetY)}`],
+    ['blur', formatDimension(layer.blur)],
+    ['spread', formatDimension(layer.spread)],
+    ['color', formatColor(layer.color)],
+  ];
+  if (layer.inset) entries.push(['inset', String(layer.inset)]);
+  return entries.flatMap(([k, v]) => [
+    <span key={`k-${k}`} style={styles.breakdownKey}>
+      {k}
+    </span>,
+    <span key={`v-${k}`}>{v}</span>,
+  ]);
+}
+
+function Layer({
+  layer,
+  index,
+  total,
+}: {
+  layer: ShadowLayer;
+  index: number;
+  total: number;
+}): ReactElement {
+  return (
+    <div style={{ gridColumn: '1 / -1' }}>
+      <div style={styles.layerHeader}>
+        layer {index + 1} of {total}
+      </div>
+      <div style={{ ...styles.breakdown, marginTop: 2 }}>{renderLayer(layer)}</div>
+    </div>
+  );
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,5 +1,7 @@
+export { BorderPreview, type BorderPreviewProps } from '#/BorderPreview.tsx';
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
 export { DimensionScale, type DimensionKind, type DimensionScaleProps } from '#/DimensionScale.tsx';
+export { ShadowPreview, type ShadowPreviewProps } from '#/ShadowPreview.tsx';
 export { TokenDetail, type TokenDetailProps } from '#/TokenDetail.tsx';
 export { TokenTable, type TokenTableProps } from '#/TokenTable.tsx';
 export { TypographyScale, type TypographyScaleProps } from '#/TypographyScale.tsx';


### PR DESCRIPTION
Closes #110
Closes #112

Stacked on #114 (DimensionScale). When #114 merges, rebase to \`main\`.

## Summary

Two composite-token preview blocks that render the token by applying it to a sample element, with a sub-value breakdown alongside. Companion to DimensionScale; same visual-legibility thesis.

### Shapes

\`\`\`tsx
<ShadowPreview filter="shadow.sys.*" />
<BorderPreview filter="border.sys.*" />
\`\`\`

- **ShadowPreview** — 120×56 card with \`box-shadow: var(--…)\` + offset / blur / spread / color breakdown. Handles DTCG shadow-list values (layered shadows like \`shadow.sys.lg\`) with per-layer sections.
- **BorderPreview** — same card shape with \`border\` + width / style / color breakdown.

### a11y

Initial draft used \`opacity: 0.5\`/\`0.6\` for secondary labels; axe \`color-contrast\` rule (running at \`test: 'error'\` in preview) flagged both. Labels now use \`var(--sb-color-sys-text-muted)\` with a \`CanvasText\` fallback — passes contrast on both themes in the reference fixture.

### Tests

Display stories + \`Tests/BlockAssertions\` play-fns asserting the sample elements resolve to a non-\`none\` \`box-shadow\` / \`border-style\`. 48/48 storybook tests pass.

### Housekeeping

\`.changeset/shadow-border-preview-blocks.md\` — \`minor\` on \`@unpunnyfuns/swatchbook-blocks\`.

Milestone: DTCG comprehension visualizations
Plan impact: none

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test build test:storybook --force\` green