### PR TITLE
feat(core): per-tuple CSS emission with compound attribute selectors

### DIFF
--- a/.changeset/per-tuple-css-emission.md
+++ b/.changeset/per-tuple-css-emission.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+CSS emission now keys per-axis instead of per-composed-theme. Multi-axis projects emit one `:root` block carrying the default-tuple values plus one block per non-default cartesian tuple, each keyed on a compound attribute selector in `Project.axes` order (`[data-mode="Dark"][data-brand="Brand A"] { … }`). Every var is redeclared per tuple — flat emission stays correct when axes collide at the same token path (`brand-a.json` overriding `color.sys.surface.default` already set by `mode.dark`), where nested cascading would need cross-axis collision analysis. Single-axis projects (one resolver modifier, or the synthetic `theme` axis) keep the familiar `[data-theme="…"]` shape. `emitCss` takes a new optional `axes` in `EmitCssOptions`; `projectCss` routes `project.axes` in by default.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,8 +15,8 @@ pnpm add @unpunnyfuns/swatchbook-core
 | `defineSwatchbookConfig(config)` | Identity helper for a typed `swatchbook.config.ts`. |
 | `loadProject(config, cwd?)` | Parse + resolve — returns `Project { axes, themes, themesResolved, graph, diagnostics, … }`. |
 | `resolveTheme(project, name)` | Pick a single composed theme out of a project. |
-| `emitCss(project, options?)` | Concatenated stylesheet, one `[data-theme="…"]` block per theme. |
-| `projectCss(project)` | Same as `emitCss` with project defaults applied. |
+| `emitCss(themes, themesResolved, options?)` | Concatenated stylesheet — `:root` for the default tuple plus one compound-selector block per non-default tuple (`[data-mode="Dark"][data-brand="Brand A"] { … }`). Single-axis projects keep the familiar `[data-theme="…"]` shape. |
+| `projectCss(project)` | Same as `emitCss` with project defaults (prefix + axes) applied. |
 | `emitTypes(project)` | TypeScript source declaring the token-path union + `SwatchbookTokenMap`. |
 | `permutationID(input)` | Stringify a tuple (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`) to the form used as `Theme.name` and CSS data-attribute values. |
 | Types | `Axis`, `Config`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
@@ -54,6 +54,21 @@ const dts = emitTypes(project);
 `Project.axes` surfaces the resolver's modifiers as first-class — one `Axis` per DTCG modifier, each with its `contexts`, `default`, and `description`. Projects loaded without a resolver fall back to a single synthetic axis named `theme`.
 
 Theme names are derived from the axis tuple via `permutationID(input)`: single-axis tuples stringify to the context value alone (`{ theme: 'Light' }` → `"Light"`); multi-axis tuples join context values with ` · ` (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`). Pick sensible context names — what you write is what the toolbar shows. Consuming code should prefer `axes` + `themes[].input` over matching names by string.
+
+## CSS emission
+
+Multi-axis projects emit one `:root` block with the default-tuple values, plus one block per non-default cartesian tuple keyed on a compound attribute selector in `Project.axes` order:
+
+```css
+:root { --sb-color-sys-surface-default: rgb(255 255 255); … }
+[data-mode="Dark"][data-brand="Default"] { --sb-color-sys-surface-default: rgb(17 17 17); … }
+[data-mode="Light"][data-brand="Brand A"] { … }
+[data-mode="Dark"][data-brand="Brand A"] { … }
+```
+
+Every var is redeclared inside every block (flat emission). Nested cascading would be smaller but breaks whenever axes collide at the same token path — see `docs/decisions.md` for the rationale. Consumers flip tuples by writing one `data-<axis>="<context>"` attribute per axis on an ancestor (typically `<html>`).
+
+Single-axis projects (one resolver modifier, or the synthetic `theme` axis) keep the familiar `[data-theme="…"]` shape — the compound selector collapses to a single attribute selector anyway, so the simpler form stays readable.
 
 ## Do / don't
 

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -1,16 +1,28 @@
 import type { TokenNormalized } from '@terrazzo/parser';
 import { generateShorthand, makeCSSVar, transformCSSValue } from '@terrazzo/token-tools/css';
