### PR TITLE
feat(blocks): aliased-by tree in TokenDetail

### DIFF
--- a/.changeset/token-detail-aliased-by.md
+++ b/.changeset/token-detail-aliased-by.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`TokenDetail` now renders an "Aliased by" tree mirroring the existing "Alias chain". For any token, it walks Terrazzo's `aliasedBy` field backward — direct consumers, their consumers, and so on — so a viewer can trace from a primitive (e.g. `color.ref.neutral.0`) to every sys and cmp token that ultimately depends on it. Each level is sorted ref → sys → cmp → other, then alphabetical. Depth is capped at 6 hops with a visible "truncated" note when hit. Only renders when the focal token has at least one direct consumer; otherwise the section is hidden.
+
+No new analysis — Terrazzo already produces `aliasedBy` during resolve. The section just surfaces it.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -231,6 +231,27 @@ export const TokenDetailShadowComposite = meta.story({
 });
 
 /**
+ * `TokenDetail` for a heavily-aliased primitive must render the "Aliased by"
+ * section listing at least one transitive descendant — that's the core
+ * promise of backward alias traversal.
+ */
+export const TokenDetailAliasedBy = meta.story({
+  render: () => <TokenDetail path='color.ref.neutral.0' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const body = canvasElement.textContent ?? '';
+    expect(body, 'must render Aliased by section').toContain('Aliased by');
+    const nodes = [...canvasElement.querySelectorAll('li span')].map((el) =>
+      el.textContent?.trim(),
+    );
+    const hasSys = nodes.some((n) => n?.startsWith('color.sys.'));
+    expect(hasSys, 'tree must include at least one sys descendant').toBe(true);
+    const hasCmp = nodes.some((n) => n?.startsWith('cmp.'));
+    expect(hasCmp, 'tree must include at least one transitive cmp descendant').toBe(true);
+  },
+});
+
+/**
  * `TokenDetail` for a missing path must render its empty state rather than
  * throwing.
  */

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -26,6 +26,7 @@ declare module 'virtual:swatchbook/tokens' {
     $description?: string;
     aliasOf?: string;
     aliasChain?: readonly string[];
+    aliasedBy?: readonly string[];
   }
 
   export const themes: readonly VirtualTheme[];

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -15,7 +15,16 @@ interface DetailToken {
   $value?: unknown;
   $description?: string;
   aliasOf?: string;
-  aliasChain?: string[];
+  aliasChain?: readonly string[];
+  aliasedBy?: readonly string[];
+}
+
+const ALIASED_BY_DEPTH_CAP = 6;
+
+interface AliasedByNode {
+  path: string;
+  children: AliasedByNode[];
+  truncated?: boolean;
 }
 
 const styles = {
@@ -148,6 +157,25 @@ const styles = {
     borderRadius: '50%',
     background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
   } satisfies CSSProperties,
+  aliasedByList: {
+    listStyle: 'none',
+    margin: 0,
+    padding: 0,
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+  } satisfies CSSProperties,
+  aliasedByRow: {
+    padding: '2px 0',
+    display: 'flex',
+    alignItems: 'center',
+    gap: 6,
+  } satisfies CSSProperties,
+  aliasedByTruncated: {
+    fontSize: 11,
+    opacity: 0.6,
+    fontStyle: 'italic',
+    marginTop: 4,
+  } satisfies CSSProperties,
   reducedMotion: {
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
@@ -160,6 +188,12 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
 
   const token = resolved[path] as DetailToken | undefined;
   const cssVar = makeCssVar(path, cssVarPrefix);
+
+  const aliasedByTree = useMemo<AliasedByNode[]>(
+    () => buildAliasedByTree(path, resolved),
+    [path, resolved],
+  );
+  const aliasedByTruncated = useMemo(() => treeHasTruncation(aliasedByTree), [aliasedByTree]);
 
   const chain = useMemo<string[]>(() => {
     if (!token) return [];
@@ -210,6 +244,22 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
               </span>
             ))}
           </div>
+        </>
+      )}
+
+      {aliasedByTree.length > 0 && (
+        <>
+          <div style={styles.sectionHeader}>Aliased by</div>
+          <ul style={styles.aliasedByList}>
+            {aliasedByTree.map((node) => (
+              <AliasedByRow key={node.path} node={node} depth={0} />
+            ))}
+          </ul>
+          {aliasedByTruncated && (
+            <div style={styles.aliasedByTruncated}>
+              Further descendants truncated at depth {ALIASED_BY_DEPTH_CAP}.
+            </div>
+          )}
         </>
       )}
 
