### PR TITLE
feat(addon): tuple-aware tokens panel and TokenDetail

### DIFF
--- a/.changeset/tuple-aware-panel-blocks.md
+++ b/.changeset/tuple-aware-panel-blocks.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-addon': minor
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+Tokens panel and `TokenDetail` block are now axis-tuple aware. The panel reads the active tuple from `globals.swatchbookAxes` (falling back to `swatchbookTheme` for back-compat) and shows a compact per-axis indicator above the token list. `TokenDetail` replaces its flat per-theme values table with an axis-aware view: tokens that are constant across every tuple collapse to one row; tokens that vary along a single axis render a compact 1-axis table (one row per context); tokens that vary along two or more axes render a matrix of the two most-varying axes, with further axes collapsed to the active selection. The `useProject()` hook now returns `activeAxes` + `axes` alongside `activeTheme` and subscribes to both `swatchbookAxes` and `swatchbookTheme` updates, keeping every block reactive to axis changes.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -435,6 +435,45 @@ export const TokenDetailMissing = meta.story({
 });
 
 /**
+ * `TokenDetail` for a token that varies only with the `brand` axis must
+ * render a compact 1-axis values table listing each brand context
+ * (Default, Brand A) exactly once — matching the axis-aware view from
+ * issue #136.
+ */
+export const TokenDetailOneAxisBrand = meta.story({
+  render: () => <TokenDetail path='color.sys.accent.bg' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const header = [...canvasElement.querySelectorAll('div')].find((el) =>
+      el.textContent?.trim().startsWith('Varies with brand'),
+    );
+    expect(header, 'must render "Varies with brand" section header').toBeTruthy();
+    const table = await waitForContent(canvasElement, '[data-testid="token-detail-values"]');
+    const rows = table.querySelectorAll('tr[data-axis="brand"]');
+    expect(rows.length, 'must render one row per brand context').toBe(2);
+    const contexts = [...rows].map((r) => r.getAttribute('data-context'));
+    expect(contexts).toEqual(expect.arrayContaining(['Default', 'Brand A']));
+  },
+});
+
+/**
+ * `TokenDetail` for a token that is constant across all axis tuples must
+ * render a single row that notes the value applies to every tuple.
+ */
+export const TokenDetailConstantAcrossAxes = meta.story({
+  render: () => <TokenDetail path='space.sys.md' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const header = [...canvasElement.querySelectorAll('div')].find(
+      (el) => el.textContent?.trim() === 'Values across axes',
+    );
+    expect(header, 'must render "Values across axes" section header').toBeTruthy();
+    const cell = await waitForContent(canvasElement, '[data-testid="token-detail-constant"]');
+    expect(cell.textContent ?? '').toMatch(/same across all/);
+  },
+});
+
+/**
  * The reference fixture is expected to load cleanly — zero errors, zero
  * warnings from the addon's project load. This story pins that baseline;
  * if a token change introduces a diagnostic, this test fails and pokes

--- a/packages/addon/src/panel.tsx
+++ b/packages/addon/src/panel.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState, type ReactElement } from 'react';
 import { addons, useGlobals } from 'storybook/manager-api';
 import { Placeholder, ScrollArea } from 'storybook/internal/components';
-import { GLOBAL_KEY, INIT_EVENT } from '#/constants.ts';
+import { AXES_GLOBAL_KEY, GLOBAL_KEY, INIT_EVENT } from '#/constants.ts';
 
 /** `React.createElement` alias so the manager bundle avoids `react/jsx-runtime`. */
 const h = React.createElement;
@@ -19,6 +19,14 @@ interface VirtualTheme {
   sources: string[];
 }
 