-import type { Theme, TokenMap } from '#/types.ts';
+import type { Axis, Theme, TokenMap } from '#/types.ts';
 
 export interface EmitCssOptions {
   /** Override the prefix from project config (default: `config.cssVarPrefix ?? ''`). */
   prefix?: string;
+  /**
+   * Project axes used to key per-tuple blocks on compound attribute selectors
+   * (`[data-mode="Dark"][data-brand="Brand A"] { … }`). When omitted, emission
+   * falls back to the legacy single-selector shape keyed on `data-theme`.
+   */
+  axes?: Axis[];
 }
 
 /**
- * Emit a single concatenated stylesheet with one `[data-theme="…"]` block per
- * theme. Consumers toggle `data-theme` on an ancestor (typically `<html>`) to
- * flip the active palette; the browser handles the repaint.
+ * Emit a single concatenated stylesheet.
+ *
+ * With axes supplied, emits a `:root` block carrying the default-tuple values
+ * plus one block per non-default cartesian tuple keyed on a compound attribute
+ * selector matching `Project.axes` order. Every var is redeclared per tuple
+ * (flat emission) — see `docs/decisions.md` for the rationale.
+ *
+ * For single-axis projects (resolver with one modifier, or synthetic `theme`),
+ * emission keeps the familiar `[data-theme="…"]` shape.
  */
 export function emitCss(
   themes: Theme[],
@@ -19,40 +31,93 @@ export function emitCss(
 ): string {
   const prefix = options.prefix ?? '';
   const varOpts = prefix ? { prefix } : {};
-  // Custom alias transform so var(--...) references inside composite values
-  // pick up our prefix (Terrazzo's default doesn't know about it).
   const transformAlias = (token: TokenNormalized): string =>
     makeCSSVar(token.id, { ...varOpts, wrapVar: true });
 
+  const axes = options.axes ?? [];
+  const multiAxis = axes.length > 1;
+  const defaultTuple = buildDefaultTuple(axes);
+  const defaultTheme = axes.length > 0 ? findThemeByTuple(themes, defaultTuple) : undefined;
+
   const blocks: string[] = [];
 
+  if (multiAxis && defaultTheme) {
+    const decls = declarationsFor(defaultTheme, themesResolved, varOpts, transformAlias);
+    if (decls.length > 0) blocks.push(`:root {\n${decls.join('\n')}\n}`);
+  }
+
   for (const theme of themes) {
-    const tokens = themesResolved[theme.name];
-    if (!tokens) continue;
-
-    const declarations: string[] = [];
-    for (const [localID, token] of Object.entries(tokens)) {
-      for (const decl of emitTokenDeclarations(
-        localID,
-        token,
-        tokens,
-        theme.input,
-        varOpts,
-        transformAlias,
-      )) {
-        declarations.push(`  ${decl}`);
-      }
-    }
-
-    if (declarations.length === 0) continue;
-
-    blocks.push(`[data-theme="${cssEscape(theme.name)}"] {\n${declarations.join('\n')}\n}`);
+    if (multiAxis && theme === defaultTheme) continue;
+    const decls = declarationsFor(theme, themesResolved, varOpts, transformAlias);
+    if (decls.length === 0) continue;
+    blocks.push(`${selectorFor(theme, axes)} {\n${decls.join('\n')}\n}`);
   }
 
   return `${blocks.join('\n\n')}\n`;
 }
 
 type VarOpts = Record<string, never> | { prefix: string };
+
+function declarationsFor(
+  theme: Theme,
+  themesResolved: Record<string, TokenMap>,
+  varOpts: VarOpts,
+  transformAlias: (token: TokenNormalized) => string,
+): string[] {
+  const tokens = themesResolved[theme.name];
+  if (!tokens) return [];
+  const declarations: string[] = [];
+  for (const [localID, token] of Object.entries(tokens)) {
+    for (const decl of emitTokenDeclarations(
+      localID,
+      token,
+      tokens,
+      theme.input,
+      varOpts,
+      transformAlias,
+    )) {
+      declarations.push(`  ${decl}`);
+    }
+  }
+  return declarations;
+}
+
+/**
+ * Compose the selector for a tuple. Multi-axis projects get a compound
+ * attribute selector in axis order; single-axis projects keep the familiar
+ * `[data-theme="…"]` shape so the single-attribute selector stays recognizable.
+ */
+function selectorFor(theme: Theme, axes: Axis[]): string {
+  if (axes.length <= 1) {
+    return `[data-theme="${cssEscape(theme.name)}"]`;
+  }
+  const parts: string[] = [];
+  for (const axis of axes) {
+    const value = theme.input[axis.name];
+    if (value === undefined) continue;
+    parts.push(`[data-${axis.name}="${cssEscape(value)}"]`);
+  }
+  return parts.length > 0 ? parts.join('') : `[data-theme="${cssEscape(theme.name)}"]`;
+}
+
+function buildDefaultTuple(axes: Axis[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of axes) out[axis.name] = axis.default;
+  return out;
+}
+
+function findThemeByTuple(
+  themes: Theme[],
+  tuple: Readonly<Record<string, string>>,
+): Theme | undefined {
+  const keys = Object.keys(tuple);
+  return themes.find((theme) => {
+    for (const key of keys) {
+      if (theme.input[key] !== tuple[key]) return false;
+    }
+    return Object.keys(theme.input).length === keys.length;
+  });
+}
 
 function emitTokenDeclarations(
   localID: string,
@@ -70,8 +135,6 @@ function emitTokenDeclarations(
     return [`${varName}: ${value};`];
   }
 
-  // Multi-value composite (typography, shadow, border, transition, gradient).
-  // Emit one sub-var per entry, plus a shorthand declaration where possible.
   const lines: string[] = [];
   for (const [subKey, subVal] of Object.entries(value)) {
     const subName = makeCSSVar(`${localID}.${subKey}`, varOpts);
@@ -84,7 +147,7 @@ function emitTokenDeclarations(
   return lines;
 }
 
-/** Escape `"` in theme names so they can safely appear inside `[data-theme="…"]`. */
+/** Escape `"` and `\` so attribute values sit safely inside `[attr="…"]`. */
 function cssEscape(name: string): string {
   return name.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }

--- a/packages/core/src/emit.ts
+++ b/packages/core/src/emit.ts
@@ -7,6 +7,9 @@ export function projectCss(project: Project, options: EmitCssOptions = {}): stri
   if (merged.prefix === undefined && project.config.cssVarPrefix) {
     merged.prefix = project.config.cssVarPrefix;
   }
+  if (merged.axes === undefined) {
+    merged.axes = project.axes;
+  }
   return emitCss(project.themes, project.themesResolved, merged);
 }
 

--- a/packages/core/test/_helpers.ts
+++ b/packages/core/test/_helpers.ts
@@ -17,12 +17,30 @@ export async function loadWithPrefix(prefix: string | undefined): Promise<Projec
   );
 }
 
