### PR TITLE
feat(blocks,tokens-reference): add strokeStyle and number coverage

### DIFF
--- a/.changeset/strokestyle-number-coverage.md
+++ b/.changeset/strokestyle-number-coverage.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+New `StrokeStyleSample` block renders DTCG `strokeStyle` tokens — string-form values (`solid`, `dashed`, `dotted`, `double`, `groove`, `ridge`, `outset`, `inset`) display as a visible horizontal line at the computed `border-top-style`; object-form values (`{ dashArray, lineCap }`) render a textual fallback because CSS `border-style` has no matching primitive. Companion additions to the reference fixture exercise both forms plus a `number` group (opacities + line-height multipliers) so the full DTCG primitive surface is now covered.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -6,6 +6,7 @@ import {
   FontWeightScale,
   MotionPreview,
   ShadowPreview,
+  StrokeStyleSample,
   TokenDetail,
   TokenTable,
   TypographyScale,
@@ -229,6 +230,30 @@ export const TokenDetailShadowComposite = meta.story({
       withShadow.length,
       'shadow composite must render a sample with non-none box-shadow',
     ).toBeGreaterThan(0);
+  },
+});
+
+/**
+ * `StrokeStyleSample` must render one row per `strokeStyle` token. Rows
+ * with a string value (`solid`, `dashed`, `dotted`, `double`) must resolve
+ * to a non-`none` `border-top-style`; object-form tokens render a textual
+ * fallback, which is acceptable.
+ */
+export const StrokeStyleSampleRenders = meta.story({
+  render: () => <StrokeStyleSample filter='stroke.ref.style.*' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'section, div');
+    const lines = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const styledLines = lines.filter((el) => {
+      const s = getComputedStyle(el).borderTopStyle;
+      return s && s !== 'none';
+    });
+    expect(
+      styledLines.length,
+      'at least one strokeStyle row must resolve to a non-none border-style',
+    ).toBeGreaterThan(0);
+    const text = canvasElement.textContent ?? '';
+    expect(text, 'block must mention the object-form fallback').toMatch(/Object-form/);
   },
 });
 

--- a/docs/type-coverage.md
+++ b/docs/type-coverage.md
@@ -2,33 +2,28 @@
 
 Inventory of how each DTCG 2025.10 `$type` is rendered visually in swatchbook. "Visual rendering" means a dedicated block or a TokenDetail composite preview — not a raw text value in `TokenTable`. Anything that bottoms out in text is a gap, because the mission is to *show* what a token means, not just print its value.
 
-Audit last run: 2026-04-18. File gap issues against the **DTCG type coverage** milestone.
+Audit last run: 2026-04-18 (refreshed after the milestone closed). File any new gaps against the **DTCG type coverage** milestone.
 
 ## Coverage matrix
 
 | `$type` | In `tokens-reference` | Dedicated block | `TokenDetail` preview |
 | --- | --- | --- | --- |
 | `color` | ✅ ref / sys / cmp | `ColorPalette` (grid) | swatch + hex |
-| `dimension` | ✅ sys / cmp | `DimensionScale` (length / radius / size) | ❌ text only |
-| `fontFamily` | ✅ ref only | ❌ — only surfaced via `typography` composite | ❌ text only |
-| `fontWeight` | ✅ ref only | ❌ — only surfaced via `typography` composite | ❌ text only |
-| `duration` | ✅ ref only | `MotionPreview` | ❌ text only |
-| `cubicBezier` | ✅ ref only | `MotionPreview` | ❌ text only |
-| `number` | ❌ not in fixture | — | — |
-| `strokeStyle` | ❌ not in fixture | — | — |
+| `dimension` | ✅ sys / cmp | `DimensionScale` (length / radius / size) | bar ✅ |
+| `fontFamily` | ✅ ref only | `FontFamilySample` | sample text ✅ |
+| `fontWeight` | ✅ ref only | `FontWeightScale` | sample text ✅ |
+| `duration` | ✅ ref only | `MotionPreview` | animated ball ✅ |
+| `cubicBezier` | ✅ ref only | `MotionPreview` | animated ball ✅ |
+| `number` | ✅ ref only | — (text-only, acceptable) | — |
+| `strokeStyle` | ✅ ref only | `StrokeStyleSample` | — (text-only) |
 | `typography` | ✅ sys | `TypographyScale` | pangram sample ✅ |
 | `shadow` | ✅ sys / cmp | `ShadowPreview` | box-shadow card ✅ |
 | `border` | ✅ sys / cmp | `BorderPreview` | border card ✅ |
 | `transition` | ✅ sys / cmp | `MotionPreview` | animated ball ✅ |
 
