### PR TITLE
feat(addon): named tuple presets in swatchbook config

### DIFF
--- a/.changeset/tuple-presets.md
+++ b/.changeset/tuple-presets.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+Named tuple presets — `defineSwatchbookConfig({ presets })` now takes an ordered list of `{ name, axes, description? }` entries. Each preset names a partial axis tuple (any axis the preset omits falls back to that axis's `default` when applied). Core validates presets at `loadProject` time: unknown axis keys and invalid context values surface as `warn` diagnostics and are sanitized out, but the preset itself is preserved (an empty preset is still a valid tuple). Project gains a `presets` field, the virtual module gains a `presets` export, and the addon broadcasts presets alongside axes/themes on `INIT_EVENT`. The toolbar renders presets as quick-select pills next to the axis dropdowns: clicking a pill writes the composed tuple into `globals.swatchbookAxes` + `globals.swatchbookTheme`, highlights the pill whose tuple matches the current selection, and shows a subtle modified-marker dot if the user tweaks an axis dropdown after applying a preset.

--- a/apps/storybook/src/stories/Presets.stories.tsx
+++ b/apps/storybook/src/stories/Presets.stories.tsx
@@ -1,0 +1,66 @@
+import { expect, waitFor } from 'storybook/test';
+import preview from '../../.storybook/preview.tsx';
+import { Button } from '../components/Button.tsx';
+import { Card } from '../components/Card.tsx';
+
+function PresetProbe() {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: 12 }}>
+      <Card data-testid='preset-card' title='Preset card'>
+        Flips with the active preset tuple.
+      </Card>
+      <Button data-testid='preset-button' variant='primary'>
+        Accent follows Brand A.
+      </Button>
+    </div>
+  );
+}
+
+const meta = preview.meta({
+  title: 'Tests/Presets',
+  component: PresetProbe,
+});
+
+export default meta;
+
+async function waitForAttr(el: Element, attr: string, expected: string): Promise<void> {
+  await waitFor(() => {
+    const actual = el.getAttribute(attr);
+    if (actual !== expected) throw new Error(`expected ${attr}=${expected}, got ${actual}`);
+  });
+}
+
+/**
+ * Preset config in `swatchbook.config.ts`: `Default Light` →
+ * `{ mode: 'Light', brand: 'Default' }`. The preview decorator
+ * writes the tuple to both `<html>` and the story wrapper.
+ */
+export const DefaultLightPreset = meta.story({
+  parameters: {
+    swatchbook: { axes: { mode: 'Light', brand: 'Default' } },
+  },
+  play: async ({ canvasElement }) => {
+    const wrapper = canvasElement.querySelector<HTMLElement>('[data-mode]');
+    if (!wrapper) throw new Error('story wrapper missing');
+    await waitForAttr(wrapper, 'data-mode', 'Light');
+    await waitForAttr(wrapper, 'data-brand', 'Default');
+    expect(wrapper.getAttribute('data-theme')).toBe('Light · Default');
+  },
+});
+
+/**
+ * `Brand A Dark` preset — full-tuple match. Per-axis `data-*` attributes
+ * should reflect the preset exactly.
+ */
+export const BrandADarkPreset = meta.story({
+  parameters: {
+    swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } },
+  },
+  play: async ({ canvasElement }) => {
+    const wrapper = canvasElement.querySelector<HTMLElement>('[data-mode]');
+    if (!wrapper) throw new Error('story wrapper missing');
+    await waitForAttr(wrapper, 'data-mode', 'Dark');
+    await waitForAttr(wrapper, 'data-brand', 'Brand A');
+    expect(wrapper.getAttribute('data-theme')).toBe('Dark · Brand A');
+  },
+});

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -6,4 +6,16 @@ export default defineSwatchbookConfig({
   resolver: resolverPath,
   default: 'Light · Default',
   cssVarPrefix: 'sb',
+  presets: [
+    {
+      name: 'Default Light',
+      axes: { mode: 'Light', brand: 'Default' },
+      description: 'Baseline light mode with the stock accent.',
+    },
+    {
+      name: 'Brand A Dark',
+      axes: { mode: 'Dark', brand: 'Brand A' },
+      description: 'Dark surfaces paired with the violet Brand A accent.',
+    },
+  ],
 });

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -67,6 +67,23 @@ function Card() {
 
 Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across themes; `value` flips with the active theme. Paths autocomplete from the generated `.swatchbook/tokens.d.ts` once the addon has run against your project.
 
+## Toolbar pills (presets)
+
+Add `presets` to your `swatchbook.config.ts` to surface quick-select pills next to the axis dropdowns:
+
+```ts
+export default defineSwatchbookConfig({
+  tokens: ['tokens/**/*.json'],
+  resolver: 'tokens/resolver.json',
+  presets: [
+    { name: 'Default Light', axes: { mode: 'Light', brand: 'Default' } },
+    { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' }, description: 'Dark + violet accent.' },
+  ],
+});
+```
+
+Clicking a pill writes the full tuple — partial presets fill in omitted axes from each axis's default. The active pill is highlighted when the current tuple matches; if you tweak an axis dropdown after applying a preset, the pill shows a small "modified" dot so you can see that the current tuple has drifted from the named preset. Presets come from config only — there is no in-session "save as".
+
 ## Per-story overrides
 
 ```ts

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -36,13 +36,21 @@ interface ThemeEntry {
   sources: string[];
 }
 
+interface PresetEntry {
+  name: string;
+  axes: Partial<Record<string, string>>;
+  description?: string;
+}
+
 interface InitPayload {
   axes: readonly AxisEntry[];
+  presets: readonly PresetEntry[];
   themes: ThemeEntry[];
   defaultTheme: string | null;
 }
 
 const EMPTY_AXES: readonly AxisEntry[] = [];
+const EMPTY_PRESETS: readonly PresetEntry[] = [];
 const EMPTY_THEMES: ThemeEntry[] = [];
 
 function ThemeIcon(): ReactElement {
@@ -160,6 +168,103 @@ function AxisDropdown({ axis, active, onSelect }: AxisDropdownProps): ReactEleme
   });
 }
 
+/**
+ * Compose a preset's sanitized partial tuple with the axis defaults, so
+ * applying a preset that only names some axes leaves the omitted ones at
+ * their defaults (not blank). Matches the preview decorator's own fallback
+ * logic so what the toolbar sends out is what the decorator honors.
+ */
+function presetTuple(
+  preset: PresetEntry,
+  axes: readonly AxisEntry[],
+  defaults: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const out: Record<string, string> = { ...defaults };
+  for (const axis of axes) {
+    const candidate = preset.axes[axis.name];
+    if (candidate !== undefined && axis.contexts.includes(candidate)) {
+      out[axis.name] = candidate;
+    }
+  }
+  return out;
+}
+
+function tuplesEqual(
+  a: Readonly<Record<string, string>>,
+  b: Readonly<Record<string, string>>,
+  axes: readonly AxisEntry[],
+): boolean {
+  for (const axis of axes) {
+    if (a[axis.name] !== b[axis.name]) return false;
+  }
+  return true;
+}
+
+interface PresetPillsProps {
+  presets: readonly PresetEntry[];
+  axes: readonly AxisEntry[];
+  defaults: Readonly<Record<string, string>>;
+  activeTuple: Readonly<Record<string, string>>;
+  lastApplied: string | null;
+  onApply: (preset: PresetEntry) => void;
+}
+
+function PresetPills({
+  presets,
+  axes,
+  defaults,
+  activeTuple,
+  lastApplied,
+  onApply,
+}: PresetPillsProps): ReactElement {
+  return h(
+    'span',
+    {
+      style: { display: 'inline-flex', alignItems: 'center', gap: 4, marginRight: 4 },
+    },
+    ...presets.map((preset) => {
+      const tuple = presetTuple(preset, axes, defaults);
+      const matches = tuplesEqual(tuple, activeTuple, axes);
+      const modified = !matches && preset.name === lastApplied;
+      const title = preset.description ? `${preset.name} — ${preset.description}` : preset.name;
+      return h(
+        IconButton,
+        {
+          key: `${TOOL_ID}/preset/${preset.name}`,
+          active: matches,
+          title,
+          onClick: () => onApply(preset),
+        },
+        h(
+          'span',
+          {
+            style: {
+              padding: '0 6px',
+              fontWeight: matches ? 600 : 400,
+            },
+          },
+          preset.name,
+          modified
+            ? h('span', {
+                'aria-hidden': true,
+                style: {
+                  display: 'inline-block',
+                  width: 6,
+                  height: 6,
+                  marginLeft: 6,
+                  borderRadius: '50%',
+                  background: 'currentColor',
+                  opacity: 0.6,
+                  verticalAlign: 'middle',
+                },
+              })
+            : null,
+        ),
+      );
+    }),
+  );
+}
+
 function AxesToolbar(): ReactElement {
   const [globals, updateGlobals] = useGlobals();
   const api = useStorybookApi();
@@ -175,8 +280,10 @@ function AxesToolbar(): ReactElement {
   }, []);
 
   const axes = payload?.axes ?? EMPTY_AXES;
+  const presets = payload?.presets ?? EMPTY_PRESETS;
   const themes = payload?.themes ?? EMPTY_THEMES;
   const defaults = useMemo(() => defaultTupleFor(axes), [axes]);
+  const [lastApplied, setLastApplied] = useState<string | null>(null);
   const globalTuple = globals[AXES_GLOBAL_KEY] as Record<string, string> | undefined;
 
   const activeTuple = useMemo<Record<string, string>>(() => {
@@ -200,6 +307,17 @@ function AxesToolbar(): ReactElement {
       updateGlobals({ [AXES_GLOBAL_KEY]: tuple, [GLOBAL_KEY]: composed });
     },
     [activeTuple, themes, payload?.defaultTheme, updateGlobals],
+  );
+
+  const applyPreset = useCallback(
+    (preset: PresetEntry): void => {
+      const tuple = presetTuple(preset, axes, defaults);
+      const fallback = payload?.defaultTheme ?? themes[0]?.name ?? '';
+      const composed = composedNameFor(tuple, themes, fallback);
+      updateGlobals({ [AXES_GLOBAL_KEY]: tuple, [GLOBAL_KEY]: composed });
+      setLastApplied(preset.name);
+    },
+    [axes, defaults, themes, payload?.defaultTheme, updateGlobals],
   );
 
   useEffect(() => {
@@ -239,6 +357,16 @@ function AxesToolbar(): ReactElement {
   return h(
     'span',
     { style: { display: 'inline-flex', alignItems: 'center', gap: 4 } },
+    presets.length > 0
+      ? h(PresetPills, {
+          presets,
+          axes,
+          defaults,
+          activeTuple,
+          lastApplied,
+          onApply: applyPreset,
+        })
+      : null,
     ...axes.map((axis) =>
       h(AxisDropdown, {
         key: axis.name,

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -7,6 +7,7 @@ import {
   cssVarPrefix,
   defaultTheme,
   diagnostics,
+  presets as virtualPresets,
   themes,
   themesResolved,
 } from 'virtual:swatchbook/tokens';
@@ -78,6 +79,7 @@ function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(INIT_EVENT, {
     axes: virtualAxes,
+    presets: virtualPresets,
     themes,
     defaultTheme,
     themesResolved,

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -37,7 +37,14 @@ declare module 'virtual:swatchbook/tokens' {
     aliasedBy?: readonly string[];
   }
 
+  interface VirtualPreset {
+    name: string;
+    axes: Partial<Record<string, string>>;
+    description?: string;
+  }
+
   export const axes: readonly VirtualAxis[];
+  export const presets: readonly VirtualPreset[];
   export const themes: readonly VirtualTheme[];
   export const defaultTheme: string | null;
   export const themesResolved: Record<string, Record<string, VirtualToken>>;

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -43,6 +43,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
       return [
         `/* swatchbook virtual module — generated */`,
         `export const axes = ${JSON.stringify(project.axes)};`,
+        `export const presets = ${JSON.stringify(project.presets)};`,
         `export const themes = ${JSON.stringify(project.themes)};`,
         `export const defaultTheme = ${JSON.stringify(project.themes[0]?.name ?? null)};`,
         `export const themesResolved = ${JSON.stringify(project.themesResolved)};`,

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -38,7 +38,14 @@ declare module 'virtual:swatchbook/tokens' {
     aliasedBy?: readonly string[];
   }
 
+  interface VirtualPreset {
+    name: string;
+    axes: Partial<Record<string, string>>;
+    description?: string;
+  }
+
   export const axes: readonly VirtualAxis[];
+  export const presets: readonly VirtualPreset[];
   export const themes: readonly VirtualTheme[];
   export const defaultTheme: string | null;
   export const themesResolved: Record<string, Record<string, VirtualToken>>;

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -19,7 +19,7 @@ pnpm add @unpunnyfuns/swatchbook-core
 | `projectCss(project)` | Same as `emitCss` with project defaults (prefix + axes) applied. |
 | `emitTypes(project)` | TypeScript source declaring the token-path union + `SwatchbookTokenMap`. |
 | `permutationID(input)` | Stringify a tuple (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`) to the form used as `Theme.name` and CSS data-attribute values. |
