### PR TITLE
feat(blocks): composite previews in TokenDetail

### DIFF
--- a/.changeset/token-detail-composite-previews.md
+++ b/.changeset/token-detail-composite-previews.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`TokenDetail` now renders live previews for composite token types in its Resolved-value section. Typography tokens get a pangram sample styled via the emitted sub-vars (font-family / font-size / font-weight / line-height / letter-spacing); shadow and border tokens get a sample card with the effect applied; transition tokens get an animated ball using the composite's duration + easing. Color tokens keep their swatch. The preview sits above the formatted value text — one read gives you "what it looks like" and "what its sub-values are" together.
+
+Reduced-motion compliance: transition previews swap to an inline "Animation suppressed" notice when `prefers-reduced-motion: reduce` is set. `usePrefersReducedMotion` lifted to `internal/prefers-reduced-motion.ts` so it's shared with `MotionPreview`.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -193,6 +193,44 @@ export const TokenDetailRenders = meta.story({
 });
 
 /**
+ * `TokenDetail` for a composite token type renders a live preview of the
+ * composite — typography as a pangram sample, shadow/border as a card with
+ * the effect applied, transition as an animated ball.
+ */
+export const TokenDetailTypographyComposite = meta.story({
+  render: () => <TokenDetail path='typography.sys.heading' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const sample = [...canvasElement.querySelectorAll<HTMLElement>('div')].find((el) =>
+      el.textContent?.startsWith('Sphinx of black quartz'),
+    );
+    expect(sample, 'typography composite must render a pangram sample').toBeTruthy();
+    if (sample) {
+      expect(
+        getComputedStyle(sample).fontFamily,
+        'sample must resolve a concrete font-family',
+      ).not.toBe('');
+    }
+  },
+});
+
+export const TokenDetailShadowComposite = meta.story({
+  render: () => <TokenDetail path='shadow.sys.md' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const withShadow = samples.filter((el) => {
+      const bs = getComputedStyle(el).boxShadow;
+      return bs && bs !== 'none';
+    });
+    expect(
+      withShadow.length,
+      'shadow composite must render a sample with non-none box-shadow',
+    ).toBeGreaterThan(0);
+  },
+});
+
+/**
  * `TokenDetail` for a missing path must render its empty state rather than
  * throwing.
  */

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export type MotionSpeed = 0.25 | 0.5 | 1 | 2;
@@ -222,19 +223,6 @@ function asEasing(
     }
   }
   return fallback;