+interface VirtualAxis {
+  name: string;
+  contexts: readonly string[];
+  default: string;
+  description?: string;
+  source: 'resolver' | 'synthetic';
+}
+
 type DiagnosticSeverity = 'error' | 'warn' | 'info';
 
 interface VirtualDiagnostic {
@@ -31,6 +39,7 @@ interface VirtualDiagnostic {
 }
 
 interface InitPayload {
+  axes: VirtualAxis[];
   themes: VirtualTheme[];
   defaultTheme: string | null;
   themesResolved: Record<string, Record<string, VirtualToken>>;
@@ -107,6 +116,12 @@ const searchBarStyle: React.CSSProperties = {
   padding: '8px 12px',
   borderBottom: '1px solid rgba(128,128,128,0.2)',
 };
+const axisIndicatorStyle: React.CSSProperties = {
+  fontSize: 11,
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
+  opacity: 0.7,
+  marginBottom: 6,
+};
 const searchInputStyle: React.CSSProperties = {
   width: '100%',
   padding: '4px 8px',
@@ -142,7 +157,41 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
   const [globals] = useGlobals();
   const [query, setQuery] = useState('');
 
-  const themeName = (globals[GLOBAL_KEY] as string | undefined) ?? payload?.defaultTheme ?? '';
+  const axes = useMemo(() => payload?.axes ?? [], [payload]);
+  const themes = useMemo(() => payload?.themes ?? [], [payload]);
+  const globalAxes = globals[AXES_GLOBAL_KEY] as Record<string, string> | undefined;
+  const globalTheme = globals[GLOBAL_KEY] as string | undefined;
+
+  const tuple: Record<string, string> = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const axis of axes) out[axis.name] = axis.default;
+    if (globalAxes && typeof globalAxes === 'object') {
+      for (const axis of axes) {
+        const candidate = globalAxes[axis.name];
+        if (candidate && axis.contexts.includes(candidate)) out[axis.name] = candidate;
+      }
+      return out;
+    }
+    if (globalTheme) {
+      const match = themes.find((t) => t.name === globalTheme);
+      if (match) {
+        for (const axis of axes) {
+          const candidate = match.input[axis.name];
+          if (candidate && axis.contexts.includes(candidate)) out[axis.name] = candidate;
+        }
+      }
+    }
+    return out;
+  }, [axes, themes, globalAxes, globalTheme]);
+
+  const themeName = useMemo(() => {
+    const match = themes.find((t) => {
+      const input = t.input;
+      return Object.keys(input).every((k) => input[k] === tuple[k]);
+    });
+    return match?.name ?? globalTheme ?? payload?.defaultTheme ?? '';
+  }, [themes, tuple, globalTheme, payload]);
+
   const prefix = payload?.cssVarPrefix ?? '';
   const tokens = useMemo(() => payload?.themesResolved[themeName] ?? {}, [payload, themeName]);
   const tokenCount = Object.keys(tokens).length;
@@ -167,12 +216,27 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
 
   const totalMatches = [...filtered.values()].reduce((n, l) => n + l.length, 0);
 