-## Confirmed gaps
+## Status
 
-- **`fontFamily` standalone** — rendered correctly inside a `typography` composite, but a standalone `font.ref.family.sans` token shows only as a JSON-stringified array in `TokenTable` and `TokenDetail`. Needs a sample-string block and a composite preview in `TokenDetail`.
-- **`fontWeight` standalone** — same story. A `font.ref.weight.bold` token needs a visual that shows the *weight* (sample text at that weight), not just the number.
-- **`duration` / `cubicBezier` in `TokenDetail`** — `MotionPreview` covers standalone duration and easing tokens at list level, but opening one in `TokenDetail` falls back to text. Extend `CompositePreview` with single-duration and single-easing cases (reuse the ball pattern from the `transition` composite).
-- **`dimension` in `TokenDetail`** — consistency gap. `CompositePreview` renders no visual for dimension tokens even though `DimensionScale` exists. A single-row `DimensionScale`-style bar would close the loop.
-- **`strokeStyle`** — not in the reference fixture. Spec has `solid` / `dashed` / `dotted` strings plus `{ dashArray, lineCap }` objects. Needs a fixture addition + a preview (either a new block or extend `BorderPreview`).
-- **`number`** — not in the reference fixture. Typically used for opacities, line-height multipliers, z-index. Text-only rendering is probably defensible, but confirm by adding one to the fixture and verifying `TokenTable` handles it cleanly.
+All DTCG 2025.10 primitives and composites now have either a dedicated block, a `TokenDetail` preview, or both. `number` tokens render as raw values in `TokenTable` — defensible because opacities / line-heights / z-index slots have no meaningful visual beyond the number itself. The `strokeStyle` object form (`{ dashArray, lineCap }`) falls back to a textual notice in `StrokeStyleSample`; if we later add SVG stroke rendering, this doc should be updated.
 
 ## Method
 

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -1,0 +1,160 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface StrokeStyleSampleProps {
+  /**
+   * Token-path filter. Defaults to every `strokeStyle` token. Use e.g.
+   * `"stroke.ref.style.*"` to scope to the ref layer.
+   */
+  filter?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const STRING_STYLES = new Set([
+  'solid',
+  'dashed',
+  'dotted',
+  'double',
+  'groove',
+  'ridge',
+  'outset',
+  'inset',
+]);
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
+    gap: 16,
+    alignItems: 'center',
+    padding: '14px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  value: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  line: {
+    height: 0,
+    borderTopWidth: 4,
+    borderTopColor: 'var(--sb-color-sys-text-default, CanvasText)',
+    width: '100%',
+  } satisfies CSSProperties,
+  objectFallback: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  cssVar: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface Row {
+  path: string;
+  cssVar: string;
+  displayValue: string;
+  cssStyle: string | null;
+}
+
+function extractCssStyle(value: unknown): string | null {
+  if (typeof value === 'string' && STRING_STYLES.has(value)) return value;
+  return null;
+}
+
+export function StrokeStyleSample({
+  filter = 'strokeStyle',
+  caption,
+}: StrokeStyleSampleProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo<Row[]>(() => {
+    return Object.entries(resolved)
+      .filter(([path, token]) => {
+        if (token.$type !== 'strokeStyle') return false;
+        return globMatch(path, filter);
+      })
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([path, token]) => ({
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        displayValue: formatValue(token.$value),
+        cssStyle: extractCssStyle(token.$value),
+      }));
+  }, [resolved, filter, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} strokeStyle token${rows.length === 1 ? '' : 's'}${filter && filter !== 'strokeStyle' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.empty}>No strokeStyle tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            <span style={styles.value}>{row.displayValue}</span>
+          </div>
+          {row.cssStyle ? (
+            <div
+              style={{
+                ...styles.line,
+                borderTopStyle: row.cssStyle as CSSProperties['borderTopStyle'],
+              }}
+              aria-hidden
+            />
+          ) : (
+            <span style={styles.objectFallback}>
+              Object-form (dashArray + lineCap) — no pure CSS `border-style` equivalent.
+            </span>
+          )}
+          <span style={styles.cssVar}>{row.cssVar}</span>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -5,6 +5,7 @@ export { FontFamilySample, type FontFamilySampleProps } from '#/FontFamilySample
 export { FontWeightScale, type FontWeightScaleProps } from '#/FontWeightScale.tsx';
 export { MotionPreview, type MotionPreviewProps, type MotionSpeed } from '#/MotionPreview.tsx';
 export { ShadowPreview, type ShadowPreviewProps } from '#/ShadowPreview.tsx';
+export { StrokeStyleSample, type StrokeStyleSampleProps } from '#/StrokeStyleSample.tsx';
 export { TokenDetail, type TokenDetailProps } from '#/TokenDetail.tsx';
 export { TokenTable, type TokenTableProps } from '#/TokenTable.tsx';
 export { TypographyScale, type TypographyScaleProps } from '#/TypographyScale.tsx';

--- a/packages/tokens-reference/tokens/ref/number.json
+++ b/packages/tokens-reference/tokens/ref/number.json
@@ -1,0 +1,18 @@
+{
+  "number": {
+    "ref": {
+      "$type": "number",
+      "$description": "Unitless numeric primitives — opacities, line-height multipliers, z-index slots.",
+      "opacity": {
+        "disabled":     { "$value": 0.4 },
+        "muted":        { "$value": 0.7 },
+        "scrim":        { "$value": 0.6 }
+      },
+      "line-height": {
+        "tight":  { "$value": 1.15 },
+        "normal": { "$value": 1.4 },
+        "loose":  { "$value": 1.7 }
+      }
+    }
+  }
+}

--- a/packages/tokens-reference/tokens/ref/stroke.json
+++ b/packages/tokens-reference/tokens/ref/stroke.json
@@ -1,0 +1,24 @@
+{
+  "stroke": {
+    "ref": {
+      "style": {
+        "$type": "strokeStyle",
+        "$description": "Raw stroke-style primitives. Includes the DTCG string enum plus one object-form token exercising the { dashArray, lineCap } shape.",
+        "solid":  { "$value": "solid" },
+        "dashed": { "$value": "dashed" },
+        "dotted": { "$value": "dotted" },
+        "double": { "$value": "double" },
+        "custom-dash": {
+          "$description": "Object-form strokeStyle. Consumers that can't express lineCap fall back to the dash array.",
+          "$value": {
+            "dashArray": [
+              { "value": 6, "unit": "px" },
+              { "value": 4, "unit": "px" }
+            ],
+            "lineCap": "round"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/tokens-reference/tokens/resolver.json
+++ b/packages/tokens-reference/tokens/resolver.json
@@ -10,7 +10,9 @@
         { "$ref": "./ref/color.palette.json" },
         { "$ref": "./ref/size.scale.json" },
         { "$ref": "./ref/font.json" },
-        { "$ref": "./ref/motion.json" }
+        { "$ref": "./ref/motion.json" },
+        { "$ref": "./ref/stroke.json" },
+        { "$ref": "./ref/number.json" }
       ]
     },
     "sys": {


### PR DESCRIPTION
## Summary
- Reference fixture gains `stroke.ref.style.*` (solid / dashed / dotted / double / object-form custom-dash) and `number.ref.opacity.*` + `number.ref.line-height.*`
- New `StrokeStyleSample` block renders string-form values as visible lines via `border-top-style`; object-form values render a textual notice (CSS `border-style` has no matching primitive for `{ dashArray, lineCap }`)
- `number` tokens ride on `TokenTable`'s default rendering — defensible since opacities / line-height multipliers / z-index slots have no meaningful visual beyond the number itself
- `docs/type-coverage.md` matrix refreshed; no remaining gaps

Closes #125

## Plan impact
`docs/type-coverage.md` updated in this PR — all DTCG 2025.10 primitives and composites now have either a dedicated block or a `TokenDetail` preview

## Test plan
- [x] `pnpm turbo run lint typecheck test test:storybook` (64/64 green, one new `StrokeStyleSampleRenders` assertion)
- [x] Core tests still pass with the new primitives loaded