@@ -325,5 +375,67 @@ function TransitionSample({ cssVar }: { cssVar: string }): ReactElement {
         aria-hidden
       />
     </div>
+  );
+}
+
+function buildAliasedByTree(rootPath: string, resolved: Record<string, unknown>): AliasedByNode[] {
+  const root = resolved[rootPath] as DetailToken | undefined;
+  const direct = root?.aliasedBy;
+  if (!direct || direct.length === 0) return [];
+
+  const visited = new Set<string>([rootPath]);
+  return sortPaths(direct).map((p) => walk(p, resolved, visited, 1));
+}
+
+function walk(
+  path: string,
+  resolved: Record<string, unknown>,
+  visited: Set<string>,
+  depth: number,
+): AliasedByNode {
+  if (visited.has(path)) return { path, children: [] };
+  visited.add(path);
+  const token = resolved[path] as DetailToken | undefined;
+  const parents = token?.aliasedBy;
+  if (!parents || parents.length === 0) return { path, children: [] };
+  if (depth >= ALIASED_BY_DEPTH_CAP) {
+    return { path, children: [], truncated: true };
+  }
+  const children = sortPaths(parents).map((p) => walk(p, resolved, visited, depth + 1));
+  return { path, children };
+}
+
+const GROUP_RANK: Record<string, number> = { ref: 0, sys: 1, cmp: 2 };
+
+function sortPaths(paths: readonly string[]): string[] {
+  return paths.toSorted((a, b) => {
+    const ra = GROUP_RANK[a.split('.')[0] ?? ''] ?? 3;
+    const rb = GROUP_RANK[b.split('.')[0] ?? ''] ?? 3;
+    return ra !== rb ? ra - rb : a.localeCompare(b);
+  });
+}
+
+function treeHasTruncation(nodes: AliasedByNode[]): boolean {
+  for (const n of nodes) {
+    if (n.truncated) return true;
+    if (treeHasTruncation(n.children)) return true;
+  }
+  return false;
+}
+
+function AliasedByRow({ node, depth }: { node: AliasedByNode; depth: number }): ReactElement {
+  return (
+    <li>
+      <div style={{ ...styles.aliasedByRow, paddingLeft: depth * 16 }}>
+        <span style={styles.chainNode}>{node.path}</span>
+      </div>
+      {node.children.length > 0 && (
+        <ul style={styles.aliasedByList}>
+          {node.children.map((child) => (
+            <AliasedByRow key={child.path} node={child} depth={depth + 1} />
+          ))}
+        </ul>
+      )}
+    </li>
   );
 }

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -27,6 +27,7 @@ declare module 'virtual:swatchbook/tokens' {
     $description?: string;
     aliasOf?: string;
     aliasChain?: readonly string[];
+    aliasedBy?: readonly string[];
   }
 
   export const themes: readonly VirtualTheme[];


### PR DESCRIPTION
## Summary
- `TokenDetail` gains an "Aliased by" section mirroring the existing "Alias chain", driven by Terrazzo's `aliasedBy` field walked transitively
- BFS over direct consumers → their consumers → …, capped at depth 6 with a visible "truncated" note when hit
- Each level sorted ref → sys → cmp → other, then alphabetical

Closes #118

## Plan impact
none — this is the seed issue for the Alias topology milestone

## Test plan
- [x] `pnpm turbo run lint typecheck test test:storybook` (56/56 green, including new `TokenDetailAliasedBy`)
- [x] Manual: navigate `TokenDetail path='color.ref.neutral.0'` — renders sys + cmp descendants as indented tree