+  const showAxisIndicator =
+    axes.length > 1 || (axes.length === 1 && axes[0]?.source !== 'synthetic');
+  const axisIndicatorText = axes
+    .map((axis) => `${axis.name}: ${tuple[axis.name] ?? axis.default}`)
+    .join('  ·  ');
+
   return h(
     'div',
     { style: { display: 'flex', flexDirection: 'column', height: '100%' } },
     h(
       'div',
       { style: searchBarStyle },
+      showAxisIndicator &&
+        h(
+          'div',
+          {
+            style: axisIndicatorStyle,
+            'data-testid': 'tokens-panel-axis-indicator',
+          },
+          axisIndicatorText,
+        ),
       h('input', {
         style: searchInputStyle,
         type: 'search',

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -207,7 +207,8 @@ const styles = {
 };
 
 export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
-  const { activeTheme, themesResolved, resolved, cssVarPrefix } = useProject();
+  const { activeTheme, activeAxes, axes, themes, themesResolved, resolved, cssVarPrefix } =
+    useProject();
 
   const token = resolved[path] as DetailToken | undefined;
   const cssVar = makeCssVar(path, cssVarPrefix);
@@ -286,33 +287,15 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
         </>
       )}
 
-      <div style={styles.sectionHeader}>Per-theme values</div>
-      <table style={styles.themeTable}>
-        <tbody>
-          {Object.entries(themesResolved).map(([themeName, tokens]) => {
-            const t = tokens[path] as DetailToken | undefined;
-            const themeValue = t ? formatValue(t.$value) : '—';
-            return (
-              <tr key={themeName} style={styles.themeRow}>
-                <td style={{ ...styles.themeCell, width: '30%' }}>{themeName}</td>
-                <td style={styles.themeCell}>
-                  {isColor && t && (
-                    <span
-                      style={{
-                        ...styles.swatch,
-                        background: cssVar,
-                      }}
-                      data-theme={themeName}
-                      aria-hidden
-                    />
-                  )}
-                  {themeValue}
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <AxisVariance
+        path={path}
+        isColor={isColor}
+        cssVar={cssVar}
+        axes={axes}
+        themes={themes}
+        themesResolved={themesResolved}
+        activeAxes={activeAxes}
+      />
 
       <div style={styles.sectionHeader}>Usage</div>
       <code style={styles.snippet}>{`color: ${cssVar};`}</code>
@@ -430,6 +413,250 @@ function TransitionSample({ transition }: { transition: string }): ReactElement 
         aria-hidden
       />
     </div>
+  );
+}
+
+interface VirtualAxisLike {
+  readonly name: string;
+  readonly contexts: readonly string[];
+  readonly default: string;
+  readonly source: 'resolver' | 'synthetic';
+}
+
+interface VirtualThemeLike {
+  readonly name: string;
+  readonly input: Record<string, string>;
+}
+
+function themeValue(
+  themesResolved: Record<string, Record<string, DetailToken>>,
+  themeName: string,
+  path: string,
+): string {
+  const t = themesResolved[themeName]?.[path];
+  return t ? formatValue(t.$value) : '—';
+}
+
+function tupleName(
+  themes: readonly VirtualThemeLike[],
+  tuple: Record<string, string>,
+): string | undefined {
+  const match = themes.find((t) => {
+    const input = t.input;
+    const keys = Object.keys(input);
+    return keys.every((k) => input[k] === tuple[k]);
+  });
+  return match?.name;
+}
+
+/**
+ * Analyze how a token's value moves across axes. Returns:
+ *   - 'constant' — same value under every tuple
+ *   - 'one-axis' — exactly one axis influences the value (the token is
+ *     insensitive to every other axis)
+ *   - 'multi-axis' — two or more axes influence the value
+ */
+interface Variance {
+  kind: 'constant' | 'one-axis' | 'multi-axis';
+  varyingAxes: readonly string[];
+}
+
+function analyzeVariance(
+  path: string,
+  axes: readonly VirtualAxisLike[],
+  themes: readonly VirtualThemeLike[],
+  themesResolved: Record<string, Record<string, DetailToken>>,
+): Variance {
+  const varyingAxes: string[] = [];
+  for (const axis of axes) {
+    // Group themes by all other axes' context values, and see whether the
+    // token's value moves when only this axis changes within each group.
+    const byOthers = new Map<string, Map<string, string>>();
+    for (const theme of themes) {
+      const others = axes
+        .filter((a) => a.name !== axis.name)
+        .map((a) => `${a.name}=${theme.input[a.name] ?? ''}`)
+        .join('|');
+      const ctx = theme.input[axis.name] ?? '';
+      const bucket = byOthers.get(others) ?? new Map<string, string>();
+      bucket.set(ctx, themeValue(themesResolved, theme.name, path));
+      byOthers.set(others, bucket);
+    }
+    let varies = false;
+    for (const bucket of byOthers.values()) {
+      const values = new Set(bucket.values());
+      if (values.size > 1) {
+        varies = true;
+        break;
+      }
+    }
+    if (varies) varyingAxes.push(axis.name);
+  }
+  if (varyingAxes.length === 0) return { kind: 'constant', varyingAxes };
+  if (varyingAxes.length === 1) return { kind: 'one-axis', varyingAxes };
+  return { kind: 'multi-axis', varyingAxes };
+}
+
+interface AxisVarianceProps {
+  path: string;
+  isColor: boolean;
+  cssVar: string;
+  axes: readonly VirtualAxisLike[];
+  themes: readonly VirtualThemeLike[];
+  themesResolved: Record<string, Record<string, DetailToken>>;
+  activeAxes: Record<string, string>;
+}
+
+function AxisVariance({
+  path,
+  isColor,
+  cssVar,
+  axes,
+  themes,
+  themesResolved,
+  activeAxes,
+}: AxisVarianceProps): ReactElement {
+  const variance = useMemo(
+    () => analyzeVariance(path, axes, themes, themesResolved),
+    [path, axes, themes, themesResolved],
+  );
+
+  if (themes.length === 0) {
+    return <></>;
+  }
+
+  if (variance.kind === 'constant') {
+    const anyTheme = themes[0];
+    const value = anyTheme ? themeValue(themesResolved, anyTheme.name, path) : '—';
+    return (
+      <>
+        <div style={styles.sectionHeader}>Values across axes</div>
+        <table style={styles.themeTable} data-testid='token-detail-values'>
+          <tbody>
+            <tr style={styles.themeRow}>
+              <td style={styles.themeCell} data-testid='token-detail-constant'>
+                {isColor && <span style={{ ...styles.swatch, background: cssVar }} aria-hidden />}
+                {value}
+                <span style={{ opacity: 0.6, marginLeft: 8 }}>
+                  same across all {themes.length} tuples
+                </span>
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </>
+    );
+  }
+
+  if (variance.kind === 'one-axis') {
+    const axisName = variance.varyingAxes[0];
+    if (!axisName) return <></>;
+    const axis = axes.find((a) => a.name === axisName);
+    if (!axis) return <></>;
+    // Pick one representative theme per context of the varying axis — the
+    // one whose other-axis contexts match the active tuple, so the displayed
+    // values line up with the rest of the doc block.
+    const contextValues = axis.contexts.map((ctx) => {
+      const target = { ...activeAxes, [axisName]: ctx };
+      const match = themes.find((t) => {
+        const input = t.input;
+        return Object.keys(input).every((k) => input[k] === target[k]);
+      });
+      const name = match?.name ?? '';
+      return {
+        ctx,
+        themeName: name,
+        value: name ? themeValue(themesResolved, name, path) : '—',
+      };
+    });
+    return (
+      <>
+        <div style={styles.sectionHeader}>Varies with {axisName}</div>
+        <table style={styles.themeTable} data-testid='token-detail-values'>
+          <tbody>
+            {contextValues.map((row) => (
+              <tr key={row.ctx} style={styles.themeRow} data-axis={axisName} data-context={row.ctx}>
+                <td style={{ ...styles.themeCell, width: '30%' }}>{row.ctx}</td>
+                <td style={styles.themeCell}>
+                  {isColor && row.themeName && (
+                    <span
+                      style={{ ...styles.swatch, background: cssVar }}
+                      data-theme={row.themeName}
+                      aria-hidden
+                    />
+                  )}
+                  {row.value}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </>
+    );
+  }
+
+  // Multi-axis: render a matrix for the two most-varying axes (by context
+  // count), collapsing further axes to the active tuple and noting their
+  // influence.
+  const varying = variance.varyingAxes
+    .map((name) => axes.find((a) => a.name === name))
+    .filter((a): a is VirtualAxisLike => Boolean(a))
+    .toSorted((a, b) => b.contexts.length - a.contexts.length);
+  const [rowAxis, colAxis, ...extra] = varying;
+  if (!rowAxis || !colAxis) return <></>;
+
+  return (
+    <>
+      <div style={styles.sectionHeader}>Varies with {variance.varyingAxes.join(' × ')}</div>
+      <table style={styles.themeTable} data-testid='token-detail-values'>
+        <thead>
+          <tr style={styles.themeRow}>
+            <th style={{ ...styles.themeCell, textAlign: 'left', opacity: 0.7 }}>
+              {rowAxis.name} \ {colAxis.name}
+            </th>
+            {colAxis.contexts.map((col) => (
+              <th key={col} style={{ ...styles.themeCell, textAlign: 'left', opacity: 0.7 }}>
+                {col}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rowAxis.contexts.map((row) => (
+            <tr key={row} style={styles.themeRow}>
+              <td style={styles.themeCell}>{row}</td>
+              {colAxis.contexts.map((col) => {
+                const target: Record<string, string> = {
+                  ...activeAxes,
+                  [rowAxis.name]: row,
+                  [colAxis.name]: col,
+                };
+                const name = tupleName(themes, target);
+                const value = name ? themeValue(themesResolved, name, path) : '—';
+                return (
+                  <td key={col} style={styles.themeCell} data-row={row} data-col={col}>
+                    {isColor && name && (
+                      <span
+                        style={{ ...styles.swatch, background: cssVar }}
+                        data-theme={name}
+                        aria-hidden
+                      />
+                    )}
+                    {value}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {extra.length > 0 && (
+        <div style={{ ...styles.aliasedByTruncated, marginTop: 6 }}>
+          Values also vary with {extra.map((a) => a.name).join(', ')}; matrix shows the slice for
+          the active selection.
+        </div>
+      )}
+    </>
   );
 }
 

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 import { addons } from 'storybook/preview-api';
-import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon/hooks';
+import { useActiveAxes, useActiveTheme } from '@unpunnyfuns/swatchbook-addon/hooks';
 import {
+  axes as virtualAxes,
   css as generatedCss,
   cssVarPrefix,
   defaultTheme,
@@ -11,9 +12,12 @@ import {
 
 type VirtualTokens = typeof themesResolved;
 type ResolvedTokens = VirtualTokens[string];
+type VirtualAxes = typeof virtualAxes;
 
 export interface ProjectData {
   activeTheme: string;
+  activeAxes: Record<string, string>;
+  axes: VirtualAxes;
   themes: typeof themes;
   resolved: ResolvedTokens;
   themesResolved: VirtualTokens;
@@ -22,6 +26,7 @@ export interface ProjectData {
 
 const STYLE_ELEMENT_ID = 'swatchbook-tokens';
 const GLOBAL_KEY = 'swatchbookTheme';
+const AXES_GLOBAL_KEY = 'swatchbookAxes';
 
 function ensureStylesheet(): void {
   if (typeof document === 'undefined') return;
@@ -38,10 +43,34 @@ interface GlobalsPayload {
   globals?: Record<string, unknown>;
 }
 
+function defaultTuple(): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of virtualAxes) out[axis.name] = axis.default;
+  return out;
+}
+
+function tupleForName(name: string): Record<string, string> | undefined {
+  const match = themes.find((t) => t.name === name);
+  return match?.input;
+}
+
+function tuplesEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
+  for (const k of keys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
+function nameForTuple(tuple: Record<string, string>): string | undefined {
+  const match = themes.find((t) => tuplesEqual(t.input as Record<string, string>, tuple));
+  return match?.name;
+}
+
 /**
  * One-stop hook for block components. Self-mounts the virtual module's
  * per-theme CSS (so blocks work in MDX/autodocs, not just inside a story
- * where the addon's decorator runs) and tracks the active theme via
+ * where the addon's decorator runs) and tracks the active tuple via
  * Storybook's `globalsUpdated` channel event.
  *
  * Can't use `useGlobals` from `storybook/preview-api` — that's a story
@@ -50,7 +79,9 @@ interface GlobalsPayload {
  */
 export function useProject(): ProjectData {
   const contextTheme = useActiveTheme();
+  const contextAxes = useActiveAxes();
   const [channelTheme, setChannelTheme] = useState<string | null>(null);
+  const [channelAxes, setChannelAxes] = useState<Record<string, string> | null>(null);
 
   useEffect(() => {
     ensureStylesheet();
@@ -59,8 +90,12 @@ export function useProject(): ProjectData {
   useEffect(() => {
     const channel = addons.getChannel();
     const onGlobals = (payload: GlobalsPayload): void => {
-      const next = payload.globals?.[GLOBAL_KEY];
-      if (typeof next === 'string') setChannelTheme(next);
+      const nextTheme = payload.globals?.[GLOBAL_KEY];
+      if (typeof nextTheme === 'string') setChannelTheme(nextTheme);
+      const nextAxes = payload.globals?.[AXES_GLOBAL_KEY];
+      if (nextAxes && typeof nextAxes === 'object') {
+        setChannelAxes(nextAxes as Record<string, string>);
+      }
     };
     channel.on('globalsUpdated', onGlobals);
     channel.on('updateGlobals', onGlobals);
@@ -70,10 +105,26 @@ export function useProject(): ProjectData {
     };
   }, []);
 
-  const activeTheme = contextTheme || channelTheme || defaultTheme || themes[0]?.name || '';
+  const hasContextAxes = Object.keys(contextAxes).length > 0;
+  const activeAxes: Record<string, string> = hasContextAxes
+    ? { ...contextAxes }
+    : (channelAxes ?? defaultTuple());
+
+  const derivedName = nameForTuple(activeAxes);
+  const fallbackTupleName = channelTheme && tupleForName(channelTheme) ? channelTheme : null;
+  const activeTheme =
+    contextTheme ||
+    derivedName ||
+    fallbackTupleName ||
+    channelTheme ||
+    defaultTheme ||
+    themes[0]?.name ||
+    '';
 
   return {
     activeTheme,
+    activeAxes,
+    axes: virtualAxes,
     themes,
     themesResolved,
     resolved: themesResolved[activeTheme] ?? {},


### PR DESCRIPTION
Milestone: Multi-axis theming UX
Closes: Closes #136
Plan impact: none

## Summary

- Tokens panel reads the active tuple from `globals.swatchbookAxes` (falling back to `swatchbookTheme` for back-compat) and renders a compact per-axis indicator above the token list.
- `TokenDetail` replaces its flat per-theme values table with an axis-aware view: constant-across-all-tuples collapses to one row, single-axis variation renders a 1-axis compact table, multi-axis variation renders a matrix of the two most-varying axes sliced against the active tuple with a note for any further axes that also vary.
- `useProject()` now returns `activeAxes` + `axes` alongside `activeTheme`, subscribes to both `swatchbookAxes` and `swatchbookTheme` channel updates, and derives `activeTheme` from the tuple when only the tuple is set — every block keeps reacting to axis changes without block-side changes.
- Adds two `BlockAssertions` play-function stories: `color.sys.accent.bg` exercises the 1-axis view (varies only with `brand`); `space.sys.md` exercises the constant view.
- Changeset: minor bump on `@unpunnyfuns/swatchbook-addon` + `@unpunnyfuns/swatchbook-blocks`.

## Test plan

- [x] `pnpm turbo run lint typecheck test` (16/16 tasks)
- [x] `pnpm turbo run test:storybook` (67/67 tests; up from 65 with the two new axis-aware detail stories)
- [x] `pnpm turbo run build`