-export function extractBlock(css: string, themeName: string): string {
-  const start = css.indexOf(`[data-theme="${themeName}"]`);
+/**
+ * Extract the body of a block by matching on any selector fragment. Pass the
+ * literal selector you want to find (`:root`, `[data-theme="Light"]`,
+ * `[data-mode="Dark"][data-brand="Default"]`) — the match is a substring scan
+ * so as long as the fragment is unique in the stylesheet, the surrounding
+ * block returns.
+ */
+export function extractBlock(css: string, selector: string): string {
+  const start = css.indexOf(selector);
   if (start < 0) return '';
   const braceStart = css.indexOf('{', start);
   const braceEnd = css.indexOf('\n}', braceStart);
   return css.slice(braceStart + 1, braceEnd);
+}
+
+/**
+ * Compose a compound attribute selector for a tuple in the supplied key order.
+ * `{ mode: 'Dark', brand: 'Default' }` becomes
+ * `[data-mode="Dark"][data-brand="Default"]`.
+ */
+export function tupleSelector(tuple: Readonly<Record<string, string>>): string {
+  return Object.entries(tuple)
+    .map(([k, v]) => `[data-${k}="${v}"]`)
+    .join('');
 }
 
 export function grep(block: string, needle: string): string | undefined {

--- a/packages/core/test/css-sb-prefix.test.ts
+++ b/packages/core/test/css-sb-prefix.test.ts
@@ -1,11 +1,11 @@
 import { beforeAll, expect, it } from 'vitest';
 import { projectCss } from '#/emit';
 import type { Project } from '#/types';
-import { extractBlock, grep, loadWithPrefix } from './_helpers';
+import { extractBlock, grep, loadWithPrefix, tupleSelector } from './_helpers';
 
 // beforeAll is a perf escape hatch here: loadProject over the reference
 // fixture takes ~1s, so running it per-test would blow the 5s default timeout
-// six-fold. All six tests in this file read from the same projectCss output.
+// six-fold. All tests in this file read from the same projectCss output.
 let project: Project;
 let css: string;
 
@@ -14,9 +14,12 @@ beforeAll(async () => {
   css = projectCss(project);
 }, 30_000);
 
-it('emits one [data-theme] block per theme', () => {
+it('emits :root for the default tuple plus compound selectors for the rest', () => {
+  expect(css).toContain(':root {');
   for (const theme of project.themes) {
-    expect(css).toContain(`[data-theme="${theme.name}"]`);
+    const isDefault = project.axes.every((a) => theme.input[a.name] === a.default);
+    if (isDefault) continue;
+    expect(css).toContain(tupleSelector(theme.input));
   }
 });
 
@@ -51,8 +54,8 @@ it('emits every primitive + composite type covered by the fixture', () => {
 });
 
 it('keeps sparse overrides: Dark flips surface, size scale identical', () => {
-  const lightBlock = extractBlock(css, 'Light · Default');
-  const darkBlock = extractBlock(css, 'Dark · Default');
+  const lightBlock = extractBlock(css, ':root');
+  const darkBlock = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default' }));
   expect(lightBlock).toBeTruthy();
   expect(darkBlock).toBeTruthy();
   const lightSize = grep(lightBlock, '--sb-size-ref-400:');

--- a/packages/core/test/css-tuple-emit.test.ts
+++ b/packages/core/test/css-tuple-emit.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, expect, it } from 'vitest';
+import { projectCss } from '#/emit';
+import type { Project } from '#/types';
+import { extractBlock, grep, loadWithPrefix, tupleSelector } from './_helpers';
+
+// beforeAll is a perf escape hatch here: loadProject over the reference
+// fixture takes ~1s, so running it per-test would blow the default timeout.
+// All tests in this file read from the same projectCss output.
+let project: Project;
+let css: string;
+
+beforeAll(async () => {
+  project = await loadWithPrefix('sb');
+  css = projectCss(project);
+}, 30_000);
+
+it('emits exactly one :root block plus N-1 per-tuple blocks', () => {
+  const rootMatches = css.match(/(^|\n):root\s*\{/g) ?? [];
+  expect(rootMatches).toHaveLength(1);
+  const tupleBlocks = (css.match(/\n\[data-[^\]]+\][^{]*\{/g) ?? []).length;
+  expect(tupleBlocks).toBe(project.themes.length - 1);
+});
+
+it('compound selector order matches Project.axes order', () => {
+  const axisNames = project.axes.map((a) => a.name);
+  const selectorMatches = css.match(/\[data-[^\]]+\](?:\[data-[^\]]+\])+/g) ?? [];
+  expect(selectorMatches.length).toBeGreaterThan(0);
+  for (const selector of selectorMatches) {
+    const order = [...selector.matchAll(/\[data-([^=]+)=/g)].map((m) => m[1]);
+    expect(order).toEqual(axisNames);
+  }
+});
+
+it('redeclares every var per tuple (flat emission, not nested cascading)', () => {
+  const lightDefault = extractBlock(css, ':root');
+  const darkDefault = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default' }));
+  expect(lightDefault).toBeTruthy();
+  expect(darkDefault).toBeTruthy();
+
+  const lightVars = new Set(
+    lightDefault
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith('--'))
+      .map((l) => l.split(':')[0]),
+  );
+  const darkVars = new Set(
+    darkDefault
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => l.startsWith('--'))
+      .map((l) => l.split(':')[0]),
+  );
+  expect(darkVars).toEqual(lightVars);
+});
+
+it('holds brand-invariant tokens stable across mode at the same brand', () => {
+  const lightDefault = extractBlock(css, ':root');
+  const darkDefault = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default' }));
+  const lightSize = grep(lightDefault, '--sb-size-ref-400:');
+  const darkSize = grep(darkDefault, '--sb-size-ref-400:');
+  expect(lightSize).toBeDefined();
+  expect(darkSize).toBeDefined();
+  expect(lightSize).toEqual(darkSize);
+});
+
+it('emits no [data-theme="…"] selector in multi-axis mode', () => {
+  expect(css).not.toMatch(/\[data-theme="/);
+});
+
+it('stays well under 100KB uncompressed for the reference fixture', () => {
+  expect(Buffer.byteLength(css, 'utf8')).toBeLessThan(100_000);
+});


### PR DESCRIPTION
## Summary

- Multi-axis projects now emit one `:root` block carrying the default-tuple values plus one block per non-default cartesian tuple, keyed on compound attribute selectors in `Project.axes` order (`[data-mode="Dark"][data-brand="Brand A"] { … }`).
- Every var is redeclared per tuple — flat emission stays correct when axes collide at the same token path, which the DTCG 2025.10 resolver spec explicitly permits. Rationale locked in by `docs/decisions.md` (2026-04-19).
- Single-axis projects (one resolver modifier, or the synthetic `theme` axis) keep the familiar `[data-theme="…"]` shape.
- `emitCss` takes a new optional `axes` in `EmitCssOptions`; `projectCss` routes `project.axes` in by default, so existing callers pick it up automatically.
- `extractBlock` test helper now accepts any selector fragment; new `tupleSelector` helper composes compound selectors from a tuple.

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck test` — 16/16 tasks green, 24 core tests passing (including 6 new `css-tuple-emit` tests).
- [x] `pnpm turbo run test:storybook` — 65/65 story tests passing against the new emission shape (decorator still sets per-axis `data-*` attributes on `<html>` + story wrapper).
- [x] `pnpm turbo run build` — all packages build green.

Milestone: Multi-axis theming UX
Closes: Closes #135
Plan impact: none — flat-per-tuple decision already captured in `docs/decisions.md` (2026-04-19).