-| Types | `Axis`, `Config`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
+| Types | `Axis`, `Config`, `Preset`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`. |
 
 ## Minimal config
 
@@ -54,6 +54,23 @@ const dts = emitTypes(project);
 `Project.axes` surfaces the resolver's modifiers as first-class — one `Axis` per DTCG modifier, each with its `contexts`, `default`, and `description`. Projects loaded without a resolver fall back to a single synthetic axis named `theme`.
 
 Theme names are derived from the axis tuple via `permutationID(input)`: single-axis tuples stringify to the context value alone (`{ theme: 'Light' }` → `"Light"`); multi-axis tuples join context values with ` · ` (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`). Pick sensible context names — what you write is what the toolbar shows. Consuming code should prefer `axes` + `themes[].input` over matching names by string.
+
+## Presets
+
+`config.presets` lets you name tuple combinations authors want quick access to — the addon renders them as toolbar pills, and downstream consumers can read them from `Project.presets`.
+
+```ts
+export default defineSwatchbookConfig({
+  tokens: ['tokens/**/*.json'],
+  resolver: 'tokens/resolver.json',
+  presets: [
+    { name: 'Default Light', axes: { mode: 'Light', brand: 'Default' } },
+    { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' }, description: 'Dark + violet accent.' },
+  ],
+});
+```
+
+Each preset names a partial tuple; any axis the preset omits resolves to that axis's `default` when applied. `loadProject` validates presets: unknown axis keys and invalid context values surface as `warn` diagnostics and are sanitized out, but the preset stays in `Project.presets` (an empty preset is still a valid tuple).
 
 ## CSS emission
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export type {
   Config,
   Diagnostic,
   DiagnosticSeverity,
+  Preset,
   Project,
   ResolvedTheme,
   Theme,

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,4 +1,5 @@
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
+import { validatePresets } from '#/presets.ts';
 import { normalizeThemes } from '#/themes/normalize.ts';
 import type { Config, Project, ResolvedTheme } from '#/types.ts';
 
@@ -17,13 +18,19 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
 
   const graph = normalized.resolved[normalized.defaultThemeName] ?? {};
 
+  const { presets, diagnostics: presetDiagnostics } = validatePresets(
+    config.presets,
+    normalized.axes,
+  );
+
   return {
     config,
     axes: normalized.axes,
+    presets,
     themes: normalized.themes,
     themesResolved: normalized.resolved,
     graph,
-    diagnostics: toDiagnostics(logger),
+    diagnostics: [...toDiagnostics(logger), ...presetDiagnostics],
   };
 }
 

