### PR TITLE
feat(blocks): preview dimension, duration, and cubicBezier in TokenDetail

### DIFF
--- a/.changeset/token-detail-primitive-previews.md
+++ b/.changeset/token-detail-primitive-previews.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`TokenDetail` now renders visual previews for `dimension`, `duration`, and `cubicBezier` primitives — closing the consistency gap where these types had dedicated blocks (`DimensionScale`, `MotionPreview`) but fell back to raw text when opened individually. Dimension tokens show a bar sized to the token value; duration tokens animate a ball at that duration with neutral easing; cubicBezier tokens animate a ball at a fixed duration applying the easing curve. Both animated variants honor `prefers-reduced-motion: reduce` via the existing suppressed-notice path.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -231,6 +231,65 @@ export const TokenDetailShadowComposite = meta.story({
 });
 
 /**
+ * `TokenDetail` for a dimension primitive must render a bar whose computed
+ * width matches the token's cssVar.
+ */
+export const TokenDetailDimensionPrimitive = meta.story({
+  render: () => <TokenDetail path='space.sys.md' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const bars = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const sized = bars.find((el) => el.getBoundingClientRect().width > 0);
+    expect(sized, 'dimension primitive must render a bar with non-zero width').toBeTruthy();
+  },
+});
+
+/**
+ * `TokenDetail` for a duration primitive must render an animating ball whose
+ * computed `transition-duration` reflects the token. Under reduced motion
+ * the suppressed-notice is acceptable.
+ */
+export const TokenDetailDurationPrimitive = meta.story({
+  render: () => <TokenDetail path='duration.ref.slow' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const balls = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const animated = balls.find((el) => {
+      const td = getComputedStyle(el).transitionDuration;
+      return td && td !== '0s';
+    });
+    const text = canvasElement.textContent ?? '';
+    if (!animated) {
+      expect(text).toMatch(/Animation suppressed/);
+    } else {
+      expect(getComputedStyle(animated).transitionDuration).not.toBe('0s');
+    }
+  },
+});
+
+/**
+ * `TokenDetail` for a cubicBezier primitive must render an animating ball
+ * whose computed `transition-timing-function` reflects the easing curve.
+ */
+export const TokenDetailCubicBezierPrimitive = meta.story({
+  render: () => <TokenDetail path='easing.ref.standard' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const balls = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const animated = balls.find((el) => {
+      const td = getComputedStyle(el).transitionDuration;
+      return td && td !== '0s';
+    });
+    const text = canvasElement.textContent ?? '';
+    if (!animated) {
+      expect(text).toMatch(/Animation suppressed/);
+    } else {
+      expect(getComputedStyle(animated).transitionTimingFunction).toContain('cubic-bezier');
+    }
+  },
+});
+
+/**
  * `TokenDetail` for a heavily-aliased primitive must render the "Aliased by"
  * section listing at least one transitive descendant — that's the core
  * promise of backward alias traversal.

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -139,6 +139,19 @@ const styles = {
     background: 'var(--sb-color-sys-surface-raised, transparent)',
     borderRadius: 6,
   } satisfies CSSProperties,
+  dimensionTrack: {
+    display: 'flex',
+    alignItems: 'center',
+    height: 32,
+    maxWidth: '100%',
+    overflow: 'hidden',
+  } satisfies CSSProperties,
+  dimensionBar: {
+    height: 16,
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+    borderRadius: 3,
+    maxWidth: '100%',
+  } satisfies CSSProperties,
   motionTrack: {
     position: 'relative',
     height: 32,
@@ -333,12 +346,29 @@ function CompositePreview({
     return <div style={{ ...styles.borderSample, border: cssVar }} aria-hidden />;
   }
   if (type === 'transition') {
-    return <TransitionSample cssVar={cssVar} />;
+    return <TransitionSample transition={cssVar} />;
+  }
+  if (type === 'dimension') {
+    return (
+      <div style={styles.dimensionTrack}>
+        <div style={{ ...styles.dimensionBar, width: cssVar }} aria-hidden />
+      </div>
+    );
+  }
+  if (type === 'duration') {
+    // Synthesize a transition with a neutral easing so the duration is
+    // perceptible on its own.
+    return <TransitionSample transition={`left ${cssVar} ease`} />;
+  }
+  if (type === 'cubicBezier') {
+    // Synthesize a transition at a fixed duration so the easing curve is
+    // perceptible on its own.
+    return <TransitionSample transition={`left 800ms ${cssVar}`} />;
   }
   return null;
 }
 
-function TransitionSample({ cssVar }: { cssVar: string }): ReactElement {
+function TransitionSample({ transition }: { transition: string }): ReactElement {
   const reduced = usePrefersReducedMotion();
   const [phase, setPhase] = useState<0 | 1>(0);
 
@@ -370,7 +400,7 @@ function TransitionSample({ cssVar }: { cssVar: string }): ReactElement {
         style={{
           ...styles.motionBall,
           left: phase === 1 ? 'calc(100% - 28px)' : '4px',
-          transition: cssVar,
+          transition,
         }}
         aria-hidden
       />


### PR DESCRIPTION
## Summary
- Extends `TokenDetail`'s `CompositePreview` with branches for `dimension` (a bar sized to the token), `duration` (animated ball at that duration with neutral easing), and `cubicBezier` (animated ball at a fixed 800ms applying the easing curve)
- Duration and cubicBezier reuse `TransitionSample` by accepting a full `transition` CSS string; reduced-motion handling carries over unchanged
- Three new play-fn assertions in `BlockAssertions`

Closes #124

## Plan impact
none — `docs/type-coverage.md` gap row will be struck when the whole milestone closes

## Test plan
- [x] `pnpm turbo run lint typecheck test test:storybook` (59/59 green, three new assertions)