### PR TITLE
feat(core): expose modifier axes on Project

### DIFF
--- a/.changeset/project-axes.md
+++ b/.changeset/project-axes.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': minor
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+Expose modifier axes as first-class on `Project`. `Project.axes: Axis[]` surfaces each DTCG resolver modifier with its `contexts`, `default`, `description`, and `source` (`'resolver' | 'synthetic'`); projects loaded without a resolver get a single synthetic `theme` axis. A new `permutationID(input)` utility centralizes the tuple-to-string logic previously inlined in the resolver loader — single-axis tuples stringify to the context value; multi-axis tuples join with ` · `. The virtual `virtual:swatchbook/tokens` module now also exports `axes`, so toolbar and panel work in follow-up PRs can key on tuples rather than flat theme names.

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -5,6 +5,14 @@
  * consumers read back.
  */
 declare module 'virtual:swatchbook/tokens' {
+  interface VirtualAxis {
+    name: string;
+    contexts: readonly string[];
+    default: string;
+    description?: string;
+    source: 'resolver' | 'synthetic';
+  }
+
   interface VirtualTheme {
     name: string;
     input: Record<string, string>;
@@ -29,6 +37,7 @@ declare module 'virtual:swatchbook/tokens' {
     aliasedBy?: readonly string[];
   }
 
+  export const axes: readonly VirtualAxis[];
   export const themes: readonly VirtualTheme[];
   export const defaultTheme: string | null;
   export const themesResolved: Record<string, Record<string, VirtualToken>>;

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -42,6 +42,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
       // Emit a typed ESM module. Values are JSON-stringified for stability.
       return [
         `/* swatchbook virtual module — generated */`,
+        `export const axes = ${JSON.stringify(project.axes)};`,
         `export const themes = ${JSON.stringify(project.themes)};`,
         `export const defaultTheme = ${JSON.stringify(project.themes[0]?.name ?? null)};`,
         `export const themesResolved = ${JSON.stringify(project.themesResolved)};`,

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -6,6 +6,14 @@
  * plus core's `Theme` and `Diagnostic`.
  */
 declare module 'virtual:swatchbook/tokens' {
+  interface VirtualAxis {
+    name: string;
+    contexts: readonly string[];
+    default: string;
+    description?: string;
+    source: 'resolver' | 'synthetic';
+  }
+
   interface VirtualTheme {
     name: string;
     input: Record<string, string>;
@@ -30,6 +38,7 @@ declare module 'virtual:swatchbook/tokens' {
     aliasedBy?: readonly string[];
   }
 
+  export const axes: readonly VirtualAxis[];
   export const themes: readonly VirtualTheme[];
   export const defaultTheme: string | null;
   export const themesResolved: Record<string, Record<string, VirtualToken>>;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -13,12 +13,13 @@ pnpm add @unpunnyfuns/swatchbook-core
 | Export | Purpose |
 | --- | --- |
 | `defineSwatchbookConfig(config)` | Identity helper for a typed `swatchbook.config.ts`. |
-| `loadProject(config, cwd?)` | Parse + resolve — returns `Project { themes, themesResolved, graph, diagnostics, … }`. |
+| `loadProject(config, cwd?)` | Parse + resolve — returns `Project { axes, themes, themesResolved, graph, diagnostics, … }`. |
 | `resolveTheme(project, name)` | Pick a single composed theme out of a project. |
 | `emitCss(project, options?)` | Concatenated stylesheet, one `[data-theme="…"]` block per theme. |
 | `projectCss(project)` | Same as `emitCss` with project defaults applied. |
 | `emitTypes(project)` | TypeScript source declaring the token-path union + `SwatchbookTokenMap`. |
-| Types | `Config`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
+| `permutationID(input)` | Stringify a tuple (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`) to the form used as `Theme.name` and CSS data-attribute values. |
+| Types | `Axis`, `Config`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
 
 ## Minimal config
 
@@ -48,9 +49,11 @@ const dts = emitTypes(project);
 
 `project.diagnostics` is always populated — severity is `'error' | 'warn' | 'info'`. The addon surfaces these in its Diagnostics panel; your own pipeline can inspect / `throw` on `severity === 'error'` as fits.
 
-## Theme naming
+## Axes and theme naming
 
-Theme names come from the resolver's permutations — single-axis resolvers use the modifier value directly (a `theme` modifier with contexts `Light` / `Dark` yields those names verbatim). Multi-axis resolvers join tuple values with ` · `, so a `mode` × `brand` resolver produces `Light · Default`, `Dark · Default`, `Light · Brand A`, `Dark · Brand A`. This stringification is a stopgap until `Project.axes` exposes per-modifier structure directly (issue #131); consuming code should already be tuple-aware where possible. Pick sensible modifier context names — what you write is what the toolbar shows.
+`Project.axes` surfaces the resolver's modifiers as first-class — one `Axis` per DTCG modifier, each with its `contexts`, `default`, and `description`. Projects loaded without a resolver fall back to a single synthetic axis named `theme`.
+
+Theme names are derived from the axis tuple via `permutationID(input)`: single-axis tuples stringify to the context value alone (`{ theme: 'Light' }` → `"Light"`); multi-axis tuples join context values with ` · ` (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`). Pick sensible context names — what you write is what the toolbar shows. Consuming code should prefer `axes` + `themes[].input` over matching names by string.
 
 ## Do / don't
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,8 +2,10 @@ export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject, resolveTheme } from '#/load.ts';
 export { projectCss, emitTypes } from '#/emit.ts';
 export { emitCss, type EmitCssOptions } from '#/css.ts';
+export { permutationID } from '#/types.ts';
 
 export type {
+  Axis,
   Config,
   Diagnostic,
   DiagnosticSeverity,

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -19,6 +19,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
 
   return {
     config,
+    axes: normalized.axes,
     themes: normalized.themes,
     themesResolved: normalized.resolved,
     graph,

--- a/packages/core/src/themes/normalize.ts
+++ b/packages/core/src/themes/normalize.ts
@@ -1,8 +1,9 @@
-import type { Config, Theme, TokenMap } from '#/types.ts';
+import type { Axis, Config, Theme, TokenMap } from '#/types.ts';
 import type { BufferedLogger } from '#/diagnostics.ts';
 import { loadResolverThemes } from '#/themes/resolver.ts';
 
 export interface NormalizedThemes {
+  axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
   defaultThemeName: string;

--- a/packages/core/src/themes/resolver.ts
+++ b/packages/core/src/themes/resolver.ts
@@ -2,11 +2,12 @@ import { readFile } from 'node:fs/promises';
 import { isAbsolute, resolve as resolvePath } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { defineConfig as defineTerrazzoConfig, loadResolver, parse } from '@terrazzo/parser';
-import type { Theme, TokenMap } from '#/types.ts';
+import { permutationID, type Axis, type Theme, type TokenMap } from '#/types.ts';
 import type { BufferedLogger } from '#/diagnostics.ts';
 import { collectGlobbedFiles } from '#/themes/util.ts';
 
 export interface ResolverLoadResult {
+  axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
   defaultThemeName: string;
@@ -67,6 +68,7 @@ export async function loadResolverThemes(
     });
     const name = explicitDefault ?? 'default';
     return {
+      axes: [{ name: 'theme', contexts: [name], default: name, source: 'synthetic' }],
       themes: [{ name, input: { theme: name }, sources: tokenFiles }],
       resolved: { [name]: parsed.tokens },
       defaultThemeName: name,
@@ -76,18 +78,19 @@ export async function loadResolverThemes(
   const { resolver } = loaded;
   const permutations = resolver.listPermutations();
 
+  const axes: Axis[] = Object.entries(resolver.source.modifiers ?? {}).map(([name, modifier]) => ({
+    name,
+    contexts: Object.keys(modifier.contexts ?? {}),
+    default: modifier.default ?? Object.keys(modifier.contexts ?? {})[0] ?? '',
+    ...(modifier.description !== undefined ? { description: modifier.description } : {}),
+    source: 'resolver' as const,
+  }));
+
   const themes: Theme[] = [];
   const resolved: Record<string, TokenMap> = {};
 
   for (const input of permutations) {
-    // Single-axis: the modifier value is itself the unique identifier
-    // (`Light` beats `{"theme":"Light"}`). Multi-axis: join the tuple values
-    // with `·` so downstream CSS selectors and toolbar labels stay readable.
-    // Terrazzo's `getPermutationID` would emit JSON here, which is lossless
-    // but hostile as a data-attribute value. A future pass replaces this
-    // stringification entirely once `Project.axes` lands (issue #131).
-    const values = Object.values(input).map(String);
-    const id = values.length === 1 ? (values[0] as string) : values.join(' · ');
+    const id = permutationID(input);
     const tokens = resolver.apply(input);
     themes.push({ name: id, input: { ...input }, sources: [] });
     resolved[id] = tokens;
@@ -96,5 +99,5 @@ export async function loadResolverThemes(
   const defaultThemeName =
     explicitDefault && resolved[explicitDefault] ? explicitDefault : (themes[0]?.name ?? '');
 
-  return { themes, resolved, defaultThemeName };
+  return { axes, themes, resolved, defaultThemeName };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,6 +11,20 @@ export interface Theme {
   sources: string[];
 }
 
+/**
+ * One modifier axis of the theming model. Resolver-backed projects surface
+ * one `Axis` per DTCG modifier; projects without a resolver (e.g. plain
+ * token parsing with no composition) get a single synthetic axis named
+ * `theme`.
+ */
+export interface Axis {
+  name: string;
+  contexts: string[];
+  default: string;
+  description?: string;
+  source: 'resolver' | 'synthetic';
+}
+
 /** Swatchbook configuration. The resolver is the sole theming input. */
 export interface Config {
   /** Glob patterns for DTCG token files. */
@@ -43,12 +57,27 @@ export interface Diagnostic {
  */
 export interface Project {
   config: Config;
+  axes: Axis[];
   themes: Theme[];
   /** Eagerly-resolved tokens per theme, keyed by `theme.name`. */
   themesResolved: Record<string, TokenMap>;
   /** Default theme's resolved tokens — convenience for global views. */
   graph: TokenMap;
   diagnostics: Diagnostic[];
+}
+
+/**
+ * Serialize an axis tuple to the stable string ID used as a `Theme.name`,
+ * CSS data-attribute value, and cache key. Single-axis tuples stringify to
+ * the context value alone (`{ theme: 'Light' }` → `"Light"`); multi-axis
+ * tuples join context values with ` · ` in insertion order
+ * (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`).
+ */
+export function permutationID(input: Record<string, string>): string {
+  const values = Object.values(input);
+  if (values.length === 0) return '';
+  if (values.length === 1) return values[0] as string;
+  return values.join(' · ');
 }
 
 export interface ResolvedTheme {

--- a/packages/core/test/load.test.ts
+++ b/packages/core/test/load.test.ts
@@ -26,6 +26,31 @@ describe('loadProject — resolver mode', () => {
     expect(Object.keys(project.graph).length).toBeGreaterThan(100);
   });
 
+  it('surfaces resolver modifiers as independent axes', () => {
+    expect(project.axes).toEqual([
+      {
+        name: 'mode',
+        contexts: ['Light', 'Dark'],
+        default: 'Light',
+        description: 'Light/dark surface + text baseline.',
+        source: 'resolver',
+      },
+      {
+        name: 'brand',
+        contexts: ['Default', 'Brand A'],
+        default: 'Default',
+        description:
+          'Accent palette. `Default` leaves sys alone; `Brand A` overrides the accent scale.',
+        source: 'resolver',
+      },
+    ]);
+  });
+
+  it('cartesian product of axis contexts matches the theme count', () => {
+    const cartesian = project.axes.reduce((n, axis) => n * axis.contexts.length, 1);
+    expect(project.themes.length).toBe(cartesian);
+  });
+
   it('resolves deep alias chains (cmp → sys → ref)', () => {
     const light = resolveTheme(project, 'Light · Default').tokens;
     const buttonBg = light['cmp.button.bg'];

--- a/packages/core/test/permutation-id.test.ts
+++ b/packages/core/test/permutation-id.test.ts
@@ -1,0 +1,14 @@
+import { expect, it } from 'vitest';
+import { permutationID } from '#/types.ts';
+
+it('returns the context value directly for single-axis tuples', () => {
+  expect(permutationID({ theme: 'Light' })).toBe('Light');
+});
+
+it('joins multi-axis tuple values with " · " in insertion order', () => {
+  expect(permutationID({ mode: 'Dark', brand: 'Brand A' })).toBe('Dark · Brand A');
+});
+
+it('returns empty string for empty tuples', () => {
+  expect(permutationID({})).toBe('');
+});


### PR DESCRIPTION
**Milestone:** Multi-axis theming UX

**Closes:** Closes #131

**Plan impact:** none

## Summary

- Add \`Axis\` type and \`Project.axes: Axis[]\` surfacing each DTCG resolver modifier's \`contexts\`, \`default\`, \`description\`, and \`source\` (\`'resolver' | 'synthetic'\`). Projects loaded without a resolver fall back to a single synthetic \`theme\` axis.
- New \`permutationID(input)\` utility centralizes the tuple-to-string logic that was previously inlined in the resolver loader. Single-axis tuples stringify to the context value; multi-axis tuples join with \` · \`.
- Virtual \`virtual:swatchbook/tokens\` module exports \`axes\`; addon + blocks virtual type decls updated so consumers (toolbar, panel, blocks) can read the axis structure directly.
- Unit tests pin: resolver axes match the fixture's \`mode × brand\` shape with correct descriptions; the cartesian product of context counts equals \`themes.length\`; \`permutationID\` handles single, multi, and empty tuples.
- \`packages/core/README.md\` updated — new \"Axes and theme naming\" section, \`Project\` row mentions \`axes\`, \`permutationID\` and \`Axis\` listed in the public API table.

This lands the structural plumbing #131 was about. Downstream issues (#133 tuple globals, #134 N-dropdown toolbar, #135 CSS emission, #136 tuple-aware panel, #137 layered axes, #138 presets) can now build on \`Project.axes\` directly.

## Test plan

- [x] \`pnpm turbo run lint typecheck test\` green
- [x] \`pnpm turbo run test:storybook\` green — 64/64 story tests pass
- [x] \`pnpm turbo run build\` green