### PR TITLE
feat(addon): globals tuple + per-axis data attributes

### DIFF
--- a/.changeset/axes-globals-tuple.md
+++ b/.changeset/axes-globals-tuple.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+Addon preview now resolves theme selection from an axis **tuple** rather than a composed name. New `swatchbookAxes` global (`Record<axisName, contextName>`) and `parameters.swatchbook.axes` per-story override take precedence over the existing `swatchbookTheme` / `parameters.swatchbook.theme` string form (still accepted for back-compat). The decorator writes one `data-<axisName>="<context>"` attribute per axis to `<html>` and the story wrapper — alongside the existing `data-theme` composed ID — giving upcoming CSS emission (#135) and toolbar (#134) work a stable target. A new `AxesContext` + `useActiveAxes()` hook exposes the tuple to consumer components.

--- a/apps/storybook/src/stories/ThemeSwitch.stories.tsx
+++ b/apps/storybook/src/stories/ThemeSwitch.stories.tsx
@@ -46,7 +46,7 @@ async function bgWhenMounted(el: Element): Promise<string> {
  * Component channels should all be near 255.
  */
 export const Light = meta.story({
-  parameters: { swatchbook: { theme: 'Light · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Light', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const card = canvasElement.querySelector<HTMLElement>('[data-testid="probe-card"]');
     if (!card) throw new Error('probe-card missing');
@@ -64,7 +64,7 @@ export const Light = meta.story({
  * Component channels should all be low.
  */
 export const Dark = meta.story({
-  parameters: { swatchbook: { theme: 'Dark · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const card = canvasElement.querySelector<HTMLElement>('[data-testid="probe-card"]');
     if (!card) throw new Error('probe-card missing');
@@ -84,7 +84,7 @@ export const Dark = meta.story({
  * defining property — whereas plain Light/Dark accents are blue-dominant.
  */
 export const LightBrandA = meta.story({
-  parameters: { swatchbook: { theme: 'Light · Brand A' } },
+  parameters: { swatchbook: { axes: { mode: 'Light', brand: 'Brand A' } } },
   play: async ({ canvasElement }) => {
     const button = canvasElement.querySelector<HTMLElement>('[data-testid="probe-button"]');
     if (!button) throw new Error('probe-button missing');
@@ -92,5 +92,23 @@ export const LightBrandA = meta.story({
     const [r, g] = parseRgb(bg);
     // Blue.700 (default accent): r=29 < g=78. Violet.700 (Brand A): r=109 > g=40.
     expect(r, `Brand A accent should be violet (r > g); got rgb(${r}, ${g}, _)`).toBeGreaterThan(g);
+  },
+});
+
+/**
+ * Preview decorator publishes the tuple as per-axis `data-<axis>` attributes
+ * on both `<html>` and the story wrapper. Upcoming toolbar + CSS-emission
+ * work keys on these.
+ */
+export const PerAxisDataAttrs = meta.story({
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },
+  play: async ({ canvasElement }) => {
+    const wrapper = canvasElement.querySelector<HTMLElement>('[data-mode]');
+    if (!wrapper) throw new Error('expected story wrapper with data-mode attribute');
+    expect(wrapper.getAttribute('data-mode')).toBe('Dark');
+    expect(wrapper.getAttribute('data-brand')).toBe('Brand A');
+    expect(wrapper.getAttribute('data-theme')).toBe('Dark · Brand A');
+    expect(document.documentElement.getAttribute('data-mode')).toBe('Dark');
+    expect(document.documentElement.getAttribute('data-brand')).toBe('Brand A');
   },
 });

--- a/apps/storybook/src/stories/UseTokenUpdates.stories.tsx
+++ b/apps/storybook/src/stories/UseTokenUpdates.stories.tsx
@@ -59,7 +59,7 @@ async function textContent(root: Element, testId: string): Promise<string> {
  * strings are theme-invariant; only the resolved `value` should shift.
  */
 export const Light = meta.story({
-  parameters: { swatchbook: { theme: 'Light · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Light', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const surface = parseSrgb(await textContent(canvasElement, 'surface-value'));
     const text = parseSrgb(await textContent(canvasElement, 'text-value'));
@@ -87,7 +87,7 @@ export const Light = meta.story({
  * the toolbar uses at runtime).
  */
 export const Dark = meta.story({
-  parameters: { swatchbook: { theme: 'Dark · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const surface = parseSrgb(await textContent(canvasElement, 'surface-value'));
     const text = parseSrgb(await textContent(canvasElement, 'text-value'));

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -70,12 +70,12 @@ Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across them
 ## Per-story overrides
 
 ```ts
-export const AlwaysDark = meta.story({
-  parameters: { swatchbook: { theme: 'Dark' } },
+export const DarkBrandA = meta.story({
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },
 });
 ```
 
-Any valid theme name — including multi-axis permutations like `'Light · Brand A'` — is accepted.
+`axes` is a tuple of `{ axisName: contextName }` entries. Any axis left out falls back to its default; unknown keys or contexts are silently ignored. The legacy `theme: 'Composed Name'` form is still accepted for single-axis overrides.
 
 ## Do / don't
 

--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -4,7 +4,10 @@ export const PANEL_ID = `${ADDON_ID}/panel`;
 export const PANEL_TOKENS_TAB = `${ADDON_ID}/tokens`;
 export const PANEL_DIAGNOSTICS_TAB = `${ADDON_ID}/diagnostics`;
 export const PARAM_KEY = 'swatchbook';
+/** Canonical active-theme global: composed permutation ID (string). Read by toolbar, panel, blocks. */
 export const GLOBAL_KEY = 'swatchbookTheme';
+/** Tuple companion: `Record<axisName, contextName>`. Optional — when present, takes precedence over the string global. */
+export const AXES_GLOBAL_KEY = 'swatchbookAxes';
 
 export const VIRTUAL_MODULE_ID = 'virtual:swatchbook/tokens';
 export const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;

--- a/packages/addon/src/hooks/index.ts
+++ b/packages/addon/src/hooks/index.ts
@@ -4,4 +4,4 @@ export {
   type TokenInfo,
   type TokenPath,
 } from '#/hooks/use-token.ts';
-export { useActiveTheme } from '#/theme-context.ts';
+export { useActiveAxes, useActiveTheme } from '#/theme-context.ts';

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -1,7 +1,14 @@
 import { definePreviewAddon } from 'storybook/internal/csf';
 import * as previewExports from './preview.tsx';
 
-export { ADDON_ID, GLOBAL_KEY, PARAM_KEY, VIRTUAL_MODULE_ID } from '#/constants.ts';
+export {
+  ADDON_ID,
+  AXES_GLOBAL_KEY,
+  GLOBAL_KEY,
+  PARAM_KEY,
+  VIRTUAL_MODULE_ID,
+} from '#/constants.ts';
+export { AxesContext, ThemeContext, useActiveAxes, useActiveTheme } from '#/theme-context.ts';
 export type { AddonOptions } from '#/options.ts';
 
 /**

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -1,7 +1,8 @@
 import type { Decorator, Preview } from '@storybook/react-vite';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { addons } from 'storybook/preview-api';
 import {
+  axes as virtualAxes,
   css,
   cssVarPrefix,
   defaultTheme,
@@ -10,13 +11,14 @@ import {
   themesResolved,
 } from 'virtual:swatchbook/tokens';
 import {
+  AXES_GLOBAL_KEY,
   DATA_THEME_ATTR,
   GLOBAL_KEY,
   INIT_EVENT,
   PARAM_KEY,
   STYLE_ELEMENT_ID,
 } from '#/constants.ts';
-import { ThemeContext } from '#/theme-context.ts';
+import { AxesContext, ThemeContext } from '#/theme-context.ts';
 
 /** CSS var name with the active prefix applied. */
 function v(name: string): string {
@@ -47,10 +49,24 @@ html, body {
   if (style.textContent !== text) style.textContent = text;
 }
 
-/** Keep <html data-theme=…> in sync so the whole iframe inherits the theme. */
-function setRootTheme(theme: string): void {
+/**
+ * Write the composed permutation ID to `data-theme` plus one
+ * `data-<axis>=<context>` per axis. The composed ID stays for CSS
+ * emission's current `[data-theme="…"]` selectors (retires in #135);
+ * per-axis attributes are what upcoming toolbar + panel work will key on.
+ */
+function setRootAxes(themeName: string, tuple: Readonly<Record<string, string>>): void {
   if (typeof document === 'undefined') return;
-  document.documentElement.setAttribute(DATA_THEME_ATTR, theme);
+  const root = document.documentElement;
+  root.setAttribute(DATA_THEME_ATTR, themeName);
+  for (const axis of virtualAxes) {
+    const value = tuple[axis.name];
+    if (value === undefined) {
+      root.removeAttribute(`data-${axis.name}`);
+    } else {
+      root.setAttribute(`data-${axis.name}`, value);
+    }
+  }
 }
 
 /**
@@ -61,6 +77,7 @@ function setRootTheme(theme: string): void {
 function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(INIT_EVENT, {
+    axes: virtualAxes,
     themes,
     defaultTheme,
     themesResolved,
@@ -69,12 +86,85 @@ function broadcastInit(): void {
   });
 }
 
+/** Axis-default tuple, used as the baseline before overrides. */
+function defaultTuple(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of virtualAxes) out[axis.name] = axis.default;
+  return out;
+}
+
+/** Look up a `Theme.input` by composed name. Returns `undefined` if no theme matches. */
+function tupleForName(name: string): Record<string, string> | undefined {
+  const match = themes.find((t) => t.name === name);
+  return match?.input;
+}
+
+/**
+ * Merge a partial tuple onto the axis defaults, dropping keys for axes that
+ * don't exist and silently falling back to the default for contexts that
+ * aren't listed on the axis.
+ */
+function normalizeTuple(partial: Readonly<Record<string, string>>): Record<string, string> {
+  const out = defaultTuple();
+  for (const axis of virtualAxes) {
+    const candidate = partial[axis.name];
+    if (candidate !== undefined && axis.contexts.includes(candidate)) {
+      out[axis.name] = candidate;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the active tuple from all four input channels, in priority order:
+ *   1. `parameters.swatchbook.axes` — per-story tuple.
+ *   2. `parameters.swatchbook.theme` — per-story composed name (legacy).
+ *   3. `globals.swatchbookAxes` — toolbar-set tuple.
+ *   4. `globals.swatchbookTheme` — toolbar-set composed name.
+ *   5. virtual module default.
+ */
+function resolveTuple(
+  globals: Record<string, unknown>,
+  parameters: Record<string, Record<string, unknown>>,
+): Record<string, string> {
+  const param = parameters[PARAM_KEY];
+  const paramAxes = param?.['axes'];
+  if (paramAxes && typeof paramAxes === 'object') {
+    return normalizeTuple(paramAxes as Record<string, string>);
+  }
+  const paramTheme = param?.['theme'];
+  if (typeof paramTheme === 'string') {
+    const hit = tupleForName(paramTheme);
+    if (hit) return normalizeTuple(hit);
+  }
+  const globalAxes = globals[AXES_GLOBAL_KEY];
+  if (globalAxes && typeof globalAxes === 'object') {
+    return normalizeTuple(globalAxes as Record<string, string>);
+  }
+  const globalTheme = globals[GLOBAL_KEY];
+  if (typeof globalTheme === 'string') {
+    const hit = tupleForName(globalTheme);
+    if (hit) return normalizeTuple(hit);
+  }
+  return defaultTuple();
+}
+
 const themedDecorator: Decorator = (Story, context) => {
-  const globalTheme = (context.globals as Record<string, unknown>)[GLOBAL_KEY];
-  const parameterTheme = (context.parameters as Record<string, Record<string, unknown>>)[
-    PARAM_KEY
-  ]?.['theme'];
-  const theme = (parameterTheme ?? globalTheme ?? defaultTheme ?? 'Light') as string;
+  const tuple = useMemo(
+    () =>
+      resolveTuple(
+        context.globals as Record<string, unknown>,
+        context.parameters as Record<string, Record<string, unknown>>,
+      ),
+    [context.globals, context.parameters],
+  );
+  const themeName = useMemo(() => {
+    const match = themes.find((t) => {
+      const input = t.input as Record<string, string>;
+      return Object.keys(input).every((k) => input[k] === tuple[k]);
+    });
+    return match?.name ?? defaultTheme ?? themes[0]?.name ?? 'Light';
+  }, [tuple]);
 
   useEffect(() => {
     ensureStylesheet();
@@ -82,20 +172,28 @@ const themedDecorator: Decorator = (Story, context) => {
   }, []);
 
   useEffect(() => {
-    setRootTheme(theme);
-  }, [theme]);
+    setRootAxes(themeName, tuple);
+  }, [themeName, tuple]);
+
+  const wrapperAttrs: Record<string, string> = { [DATA_THEME_ATTR]: themeName };
+  for (const axis of virtualAxes) {
+    const value = tuple[axis.name];
+    if (value !== undefined) wrapperAttrs[`data-${axis.name}`] = value;
+  }
 
   return (
-    <ThemeContext.Provider value={theme}>
-      <div
-        {...{ [DATA_THEME_ATTR]: theme }}
-        style={{
-          padding: '1rem',
-          minHeight: '100%',
-        }}
-      >
-        <Story />
-      </div>
+    <ThemeContext.Provider value={themeName}>
+      <AxesContext.Provider value={tuple}>
+        <div
+          {...wrapperAttrs}
+          style={{
+            padding: '1rem',
+            minHeight: '100%',
+          }}
+        >
+          <Story />
+        </div>
+      </AxesContext.Provider>
     </ThemeContext.Provider>
   );
 };
@@ -109,10 +207,21 @@ export const decorators: NonNullable<Preview['decorators']> = [themedDecorator];
 export const globalTypes: NonNullable<Preview['globalTypes']> = {
   [GLOBAL_KEY]: {
     name: 'Theme',
-    description: 'Active swatchbook theme. UI lives in the manager toolbar tool.',
+    description: 'Active swatchbook theme (composed permutation ID).',
+  },
+  [AXES_GLOBAL_KEY]: {
+    name: 'Axes',
+    description: 'Per-axis context selection. Takes precedence over the composed theme name.',
   },
 };
 
+function buildInitialAxes(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of virtualAxes) out[axis.name] = axis.default;
+  return out;
+}
+
 export const initialGlobals: NonNullable<Preview['initialGlobals']> = {
   [GLOBAL_KEY]: defaultTheme ?? themes[0]?.name ?? 'Light',
+  [AXES_GLOBAL_KEY]: buildInitialAxes(),
 };

--- a/packages/addon/src/theme-context.ts
+++ b/packages/addon/src/theme-context.ts
@@ -14,3 +14,15 @@ export const ThemeContext = createContext<string>('');
 export function useActiveTheme(): string {
   return useContext(ThemeContext);
 }
+
+/**
+ * Active axis tuple for the current story/docs render — `Record<axisName,
+ * contextName>`. Derived from the same input as {@link ThemeContext}; split
+ * out so consumers needing per-axis info (toolbar, panel, tuple-aware
+ * blocks) don't have to reparse the composed permutation ID.
+ */
+export const AxesContext = createContext<Readonly<Record<string, string>>>({});
+
+export function useActiveAxes(): Readonly<Record<string, string>> {
+  return useContext(AxesContext);
+}


### PR DESCRIPTION
**Milestone:** Multi-axis theming UX

**Closes:** Closes #133

**Plan impact:** none

## Summary

- Preview decorator resolves theme selection from an axis **tuple** (\`Record<axisName, contextName>\`) rather than a composed permutation ID string.
- New \`swatchbookAxes\` global and \`parameters.swatchbook.axes\` per-story override take precedence over the legacy \`swatchbookTheme\` / \`.theme\` forms — still accepted for back-compat with the current toolbar.
- Decorator writes one \`data-<axisName>=\"<context>\"\` attribute per axis to both \`<html>\` and the story wrapper, alongside the existing composed \`data-theme\` ID. Upcoming CSS emission (#135) and N-dropdown toolbar (#134) key on these.
- New \`AxesContext\` + \`useActiveAxes()\` hook exposes the tuple to consumer components needing per-axis info rather than the composed name.
- Resolution priority: \`parameters.swatchbook.axes\` → \`parameters.swatchbook.theme\` → \`globals.swatchbookAxes\` → \`globals.swatchbookTheme\` → virtual-module default. Unknown axes and invalid contexts fall back to axis defaults.
- Storybook fixture stories (\`ThemeSwitch\`, \`UseTokenUpdates\`) switched to the new tuple form. New \`PerAxisDataAttrs\` play-function test asserts the per-axis data attributes are set on both the wrapper and \`<html>\`.

## Test plan

- [x] \`pnpm turbo run lint typecheck test\` green
- [x] \`pnpm turbo run test:storybook\` — 65/65 story tests pass (was 64; new test for per-axis data attrs)
- [x] \`pnpm turbo run build\` green