-}
-
-function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setReduced(query.matches);
-    const onChange = (e: MediaQueryListEvent): void => setReduced(e.matches);
-    query.addEventListener('change', onChange);
-    return () => query.removeEventListener('change', onChange);
-  }, []);
-  return reduced;
 }
 
 export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactElement {

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { formatValue, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface TokenDetailProps {
@@ -113,6 +114,45 @@ const styles = {
     padding: 12,
     opacity: 0.7,
   } satisfies CSSProperties,
+  typographySample: {
+    padding: '8px 0',
+  } satisfies CSSProperties,
+  shadowSample: {
+    width: 140,
+    height: 56,
+    background: 'var(--sb-color-sys-surface-raised, #fff)',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  borderSample: {
+    width: 140,
+    height: 56,
+    background: 'var(--sb-color-sys-surface-raised, transparent)',
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  motionTrack: {
+    position: 'relative',
+    height: 32,
+    width: '100%',
+    maxWidth: 320,
+    background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.08))',
+    borderRadius: 16,
+    overflow: 'hidden',
+  } satisfies CSSProperties,
+  motionBall: {
+    position: 'absolute',
+    top: '50%',
+    width: 24,
+    height: 24,
+    marginTop: -12,
+    borderRadius: '50%',
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+  } satisfies CSSProperties,
+  reducedMotion: {
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+    fontStyle: 'italic',
+  } satisfies CSSProperties,
 };
 
 export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
@@ -153,6 +193,7 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
       {token.$description && <p style={styles.description}>{token.$description}</p>}
 
       <div style={styles.sectionHeader}>Resolved value · {activeTheme}</div>
+      <CompositePreview type={token.$type} cssVar={cssVar} />
       <div style={styles.chain}>
         {isColor && <span style={{ ...styles.swatch, background: cssVar }} aria-hidden />}
         <span>{value}</span>
@@ -202,6 +243,87 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
 
       <div style={styles.sectionHeader}>Usage</div>
       <code style={styles.snippet}>{`color: ${cssVar};`}</code>
+    </div>
+  );
+}
+
+const PANGRAM = 'Sphinx of black quartz, judge my vow.';
+
+function CompositePreview({
+  type,
+  cssVar,
+}: {
+  type: string | undefined;
+  cssVar: string;
+}): ReactElement | null {
+  if (type === 'typography') {
+    // cssVar for a composite looks like `var(--…-<path>)`; the emitter also
+    // emits sub-vars named `--…-<path>-font-family`, `-font-size`, etc.
+    // Peel the `var(--…)` wrapping to reuse the base name.
+    const base = cssVar.replace(/^var\(/, '').replace(/\)$/, '');
+    return (
+      <div
+        style={{
+          ...styles.typographySample,
+          fontFamily: `var(${base}-font-family)`,
+          fontSize: `var(${base}-font-size)`,
+          fontWeight: `var(${base}-font-weight)` as unknown as number,
+          lineHeight: `var(${base}-line-height)` as unknown as number,
+          letterSpacing: `var(${base}-letter-spacing)`,
+        }}
+      >
+        {PANGRAM}
+      </div>
+    );
+  }
+  if (type === 'shadow') {
+    return <div style={{ ...styles.shadowSample, boxShadow: cssVar }} aria-hidden />;
+  }
+  if (type === 'border') {
+    return <div style={{ ...styles.borderSample, border: cssVar }} aria-hidden />;
+  }
+  if (type === 'transition') {
+    return <TransitionSample cssVar={cssVar} />;
+  }
+  return null;
+}
+
+function TransitionSample({ cssVar }: { cssVar: string }): ReactElement {
+  const reduced = usePrefersReducedMotion();
+  const [phase, setPhase] = useState<0 | 1>(0);
+
+  useEffect(() => {
+    if (reduced) return;
+    // Loop between 0 and 1 at a fixed cadence a bit slower than the token's
+    // own duration so the easing curve is perceptible.
+    const id = requestAnimationFrame(() => setPhase(1));
+    const loop = window.setInterval(() => {
+      setPhase((p) => (p === 0 ? 1 : 0));
+    }, 1200);
+    return () => {
+      cancelAnimationFrame(id);
+      window.clearInterval(loop);
+    };
+  }, [reduced]);
+
+  if (reduced) {
+    return (
+      <div style={styles.reducedMotion}>
+        Animation suppressed by `prefers-reduced-motion: reduce`.
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.motionTrack}>
+      <div
+        style={{
+          ...styles.motionBall,
+          left: phase === 1 ? 'calc(100% - 28px)' : '4px',
+          transition: cssVar,
+        }}
+        aria-hidden
+      />
     </div>
   );
 }

--- a/packages/blocks/src/internal/prefers-reduced-motion.ts
+++ b/packages/blocks/src/internal/prefers-reduced-motion.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Reactive `prefers-reduced-motion: reduce` detector. Returns the current
+ * match and updates if the user toggles the OS-level preference.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(query.matches);
+    const onChange = (e: MediaQueryListEvent): void => setReduced(e.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
+  return reduced;
+}


### PR DESCRIPTION
Closes #113

## Summary

\`TokenDetail\`'s Resolved-value section gains live previews for composite token types, so one read gives the viewer "what it looks like" and "what its sub-values are" together.

| \`\$type\` | Preview |
| --- | --- |
| \`color\` | Swatch (as before) |
| \`typography\` | Pangram sample styled via emitted sub-vars (\`-font-family\` / \`-font-size\` / \`-font-weight\` / \`-line-height\` / \`-letter-spacing\`) — no JS parsing of the \`\$value\` object needed |
| \`shadow\` | 140×56 card with \`box-shadow\` applied |
| \`border\` | 140×56 card with \`border\` applied |
| \`transition\` | Compact animated ball using the composite as the \`transition\` shorthand; respects \`prefers-reduced-motion: reduce\` with an inline "Animation suppressed" notice |

## Internals

- \`usePrefersReducedMotion\` lifted from \`MotionPreview\` to \`internal/prefers-reduced-motion.ts\` so both consumers share one hook.
- Composite-preview rendering stays inline in \`TokenDetail.tsx\` — small enough that a shared helper wouldn't pay rent yet.

## Tests

Two new \`Tests/BlockAssertions\` play-fns:
- \`TokenDetailTypographyComposite\` — pangram renders with a resolved \`font-family\`.
- \`TokenDetailShadowComposite\` — sample resolves to a non-\`none\` \`box-shadow\`.

55/55 storybook tests pass.

Milestone: DTCG comprehension visualizations
Plan impact: none

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test build test:storybook --force\` green