### PR TITLE
chore: storybook task depends on ^build

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -42,6 +42,7 @@
       "outputs": []
     },
     "storybook": {
+      "dependsOn": ["^build"],
       "cache": false,
       "persistent": true
     }


### PR DESCRIPTION
**Milestone:** Maintenance

**Closes:** Closes #145

**Plan impact:** none

## Summary

- Adds \`dependsOn: [\"^build\"]\` to the \`storybook\` task in \`turbo.json\`.
- Without it, \`pnpm dev\` silently served stale addon/core dists right after a merge that updated workspace-package source.
- Dev workflow is still not hot for workspace-package edits (no watch mode), but startup now guarantees fresh builds.

## Test plan

- [x] \`pnpm turbo run storybook --dry-run\` shows addon/core/blocks \`build\` tasks ahead of \`storybook\`