### PR TITLE
feat(addon): per-axis dropdowns in the theme toolbar

### DIFF
--- a/.changeset/axes-globals-tuple.md
+++ b/.changeset/axes-globals-tuple.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+Addon preview now resolves theme selection from an axis **tuple** rather than a composed name. New `swatchbookAxes` global (`Record<axisName, contextName>`) and `parameters.swatchbook.axes` per-story override take precedence over the existing `swatchbookTheme` / `parameters.swatchbook.theme` string form (still accepted for back-compat). The decorator writes one `data-<axisName>="<context>"` attribute per axis to `<html>` and the story wrapper — alongside the existing `data-theme` composed ID — giving upcoming CSS emission (#135) and toolbar (#134) work a stable target. A new `AxesContext` + `useActiveAxes()` hook exposes the tuple to consumer components.

--- a/.changeset/n-dropdown-toolbar.md
+++ b/.changeset/n-dropdown-toolbar.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+Toolbar now renders one dropdown per modifier axis instead of a single flat list of composed theme names. For a project with independent `mode` and `brand` axes you get two controls (`mode: Light`, `brand: Brand A`) that combine into any valid permutation; the synthetic single-theme axis still presents as one "Theme" dropdown so UX is unchanged for projects without a resolver. Each dropdown shows the axis contexts with the current selection checked, surfaces the axis description in a tooltip when present, and updates both `swatchbookAxes` (the canonical tuple) and `swatchbookTheme` (the composed permutation ID for the panel + legacy consumers) atomically. The `alt+T` shortcut now cycles the primary (first) axis's contexts while pinning the rest of the tuple.

--- a/apps/storybook/src/stories/ThemeSwitch.stories.tsx
+++ b/apps/storybook/src/stories/ThemeSwitch.stories.tsx
@@ -46,7 +46,7 @@ async function bgWhenMounted(el: Element): Promise<string> {
  * Component channels should all be near 255.
  */
 export const Light = meta.story({
-  parameters: { swatchbook: { theme: 'Light · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Light', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const card = canvasElement.querySelector<HTMLElement>('[data-testid="probe-card"]');
     if (!card) throw new Error('probe-card missing');
@@ -64,7 +64,7 @@ export const Light = meta.story({
  * Component channels should all be low.
  */
 export const Dark = meta.story({
-  parameters: { swatchbook: { theme: 'Dark · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const card = canvasElement.querySelector<HTMLElement>('[data-testid="probe-card"]');
     if (!card) throw new Error('probe-card missing');
@@ -84,7 +84,7 @@ export const Dark = meta.story({
  * defining property — whereas plain Light/Dark accents are blue-dominant.
  */
 export const LightBrandA = meta.story({
-  parameters: { swatchbook: { theme: 'Light · Brand A' } },
+  parameters: { swatchbook: { axes: { mode: 'Light', brand: 'Brand A' } } },
   play: async ({ canvasElement }) => {
     const button = canvasElement.querySelector<HTMLElement>('[data-testid="probe-button"]');
     if (!button) throw new Error('probe-button missing');
@@ -92,5 +92,23 @@ export const LightBrandA = meta.story({
     const [r, g] = parseRgb(bg);
     // Blue.700 (default accent): r=29 < g=78. Violet.700 (Brand A): r=109 > g=40.
     expect(r, `Brand A accent should be violet (r > g); got rgb(${r}, ${g}, _)`).toBeGreaterThan(g);
+  },
+});
+
+/**
+ * Preview decorator publishes the tuple as per-axis `data-<axis>` attributes
+ * on both `<html>` and the story wrapper. Upcoming toolbar + CSS-emission
+ * work keys on these.
+ */
+export const PerAxisDataAttrs = meta.story({
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },
+  play: async ({ canvasElement }) => {
+    const wrapper = canvasElement.querySelector<HTMLElement>('[data-mode]');
+    if (!wrapper) throw new Error('expected story wrapper with data-mode attribute');
+    expect(wrapper.getAttribute('data-mode')).toBe('Dark');
+    expect(wrapper.getAttribute('data-brand')).toBe('Brand A');
+    expect(wrapper.getAttribute('data-theme')).toBe('Dark · Brand A');
+    expect(document.documentElement.getAttribute('data-mode')).toBe('Dark');
+    expect(document.documentElement.getAttribute('data-brand')).toBe('Brand A');
   },
 });

--- a/apps/storybook/src/stories/UseTokenUpdates.stories.tsx
+++ b/apps/storybook/src/stories/UseTokenUpdates.stories.tsx
@@ -59,7 +59,7 @@ async function textContent(root: Element, testId: string): Promise<string> {
  * strings are theme-invariant; only the resolved `value` should shift.
  */
 export const Light = meta.story({
-  parameters: { swatchbook: { theme: 'Light · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Light', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const surface = parseSrgb(await textContent(canvasElement, 'surface-value'));
     const text = parseSrgb(await textContent(canvasElement, 'text-value'));
@@ -87,7 +87,7 @@ export const Light = meta.story({
  * the toolbar uses at runtime).
  */
 export const Dark = meta.story({
-  parameters: { swatchbook: { theme: 'Dark · Default' } },
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Default' } } },
   play: async ({ canvasElement }) => {
     const surface = parseSrgb(await textContent(canvasElement, 'surface-value'));
     const text = parseSrgb(await textContent(canvasElement, 'text-value'));

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,6 +1,6 @@
 # @unpunnyfuns/swatchbook-addon
 
-Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview over a virtual module, renders a theme switcher in the toolbar and a browser + diagnostics panel, and ships a `useToken()` hook with typed paths.
+Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview over a virtual module, renders one toolbar dropdown per modifier axis (one control per `mode`, `brand`, …) plus a browser + diagnostics panel, and ships a `useToken()` hook with typed paths.
 
 ## Install
 

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -70,12 +70,12 @@ Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across them
 ## Per-story overrides
 
 ```ts
-export const AlwaysDark = meta.story({
-  parameters: { swatchbook: { theme: 'Dark' } },
+export const DarkBrandA = meta.story({
+  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },
 });
 ```
 
-Any valid theme name — including multi-axis permutations like `'Light · Brand A'` — is accepted.
+`axes` is a tuple of `{ axisName: contextName }` entries. Any axis left out falls back to its default; unknown keys or contexts are silently ignored. The legacy `theme: 'Composed Name'` form is still accepted for single-axis overrides.
 
 ## Do / don't
 

--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -4,7 +4,10 @@ export const PANEL_ID = `${ADDON_ID}/panel`;
 export const PANEL_TOKENS_TAB = `${ADDON_ID}/tokens`;
 export const PANEL_DIAGNOSTICS_TAB = `${ADDON_ID}/diagnostics`;
 export const PARAM_KEY = 'swatchbook';
+/** Canonical active-theme global: composed permutation ID (string). Read by toolbar, panel, blocks. */
 export const GLOBAL_KEY = 'swatchbookTheme';
+/** Tuple companion: `Record<axisName, contextName>`. Optional — when present, takes precedence over the string global. */
+export const AXES_GLOBAL_KEY = 'swatchbookAxes';
 
 export const VIRTUAL_MODULE_ID = 'virtual:swatchbook/tokens';
 export const RESOLVED_VIRTUAL_MODULE_ID = `\0${VIRTUAL_MODULE_ID}`;

--- a/packages/addon/src/hooks/index.ts
+++ b/packages/addon/src/hooks/index.ts
@@ -4,4 +4,4 @@ export {
   type TokenInfo,
   type TokenPath,
 } from '#/hooks/use-token.ts';
-export { useActiveTheme } from '#/theme-context.ts';
+export { useActiveAxes, useActiveTheme } from '#/theme-context.ts';

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -1,7 +1,14 @@
 import { definePreviewAddon } from 'storybook/internal/csf';
 import * as previewExports from './preview.tsx';
 
-export { ADDON_ID, GLOBAL_KEY, PARAM_KEY, VIRTUAL_MODULE_ID } from '#/constants.ts';
+export {
+  ADDON_ID,
+  AXES_GLOBAL_KEY,
+  GLOBAL_KEY,
+  PARAM_KEY,
+  VIRTUAL_MODULE_ID,
+} from '#/constants.ts';
+export { AxesContext, ThemeContext, useActiveAxes, useActiveTheme } from '#/theme-context.ts';
 export type { AddonOptions } from '#/options.ts';
 
 /**

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useMemo, useState, type ReactElement } from 'react';
+import React, { useCallback, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { IconButton, TooltipLinkList, WithTooltip } from 'storybook/internal/components';
 import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
 import {
   ADDON_ID,
+  AXES_GLOBAL_KEY,
   GLOBAL_KEY,
   INIT_EVENT,
   PANEL_DIAGNOSTICS_TAB,
@@ -21,6 +22,14 @@ import { DiagnosticsPanel, TokensPanel } from '#/panel.tsx';
  */
 const h = React.createElement;
 
+interface AxisEntry {
+  name: string;
+  contexts: readonly string[];
+  default: string;
+  description?: string;
+  source: 'resolver' | 'synthetic';
+}
+
 interface ThemeEntry {
   name: string;
   input: Record<string, string>;
@@ -28,19 +37,13 @@ interface ThemeEntry {
 }
 
 interface InitPayload {
+  axes: readonly AxisEntry[];
   themes: ThemeEntry[];
   defaultTheme: string | null;
 }
 
+const EMPTY_AXES: readonly AxisEntry[] = [];
 const EMPTY_THEMES: ThemeEntry[] = [];
-
-/** Split a resolver permutation like `{ appearance: 'light', brand: 'a' }` into display chips. */
-function chipsFor(theme: ThemeEntry): string[] {
-  const entries = Object.entries(theme.input);
-  // Single-modifier resolvers use `{ theme: name }` — the name alone is already the chip.
-  if (entries.length === 1 && entries[0]?.[0] === 'theme') return [];
-  return entries.map(([key, value]) => `${key}: ${value}`);
-}
 
 function ThemeIcon(): ReactElement {
   return h(
@@ -54,60 +57,55 @@ function ThemeIcon(): ReactElement {
   );
 }
 
-function ThemeToolbar(): ReactElement {
-  const [globals, updateGlobals] = useGlobals();
-  const api = useStorybookApi();
-  const [payload, setPayload] = useState<InitPayload | null>(null);
+function tupleMatchesInput(
+  tuple: Readonly<Record<string, string>>,
+  input: Readonly<Record<string, string>>,
+): boolean {
+  const keys = Object.keys(input);
+  if (keys.length === 0) return false;
+  return keys.every((k) => input[k] === tuple[k]);
+}
 
-  useEffect(() => {
-    const channel = addons.getChannel();
-    const onInit = (next: InitPayload): void => setPayload(next);
-    channel.on(INIT_EVENT, onInit);
-    return () => {
-      channel.off(INIT_EVENT, onInit);
-    };
-  }, []);
+function composedNameFor(
+  tuple: Readonly<Record<string, string>>,
+  themes: readonly ThemeEntry[],
+  fallback: string,
+): string {
+  const match = themes.find((t) => tupleMatchesInput(tuple, t.input));
+  return match?.name ?? fallback;
+}
 
-  const themes = payload?.themes ?? EMPTY_THEMES;
-  const active =
-    (globals[GLOBAL_KEY] as string | undefined) ?? payload?.defaultTheme ?? themes[0]?.name ?? '';
+function defaultTupleFor(axes: readonly AxisEntry[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of axes) out[axis.name] = axis.default;
+  return out;
+}
 
-  const selectTheme = useMemo(
-    () =>
-      (name: string): void => {
-        updateGlobals({ [GLOBAL_KEY]: name });
-      },
-    [updateGlobals],
-  );
+/**
+ * Treat the `{ name: 'theme', source: 'synthetic' }` axis — the one core
+ * fabricates for single-theme projects with no resolver — as a special case
+ * that uses the label "Theme" instead of the axis name. Authored single-axis
+ * resolvers keep their real axis name (e.g. `mode`).
+ */
+function displayLabelFor(axis: AxisEntry): string {
+  if (axis.source === 'synthetic' && axis.name === 'theme') return 'Theme';
+  return axis.name;
+}
 
-  useEffect(() => {
-    if (themes.length === 0) return;
-    api.setAddonShortcut(ADDON_ID, {
-      label: 'Cycle swatchbook theme',
-      defaultShortcut: ['alt', 'T'],
-      actionName: 'cycleTheme',
-      showInMenu: true,
-      action: () => {
-        const idx = themes.findIndex((t) => t.name === active);
-        const next = themes[(idx + 1) % themes.length];
-        if (next) selectTheme(next.name);
-      },
-    });
-  }, [api, themes, active, selectTheme]);
+interface AxisDropdownProps {
+  axis: AxisEntry;
+  active: string;
+  onSelect: (next: string) => void;
+}
 
-  if (themes.length === 0) {
-    return h(
-      IconButton,
-      { key: TOOL_ID, title: 'Swatchbook theme (loading…)', disabled: true },
-      h(ThemeIcon),
-      h('span', { style: { marginLeft: 6, opacity: 0.6 } }, '—'),
-    );
-  }
+function AxisDropdown({ axis, active, onSelect }: AxisDropdownProps): ReactElement {
+  const label = displayLabelFor(axis);
+  const title = axis.description ? `${label} — ${axis.description}` : label;
 
   const tooltip = ({ onHide }: { onHide: () => void }): ReactElement =>
     h(
       'div',
-      { style: { minWidth: 220 } },
+      { style: { minWidth: 200 } },
       h(
         'div',
         {
@@ -119,16 +117,29 @@ function ThemeToolbar(): ReactElement {
             opacity: 0.6,
           },
         },
-        'Theme',
+        label,
       ),
+      axis.description
+        ? h(
+            'div',
+            {
+              style: {
+                padding: '0 12px 8px',
+                fontSize: 12,
+                opacity: 0.7,
+                lineHeight: 1.4,
+              },
+            },
+            axis.description,
+          )
+        : null,
       h(TooltipLinkList, {
-        links: themes.map((theme) => ({
-          id: theme.name,
-          title: theme.name,
-          right: chipsFor(theme).join(' · ') || undefined,
-          active: theme.name === active,
+        links: axis.contexts.map((ctx) => ({
+          id: ctx,
+          title: ctx,
+          active: ctx === active,
           onClick: () => {
-            selectTheme(theme.name);
+            onSelect(ctx);
             onHide();
           },
         })),
@@ -142,11 +153,101 @@ function ThemeToolbar(): ReactElement {
     tooltip,
     children: h(
       IconButton,
-      { key: TOOL_ID, title: 'Swatchbook theme' },
+      { key: `${TOOL_ID}/${axis.name}`, title },
       h(ThemeIcon),
-      h('span', { style: { marginLeft: 6 } }, active),
+      h('span', { style: { marginLeft: 6 } }, `${label}: ${active}`),
     ),
   });
+}
+
+function AxesToolbar(): ReactElement {
+  const [globals, updateGlobals] = useGlobals();
+  const api = useStorybookApi();
+  const [payload, setPayload] = useState<InitPayload | null>(null);
+
+  useEffect(() => {
+    const channel = addons.getChannel();
+    const onInit = (next: InitPayload): void => setPayload(next);
+    channel.on(INIT_EVENT, onInit);
+    return () => {
+      channel.off(INIT_EVENT, onInit);
+    };
+  }, []);
+
+  const axes = payload?.axes ?? EMPTY_AXES;
+  const themes = payload?.themes ?? EMPTY_THEMES;
+  const defaults = useMemo(() => defaultTupleFor(axes), [axes]);
+  const globalTuple = globals[AXES_GLOBAL_KEY] as Record<string, string> | undefined;
+
+  const activeTuple = useMemo<Record<string, string>>(() => {
+    const out: Record<string, string> = { ...defaults };
+    if (globalTuple) {
+      for (const axis of axes) {
+        const candidate = globalTuple[axis.name];
+        if (candidate !== undefined && axis.contexts.includes(candidate)) {
+          out[axis.name] = candidate;
+        }
+      }
+    }
+    return out;
+  }, [axes, defaults, globalTuple]);
+
+  const setAxis = useCallback(
+    (axisName: string, next: string): void => {
+      const tuple: Record<string, string> = { ...activeTuple, [axisName]: next };
+      const fallback = payload?.defaultTheme ?? themes[0]?.name ?? '';
+      const composed = composedNameFor(tuple, themes, fallback);
+      updateGlobals({ [AXES_GLOBAL_KEY]: tuple, [GLOBAL_KEY]: composed });
+    },
+    [activeTuple, themes, payload?.defaultTheme, updateGlobals],
+  );
+
+  useEffect(() => {
+    if (axes.length === 0) return;
+    /**
+     * alt+T cycles the primary (first) axis's contexts, keeping the rest
+     * of the tuple pinned. With multi-axis projects this makes the shortcut
+     * predictable — you always know which wheel you're spinning. For
+     * single-axis projects the behavior is identical to the pre-N-dropdown
+     * toolbar (cycle through every theme).
+     */
+    const primary = axes[0];
+    if (!primary) return;
+    api.setAddonShortcut(ADDON_ID, {
+      label: `Cycle swatchbook ${displayLabelFor(primary)}`,
+      defaultShortcut: ['alt', 'T'],
+      actionName: 'cycleAxis',
+      showInMenu: true,
+      action: () => {
+        const current = activeTuple[primary.name] ?? primary.default;
+        const idx = primary.contexts.indexOf(current);
+        const next = primary.contexts[(idx + 1) % primary.contexts.length];
+        if (next !== undefined) setAxis(primary.name, next);
+      },
+    });
+  }, [api, axes, activeTuple, setAxis]);
+
+  if (axes.length === 0) {
+    return h(
+      IconButton,
+      { key: TOOL_ID, title: 'Swatchbook theme (loading…)', disabled: true },
+      h(ThemeIcon),
+      h('span', { style: { marginLeft: 6, opacity: 0.6 } }, '—'),
+    );
+  }
+
+  return h(
+    'span',
+    { style: { display: 'inline-flex', alignItems: 'center', gap: 4 } },
+    ...axes.map((axis) =>
+      h(AxisDropdown, {
+        key: axis.name,
+        axis,
+        active: activeTuple[axis.name] ?? axis.default,
+        onSelect: (next: string) => setAxis(axis.name, next),
+      }),
+    ),
+  );
 }
 
 addons.register(ADDON_ID, () => {
@@ -154,7 +255,7 @@ addons.register(ADDON_ID, () => {
     type: types.TOOL,
     title: 'Swatchbook theme',
     match: ({ viewMode, tabId }) => !tabId && (viewMode === 'story' || viewMode === 'docs'),
-    render: () => h(ThemeToolbar),
+    render: () => h(AxesToolbar),
   });
 
   addons.add(PANEL_TOKENS_TAB, {

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -1,7 +1,8 @@
 import type { Decorator, Preview } from '@storybook/react-vite';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { addons } from 'storybook/preview-api';
 import {
+  axes as virtualAxes,
   css,
   cssVarPrefix,
   defaultTheme,
@@ -10,13 +11,14 @@ import {
   themesResolved,
 } from 'virtual:swatchbook/tokens';
 import {
+  AXES_GLOBAL_KEY,
   DATA_THEME_ATTR,
   GLOBAL_KEY,
   INIT_EVENT,
   PARAM_KEY,
   STYLE_ELEMENT_ID,
 } from '#/constants.ts';
-import { ThemeContext } from '#/theme-context.ts';
+import { AxesContext, ThemeContext } from '#/theme-context.ts';
 
 /** CSS var name with the active prefix applied. */
 function v(name: string): string {
@@ -47,10 +49,24 @@ html, body {
   if (style.textContent !== text) style.textContent = text;
 }
 
-/** Keep <html data-theme=…> in sync so the whole iframe inherits the theme. */
-function setRootTheme(theme: string): void {
+/**
+ * Write the composed permutation ID to `data-theme` plus one
+ * `data-<axis>=<context>` per axis. The composed ID stays for CSS
+ * emission's current `[data-theme="…"]` selectors (retires in #135);
+ * per-axis attributes are what upcoming toolbar + panel work will key on.
+ */
+function setRootAxes(themeName: string, tuple: Readonly<Record<string, string>>): void {
   if (typeof document === 'undefined') return;
-  document.documentElement.setAttribute(DATA_THEME_ATTR, theme);
+  const root = document.documentElement;
+  root.setAttribute(DATA_THEME_ATTR, themeName);
+  for (const axis of virtualAxes) {
+    const value = tuple[axis.name];
+    if (value === undefined) {
+      root.removeAttribute(`data-${axis.name}`);
+    } else {
+      root.setAttribute(`data-${axis.name}`, value);
+    }
+  }
 }
 
 /**
@@ -61,6 +77,7 @@ function setRootTheme(theme: string): void {
 function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(INIT_EVENT, {
+    axes: virtualAxes,
     themes,
     defaultTheme,
     themesResolved,
@@ -69,12 +86,85 @@ function broadcastInit(): void {
   });
 }
 
+/** Axis-default tuple, used as the baseline before overrides. */
+function defaultTuple(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of virtualAxes) out[axis.name] = axis.default;
+  return out;
+}
+
+/** Look up a `Theme.input` by composed name. Returns `undefined` if no theme matches. */
+function tupleForName(name: string): Record<string, string> | undefined {
+  const match = themes.find((t) => t.name === name);
+  return match?.input;
+}
+
+/**
+ * Merge a partial tuple onto the axis defaults, dropping keys for axes that
+ * don't exist and silently falling back to the default for contexts that
+ * aren't listed on the axis.
+ */
+function normalizeTuple(partial: Readonly<Record<string, string>>): Record<string, string> {
+  const out = defaultTuple();
+  for (const axis of virtualAxes) {
+    const candidate = partial[axis.name];
+    if (candidate !== undefined && axis.contexts.includes(candidate)) {
+      out[axis.name] = candidate;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the active tuple from all four input channels, in priority order:
+ *   1. `parameters.swatchbook.axes` — per-story tuple.
+ *   2. `parameters.swatchbook.theme` — per-story composed name (legacy).
+ *   3. `globals.swatchbookAxes` — toolbar-set tuple.
+ *   4. `globals.swatchbookTheme` — toolbar-set composed name.
+ *   5. virtual module default.
+ */
+function resolveTuple(
+  globals: Record<string, unknown>,
+  parameters: Record<string, Record<string, unknown>>,
+): Record<string, string> {
+  const param = parameters[PARAM_KEY];
+  const paramAxes = param?.['axes'];
+  if (paramAxes && typeof paramAxes === 'object') {
+    return normalizeTuple(paramAxes as Record<string, string>);
+  }
+  const paramTheme = param?.['theme'];
+  if (typeof paramTheme === 'string') {
+    const hit = tupleForName(paramTheme);
+    if (hit) return normalizeTuple(hit);
+  }
+  const globalAxes = globals[AXES_GLOBAL_KEY];
+  if (globalAxes && typeof globalAxes === 'object') {
+    return normalizeTuple(globalAxes as Record<string, string>);
+  }
+  const globalTheme = globals[GLOBAL_KEY];
+  if (typeof globalTheme === 'string') {
+    const hit = tupleForName(globalTheme);
+    if (hit) return normalizeTuple(hit);
+  }
+  return defaultTuple();
+}
+
 const themedDecorator: Decorator = (Story, context) => {
-  const globalTheme = (context.globals as Record<string, unknown>)[GLOBAL_KEY];
-  const parameterTheme = (context.parameters as Record<string, Record<string, unknown>>)[
-    PARAM_KEY
-  ]?.['theme'];
-  const theme = (parameterTheme ?? globalTheme ?? defaultTheme ?? 'Light') as string;
+  const tuple = useMemo(
+    () =>
+      resolveTuple(
+        context.globals as Record<string, unknown>,
+        context.parameters as Record<string, Record<string, unknown>>,
+      ),
+    [context.globals, context.parameters],
+  );
+  const themeName = useMemo(() => {
+    const match = themes.find((t) => {
+      const input = t.input as Record<string, string>;
+      return Object.keys(input).every((k) => input[k] === tuple[k]);
+    });
+    return match?.name ?? defaultTheme ?? themes[0]?.name ?? 'Light';
+  }, [tuple]);
 
   useEffect(() => {
     ensureStylesheet();
@@ -82,20 +172,28 @@ const themedDecorator: Decorator = (Story, context) => {
   }, []);
 
   useEffect(() => {
-    setRootTheme(theme);
-  }, [theme]);
+    setRootAxes(themeName, tuple);
+  }, [themeName, tuple]);
+
+  const wrapperAttrs: Record<string, string> = { [DATA_THEME_ATTR]: themeName };
+  for (const axis of virtualAxes) {
+    const value = tuple[axis.name];
+    if (value !== undefined) wrapperAttrs[`data-${axis.name}`] = value;
+  }
 
   return (
-    <ThemeContext.Provider value={theme}>
-      <div
-        {...{ [DATA_THEME_ATTR]: theme }}
-        style={{
-          padding: '1rem',
-          minHeight: '100%',
-        }}
-      >
-        <Story />
-      </div>
+    <ThemeContext.Provider value={themeName}>
+      <AxesContext.Provider value={tuple}>
+        <div
+          {...wrapperAttrs}
+          style={{
+            padding: '1rem',
+            minHeight: '100%',
+          }}
+        >
+          <Story />
+        </div>
+      </AxesContext.Provider>
     </ThemeContext.Provider>
   );
 };
@@ -109,10 +207,21 @@ export const decorators: NonNullable<Preview['decorators']> = [themedDecorator];
 export const globalTypes: NonNullable<Preview['globalTypes']> = {
   [GLOBAL_KEY]: {
     name: 'Theme',
-    description: 'Active swatchbook theme. UI lives in the manager toolbar tool.',
+    description: 'Active swatchbook theme (composed permutation ID).',
+  },
+  [AXES_GLOBAL_KEY]: {
+    name: 'Axes',
+    description: 'Per-axis context selection. Takes precedence over the composed theme name.',
   },
 };
 
+function buildInitialAxes(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of virtualAxes) out[axis.name] = axis.default;
+  return out;
+}
+
 export const initialGlobals: NonNullable<Preview['initialGlobals']> = {
   [GLOBAL_KEY]: defaultTheme ?? themes[0]?.name ?? 'Light',
+  [AXES_GLOBAL_KEY]: buildInitialAxes(),
 };

--- a/packages/addon/src/theme-context.ts
+++ b/packages/addon/src/theme-context.ts
@@ -14,3 +14,15 @@ export const ThemeContext = createContext<string>('');
 export function useActiveTheme(): string {
   return useContext(ThemeContext);
 }
+
+/**
+ * Active axis tuple for the current story/docs render — `Record<axisName,
+ * contextName>`. Derived from the same input as {@link ThemeContext}; split
+ * out so consumers needing per-axis info (toolbar, panel, tuple-aware
+ * blocks) don't have to reparse the composed permutation ID.
+ */
+export const AxesContext = createContext<Readonly<Record<string, string>>>({});
+
+export function useActiveAxes(): Readonly<Record<string, string>> {
+  return useContext(AxesContext);
+}


### PR DESCRIPTION
Milestone: Multi-axis theming UX
Closes: Closes #134
Plan impact: none

## Summary

- Replaces the single `ThemeToolbar` dropdown with one `IconButton` popover per axis (`mode: Light`, `brand: Brand A`, …), driven by `payload.axes` from the `INIT_EVENT`.
- Each dropdown reads `globals[AXES_GLOBAL_KEY]?.[axis.name]` (falling back to `axis.default`), shows the axis contexts with the current selection checked, and surfaces `axis.description` in a tooltip when present.
- Selecting a context updates both `swatchbookAxes` (the canonical tuple) and `swatchbookTheme` (the composed permutation ID, matched by deep-equal of `Theme.input`) in the same `updateGlobals` call so the panel + legacy consumers keep working.
- `alt+T` now cycles the primary (first) axis's contexts while pinning the rest of the tuple — predictable on multi-axis projects, identical behaviour on single-axis ones.
- Synthetic `{ name: 'theme', source: 'synthetic' }` axis renders as a "Theme" label so single-theme projects look unchanged; authored single-axis resolvers keep their real axis name.
- Drops `chipsFor` — per-axis controls render their own state, which makes the composed `key: value` chips redundant.

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck test` — green
- [x] `pnpm turbo run test:storybook` — 65/65 passing
- [x] `pnpm turbo run build` — green
- [x] Changeset added (`@unpunnyfuns/swatchbook-addon: minor`)