--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -1,0 +1,50 @@
+import type { Axis, Diagnostic, Preset } from '#/types.ts';
+
+export interface PresetValidationResult {
+  presets: Preset[];
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Validate + sanitize user-authored presets against the project's axes.
+ * Unknown axis keys and invalid context values produce `warn` diagnostics;
+ * the offending entries are stripped but the preset itself is kept (possibly
+ * empty, which is still a valid tuple — it just resolves to all defaults).
+ */
+export function validatePresets(raw: Preset[] | undefined, axes: Axis[]): PresetValidationResult {
+  const diagnostics: Diagnostic[] = [];
+  if (!raw || raw.length === 0) return { presets: [], diagnostics };
+
+  const axisByName = new Map<string, Axis>();
+  for (const axis of axes) axisByName.set(axis.name, axis);
+
+  const presets: Preset[] = raw.map((preset) => {
+    const sanitized: Partial<Record<string, string>> = {};
+    for (const [axisName, ctx] of Object.entries(preset.axes)) {
+      if (ctx === undefined) continue;
+      const axis = axisByName.get(axisName);
+      if (!axis) {
+        diagnostics.push({
+          severity: 'warn',
+          group: 'swatchbook/presets',
+          message: `Preset "${preset.name}" references unknown axis "${axisName}" — dropped.`,
+        });
+        continue;
+      }
+      if (!axis.contexts.includes(ctx)) {
+        diagnostics.push({
+          severity: 'warn',
+          group: 'swatchbook/presets',
+          message: `Preset "${preset.name}" sets axis "${axisName}" to "${ctx}" which isn't a known context (${axis.contexts.join(', ')}) — dropped.`,
+        });
+        continue;
+      }
+      sanitized[axisName] = ctx;
+    }
+    const out: Preset = { name: preset.name, axes: sanitized };
+    if (preset.description !== undefined) out.description = preset.description;
+    return out;
+  });
+
+  return { presets, diagnostics };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -25,6 +25,18 @@ export interface Axis {
   source: 'resolver' | 'synthetic';
 }
 
+/**
+ * A named quick-select combination of axis contexts. Rendered as a pill in
+ * the toolbar. Any axis the preset omits falls back to that axis's
+ * `default` when applied.
+ */
+export interface Preset {
+  name: string;
+  /** axisName → contextName. Unknown keys or invalid values produce diagnostics and are sanitized. */
+  axes: Partial<Record<string, string>>;
+  description?: string;
+}
+
 /** Swatchbook configuration. The resolver is the sole theming input. */
 export interface Config {
   /** Glob patterns for DTCG token files. */
@@ -37,6 +49,8 @@ export interface Config {
   cssVarPrefix?: string;
   /** Project-local output directory for codegen artifacts. */
   outDir?: string;
+  /** Named tuple presets — rendered as quick-select pills in the toolbar. */
+  presets?: Preset[];
 }
 
 export type DiagnosticSeverity = 'error' | 'warn' | 'info';
@@ -58,6 +72,8 @@ export interface Diagnostic {
 export interface Project {
   config: Config;
   axes: Axis[];
+  /** Validated + sanitized presets from `config.presets`. Empty if unset. */
+  presets: Preset[];
   themes: Theme[];
   /** Eagerly-resolved tokens per theme, keyed by `theme.name`. */
   themesResolved: Record<string, TokenMap>;

--- a/packages/core/test/presets.test.ts
+++ b/packages/core/test/presets.test.ts
@@ -1,0 +1,111 @@
+import { dirname } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
+import { loadProject } from '#/load';
+import { validatePresets } from '#/presets';
+import type { Axis, Preset, Project } from '#/types';
+
+const fixtureCwd = dirname(tokensDir);
+
+const axes: Axis[] = [
+  {
+    name: 'mode',
+    contexts: ['Light', 'Dark'],
+    default: 'Light',
+    source: 'resolver',
+  },
+  {
+    name: 'brand',
+    contexts: ['Default', 'Brand A'],
+    default: 'Default',
+    source: 'resolver',
+  },
+];
+
+describe('validatePresets', () => {
+  it('passes a well-formed preset through unchanged', () => {
+    const raw: Preset[] = [
+      { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' } },
+    ];
+    const { presets, diagnostics } = validatePresets(raw, axes);
+    expect(diagnostics).toEqual([]);
+    expect(presets).toEqual(raw);
+  });
+
+  it('sanitizes unknown axis keys and emits a warn diagnostic', () => {
+    const raw: Preset[] = [
+      { name: 'Weird', axes: { mode: 'Dark', nonsense: 'Whatever' } },
+    ];
+    const { presets, diagnostics } = validatePresets(raw, axes);
+    expect(presets).toEqual([{ name: 'Weird', axes: { mode: 'Dark' } }]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toMatch(/unknown axis "nonsense"/);
+    expect(diagnostics[0]?.message).toMatch(/"Weird"/);
+  });
+
+  it('sanitizes invalid context values and emits a warn diagnostic', () => {
+    const raw: Preset[] = [
+      { name: 'Bad Mode', axes: { mode: 'Sepia' } },
+    ];
+    const { presets, diagnostics } = validatePresets(raw, axes);
+    expect(presets).toEqual([{ name: 'Bad Mode', axes: {} }]);
+    expect(diagnostics).toHaveLength(1);
+    expect(diagnostics[0]?.severity).toBe('warn');
+    expect(diagnostics[0]?.message).toMatch(/"Sepia"/);
+  });
+
+  it('keeps an empty preset after sanitization (resolves to all defaults)', () => {
+    const raw: Preset[] = [{ name: 'All Wrong', axes: { nope: 'x' } }];
+    const { presets } = validatePresets(raw, axes);
+    expect(presets).toEqual([{ name: 'All Wrong', axes: {} }]);
+  });
+
+  it('preserves description when present', () => {
+    const raw: Preset[] = [
+      { name: 'Described', axes: { mode: 'Light' }, description: 'Baseline.' },
+    ];
+    const { presets } = validatePresets(raw, axes);
+    expect(presets[0]?.description).toBe('Baseline.');
+  });
+
+  it('returns empty arrays when input is undefined', () => {
+    const { presets, diagnostics } = validatePresets(undefined, axes);
+    expect(presets).toEqual([]);
+    expect(diagnostics).toEqual([]);
+  });
+});
+
+describe('loadProject — presets', () => {
+  let project: Project;
+
+  beforeAll(async () => {
+    project = await loadProject(
+      {
+        tokens: ['tokens/**/*.json'],
+        resolver: resolverPath,
+        default: 'Light · Default',
+        presets: [
+          { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' } },
+          { name: 'Default Light', axes: { mode: 'Light' } },
+        ],
+      },
+      fixtureCwd,
+    );
+  }, 30_000);
+
+  it('exposes validated presets on the project', () => {
+    expect(project.presets).toEqual([
+      { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' } },
+      { name: 'Default Light', axes: { mode: 'Light' } },
+    ]);
+  });
+
+  it('defaults to an empty presets array when config.presets is absent', async () => {
+    const p = await loadProject(
+      { tokens: ['tokens/**/*.json'], resolver: resolverPath, default: 'Light · Default' },
+      fixtureCwd,
+    );
+    expect(p.presets).toEqual([]);
+  });
+});


### PR DESCRIPTION
Milestone: Multi-axis theming UX
Closes: Closes #138
Plan impact: none

## Summary

- Adds `defineSwatchbookConfig({ presets })` — ordered list of `{ name, axes, description? }` entries surfaced as toolbar pills. Presets name a partial axis tuple; omitted axes fall back to each axis's `default` when applied.
- Core validates presets at `loadProject` time — unknown axis keys and invalid context values surface as `warn` diagnostics and are sanitized out; the preset itself is preserved (even empty).
- `Project.presets` and the virtual module's `presets` export round-trip the sanitized list; preview decorator broadcasts it on `INIT_EVENT` alongside axes/themes.
- Toolbar renders pills next to the existing axis dropdowns — active pill is highlighted when the current tuple matches; a subtle modified-dot appears on the last-applied pill once the user tweaks an axis after applying it. Clicking a pill writes both `swatchbookAxes` (tuple) and `swatchbookTheme` (composed name).
- Sample presets wired into `apps/storybook/swatchbook.config.ts` (`Default Light`, `Brand A Dark`) so the storybook app exercises the UI.

## Test plan

- [x] `pnpm turbo run lint typecheck test` — 16 tasks green
- [x] `pnpm turbo run test:storybook` — 67 tests green, including new `Tests/Presets` stories
- [x] `pnpm turbo run build` — green
- [ ] Manual: in storybook, verify the two pills render next to `mode` / `brand` dropdowns, that `Brand A Dark` activates the pill and updates `data-mode` / `data-brand` on the story wrapper, and that tweaking one dropdown afterward surfaces the modified-dot.