### PR TITLE
docs: rework readmes and docs for tone, terrazzo credit, gh pages links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Swatchbook
 
-**An addon and tools to help people visualize their future design token projects using Storybook.**
+A Storybook addon and supporting packages for documenting [DTCG](https://www.designtokens.org/) design tokens — parsed via [Terrazzo](https://terrazzo.app/) — inside your Storybook. Design-system engineers use it to publish a searchable, interactive reference of their token set; feature engineers and stakeholders use it to see what's available without opening token JSON files.
 
-In more detail: a comprehensive visual overview of [DTCG](https://www.designtokens.org/) design tokens (parsed via [Terrazzo](https://terrazzo.app/)) that actually exist in your project — rendered inside Storybook. Design-system engineers use it to show their token set to feature engineers and stakeholders; everyone else uses it to see what's there without cracking open a token JSON.
+**Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) (live Storybook at [`/storybook`](https://unpunnyfuns.github.io/swatchbook/storybook/)).
 
-Swatchbook is an **exploration vehicle**, not an ecosystem-capture tool. We serve people building DTCG-native projects going forward — including the people still evolving the spec. Legacy-format compatibility is explicitly an anti-goal.
+## Scope
 
-**Not for you if**: you want to build something with existing mature tooling and walk away for a few years. DTCG is a moving draft; we move with it. Pick Style Dictionary or Tokens Studio if you need long-term stability over frontier exploration.
+Swatchbook focuses on DTCG-native projects — the current 2025.10 draft and onward. The guiding principle: **extrapolate what's in the token set; don't invent new analysis.** If Terrazzo surfaces a piece of data, we render it. If we'd have to compute something new, that's upstream work or a different tool, not ours.
 
-The guiding principle: **extrapolate what's in the token set, don't invent new analysis.** If Terrazzo surfaces a piece of data, we render it. If we'd have to compute something new, that's Terrazzo's conversation (or someone else's tool) — not ours.
+Consider alternatives like Style Dictionary or Tokens Studio if you need long-term stability over the draft spec.
 
 Monorepo published under the `@unpunnyfuns` scope.
 
@@ -16,16 +16,15 @@ Monorepo published under the `@unpunnyfuns` scope.
 
 | Package | Purpose |
 | --- | --- |
-| [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Wraps Terrazzo's parser + DTCG 2025.10 resolver, emits CSS variables + TypeScript types. |
-| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Preset wires core into Vite via a virtual module, the toolbar tool switches themes, the panel browses tokens + diagnostics, `useToken()` gives typed reads from your stories. |
-| [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks consumed from Storybook docs pages. Per-type renderings — color swatches, dimension bars, typography samples, shadow / border / motion previews, per-token detail with full alias chain. Self-mount the addon's CSS and react to toolbar theme changes. |
-| [`@unpunnyfuns/swatchbook-tokens`](./packages/tokens-starter) | Opinionated starter token set. Prebuilt CSS per theme + typed JSON + token-path unions. Install to get something working in five minutes. |
+| [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Wraps Terrazzo's parser and DTCG 2025.10 resolver; emits CSS variables and TypeScript types. |
+| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Preset wires core into Vite via a virtual module, the toolbar renders one dropdown per modifier axis, the panels browse tokens and diagnostics, and `useToken()` gives typed reads from stories. |
+| [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks for Storybook docs pages. Per-type rendering — color swatches, dimension bars, typography samples, composite previews, per-token detail with the full alias chain. |
+| [`@unpunnyfuns/swatchbook-tokens`](./packages/tokens-starter) | Minimal DTCG starter set (iceboxed past v0.1.0 — see `docs/decisions.md`). |
 
 ## Install
 
-```
-pnpm add -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-blocks
-pnpm add @unpunnyfuns/swatchbook-tokens  # or bring your own tokens/
+```sh
+pnpm add -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-blocks @unpunnyfuns/swatchbook-core
 ```
 
 Register the addon in `.storybook/main.ts`:
@@ -39,15 +38,13 @@ export default defineMain({
   addons: [
     {
       name: '@unpunnyfuns/swatchbook-addon',
-      options: {
-        configPath: '../swatchbook.config.ts',
-      },
+      options: { configPath: '../swatchbook.config.ts' },
     },
   ],
 });
 ```
 
-Opt in inside the preview (CSF Next):
+Opt the preview into the addon's annotations (CSF Next):
 
 ```ts
 import { definePreview } from '@storybook/react-vite';
@@ -58,57 +55,46 @@ export default definePreview({
 });
 ```
 
-Drop a `swatchbook.config.ts` at the storybook root:
+Add a `swatchbook.config.ts` at the Storybook root:
 
 ```ts
-import { defineConfig } from '@unpunnyfuns/swatchbook-core';
+import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 
-export default defineConfig({
+export default defineSwatchbookConfig({
   tokens: ['tokens/**/*.json'],
   resolver: 'tokens/resolver.json',
-  default: 'Light',
-  cssVarPrefix: 'sb',
+  cssVarPrefix: 'ds',
 });
 ```
 
-Every `color.sys.surface.default` (and friends) now resolves to `var(--sb-color-sys-surface-default)` at runtime, bound to the active theme via `<html data-theme="…">`.
+Every `color.sys.surface.default` (and similar) now resolves to `var(--ds-color-sys-surface-default)` at runtime, bound to the active theme via per-axis `data-*` attributes on `<html>`.
 
-## Theming via DTCG resolver
+See the [documentation](https://unpunnyfuns.github.io/swatchbook/) for concepts, guides, and the full API reference.
 
-Swatchbook takes exactly one input for theme composition: a [DTCG 2025.10 resolver](https://design-tokens.org/tr/2025/drafts/resolver/) document. The resolver defines `sets` (raw token files) and `modifiers` (axes like theme/appearance/brand), and `resolutionOrder` combines them into named compositions.
+## Theming
 
-Theme names come from the resolver's modifier contexts. For a single-axis resolver (one modifier named `theme` with contexts `Light` / `Dark` / `High Contrast`), those context names are the theme names you'll see in the toolbar. Multi-axis resolvers produce Terrazzo's cross-product permutation IDs — still deterministic, just structured.
+Swatchbook accepts a [DTCG 2025.10 resolver](https://design-tokens.org/tr/2025/drafts/resolver/) file as its primary theming input. The resolver declares `sets` (raw token files) and `modifiers` (theming axes such as mode, brand, contrast), and `resolutionOrder` specifies how they combine.
 
-See [`docs/plan.md`](./docs/plan.md) for the full design doc.
+Each modifier surfaces as an independent dropdown in the toolbar. Selecting a context for each modifier determines the active theme — a simple resolver with one `theme` modifier behaves like a traditional theme switcher; a resolver with `mode × brand` presents two dropdowns and repaints as either changes.
 
-## Storybook MCP
+Projects that don't want to author a resolver file can declare axes inline via `defineSwatchbookConfig({ axes: [...] })`; see [`@unpunnyfuns/swatchbook-core`](./packages/core) for the shape.
 
-`apps/storybook` ships an MCP server via `@storybook/addon-mcp` at `http://localhost:6006/mcp` — useful when driving Claude Code or other MCP clients against a running Storybook.
+## Credits
 
-The MCP endpoint only exists while Storybook is running. **Start order matters**:
-
-```
-# Terminal 1
-pnpm dev           # = turbo run storybook — launches on :6006
-
-# Terminal 2
-claude             # MCP tools for Storybook now resolve
-```
-
-Starting Claude before Storybook makes the MCP handshake fail silently. If that happens, restart Claude after Storybook comes up.
+Swatchbook parses DTCG tokens through [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) — its parser, resolver evaluation, and alias resolution are the foundation this project builds on.
 
 ## Development
 
-Monorepo with pnpm workspaces + Turborepo. Node 24 (latest LTS). ESM everywhere. `tsdown` for package builds.
+pnpm workspaces + Turborepo. Node 24 (latest LTS). ESM throughout. `tsdown` for package builds.
 
-```
+```sh
 pnpm install
-pnpm dev            # start the docs storybook
+pnpm dev                           # starts apps/storybook on :6006
 pnpm turbo run lint typecheck test build
-pnpm turbo run test:storybook    # play-function interaction tests (chromium)
+pnpm turbo run test:storybook      # Playwright-backed play-function tests
 ```
 
-More in [`CLAUDE.md`](./CLAUDE.md) (project conventions + pre-commit checks) and [`docs/plan.md`](./docs/plan.md) (milestones, architecture).
+See [`CLAUDE.md`](./CLAUDE.md) for project conventions and pre-commit checks, and [`docs/plan.md`](./docs/plan.md) for the design doc and milestone history.
 
 ## License
 

--- a/apps/docs/docs/concepts/axes.mdx
+++ b/apps/docs/docs/concepts/axes.mdx
@@ -6,17 +6,17 @@ sidebar_position: 2
 
 # Axes
 
-An **axis** is one orthogonal dimension of your theming model — `mode`, `brand`, `density`, `contrast`, whatever. Each axis has a set of named **contexts** (one of which is the default) and at any moment exactly one context is selected per axis.
+An **axis** is one independent dimension of your theming model — `mode`, `brand`, `density`, `contrast`, whatever fits your system. Each axis has a set of named **contexts** (one of which is the default), and at any moment exactly one context is selected per axis.
 
 ## Tuples, not strings
 
-The addon's canonical representation of "what theme is active" is a **tuple**: `Record<axisName, contextName>`. For a resolver with `mode × brand`, a tuple looks like:
+The addon's canonical representation of "what theme is active" is a **tuple**: one context selected per axis. For a resolver with `mode` and `brand`, a tuple looks like:
 
 ```ts
 { mode: 'Dark', brand: 'Brand A' }
 ```
 
-Every resolved token, every CSS selector, every panel readout keys on this tuple. The flat composed string (`"Dark · Brand A"`) exists only for back-compat and cosmetic display — downstream code should prefer the tuple.
+Every resolved token, every CSS selector, every panel readout keys on this tuple. The composed string name (`"Dark · Brand A"`) exists for back-compat and display — prefer the tuple in consuming code.
 
 ## Data attributes
 
@@ -40,11 +40,11 @@ CSS emission matches these per-axis attributes with compound selectors:
 }
 ```
 
-Each non-default tuple gets its own flat block (every var redeclared). The `:root` block carries the default tuple. No nested cascading — that would require cross-axis collision analysis we don't own, and the DTCG spec explicitly allows axes to write to the same token path.
+Each non-default tuple gets its own flat block (every var redeclared). The `:root` block carries the default tuple. Nested cascading isn't used because axes are allowed to write to the same token path under the DTCG spec; flat emission avoids the collision-detection work that nesting would require.
 
 ## Independence
 
-Axes are **independent**. Selecting `mode=Dark` does not constrain `brand`; the resolver evaluates each modifier in `resolutionOrder` and each contributes its own layer stack. This is why the toolbar renders one dropdown per axis rather than one flat dropdown listing every combination.
+Axes are independent. Selecting `mode=Dark` does not constrain `brand`; the resolver evaluates each modifier in `resolutionOrder` and each contributes its own layer stack. The toolbar reflects this by rendering one dropdown per axis rather than a single flat dropdown that lists every theme.
 
 ## Where axes come from
 

--- a/apps/docs/docs/concepts/theming-inputs.mdx
+++ b/apps/docs/docs/concepts/theming-inputs.mdx
@@ -47,7 +47,7 @@ export default defineSwatchbookConfig({
 **Pick this when**:
 - Your tokens are already published as a DTCG-spec-compliant package, or you want them to be.
 - You want portability: any spec-compliant parser can consume the same file unchanged.
-- You have multiple modifiers (mode, brand, contrast, density, …) and want them independently orthogonal.
+- You have multiple modifiers (mode, brand, contrast, density, …) and want each one switchable independently of the others.
 
 ## Layered (authored)
 
@@ -81,13 +81,13 @@ export default defineSwatchbookConfig({
 **Pick this when**:
 - You haven't adopted the DTCG resolver spec and don't want to.
 - Your layers are shaped as "base + optional override files" without needing spec machinery.
-- You want config lives in TypeScript rather than JSON.
+- You want config to live in TypeScript rather than JSON.
 
 The empty `contexts: { Default: [] }` is legal — it means "no override for this context," which is the baseline for a brand/contrast axis.
 
 ## Same mental model either way
 
-Internally, both inputs produce the same shape: a list of `axes`, each with `contexts` and a `default`. Themes are the cartesian product of contexts across all axes. The rest of the documentation talks about axes generically; whichever input you use, the addon UI is identical.
+Internally, both inputs produce the same shape: a list of `axes`, each with `contexts` and a `default`. Themes are every combination of contexts across all axes (so 2 axes with 2 contexts each yields 4 themes). The rest of the documentation talks about axes generically; whichever input you use, the addon UI is identical.
 
 ## What about Tokens Studio `$themes` manifests?
 

--- a/apps/docs/docs/guides/multi-axis-walkthrough.mdx
+++ b/apps/docs/docs/guides/multi-axis-walkthrough.mdx
@@ -117,7 +117,7 @@ The toolbar now renders pills next to the dropdowns. Clicking a pill writes the 
 
 ## 6. A third axis
 
-Adding a `contrast` modifier is additive — existing axes stay as-is, the cartesian product grows from 4 to 8 tuples. For contrast to compose cleanly with mode + brand, each contrast override should only touch **contrast-specific** paths (borders, focus rings, maybe text), letting mode handle surfaces and brand handle accents. See [axes](../concepts/axes) on how the spec lets axes collide at the same path (and why the CSS emission is flat).
+Adding a `contrast` modifier is additive — existing axes stay as-is, the total theme count grows from 4 to 8. For contrast to compose cleanly with mode and brand, each contrast override should only touch **contrast-specific** paths (borders, focus rings, text), letting mode handle surfaces and brand handle accents. See [axes](../concepts/axes) on why the CSS emission is flat rather than nested.
 
 ## See also
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # Swatchbook
 
-A Storybook addon for documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/). It parses your token files, composes themes through a resolver or layered configuration, and renders a live documentation surface inside your Storybook — searchable token panel, per-axis theme switcher, tuple-aware `TokenDetail` blocks, `ColorPalette`, `TypographyScale`, and more.
+A Storybook addon for documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/). It parses your token files through [Terrazzo](https://terrazzo.app/), composes themes through a resolver or layered configuration, and renders a live documentation surface inside your Storybook — searchable token panel, per-axis theme switcher, tuple-aware `TokenDetail` blocks, `ColorPalette`, `TypographyScale`, and more.
 
 ## Who it's for
 

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,6 +1,8 @@
 # @unpunnyfuns/swatchbook-addon
 
-Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview over a virtual module, renders one toolbar dropdown per modifier axis (one control per `mode`, `brand`, …) plus a browser + diagnostics panel, and ships a `useToken()` hook with typed paths.
+Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus tokens and diagnostics panels, and ships a `useToken()` hook with typed paths.
+
+> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) via `@unpunnyfuns/swatchbook-core`.
 
 ## Install
 
@@ -105,4 +107,5 @@ export const DarkBrandA = meta.story({
 
 - [`@unpunnyfuns/swatchbook-core`](../core) — the loader this addon wraps. Consume directly if you need DTCG processing outside Storybook.
 - [`@unpunnyfuns/swatchbook-blocks`](../blocks) — MDX doc blocks that build on this addon's virtual module.
-- [Project README](../../README.md) — the full install + wiring flow.
+- [Project README](../../README.md) — install and wiring flow for the whole toolchain.
+- [Documentation](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,6 +1,8 @@
 # @unpunnyfuns/swatchbook-blocks
 
-Storybook MDX doc blocks for DTCG design tokens. Drop-in React components for rendering token documentation inside `.mdx` pages or standard React stories. Self-mount the addon's CSS and react to the toolbar theme switcher; work inside the docs container even though story decorators don't.
+Storybook MDX doc blocks for DTCG design tokens. React components for rendering token documentation inside `.mdx` pages or regular stories. Self-mount the addon's CSS and react to axis changes from the toolbar; work inside the docs container even though story decorators don't.
+
+> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) via `@unpunnyfuns/swatchbook-core`.
 
 ## Install
 
@@ -12,12 +14,15 @@ Requires `@unpunnyfuns/swatchbook-addon` to be registered in your Storybook conf
 
 ## Blocks
 
-| Block              | What                                                                |
-| ------------------ | ------------------------------------------------------------------- |
-| `TokenTable`       | Searchable table of tokens, filterable by path glob and `$type`.    |
-| `ColorPalette`     | Swatch grid grouped by sub-path (`groupBy` controls depth).         |
-| `TypographyScale`  | Each typography token rendered as a sample line using its own value.|
-| `TokenDetail`      | Single-token inspector — type, value, alias chain, per-theme table. |
+| Block               | What                                                                                |
+| ------------------- | ----------------------------------------------------------------------------------- |
+| `TokenTable`        | Searchable table of tokens, filterable by path glob and `$type`.                    |
+| `ColorPalette`      | Swatch grid grouped by sub-path (`groupBy` controls depth).                         |
+| `TypographyScale`   | Each typography composite token rendered as a sample line using its own value.      |
+| `FontFamilySample`  | Pangram rendered per `fontFamily` primitive.                                        |
+| `FontWeightScale`   | Same sample text rendered at each `fontWeight` primitive, sorted ascending.         |
+| `StrokeStyleSample` | Border rendered per `strokeStyle` primitive.                                        |
+| `TokenDetail`       | Single-token inspector — type, value, alias chain, aliased-by tree, per-axis variance, composite preview. |
 
 Shared: every block accepts a `caption` override and renders against the addon's `var(--<prefix>-…)` output.
 
@@ -59,4 +64,5 @@ import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-b
 
 - [`@unpunnyfuns/swatchbook-addon`](../addon) — required peer. Registers the virtual module and the toolbar.
 - [`@unpunnyfuns/swatchbook-core`](../core) — underlying loader.
-- [Project README](../../README.md) — install + wiring flow for the whole toolchain.
+- [Project README](../../README.md) — install and wiring flow for the whole toolchain.
+- [Documentation](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,8 @@
 # @unpunnyfuns/swatchbook-core
 
-Framework-free DTCG loader. Parses token files (via Terrazzo), resolves aliases, composes themes through a DTCG 2025.10 resolver, and emits CSS variables + TypeScript types.
+Framework-free DTCG loader. Parses token files via [Terrazzo](https://terrazzo.app/), resolves aliases, composes themes through a DTCG 2025.10 resolver, and emits CSS variables and TypeScript types.
+
+> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/).
 
 ## Install
 
@@ -38,7 +40,7 @@ The resolver file is the spec-defined document describing how token sets compose
 
 ### Layered axes (resolver-less)
 
-Projects that don't want to author a DTCG resolver can declare axes inline. Each context names an ordered list of overlay files that layer on top of `tokens` for that context; for every cartesian tuple, Swatchbook parses `[...base, ...overlaysInAxisOrder]` with alias resolution — last write wins on duplicate token paths:
+Projects that don't want to author a DTCG resolver can declare axes inline. Each context names an ordered list of overlay files that layer on top of `tokens` for that context; for every combination of axis contexts, Swatchbook parses `[...base, ...overlaysInAxisOrder]` with alias resolution — last write wins on duplicate token paths:
 
 ```ts
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
@@ -108,7 +110,7 @@ Each preset names a partial tuple; any axis the preset omits resolves to that ax
 
 ## CSS emission
 
-Multi-axis projects emit one `:root` block with the default-tuple values, plus one block per non-default cartesian tuple keyed on a compound attribute selector in `Project.axes` order:
+Multi-axis projects emit one `:root` block with the default-tuple values, plus one block per non-default combination of axis contexts keyed on a compound attribute selector in `Project.axes` order:
 
 ```css
 :root { --sb-color-sys-surface-default: rgb(255 255 255); … }
@@ -128,8 +130,13 @@ Single-axis projects (one resolver modifier, or the synthetic `theme` axis) keep
 - ❌ Don't import from `@terrazzo/parser` directly unless you need features core doesn't expose. Stay on the core surface so upgrades don't churn your code.
 - ❌ Don't ship the `Project` object to the browser — it's node-parsed and carries full raw-AST references. Use `emitCss` / `emitTypes` / `themesResolved` projections instead.
 
+## Credits
+
+Token parsing, alias resolution, and DTCG resolver evaluation are provided by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow). This package wraps those APIs into a Swatchbook-shaped project.
+
 ## See also
 
 - [`@unpunnyfuns/swatchbook-addon`](../addon) — the Storybook wrapper. Uses `loadProject` at startup, exposes results over a virtual module.
 - [`@unpunnyfuns/swatchbook-blocks`](../blocks) — React doc blocks consumed from MDX.
 - [Project README](../../README.md) — install + wiring flow for the whole toolchain.
+- [Documentation](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/tokens-reference/README.md
+++ b/packages/tokens-reference/README.md
@@ -13,7 +13,7 @@ Exhaustive DTCG 2025.10 pyramid used as swatchbook's internal test bed. Private 
 
 ## Theming compositions
 
-`tokens/resolver.json` — a DTCG 2025.10 native resolver (`sets` + `modifiers` + `resolutionOrder`). Two independent modifiers compose into a 4-permutation cartesian product: `mode` (Light/Dark) × `brand` (Default/Brand A).
+`tokens/resolver.json` — a DTCG 2025.10 native resolver (`sets` + `modifiers` + `resolutionOrder`). Two independent modifiers compose into 4 named themes: every combination of `mode` (Light/Dark) and `brand` (Default/Brand A).
 
 ## Consumption
 


### PR DESCRIPTION
**Milestone:** Maintenance

**Closes:** Closes #159

**Plan impact:** none

## Summary

- Root README, \`core\` / \`addon\` / \`blocks\` / \`tokens-reference\` READMEs, and all docs MDX:
  - Credit [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) where the parser is first mentioned.
  - Link to the GH Pages docs site from every README and at the top of each package README.
  - Drop jargon that isn't part of the design-token vernacular (\"orthogonal\" → \"independent\", \"cartesian product\" → \"every combination\" / explicit \"N themes\").
  - Neutralize the root README tone; fix stale install examples (\`defineSwatchbookConfig\`, drop obsolete \`default: 'Light'\`).
  - Expand the blocks package block table to include the new primitives (\`FontFamilySample\`, \`FontWeightScale\`, \`StrokeStyleSample\`) and the tuple-aware \`TokenDetail\` shape.
- Docs-only; no runtime changes.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs build\` green (broken-link warnings expected pre-deploy but are now all documented).