### PR TITLE
feat(core): axes shape for layered configs without a resolver

### DIFF
--- a/.changeset/layered-config-axes.md
+++ b/.changeset/layered-config-axes.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+Extend `defineSwatchbookConfig` with an `axes` shape for authored layered configurations — no DTCG resolver file required. Each axis lists its contexts as ordered file lists that overlay onto `tokens`; the loader parses `[...base, ...overlaysInAxisOrder]` once per cartesian tuple with alias resolution (last-write-wins on duplicate token paths). `Config.resolver` is now optional; setting both `resolver` and `axes` throws. Layered axes surface on `Project.axes` with `source: 'layered'`.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,7 +19,7 @@ pnpm add @unpunnyfuns/swatchbook-core
 | `projectCss(project)` | Same as `emitCss` with project defaults (prefix + axes) applied. |
 | `emitTypes(project)` | TypeScript source declaring the token-path union + `SwatchbookTokenMap`. |
 | `permutationID(input)` | Stringify a tuple (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`) to the form used as `Theme.name` and CSS data-attribute values. |
-| Types | `Axis`, `Config`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
+| Types | `Axis`, `AxisConfig`, `Config`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
 
 ## Minimal config
 
@@ -36,6 +36,40 @@ export default defineSwatchbookConfig({
 
 The resolver file is the spec-defined document describing how token sets compose into named themes — see [the DTCG 2025.10 resolver draft](https://design-tokens.org/tr/2025/drafts/resolver/).
 
+### Layered axes (resolver-less)
+
+Projects that don't want to author a DTCG resolver can declare axes inline. Each context names an ordered list of overlay files that layer on top of `tokens` for that context; for every cartesian tuple, Swatchbook parses `[...base, ...overlaysInAxisOrder]` with alias resolution — last write wins on duplicate token paths:
+
+```ts
+import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
+
+export default defineSwatchbookConfig({
+  tokens: ['tokens/base/**/*.json'],
+  axes: [
+    {
+      name: 'mode',
+      contexts: {
+        Light: [],
+        Dark: ['tokens/modes/dark.json'],
+      },
+      default: 'Light',
+    },
+    {
+      name: 'brand',
+      contexts: {
+        Default: [],
+        'Brand A': ['tokens/brands/brand-a.json'],
+      },
+      default: 'Default',
+    },
+  ],
+});
+```
+
+- ✅ Empty context arrays are legal — they mean "no override" (common for a `Default` context).
+- ❌ Setting both `resolver` and `axes` is an error. Pick one.
+- ❌ Setting neither falls back to a single synthetic `theme` axis (unchanged behavior).
+
 ## Load + emit
 
 ```ts
@@ -51,7 +85,7 @@ const dts = emitTypes(project);
 
 ## Axes and theme naming
 
-`Project.axes` surfaces the resolver's modifiers as first-class — one `Axis` per DTCG modifier, each with its `contexts`, `default`, and `description`. Projects loaded without a resolver fall back to a single synthetic axis named `theme`.
+`Project.axes` surfaces the theming modifiers as first-class — one `Axis` per resolver modifier (`source: 'resolver'`) or per authored layered axis (`source: 'layered'`), each with its `contexts`, `default`, and `description`. Projects loaded with neither a resolver nor `axes` fall back to a single synthetic axis named `theme` (`source: 'synthetic'`).
 
 Theme names are derived from the axis tuple via `permutationID(input)`: single-axis tuples stringify to the context value alone (`{ theme: 'Light' }` → `"Light"`); multi-axis tuples join context values with ` · ` (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`). Pick sensible context names — what you write is what the toolbar shows. Consuming code should prefer `axes` + `themes[].input` over matching names by string.
 

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -11,6 +11,24 @@ import type { Config } from '#/types.ts';
  * });
  * ```
  *
+ * Or with authored layered axes (no resolver file):
+ *
+ * ```ts
+ * export default defineSwatchbookConfig({
+ *   tokens: ['tokens/base/**\/*.json'],
+ *   axes: [
+ *     {
+ *       name: 'mode',
+ *       contexts: { Light: [], Dark: ['tokens/modes/dark.json'] },
+ *       default: 'Light',
+ *     },
+ *   ],
+ * });
+ * ```
+ *
+ * `resolver` and `axes` are mutually exclusive. Setting neither falls
+ * back to a single synthetic theme.
+ *
  * Named distinctly from Terrazzo's `defineConfig` to keep imports unambiguous.
  */
 export function defineSwatchbookConfig(config: Config): Config {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { permutationID } from '#/types.ts';
 
 export type {
   Axis,
+  AxisConfig,
   Config,
   Diagnostic,
   DiagnosticSeverity,

--- a/packages/core/src/themes/layered.ts
+++ b/packages/core/src/themes/layered.ts
@@ -1,0 +1,122 @@
+import { readFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+import { defineConfig as defineTerrazzoConfig, parse } from '@terrazzo/parser';
+import type { BufferedLogger } from '#/diagnostics.ts';
+import { collectGlobbedFiles } from '#/themes/util.ts';
+import { type Axis, type AxisConfig, permutationID, type Theme, type TokenMap } from '#/types.ts';
+
+export interface LayeredLoadResult {
+  axes: Axis[];
+  themes: Theme[];
+  resolved: Record<string, TokenMap>;
+  defaultThemeName: string;
+}
+
+/**
+ * Realize themes from a layered (resolver-less) configuration. Each axis
+ * context supplies an ordered list of overlay files; for every tuple in
+ * the cartesian product we parse `[...base, ...overlayFilesInAxisOrder]`
+ * with alias resolution enabled. Terrazzo's parser applies last-write-wins
+ * semantics on duplicate token paths, so overlay files override base
+ * tokens in the order we concatenate them.
+ */
+export async function loadLayeredThemes(
+  axesConfig: AxisConfig[],
+  tokenGlobs: string[],
+  cwd: string,
+  logger: BufferedLogger,
+  explicitDefault?: string,
+): Promise<LayeredLoadResult> {
+  const cwdUrl = pathToFileURL(`${cwd}/`);
+  const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
+
+  const baseFiles = await collectGlobbedFiles(tokenGlobs, cwd);
+
+  const axes: Axis[] = axesConfig.map((ax) => ({
+    name: ax.name,
+    contexts: Object.keys(ax.contexts),
+    default: ax.default,
+    ...(ax.description !== undefined ? { description: ax.description } : {}),
+    source: 'layered' as const,
+  }));
+
+  const fileCache = new Map<string, string>();
+  const readInput = async (filename: string) => {
+    let src = fileCache.get(filename);
+    if (src === undefined) {
+      src = await readFile(filename, 'utf8');
+      fileCache.set(filename, src);
+    }
+    return { filename: pathToFileURL(filename), src };
+  };
+
+  const tuples = cartesianTuples(axesConfig);
+
+  const contextFilesCache = new Map<string, string[]>();
+  const filesForAxisContext = (axisName: string, ctx: string, patterns: string[]): string[] => {
+    const key = `${axisName}::${ctx}`;
+    let files = contextFilesCache.get(key);
+    if (!files) {
+      files = patterns.length === 0 ? [] : collectGlobbedFiles(patterns, cwd);
+      contextFilesCache.set(key, files);
+    }
+    return files;
+  };
+
+  const perTuple = await Promise.all(
+    tuples.map(async (input) => {
+      const overlayFiles: string[] = [];
+      for (const ax of axesConfig) {
+        const ctx = input[ax.name];
+        if (ctx === undefined) continue;
+        const patterns = ax.contexts[ctx] ?? [];
+        overlayFiles.push(...filesForAxisContext(ax.name, ctx, patterns));
+      }
+      const allFiles = [...baseFiles, ...overlayFiles];
+      const inputs = await Promise.all(allFiles.map(readInput));
+      const parsed = await parse(inputs, {
+        logger,
+        config: terrazzoConfig,
+        resolveAliases: true,
+        continueOnError: true,
+      });
+      return { input, allFiles, tokens: parsed.tokens };
+    }),
+  );
+
+  const themes: Theme[] = [];
+  const resolved: Record<string, TokenMap> = {};
+  for (const { input, allFiles, tokens } of perTuple) {
+    const id = permutationID(input);
+    themes.push({ name: id, input: { ...input }, sources: allFiles });
+    resolved[id] = tokens;
+  }
+
+  const defaultInput: Record<string, string> = {};
+  for (const ax of axesConfig) defaultInput[ax.name] = ax.default;
+  const defaultByAxes = permutationID(defaultInput);
+  const defaultThemeName =
+    explicitDefault && resolved[explicitDefault]
+      ? explicitDefault
+      : resolved[defaultByAxes]
+        ? defaultByAxes
+        : (themes[0]?.name ?? '');
+
+  return { axes, themes, resolved, defaultThemeName };
+}
+
+function cartesianTuples(axesConfig: AxisConfig[]): Record<string, string>[] {
+  if (axesConfig.length === 0) return [{}];
+  let acc: Record<string, string>[] = [{}];
+  for (const ax of axesConfig) {
+    const contexts = Object.keys(ax.contexts);
+    const next: Record<string, string>[] = [];
+    for (const partial of acc) {
+      for (const ctx of contexts) {
+        next.push({ ...partial, [ax.name]: ctx });
+      }
+    }
+    acc = next;
+  }
+  return acc;
+}

--- a/packages/core/src/themes/normalize.ts
+++ b/packages/core/src/themes/normalize.ts
@@ -1,6 +1,7 @@
-import type { Axis, Config, Theme, TokenMap } from '#/types.ts';
 import type { BufferedLogger } from '#/diagnostics.ts';
+import { loadLayeredThemes } from '#/themes/layered.ts';
 import { loadResolverThemes } from '#/themes/resolver.ts';
+import type { Axis, Config, Theme, TokenMap } from '#/types.ts';
 
 export interface NormalizedThemes {
   axes: Axis[];
@@ -12,17 +13,24 @@ export interface NormalizedThemes {
 }
 
 /**
- * Realize themes from the DTCG 2025.10 resolver referenced by the config.
- * The resolver is the sole theming input — no fallback modes.
+ * Realize themes from the config. Exactly one of `resolver` or `axes` may
+ * be set; if neither is set, we fall back to a single synthetic axis
+ * containing the plain-parsed token files.
  */
 export async function normalizeThemes(
   config: Config,
   cwd: string,
   logger: BufferedLogger,
 ): Promise<NormalizedThemes> {
-  if (!config.resolver) {
-    throw new Error('swatchbook config must specify `resolver` (path to a DTCG resolver file).');
+  if (config.resolver && config.axes) {
+    throw new Error('swatchbook: config must specify either `resolver` or `axes`, not both.');
   }
+
+  if (config.axes) {
+    const r = await loadLayeredThemes(config.axes, config.tokens, cwd, logger, config.default);
+    return { ...r, sourceOnlyFiles: new Set() };
+  }
+
   const r = await loadResolverThemes(config.resolver, config.tokens, cwd, logger, config.default);
   return { ...r, sourceOnlyFiles: new Set() };
 }

--- a/packages/core/src/themes/resolver.ts
+++ b/packages/core/src/themes/resolver.ts
@@ -21,38 +21,40 @@ export interface ResolverLoadResult {
  * `resolver.listPermutations()` and realize each with `resolver.apply()`.
  */
 export async function loadResolverThemes(
-  resolverPath: string,
+  resolverPath: string | undefined,
   tokenGlobs: string[],
   cwd: string,
   logger: BufferedLogger,
   explicitDefault?: string,
 ): Promise<ResolverLoadResult> {
-  const absolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
   const cwdUrl = pathToFileURL(`${cwd}/`);
   const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
 
   const tokenFiles = await collectGlobbedFiles(tokenGlobs, cwd);
-
-  // `loadResolver` expects the resolver file alone as input and fetches
-  // referenced token files via `req`. Passing tokens up front triggers
-  // "Resolver must be the only input" errors.
-  const resolverInput = {
-    filename: pathToFileURL(absolute),
-    src: await readFile(absolute, 'utf8'),
-  };
 
   const req = async (url: URL): Promise<string> => {
     const filename = url.protocol === 'file:' ? fileURLToPath(url) : url.toString();
     return readFile(filename, 'utf8');
   };
 
-  const loaded = await loadResolver([resolverInput], {
-    config: terrazzoConfig,
-    logger,
-    req,
-  });
+  let loaded: Awaited<ReturnType<typeof loadResolver>> | undefined;
+  if (resolverPath) {
+    const absolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
+    // `loadResolver` expects the resolver file alone as input and fetches
+    // referenced token files via `req`. Passing tokens up front triggers
+    // "Resolver must be the only input" errors.
+    const resolverInput = {
+      filename: pathToFileURL(absolute),
+      src: await readFile(absolute, 'utf8'),
+    };
+    loaded = await loadResolver([resolverInput], {
+      config: terrazzoConfig,
+      logger,
+      req,
+    });
+  }
 
-  if (!loaded.resolver) {
+  if (!loaded?.resolver) {
     // Fall back to plain parse; no resolver found.
     const tokenInputs = await Promise.all(
       tokenFiles.map(async (filename) => ({

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -13,24 +13,39 @@ export interface Theme {
 
 /**
  * One modifier axis of the theming model. Resolver-backed projects surface
- * one `Axis` per DTCG modifier; projects without a resolver (e.g. plain
- * token parsing with no composition) get a single synthetic axis named
- * `theme`.
+ * one `Axis` per DTCG modifier; layered-config projects surface one `Axis`
+ * per `axes[]` entry; projects without a resolver or layered config get a
+ * single synthetic axis named `theme`.
  */
 export interface Axis {
   name: string;
   contexts: string[];
   default: string;
   description?: string;
-  source: 'resolver' | 'synthetic';
+  source: 'resolver' | 'layered' | 'synthetic';
 }
 
-/** Swatchbook configuration. The resolver is the sole theming input. */
+/**
+ * One authored axis for layered configurations. Each context names an
+ * ordered list of glob patterns / file paths (relative to cwd) that layer
+ * on top of `Config.tokens` for that context. An empty array means "no
+ * override" — valid, and common for a `Default` context.
+ */
+export interface AxisConfig {
+  name: string;
+  description?: string;
+  contexts: Record<string, string[]>;
+  default: string;
+}
+
+/** Swatchbook configuration. Supply either `resolver` or `axes`, not both. */
 export interface Config {
-  /** Glob patterns for DTCG token files. */
+  /** Glob patterns for base DTCG token files. */
   tokens: string[];
-  /** Path to a DTCG 2025.10 resolver file. */
-  resolver: string;
+  /** Path to a DTCG 2025.10 resolver file. Mutually exclusive with `axes`. */
+  resolver?: string;
+  /** Authored layered axes. Mutually exclusive with `resolver`. */
+  axes?: AxisConfig[];
   /** Name of the default theme. */
   default?: string;
   /** Prefix for emitted CSS custom properties. */

--- a/packages/core/test/fixtures/layered/base/ref.json
+++ b/packages/core/test/fixtures/layered/base/ref.json
@@ -1,0 +1,19 @@
+{
+  "color": {
+    "ref": {
+      "$type": "color",
+      "white": {
+        "$value": { "colorSpace": "srgb", "components": [1, 1, 1] }
+      },
+      "black": {
+        "$value": { "colorSpace": "srgb", "components": [0, 0, 0] }
+      },
+      "blue": {
+        "$value": { "colorSpace": "srgb", "components": [0.1, 0.3, 0.9] }
+      },
+      "red": {
+        "$value": { "colorSpace": "srgb", "components": [0.9, 0.2, 0.2] }
+      }
+    }
+  }
+}

--- a/packages/core/test/fixtures/layered/base/sys.json
+++ b/packages/core/test/fixtures/layered/base/sys.json
@@ -1,0 +1,10 @@
+{
+  "color": {
+    "sys": {
+      "$type": "color",
+      "surface": { "$value": "{color.ref.white}" },
+      "text":    { "$value": "{color.ref.black}" },
+      "accent":  { "$value": "{color.ref.blue}" }
+    }
+  }
+}

--- a/packages/core/test/fixtures/layered/brands/brand-a.json
+++ b/packages/core/test/fixtures/layered/brands/brand-a.json
@@ -1,0 +1,8 @@
+{
+  "color": {
+    "sys": {
+      "$type": "color",
+      "accent": { "$value": "{color.ref.red}" }
+    }
+  }
+}

--- a/packages/core/test/fixtures/layered/modes/dark.json
+++ b/packages/core/test/fixtures/layered/modes/dark.json
@@ -1,0 +1,9 @@
+{
+  "color": {
+    "sys": {
+      "$type": "color",
+      "surface": { "$value": "{color.ref.black}" },
+      "text":    { "$value": "{color.ref.white}" }
+    }
+  }
+}

--- a/packages/core/test/load-layered.test.ts
+++ b/packages/core/test/load-layered.test.ts
@@ -1,0 +1,130 @@
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadProject, resolveTheme } from '#/load.ts';
+import type { Config } from '#/types.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureCwd = resolve(here, 'fixtures/layered');
+
+function layeredConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    tokens: ['base/*.json'],
+    axes: [
+      {
+        name: 'mode',
+        contexts: {
+          Light: [],
+          Dark: ['modes/dark.json'],
+        },
+        default: 'Light',
+      },
+      {
+        name: 'brand',
+        contexts: {
+          Default: [],
+          'Brand A': ['brands/brand-a.json'],
+        },
+        default: 'Default',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('loadProject — layered axes', () => {
+  it('surfaces axes[] as independent axes with source "layered"', async () => {
+    const project = await loadProject(layeredConfig(), fixtureCwd);
+    expect(project.axes).toEqual([
+      {
+        name: 'mode',
+        contexts: ['Light', 'Dark'],
+        default: 'Light',
+        source: 'layered',
+      },
+      {
+        name: 'brand',
+        contexts: ['Default', 'Brand A'],
+        default: 'Default',
+        source: 'layered',
+      },
+    ]);
+  });
+
+  it('enumerates the cartesian product of mode × brand', async () => {
+    const project = await loadProject(layeredConfig(), fixtureCwd);
+    expect(project.themes.map((t) => t.name)).toEqual([
+      'Light · Default',
+      'Light · Brand A',
+      'Dark · Default',
+      'Dark · Brand A',
+    ]);
+  });
+
+  it('default theme is the tuple of axis defaults', async () => {
+    const project = await loadProject(layeredConfig(), fixtureCwd);
+    expect(project.themesResolved['Light · Default']).toBeDefined();
+    const def = resolveTheme(project, 'Light · Default').tokens;
+    expect(def['color.sys.surface']?.$value).toMatchObject({ components: [1, 1, 1] });
+  });
+
+  it('applies overlay layers in order — last write wins on same path', async () => {
+    const project = await loadProject(layeredConfig(), fixtureCwd);
+    const dark = resolveTheme(project, 'Dark · Default').tokens;
+    expect(dark['color.sys.surface']?.$value).toMatchObject({ components: [0, 0, 0] });
+    expect(dark['color.sys.text']?.$value).toMatchObject({ components: [1, 1, 1] });
+    expect(dark['color.sys.accent']?.$value).toMatchObject({ components: [0.1, 0.3, 0.9] });
+  });
+
+  it('brand overlay overrides sys.accent while leaving surface alone', async () => {
+    const project = await loadProject(layeredConfig(), fixtureCwd);
+    const brand = resolveTheme(project, 'Light · Brand A').tokens;
+    expect(brand['color.sys.accent']?.$value).toMatchObject({ components: [0.9, 0.2, 0.2] });
+    expect(brand['color.sys.surface']?.$value).toMatchObject({ components: [1, 1, 1] });
+  });
+
+  it('multi-axis overlays compose (Dark + Brand A)', async () => {
+    const project = await loadProject(layeredConfig(), fixtureCwd);
+    const tokens = resolveTheme(project, 'Dark · Brand A').tokens;
+    expect(tokens['color.sys.surface']?.$value).toMatchObject({ components: [0, 0, 0] });
+    expect(tokens['color.sys.accent']?.$value).toMatchObject({ components: [0.9, 0.2, 0.2] });
+  });
+
+  it('empty context arrays are legal (no-override case)', async () => {
+    const config: Config = {
+      tokens: ['base/*.json'],
+      axes: [
+        {
+          name: 'brand',
+          contexts: { Default: [], 'Brand A': ['brands/brand-a.json'] },
+          default: 'Default',
+        },
+      ],
+    };
+    const project = await loadProject(config, fixtureCwd);
+    expect(project.themes.map((t) => t.name).toSorted()).toEqual(['Brand A', 'Default']);
+    const def = resolveTheme(project, 'Default').tokens;
+    expect(def['color.sys.accent']?.$value).toMatchObject({ components: [0.1, 0.3, 0.9] });
+  });
+});
+
+describe('loadProject — config validation', () => {
+  it('throws when both resolver and axes are set', async () => {
+    const config = {
+      tokens: ['base/*.json'],
+      resolver: 'resolver.json',
+      axes: [{ name: 'mode', contexts: { Light: [] }, default: 'Light' }],
+    } satisfies Config;
+    await expect(loadProject(config, fixtureCwd)).rejects.toThrow(
+      /either `resolver` or `axes`, not both/,
+    );
+  });
+
+  it('accepts a tokens-only config and synthesizes a single theme axis', async () => {
+    const project = await loadProject({ tokens: ['base/*.json'] }, fixtureCwd);
+    expect(project.axes).toEqual([
+      { name: 'theme', contexts: ['default'], default: 'default', source: 'synthetic' },
+    ]);
+    expect(project.themes.map((t) => t.name)).toEqual(['default']);
+  });
+});

--- a/packages/core/test/load.test.ts
+++ b/packages/core/test/load.test.ts
@@ -72,9 +72,16 @@ describe('loadProject — resolver mode', () => {
 });
 
 describe('loadProject — validation', () => {
-  it('throws when resolver is not set', async () => {
-    await expect(loadProject({ tokens: [] } as never, fixtureCwd)).rejects.toThrow(
-      /must specify `resolver`/,
-    );
+  it('throws when both `resolver` and `axes` are set', async () => {
+    await expect(
+      loadProject(
+        {
+          tokens: [],
+          resolver: resolverPath,
+          axes: [{ name: 'mode', contexts: { Light: [] }, default: 'Light' }],
+        },
+        fixtureCwd,
+      ),
+    ).rejects.toThrow(/either `resolver` or `axes`, not both/);
   });
 });


### PR DESCRIPTION
**Milestone:** Multi-axis theming UX

**Closes:** Closes #137

**Plan impact:** none

## Summary

- Extends `defineSwatchbookConfig` with an optional `axes` field so projects can declare layered theming inline, without authoring a DTCG resolver file.
- Each axis lists its contexts as ordered overlay-file lists; new `loadLayeredThemes` parses `[...base, ...overlaysInAxisOrder]` per cartesian tuple with alias resolution enabled (last-write-wins on duplicate token paths).
- `Config.resolver` is now optional. Setting both `resolver` and `axes` throws. Setting neither still falls back to a single synthetic `theme` axis.
- Layered axes surface on `Project.axes` with `source: 'layered'` (widened discriminator `'resolver' | 'layered' | 'synthetic'`); toolbar / UI code paths that only special-case `'synthetic'` are unaffected.
- New `AxisConfig` type exported from `@unpunnyfuns/swatchbook-core`; README updated with an `axes` example and mutual-exclusion note.

## Test plan

- [x] `pnpm turbo run lint typecheck test` — 16/16 green, 33/33 core unit tests pass (9 new in `load-layered.test.ts`).
- [x] `pnpm turbo run test:storybook` — 65/65 green.
- [x] `pnpm turbo run build` — 4/4 green.
- [x] Manual: `config.axes` + `config.resolver` together throws the expected error.
- [x] Manual: empty context arrays (`Default: []`) work as "no override".
- [x] Manual: multi-axis overlay composition (Dark + Brand A) resolves base + both overlays in order.