### PR TITLE
feat(blocks): add FontFamilySample and FontWeightScale blocks

### DIFF
--- a/.changeset/font-primitive-blocks.md
+++ b/.changeset/font-primitive-blocks.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+Two new blocks surface standalone font primitives that were previously visible only inside `typography` composites:
+
+- `FontFamilySample` renders one row per `fontFamily` token with sample text in that family, plus the full font stack as metadata.
+- `FontWeightScale` renders one row per `fontWeight` token with sample text at that weight, sorted ascending by numeric weight so the scale is visually legible.
+
+`TokenDetail`'s `CompositePreview` gains matching branches so opening a `font.ref.family.sans` or `font.ref.weight.bold` token in isolation *looks like* the font / weight rather than falling back to a JSON blob or bare integer.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -2,6 +2,8 @@ import {
   BorderPreview,
   ColorPalette,
   DimensionScale,
+  FontFamilySample,
+  FontWeightScale,
   MotionPreview,
   ShadowPreview,
   TokenDetail,
@@ -227,6 +229,87 @@ export const TokenDetailShadowComposite = meta.story({
       withShadow.length,
       'shadow composite must render a sample with non-none box-shadow',
     ).toBeGreaterThan(0);
+  },
+});
+
+/**
+ * `FontFamilySample` must render one row per fontFamily token, and each
+ * sample's computed `font-family` must resolve to a non-empty stack.
+ */
+export const FontFamilySampleRenders = meta.story({
+  render: () => <FontFamilySample filter='font.ref.family.*' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'section, div');
+    const paths = [...canvasElement.querySelectorAll('span')].filter((el) =>
+      el.textContent?.startsWith('font.ref.family.'),
+    );
+    expect(paths.length, 'at least one fontFamily row must render').toBeGreaterThan(0);
+    const samples = [...canvasElement.querySelectorAll<HTMLElement>('div')].filter((el) =>
+      el.textContent?.includes('quick brown fox'),
+    );
+    const resolved = samples.filter((el) => getComputedStyle(el).fontFamily !== '');
+    expect(
+      resolved.length,
+      'at least one sample must resolve to a non-empty font-family',
+    ).toBeGreaterThan(0);
+  },
+});
+
+/**
+ * `FontWeightScale` must render one row per fontWeight token with the
+ * computed `font-weight` reflecting each token's value.
+ */
+export const FontWeightScaleRenders = meta.story({
+  render: () => <FontWeightScale filter='font.ref.weight.*' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'section, div');
+    const samples = [...canvasElement.querySelectorAll<HTMLElement>('div')].filter(
+      (el) => el.textContent === 'Aa',
+    );
+    expect(samples.length, 'at least one fontWeight sample must render').toBeGreaterThan(0);
+    const weights = samples.map((el) => Number.parseInt(getComputedStyle(el).fontWeight, 10));
+    const numeric = weights.filter((w) => Number.isFinite(w));
+    expect(numeric.length).toBeGreaterThan(0);
+    const max = Math.max(...numeric);
+    const min = Math.min(...numeric);
+    expect(max, 'scale must include a weight heavier than the lightest').toBeGreaterThan(min);
+  },
+});
+
+/**
+ * `TokenDetail` for a fontFamily primitive must render sample text whose
+ * computed `font-family` reflects the token's stack.
+ */
+export const TokenDetailFontFamilyPrimitive = meta.story({
+  render: () => <TokenDetail path='font.ref.family.sans' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const sample = [...canvasElement.querySelectorAll<HTMLElement>('div')].find((el) =>
+      el.textContent?.startsWith('Sphinx of black quartz'),
+    );
+    expect(sample, 'fontFamily primitive must render a pangram sample').toBeTruthy();
+    if (sample) {
+      expect(getComputedStyle(sample).fontFamily).not.toBe('');
+    }
+  },
+});
+
+/**
+ * `TokenDetail` for a fontWeight primitive must render sample text whose
+ * computed `font-weight` matches the token value.
+ */
+export const TokenDetailFontWeightPrimitive = meta.story({
+  render: () => <TokenDetail path='font.ref.weight.bold' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const sample = [...canvasElement.querySelectorAll<HTMLElement>('div')].find(
+      (el) => el.textContent === 'Aa',
+    );
+    expect(sample, 'fontWeight primitive must render a sample').toBeTruthy();
+    if (sample) {
+      const w = Number.parseInt(getComputedStyle(sample).fontWeight, 10);
+      expect(w, 'bold sample must compute to weight ≥ 600').toBeGreaterThanOrEqual(600);
+    }
   },
 });
 

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -1,0 +1,132 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface FontFamilySampleProps {
+  /**
+   * Token-path filter. Defaults to every `fontFamily` token. Use e.g.
+   * `"font.ref.family.*"` to scope to the ref layer.
+   */
+  filter?: string;
+  /** Override the sample text rendered for each token. */
+  sample?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
+    gap: 16,
+    alignItems: 'baseline',
+    padding: '14px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  stack: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  sample: {
+    fontSize: 22,
+    lineHeight: 1.2,
+  } satisfies CSSProperties,
+  cssVar: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface Row {
+  path: string;
+  cssVar: string;
+  stack: string;
+}
+
+function stackString(raw: unknown): string {
+  if (typeof raw === 'string') return raw;
+  if (Array.isArray(raw)) return raw.map(String).join(', ');
+  return '';
+}
+
+export function FontFamilySample({
+  filter = 'fontFamily',
+  sample = 'The quick brown fox jumps over the lazy dog.',
+  caption,
+}: FontFamilySampleProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo<Row[]>(() => {
+    return Object.entries(resolved)
+      .filter(([path, token]) => {
+        if (token.$type !== 'fontFamily') return false;
+        return globMatch(path, filter);
+      })
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([path, token]) => ({
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        stack: stackString(token.$value),
+      }));
+  }, [resolved, filter, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} fontFamily token${rows.length === 1 ? '' : 's'}${filter && filter !== 'fontFamily' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.empty}>No fontFamily tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            <span style={styles.stack}>{row.stack}</span>
+          </div>
+          <div style={{ ...styles.sample, fontFamily: row.cssVar }}>{sample}</div>
+          <span style={styles.cssVar}>{row.cssVar}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -1,0 +1,148 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface FontWeightScaleProps {
+  /**
+   * Token-path filter. Defaults to every `fontWeight` token. Use e.g.
+   * `"font.ref.weight.*"` to scope to the ref layer.
+   */
+  filter?: string;
+  /** Override the sample text rendered for each token. */
+  sample?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
+    gap: 16,
+    alignItems: 'baseline',
+    padding: '12px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  value: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  sample: {
+    fontSize: 28,
+    lineHeight: 1,
+  } satisfies CSSProperties,
+  cssVar: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface Row {
+  path: string;
+  cssVar: string;
+  display: string;
+  weight: number;
+}
+
+function toWeight(raw: unknown): number {
+  if (typeof raw === 'number') return raw;
+  if (typeof raw === 'string') {
+    const n = Number.parseInt(raw, 10);
+    return Number.isFinite(n) ? n : Number.NaN;
+  }
+  return Number.NaN;
+}
+
+export function FontWeightScale({
+  filter = 'fontWeight',
+  sample = 'Aa',
+  caption,
+}: FontWeightScaleProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo<Row[]>(() => {
+    const collected: Row[] = [];
+    for (const [path, token] of Object.entries(resolved)) {
+      if (token.$type !== 'fontWeight') continue;
+      if (!globMatch(path, filter)) continue;
+      collected.push({
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        display: token.$value == null ? '' : String(token.$value),
+        weight: toWeight(token.$value),
+      });
+    }
+    collected.sort((a, b) => {
+      if (Number.isFinite(a.weight) && Number.isFinite(b.weight)) return a.weight - b.weight;
+      return a.path.localeCompare(b.path);
+    });
+    return collected;
+  }, [resolved, filter, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} fontWeight token${rows.length === 1 ? '' : 's'}${filter && filter !== 'fontWeight' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.empty}>No fontWeight tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            <span style={styles.value}>{row.display}</span>
+          </div>
+          <div
+            style={{
+              ...styles.sample,
+              fontWeight: row.cssVar as unknown as CSSProperties['fontWeight'],
+            }}
+          >
+            {sample}
+          </div>
+          <span style={styles.cssVar}>{row.cssVar}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -139,6 +139,16 @@ const styles = {
     background: 'var(--sb-color-sys-surface-raised, transparent)',
     borderRadius: 6,
   } satisfies CSSProperties,
+  fontFamilySample: {
+    padding: '4px 0',
+    fontSize: 22,
+    lineHeight: 1.2,
+  } satisfies CSSProperties,
+  fontWeightSample: {
+    padding: '4px 0',
+    fontSize: 32,
+    lineHeight: 1,
+  } satisfies CSSProperties,
   dimensionTrack: {
     display: 'flex',
     alignItems: 'center',
@@ -359,6 +369,21 @@ function CompositePreview({
     // Synthesize a transition with a neutral easing so the duration is
     // perceptible on its own.
     return <TransitionSample transition={`left ${cssVar} ease`} />;
+  }
+  if (type === 'fontFamily') {
+    return <div style={{ ...styles.fontFamilySample, fontFamily: cssVar }}>{PANGRAM}</div>;
+  }
+  if (type === 'fontWeight') {
+    return (
+      <div
+        style={{
+          ...styles.fontWeightSample,
+          fontWeight: cssVar as unknown as number,
+        }}
+      >
+        Aa
+      </div>
+    );
   }
   if (type === 'cubicBezier') {
     // Synthesize a transition at a fixed duration so the easing curve is

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,6 +1,8 @@
 export { BorderPreview, type BorderPreviewProps } from '#/BorderPreview.tsx';
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
 export { DimensionScale, type DimensionKind, type DimensionScaleProps } from '#/DimensionScale.tsx';
+export { FontFamilySample, type FontFamilySampleProps } from '#/FontFamilySample.tsx';
+export { FontWeightScale, type FontWeightScaleProps } from '#/FontWeightScale.tsx';
 export { MotionPreview, type MotionPreviewProps, type MotionSpeed } from '#/MotionPreview.tsx';
 export { ShadowPreview, type ShadowPreviewProps } from '#/ShadowPreview.tsx';
 export { TokenDetail, type TokenDetailProps } from '#/TokenDetail.tsx';


### PR DESCRIPTION
## Summary
- `FontFamilySample` renders one row per `fontFamily` token with sample text set in that family, plus the full stack as metadata
- `FontWeightScale` renders one row per `fontWeight` token with sample text at that weight, sorted ascending so the scale reads bottom-to-top
- `TokenDetail`'s `CompositePreview` gains `fontFamily` and `fontWeight` branches so opening either primitive in isolation shows the visual rather than a JSON blob or bare integer
- Four new play-fn assertions in `BlockAssertions`

Closes #122
Closes #123

## Plan impact
none — `docs/type-coverage.md` gap rows will be struck when the DTCG type coverage milestone closes

## Test plan
- [x] `pnpm turbo run lint typecheck test test:storybook` (63/63 green)