### PR TITLE
feat(ci): deploy docs + storybook to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,60 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: docs-deploy
+  cancel-in-progress: false
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Cache Turbo
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: turbo-docs-${{ github.sha }}
+          restore-keys: |
+            turbo-docs-
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build Docusaurus + Storybook
+        run: pnpm turbo run build build:storybook --filter=@unpunnyfuns/swatchbook-docs --filter=@unpunnyfuns/swatchbook-storybook
+
+      - name: Merge Storybook into docs build
+        run: |
+          rm -rf apps/docs/build/storybook
+          cp -r apps/storybook/storybook-static apps/docs/build/storybook
+
+      - uses: actions/configure-pages@v6
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: apps/docs/build
+
+      - id: deploy
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
**Milestone:** Documentation site

**Closes:** Closes #152

**Plan impact:** none

## Summary

- New \`.github/workflows/docs.yml\` on push to \`main\` (+ \`workflow_dispatch\` for manual triggers).
- Builds Docusaurus (\`apps/docs/build/\`) and Storybook (\`apps/storybook/storybook-static/\`) in parallel via \`turbo run\`.
- Merges storybook-static into \`apps/docs/build/storybook/\` — single artifact deploys to:
  - Docs: \`https://unpunnyfuns.github.io/swatchbook/\`
  - Storybook: \`https://unpunnyfuns.github.io/swatchbook/storybook/\`
- Actions at current latest: \`configure-pages@v6\`, \`upload-pages-artifact@v5\`, \`deploy-pages@v5\`, \`checkout@v6\`, \`setup-node@v6\`, \`cache@v5\`, \`pnpm/action-setup@v5\`.
- Single concurrency group prevents overlapping deploys.
- No test gate — CI already blocks non-green code from reaching \`main\`.

## One-time setup the repo owner needs

GitHub Pages needs \"Build and deployment\" → \"Source: GitHub Actions\" under Settings → Pages. Without that flip, the \`deploy-pages\` action will 404 on its first run.

## Verified locally

- \`pnpm turbo run build build:storybook --filter=@unpunnyfuns/swatchbook-docs --filter=@unpunnyfuns/swatchbook-storybook\` — both builds green.
- Manual merge of \`storybook-static/\` into \`apps/docs/build/storybook/\` — ~12MB total (11MB Storybook), well under GH Pages limits.

## Test plan

- [x] Local build matches what CI will do
- [x] Workflow YAML syntactically valid (\`actionlint\` / gh renders)
- [ ] First \`main\` push after merge will trigger actual deploy — monitor that run