### PR TITLE
docs: tighten mission — comprehensive overview, extrapolate don't invent

### DIFF
--- a/.changeset/token-detail-composite-previews.md
+++ b/.changeset/token-detail-composite-previews.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`TokenDetail` now renders live previews for composite token types in its Resolved-value section. Typography tokens get a pangram sample styled via the emitted sub-vars (font-family / font-size / font-weight / line-height / letter-spacing); shadow and border tokens get a sample card with the effect applied; transition tokens get an animated ball using the composite's duration + easing. Color tokens keep their swatch. The preview sits above the formatted value text — one read gives you "what it looks like" and "what its sub-values are" together.
+
+Reduced-motion compliance: transition previews swap to an inline "Animation suppressed" notice when `prefers-reduced-motion: reduce` is set. `usePrefersReducedMotion` lifted to `internal/prefers-reduced-motion.ts` so it's shared with `MotionPreview`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfun
 
 ## Current milestone
 
-`Current: DTCG comprehension visualizations` — every token type earns a block that makes its value legible. Five sibling issues seeded (#108–#113). First pickup: #108 DimensionScale.
+`Current: between milestones` — comprehension visualizations milestone closes when #117 lands. After mission tightening (2026-04-18), next active buckets are **Multi-axis theming UX**, **Alias topology** (#118), and **DTCG type coverage** (#119). Token-aware controls and the component reverse-index have been closed — see `docs/plan.md` "Extrapolate, don't invent".
 
 Update this line when a milestone closes. See the matching GitHub milestones for per-issue state.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Swatchbook
 
-Storybook addon + MDX doc blocks for [DTCG](https://www.designtokens.org/) design tokens. Browse tokens, switch themes from the toolbar, render tokens in docs, read typed tokens from JS — all wired to your DTCG source of truth with live HMR.
+**A comprehensive visual overview of the [DTCG](https://www.designtokens.org/) design tokens (parsed via [Terrazzo](https://terrazzo.app/)) that actually exist in your project — rendered inside Storybook.** Design-system engineers use it to show their token set to feature engineers and stakeholders; everyone else uses it to see what's there without cracking open a token JSON.
+
+The guiding principle: **extrapolate what's in the token set, don't invent new analysis.** If Terrazzo surfaces a piece of data, we render it. If we'd have to compute something new, that's Terrazzo's conversation (or someone else's tool) — not ours.
 
 Monorepo published under the `@unpunnyfuns` scope.
 
@@ -8,9 +10,9 @@ Monorepo published under the `@unpunnyfuns` scope.
 
 | Package | Purpose |
 | --- | --- |
-| [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Parses token files, resolves aliases, composes themes (explicit layers, DTCG 2025.10 resolvers, or Tokens Studio `$themes` manifests), emits CSS variables + TypeScript types. |
+| [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Wraps Terrazzo's parser + DTCG 2025.10 resolver, emits CSS variables + TypeScript types. |
 | [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Preset wires core into Vite via a virtual module, the toolbar tool switches themes, the panel browses tokens + diagnostics, `useToken()` gives typed reads from your stories. |
-| [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks consumed from Storybook docs pages — `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`. Self-mount the addon's CSS and react to toolbar theme changes. |
+| [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks consumed from Storybook docs pages. Per-type renderings — color swatches, dimension bars, typography samples, shadow / border / motion previews, per-token detail with full alias chain. Self-mount the addon's CSS and react to toolbar theme changes. |
 | [`@unpunnyfuns/swatchbook-tokens`](./packages/tokens-starter) | Opinionated starter token set. Prebuilt CSS per theme + typed JSON + token-path unions. Install to get something working in five minutes. |
 
 ## Install

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Swatchbook
 
-**A comprehensive visual overview of the [DTCG](https://www.designtokens.org/) design tokens (parsed via [Terrazzo](https://terrazzo.app/)) that actually exist in your project — rendered inside Storybook.** Design-system engineers use it to show their token set to feature engineers and stakeholders; everyone else uses it to see what's there without cracking open a token JSON.
+**An addon and tools to help people visualize their future design token projects using Storybook.**
+
+In more detail: a comprehensive visual overview of [DTCG](https://www.designtokens.org/) design tokens (parsed via [Terrazzo](https://terrazzo.app/)) that actually exist in your project — rendered inside Storybook. Design-system engineers use it to show their token set to feature engineers and stakeholders; everyone else uses it to see what's there without cracking open a token JSON.
 
 The guiding principle: **extrapolate what's in the token set, don't invent new analysis.** If Terrazzo surfaces a piece of data, we render it. If we'd have to compute something new, that's Terrazzo's conversation (or someone else's tool) — not ours.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 In more detail: a comprehensive visual overview of [DTCG](https://www.designtokens.org/) design tokens (parsed via [Terrazzo](https://terrazzo.app/)) that actually exist in your project — rendered inside Storybook. Design-system engineers use it to show their token set to feature engineers and stakeholders; everyone else uses it to see what's there without cracking open a token JSON.
 
+Swatchbook is an **exploration vehicle**, not an ecosystem-capture tool. We serve people building DTCG-native projects going forward — including the people still evolving the spec. Legacy-format compatibility is explicitly an anti-goal.
+
+**Not for you if**: you want to build something with existing mature tooling and walk away for a few years. DTCG is a moving draft; we move with it. Pick Style Dictionary or Tokens Studio if you need long-term stability over frontier exploration.
+
 The guiding principle: **extrapolate what's in the token set, don't invent new analysis.** If Terrazzo surfaces a piece of data, we render it. If we'd have to compute something new, that's Terrazzo's conversation (or someone else's tool) — not ours.
 
 Monorepo published under the `@unpunnyfuns` scope.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -193,6 +193,44 @@ export const TokenDetailRenders = meta.story({
 });
 
 /**
+ * `TokenDetail` for a composite token type renders a live preview of the
+ * composite — typography as a pangram sample, shadow/border as a card with
+ * the effect applied, transition as an animated ball.
+ */
+export const TokenDetailTypographyComposite = meta.story({
+  render: () => <TokenDetail path='typography.sys.heading' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const sample = [...canvasElement.querySelectorAll<HTMLElement>('div')].find((el) =>
+      el.textContent?.startsWith('Sphinx of black quartz'),
+    );
+    expect(sample, 'typography composite must render a pangram sample').toBeTruthy();
+    if (sample) {
+      expect(
+        getComputedStyle(sample).fontFamily,
+        'sample must resolve a concrete font-family',
+      ).not.toBe('');
+    }
+  },
+});
+
+export const TokenDetailShadowComposite = meta.story({
+  render: () => <TokenDetail path='shadow.sys.md' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const withShadow = samples.filter((el) => {
+      const bs = getComputedStyle(el).boxShadow;
+      return bs && bs !== 'none';
+    });
+    expect(
+      withShadow.length,
+      'shadow composite must render a sample with non-none box-shadow',
+    ).toBeGreaterThan(0);
+  },
+});
+
+/**
  * `TokenDetail` for a missing path must render its empty state rather than
  * throwing.
  */

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -205,3 +205,24 @@ Dropped (TS 6 handles by default): `strict`, `module`, `target`, `esModuleIntero
 **Rationale:** The milestone system was two things mashed together — ordered phases on a release path, and scope buckets. Dropping the release pressure makes the ordering imaginary; without ordering, the prefix was misleading cosmetic. Scope buckets still earn their keep.
 
 **Prior-reference preservation:** Old decisions entries ("Defer M5", "Iceboxed starter past v0.1.0", "Drop manifest support") still reference M-prefixed names. The log is append-only; those stay as-written. Readers encountering `M5`, `M8`, etc. in historical entries can cross-reference via GitHub milestone history (titles changed, numbers in commit history unchanged).
+
+---
+
+## 2026-04-18 — Tighten mission: "comprehensive visual overview of DTCG tokens, via Terrazzo"
+
+**Context:** The original mission was "make DTCG tokens easier to understand and author inside Storybook." That framing bundled two products — understanding (presentation) and authoring (ergonomics) — with different users. After running the product to ground through the comprehension milestone, the project lead clarified: swatchbook is for **design-system engineers educating feature engineers and stakeholders**. Education is one-way: the DS engineer curates the surface; the audience reads.
+
+That reframing was tightened further: "we only care about DTCG, via Terrazzo, to provide a comprehensive overview of what actually exists within our tokens." And the governing principle: **extrapolate what's there, don't invent new analysis.**
+
+**Decision:**
+- **Mission statement** in `docs/plan.md` rewritten. Positions swatchbook as *"a comprehensive visual overview of the DTCG design tokens (parsed via Terrazzo) that actually exist in your project — rendered inside Storybook."*
+- **New "Extrapolate, don't invent" section** in the plan captures the governing principle: in-scope = any visualization projected from Terrazzo's `TokenNormalized` fields; out-of-scope = analysis swatchbook would have to invent (orphan detection, duplicate-value flagging, depth distributions, external-code scanning). Anything analytical valuable to the DTCG ecosystem belongs upstream in Terrazzo, not here.
+- **Closed: Token-aware controls milestone.** Authoring ergonomics, not overview. Out.
+- **Closed: Component ↔ token reverse index milestone.** Requires scanning the consumer's external stylesheets; external-code analysis is outside the token set.
+- **Opened: Alias topology milestone.** Surface Terrazzo's `aliasedBy` data so viewers can trace `cmp.button.bg ↔ color.sys.accent.bg ↔ color.ref.blue.500` backwards as well as forwards. Purely extrapolation — Terrazzo already has the data.
+- **Opened: DTCG type coverage milestone.** Ensure every DTCG `$type` has a dedicated visual rendering. "Comprehensive" is the completeness bar.
+- **Root README tagline + core README description** updated to match.
+
+**Rationale:** Two products served one user poorly. One product serves three users (DS engineer as curator; feature engineers + stakeholders as audience) cleanly. The "extrapolate, don't invent" principle keeps scope narrow, pushes shared value upstream, and stops us turning the addon into a custom analyzer.
+
+**Plan impact:** Mission + roadmap sections rewritten. Token-aware controls and reverse-index milestones closed with reasoning. Two new milestones created with seed issues.

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,13 +2,16 @@
 
 ## Mission
 
-**Swatchbook is a comprehensive visual overview of the DTCG design tokens (parsed via Terrazzo) that actually exist in your project — rendered inside Storybook.** It's the tool design-system engineers use to show their token set to the rest of the team: feature engineers reading docs, stakeholders verifying that the system composes correctly, anyone who needs to see what's in there without cracking open a token JSON file.
+**An addon and tools to help people visualize their future design token projects using Storybook.**
 
-Three things the mission pins down:
+In more detail: swatchbook is a comprehensive visual overview of the DTCG design tokens (parsed via Terrazzo) that actually exist in your project — rendered inside Storybook. It's the tool design-system engineers use to show their token set to the rest of the team: feature engineers reading docs, stakeholders verifying that the system composes correctly, anyone who needs to see what's in there without cracking open a token JSON file.
+
+Four things the mission pins down:
 
 - **Only DTCG, via Terrazzo.** Not a general doc-tool; not a multi-format gadget. We present what the spec produces through the one parser we trust.
 - **Comprehensive.** Every DTCG type earns a dedicated visual. A type without a rendering is a regression, not a feature gap.
 - **What actually exists within the tokens.** The token set is the subject. Not consumer code. Not authoring tools. Not a Figma bridge. The tokens themselves, in every shape they take.
+- **Audience includes people still defining the spec.** We're not downstream-only. DTCG is a draft that's actively evolving; editors and implementers prototyping against real token sets are part of who swatchbook serves. That's extra weight behind the *extrapolate, don't invent* principle — people evaluating the spec want to see exactly what the spec produces, not what we'd like it to produce.
 
 ## Extrapolate, don't invent
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -6,12 +6,15 @@
 
 In more detail: swatchbook is a comprehensive visual overview of the DTCG design tokens (parsed via Terrazzo) that actually exist in your project — rendered inside Storybook. It's the tool design-system engineers use to show their token set to the rest of the team: feature engineers reading docs, stakeholders verifying that the system composes correctly, anyone who needs to see what's in there without cracking open a token JSON file.
 
-Four things the mission pins down:
+**We're an exploration vehicle, not an ecosystem-capture tool.** The distinction matters because it shapes every scope call: swatchbook exists to *drive forward* the design-token space — to let people building DTCG-native projects see what they have, iterate on it, and push the frontier — not to absorb whatever the current ecosystem (Tokens Studio, Style Dictionary adapters, format-of-the-week) already does. Closing legacy compatibility (the manifest drop, the layered drop) was this mission choosing itself.
+
+Five things the mission pins down:
 
 - **Only DTCG, via Terrazzo.** Not a general doc-tool; not a multi-format gadget. We present what the spec produces through the one parser we trust.
-- **Comprehensive.** Every DTCG type earns a dedicated visual. A type without a rendering is a regression, not a feature gap.
+- **Exploratory, not archival.** We serve the *future* of design tokens — people evaluating and extending DTCG — not the present ecosystem they might be migrating from. Legacy-format support is an anti-goal.
+- **Comprehensive across DTCG.** Every DTCG type earns a dedicated visual, including draft/new types the spec is still evolving. A type without a rendering is a regression, not a feature gap.
 - **What actually exists within the tokens.** The token set is the subject. Not consumer code. Not authoring tools. Not a Figma bridge. The tokens themselves, in every shape they take.
-- **Audience includes people still defining the spec.** We're not downstream-only. DTCG is a draft that's actively evolving; editors and implementers prototyping against real token sets are part of who swatchbook serves. That's extra weight behind the *extrapolate, don't invent* principle — people evaluating the spec want to see exactly what the spec produces, not what we'd like it to produce.
+- **Audience includes people still defining the spec.** DTCG is a draft that's actively evolving; editors and implementers prototyping against real token sets are part of who swatchbook serves. That's extra weight behind the *extrapolate, don't invent* principle — people evaluating the spec want to see exactly what the spec produces, not what we'd like it to produce.
 
 ## Extrapolate, don't invent
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -2,15 +2,29 @@
 
 ## Mission
 
-Make [DTCG](https://www.designtokens.org/) design tokens **easier to understand and author** inside Storybook — specifically for React consumers. Not framework-agnostic; not a general-purpose DTCG toolkit. Sibling packages for React Native / Vue / Lit are possible later but deliberately out of scope for now. For today: one platform, one spec.
+**Swatchbook is a comprehensive visual overview of the DTCG design tokens (parsed via Terrazzo) that actually exist in your project — rendered inside Storybook.** It's the tool design-system engineers use to show their token set to the rest of the team: feature engineers reading docs, stakeholders verifying that the system composes correctly, anyone who needs to see what's in there without cracking open a token JSON file.
 
-The comprehension story is the differentiator: dimensions rendered as visual bars (not just "4px"), colors shown in every color space with contrast scores, shadows and motion previewed live, composite tokens shown as a unit. The authoring story is the companion: theme-aware Storybook controls, multi-axis theme composition, reverse-indexes tying tokens back to the components that use them.
+Three things the mission pins down:
+
+- **Only DTCG, via Terrazzo.** Not a general doc-tool; not a multi-format gadget. We present what the spec produces through the one parser we trust.
+- **Comprehensive.** Every DTCG type earns a dedicated visual. A type without a rendering is a regression, not a feature gap.
+- **What actually exists within the tokens.** The token set is the subject. Not consumer code. Not authoring tools. Not a Figma bridge. The tokens themselves, in every shape they take.
+
+## Extrapolate, don't invent
+
+The governing principle for scope decisions: **we extrapolate information that's already there. We don't invent new analysis.**
+
+"Already there" means: data produced by Terrazzo during parse + resolve — `$type`, `$value`, `$description`, `aliasChain`, `aliasedBy`, `dependencies`, `group`, diagnostics. Any visualization that projects those fields is in scope, however creative the rendering.
+
+"Invent new" means: analysis swatchbook would have to compute from scratch — orphan detection, duplicate-value flagging, depth distributions, token-graph health scores, external-code scanning for token usage. If any of these turn out to be valuable, they're valuable to every DTCG tool: push them upstream into Terrazzo (or a sibling analysis package), and we'll render whatever they surface. We don't grow the addon into a custom analyzer.
+
+This keeps the addon narrow, keeps the value shareable across the DTCG ecosystem, and avoids re-deriving data the parser already has opinions about.
 
 ## Scope today
 
 - **Storybook 10.3+ on Vite + React.** Other renderers / bundlers out of scope.
 - **DTCG 2025.10 resolver** is the sole theming input. No manifest, no layered shortcut, no migration helpers.
-- **Four doc blocks** cover the basic token types: `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`. Richer visualizations (comparison, contrast, motion preview) are scoped as a feature milestone.
+- **Rendering blocks** cover DTCG types: `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail` (with composite previews for typography / shadow / border / transition), `DimensionScale`, `ShadowPreview`, `BorderPreview`, `MotionPreview`. Gaps in type coverage are tracked as their own scope bucket.
 - **Single-axis resolvers** get clean theme names automatically. Multi-axis resolvers use Terrazzo's permutation IDs — a known rough edge, addressed in the multi-axis theming milestone.
 
 **Release cadence: deferred.** Iterating on features takes priority over shipping versions to npm. Packages stay unpublished until we explicitly decide to ship; `@unpunnyfuns/swatchbook-tokens` is iceboxed (see `docs/decisions.md`).
@@ -553,7 +567,7 @@ Each milestone has a single measurable demo step. Progress is tracked by which m
 
 Each feature milestone has a scope area on GitHub. PRs reference their milestone (body, not title). A "Current:" line in `CLAUDE.md` names the active one. No implied ordering across milestones beyond what's written here — scope areas are parallelizable; pick based on thesis value, not position.
 
-## Feature roadmap — comprehension, composition, authoring
+## Feature roadmap — overview, composition, topology
 
 Beyond spec convergence, four scope areas deepen the "easier to understand DTCG" thesis rather than broadening framework surface. Listed in the order I'd probably reach for them, not a contract:
 
@@ -586,31 +600,27 @@ Beyond spec convergence, four scope areas deepen the "easier to understand DTCG"
 **Exit:** A resolver with `appearance × brand × density` renders cleanly in the toolbar; each axis is pickable independently; saved combos persist across reloads. Interaction tests cover the composer.
 **Demo:** Toolbar shows three columns; picking "dark × brand-a × compact" repaints the preview.
 
-### Token-aware controls
+### Alias topology
 
-**Goal:** Storybook `argTypes` can be "a token of this type" — not a raw string — so author-time picking is token-native.
-
-**Work:**
-- **`swatchbook-color` argType** — popover picker of color tokens, stores `var(--…)` directly in args. Honest with the Args panel.
-- **`swatchbook-dimension` argType** — same pattern for dimension tokens, keyed by path.
-- **`swatchbook-typography` argType** — bundles the composite; writes `var(--…-font-family)`, `…-font-size`, etc. into a ref-object arg or individual args (TBD which reads better).
-- Groundwork lives in an `addon/src/controls/` folder; each control registers through Storybook's `argType` extension point.
-- Decision log entry explains the path chosen (Storybook upstream may have shifted since M5; re-validate before committing).
-
-**Exit:** A Button story has `bg: { control: 'swatchbook-color' }` — picking a token in the Controls panel writes `var(--…)` into the args; the component renders with that value.
-
-### Component ↔ token reverse index
-
-**Goal:** Docs answer "which components consume this token" and "which tokens does this component consume".
+**Goal:** From any token, show the full forward + backward alias chains so a viewer can trace `cmp.button.bg` ↔ `color.sys.accent.bg` ↔ `color.ref.blue.500` in either direction. Purely Terrazzo's `aliasChain` + `aliasedBy` data — no analysis we'd have to invent.
 
 **Work:**
-- **Static analyzer** — scan component CSS / CSS-in-JS / inline styles for `var(--<prefix>-…)` references; emit a path → components map at build time.
-- **`ConsumedBy` block** — `<ConsumedBy path="color.sys.accent.bg" />` lists the components referencing that token.
-- **`Consumes` block** — `<Consumes component="Button" />` lists every token the component reads.
-- **`TokenDetail` augmentation** — show "Used by: Button, Card" under the resolved-value section when the index is available.
+- **`TokenDetail` gains an "Aliased by" section** — direct references + transitive, walked via `aliasedBy` with a reasonable depth cap. Siblings the existing "Alias chain" (forward) section.
+- Path labels on each hop so consumers see *why* a chain exists, not just that one does.
+- Optionally a standalone `<AliasedBy path="…" />` block for MDX pages that want the reverse index in isolation — defer unless the `TokenDetail` section proves insufficient.
 
-**Exit:** MDX page `/docs/tokens/color-sys-accent-bg` renders a reverse index; changes to components repopulate the index on HMR.
-**Demo:** Clicking a row in the Tokens panel scrolls to its consumers.
+**Exit:** `TokenDetail` for `color.ref.blue.500` lists every token that transitively aliases it in the active theme, through any number of hops.
+
+### DTCG type coverage audit
+
+**Goal:** Every DTCG type — primitive and composite — has a dedicated visual rendering. "Comprehensive" is the completeness bar.
+
+**Work:**
+- Audit `$type` coverage across existing blocks + `TokenDetail`.
+- Likely gaps: primitive `fontFamily` (currently only rendered inside typography composite), primitive `fontWeight` (same), `strokeStyle` (DTCG 2024+ — dashed/dotted/etc.), primitive `number` (rendered as text; may not need more).
+- File a sibling issue per confirmed gap.
+
+**Exit:** A token of any DTCG type has a dedicated visual inside at least one block or `TokenDetail` preview. No fallback-to-text for a type we haven't considered.
 
 ### Further out
 
@@ -620,6 +630,9 @@ Out of scope as named milestones but worth capturing the shape:
 - **Write-back from the addon UI.** See `docs/future.md` — token edits from the panel, via Storybook's `experimental_serverChannel`, landing on disk.
 - **Tokens Studio → DTCG migration helper.** A standalone CLI that converts `$themes.manifest.json` + token files to a DTCG `resolver.json`.
 - **Public tokens-starter.** Thaw `@unpunnyfuns/swatchbook-tokens` once there's consumer signal for a canned palette.
+- **Token-aware Storybook controls** (`swatchbook-color` argType etc.) — originally a planned milestone; dropped after mission tightening (authoring ergonomics, not overview).
+- **Component ↔ token reverse index.** Reads consumer stylesheets to build usage maps. Explicitly external-code analysis — outside our mission line.
+- **Graph analysis** (orphans, duplicate values, depth distributions, health scores) — belongs in Terrazzo, not here. Open a conversation if it's needed; contribute upstream.
 - **Release cadence.** Changesets versioning, publish workflow, tag cutting. Deferred by decision; re-adopt when we're ready to ship.
 
 ## Verification

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export type MotionSpeed = 0.25 | 0.5 | 1 | 2;
@@ -222,19 +223,6 @@ function asEasing(
     }
   }
   return fallback;
-}
-
-function usePrefersReducedMotion(): boolean {
-  const [reduced, setReduced] = useState(false);
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setReduced(query.matches);
-    const onChange = (e: MediaQueryListEvent): void => setReduced(e.matches);
-    query.addEventListener('change', onChange);
-    return () => query.removeEventListener('change', onChange);
-  }, []);
-  return reduced;
 }
 
 export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactElement {

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { formatValue, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface TokenDetailProps {
@@ -113,6 +114,45 @@ const styles = {
     padding: 12,
     opacity: 0.7,
   } satisfies CSSProperties,
+  typographySample: {
+    padding: '8px 0',
+  } satisfies CSSProperties,
+  shadowSample: {
+    width: 140,
+    height: 56,
+    background: 'var(--sb-color-sys-surface-raised, #fff)',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  borderSample: {
+    width: 140,
+    height: 56,
+    background: 'var(--sb-color-sys-surface-raised, transparent)',
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  motionTrack: {
+    position: 'relative',
+    height: 32,
+    width: '100%',
+    maxWidth: 320,
+    background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.08))',
+    borderRadius: 16,
+    overflow: 'hidden',
+  } satisfies CSSProperties,
+  motionBall: {
+    position: 'absolute',
+    top: '50%',
+    width: 24,
+    height: 24,
+    marginTop: -12,
+    borderRadius: '50%',
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+  } satisfies CSSProperties,
+  reducedMotion: {
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+    fontStyle: 'italic',
+  } satisfies CSSProperties,
 };
 
 export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
@@ -153,6 +193,7 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
       {token.$description && <p style={styles.description}>{token.$description}</p>}
 
       <div style={styles.sectionHeader}>Resolved value · {activeTheme}</div>
+      <CompositePreview type={token.$type} cssVar={cssVar} />
       <div style={styles.chain}>
         {isColor && <span style={{ ...styles.swatch, background: cssVar }} aria-hidden />}
         <span>{value}</span>
@@ -202,6 +243,87 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
 
       <div style={styles.sectionHeader}>Usage</div>
       <code style={styles.snippet}>{`color: ${cssVar};`}</code>
+    </div>
+  );
+}
+
+const PANGRAM = 'Sphinx of black quartz, judge my vow.';
+
+function CompositePreview({
+  type,
+  cssVar,
+}: {
+  type: string | undefined;
+  cssVar: string;
+}): ReactElement | null {
+  if (type === 'typography') {
+    // cssVar for a composite looks like `var(--…-<path>)`; the emitter also
+    // emits sub-vars named `--…-<path>-font-family`, `-font-size`, etc.
+    // Peel the `var(--…)` wrapping to reuse the base name.
+    const base = cssVar.replace(/^var\(/, '').replace(/\)$/, '');
+    return (
+      <div
+        style={{
+          ...styles.typographySample,
+          fontFamily: `var(${base}-font-family)`,
+          fontSize: `var(${base}-font-size)`,
+          fontWeight: `var(${base}-font-weight)` as unknown as number,
+          lineHeight: `var(${base}-line-height)` as unknown as number,
+          letterSpacing: `var(${base}-letter-spacing)`,
+        }}
+      >
+        {PANGRAM}
+      </div>
+    );
+  }
+  if (type === 'shadow') {
+    return <div style={{ ...styles.shadowSample, boxShadow: cssVar }} aria-hidden />;
+  }
+  if (type === 'border') {
+    return <div style={{ ...styles.borderSample, border: cssVar }} aria-hidden />;
+  }
+  if (type === 'transition') {
+    return <TransitionSample cssVar={cssVar} />;
+  }
+  return null;
+}
+
+function TransitionSample({ cssVar }: { cssVar: string }): ReactElement {
+  const reduced = usePrefersReducedMotion();
+  const [phase, setPhase] = useState<0 | 1>(0);
+
+  useEffect(() => {
+    if (reduced) return;
+    // Loop between 0 and 1 at a fixed cadence a bit slower than the token's
+    // own duration so the easing curve is perceptible.
+    const id = requestAnimationFrame(() => setPhase(1));
+    const loop = window.setInterval(() => {
+      setPhase((p) => (p === 0 ? 1 : 0));
+    }, 1200);
+    return () => {
+      cancelAnimationFrame(id);
+      window.clearInterval(loop);
+    };
+  }, [reduced]);
+
+  if (reduced) {
+    return (
+      <div style={styles.reducedMotion}>
+        Animation suppressed by `prefers-reduced-motion: reduce`.
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.motionTrack}>
+      <div
+        style={{
+          ...styles.motionBall,
+          left: phase === 1 ? 'calc(100% - 28px)' : '4px',
+          transition: cssVar,
+        }}
+        aria-hidden
+      />
     </div>
   );
 }

--- a/packages/blocks/src/internal/prefers-reduced-motion.ts
+++ b/packages/blocks/src/internal/prefers-reduced-motion.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Reactive `prefers-reduced-motion: reduce` detector. Returns the current
+ * match and updates if the user toggles the OS-level preference.
+ */
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(query.matches);
+    const onChange = (e: MediaQueryListEvent): void => setReduced(e.matches);
+    query.addEventListener('change', onChange);
+    return () => query.removeEventListener('change', onChange);
+  }, []);
+  return reduced;
+}


### PR DESCRIPTION
Codifies the mission tightening from today's discussion. Net: clearer product, tighter scope, fewer half-built products.

## Mission — new wording

> Swatchbook is a **comprehensive visual overview of the DTCG design tokens (parsed via Terrazzo) that actually exist in your project — rendered inside Storybook.** Design-system engineers use it to show their token set to feature engineers and stakeholders; everyone else uses it to see what's there without cracking open a token JSON.

## Governing principle — new

> **Extrapolate what's in the token set, don't invent new analysis.** In: any visualization projected from Terrazzo's \`TokenNormalized\` fields. Out: orphan detection, duplicate-value flagging, depth distributions, external-code scanning, any "graph health" scoring. Valuable-to-the-ecosystem analysis belongs upstream in Terrazzo.

## Milestone shake-up (done out-of-band on GitHub)

**Closed:**
- **Token-aware controls** — authoring ergonomics, not overview.
- **Component ↔ token reverse index** — external-code analysis.

**Opened + seeded:**
- **Alias topology** (#118) — surface Terrazzo's \`aliasedBy\` so viewers can trace \`color.ref.blue.500 ← color.sys.accent.bg ← cmp.button.bg\` transitively. Pure extrapolation.
- **DTCG type coverage** (#119) — audit every \`\$type\`, fill visual gaps (primitive \`fontFamily\` / \`fontWeight\`, \`strokeStyle\`, etc.).

## Updated files

- \`docs/plan.md\` — Mission, new "Extrapolate, don't invent" section, roadmap reshaped.
- \`README.md\` — tagline + packages table aligned with new framing.
- \`CLAUDE.md\` — current-milestone line updated ("between milestones" until comprehension closes).
- \`docs/decisions.md\` — ADR-lite entry capturing context + rationale.

Milestone: _(repo hygiene / scope)_
Plan impact: update included

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck\` green (docs-only changes)
- [ ] GitHub milestone page reflects the closures + new milestones