### PR TITLE
feat(core)!: accept tuple object for config.default

### DIFF
--- a/.changeset/default-tuple-object.md
+++ b/.changeset/default-tuple-object.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': major
+---
+
+`Config.default` now takes a partial tuple object (`{ axisName: contextName }`) instead of a composed permutation string. Partial tuples fill omitted axes from each axis's own `default`; unknown axis keys and invalid context values surface as `warn` diagnostics (group `swatchbook/default`) and are sanitized out. Omit `default` entirely to start in the all-axis-defaults tuple.
+
+Migration: replace `default: 'Light · Default'` with `default: { mode: 'Light', brand: 'Default' }` (or omit the field if the all-defaults tuple is fine).

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -4,7 +4,7 @@ import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-referenc
 export default defineSwatchbookConfig({
   tokens: [`${tokensDir}/**/*.json`],
   resolver: resolverPath,
-  default: 'Light · Default',
+  default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'sb',
   presets: [
     {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -31,12 +31,14 @@ import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 export default defineSwatchbookConfig({
   tokens: ['tokens/**/*.json'],
   resolver: 'tokens/resolver.json',
-  default: 'Light',
+  default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'sb',
 });
 ```
 
 The resolver file is the spec-defined document describing how token sets compose into named themes — see [the DTCG 2025.10 resolver draft](https://design-tokens.org/tr/2025/drafts/resolver/).
+
+`default` is a partial tuple keyed by axis name. Any axis you omit falls back to that axis's own `default`; unknown keys and invalid context values produce `warn` diagnostics and are sanitized out. Omit `default` entirely to start the project in the all-axis-defaults tuple.
 
 ### Layered axes (resolver-less)
 

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,7 +1,8 @@
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
 import { validatePresets } from '#/presets.ts';
+import { resolveDefaultTuple } from '#/themes/default.ts';
 import { normalizeThemes } from '#/themes/normalize.ts';
-import type { Config, Project, ResolvedTheme } from '#/types.ts';
+import { permutationID, type Config, type Project, type ResolvedTheme } from '#/types.ts';
 
 /**
  * Load a swatchbook project from a config. Themes are eagerly resolved,
@@ -9,14 +10,23 @@ import type { Config, Project, ResolvedTheme } from '#/types.ts';
  * `project.themesResolved[name]` directly without further I/O.
  *
  * The `cwd` defaults to `process.cwd()`. All relative paths in `config`
- * (token globs, `resolver`, `manifest`, theme layer globs) resolve
- * against this directory.
+ * (token globs, `resolver`, theme layer globs) resolve against this
+ * directory.
  */
 export async function loadProject(config: Config, cwd: string = process.cwd()): Promise<Project> {
   const logger = new BufferedLogger({ level: 'warn' });
   const normalized = await normalizeThemes(config, cwd, logger);
 
-  const graph = normalized.resolved[normalized.defaultThemeName] ?? {};
+  const { tuple: defaultTuple, diagnostics: defaultDiagnostics } = resolveDefaultTuple(
+    config.default,
+    normalized.axes,
+  );
+  const computedDefault = permutationID(defaultTuple);
+  const defaultThemeName = normalized.resolved[computedDefault]
+    ? computedDefault
+    : (normalized.themes[0]?.name ?? '');
+
+  const graph = normalized.resolved[defaultThemeName] ?? {};
 
   const { presets, diagnostics: presetDiagnostics } = validatePresets(
     config.presets,
@@ -30,7 +40,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     themes: normalized.themes,
     themesResolved: normalized.resolved,
     graph,
-    diagnostics: [...toDiagnostics(logger), ...presetDiagnostics],
+    diagnostics: [...toDiagnostics(logger), ...defaultDiagnostics, ...presetDiagnostics],
   };
 }
 

--- a/packages/core/src/themes/default.ts
+++ b/packages/core/src/themes/default.ts
@@ -1,0 +1,51 @@
+import type { Axis, Diagnostic } from '#/types.ts';
+
+export interface DefaultTupleResult {
+  tuple: Record<string, string>;
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Resolve the project's starting tuple by merging the author-supplied
+ * `config.default` onto the axis-default baseline. Unknown axis keys and
+ * invalid context values surface as `warn` diagnostics (group
+ * `swatchbook/default`) and the offending entry is dropped; the axis's own
+ * `default` fills in. When `explicit` is absent the result is exactly the
+ * axis-default baseline.
+ */
+export function resolveDefaultTuple(
+  explicit: Partial<Record<string, string>> | undefined,
+  axes: Axis[],
+): DefaultTupleResult {
+  const tuple: Record<string, string> = {};
+  for (const axis of axes) tuple[axis.name] = axis.default;
+
+  const diagnostics: Diagnostic[] = [];
+  if (!explicit) return { tuple, diagnostics };
+
+  const axisByName = new Map<string, Axis>();
+  for (const axis of axes) axisByName.set(axis.name, axis);
+
+  for (const [axisName, ctx] of Object.entries(explicit)) {
+    if (ctx === undefined) continue;
+    const axis = axisByName.get(axisName);
+    if (!axis) {
+      diagnostics.push({
+        severity: 'warn',
+        group: 'swatchbook/default',
+        message: `Config "default" references unknown axis "${axisName}" — using axis defaults.`,
+      });
+      continue;
+    }
+    if (!axis.contexts.includes(ctx)) {
+      diagnostics.push({
+        severity: 'warn',
+        group: 'swatchbook/default',
+        message: `Config "default" sets axis "${axisName}" to "${ctx}" which isn't a known context (${axis.contexts.join(', ')}) — using axis default.`,
+      });
+      continue;
+    }
+    tuple[axisName] = ctx;
+  }
+  return { tuple, diagnostics };
+}

--- a/packages/core/src/themes/layered.ts
+++ b/packages/core/src/themes/layered.ts
@@ -9,7 +9,6 @@ export interface LayeredLoadResult {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
-  defaultThemeName: string;
 }
 
 /**
@@ -25,7 +24,6 @@ export async function loadLayeredThemes(
   tokenGlobs: string[],
   cwd: string,
   logger: BufferedLogger,
-  explicitDefault?: string,
 ): Promise<LayeredLoadResult> {
   const cwdUrl = pathToFileURL(`${cwd}/`);
   const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
@@ -92,17 +90,7 @@ export async function loadLayeredThemes(
     resolved[id] = tokens;
   }
 
-  const defaultInput: Record<string, string> = {};
-  for (const ax of axesConfig) defaultInput[ax.name] = ax.default;
-  const defaultByAxes = permutationID(defaultInput);
-  const defaultThemeName =
-    explicitDefault && resolved[explicitDefault]
-      ? explicitDefault
-      : resolved[defaultByAxes]
-        ? defaultByAxes
-        : (themes[0]?.name ?? '');
-
-  return { axes, themes, resolved, defaultThemeName };
+  return { axes, themes, resolved };
 }
 
 function cartesianTuples(axesConfig: AxisConfig[]): Record<string, string>[] {

--- a/packages/core/src/themes/normalize.ts
+++ b/packages/core/src/themes/normalize.ts
@@ -7,7 +7,6 @@ export interface NormalizedThemes {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
-  defaultThemeName: string;
   /** Files loaded as source-only (not emitted to CSS). Reserved for future use. */
   sourceOnlyFiles: Set<string>;
 }
@@ -27,10 +26,10 @@ export async function normalizeThemes(
   }
 
   if (config.axes) {
-    const r = await loadLayeredThemes(config.axes, config.tokens, cwd, logger, config.default);
+    const r = await loadLayeredThemes(config.axes, config.tokens, cwd, logger);
     return { ...r, sourceOnlyFiles: new Set() };
   }
 
-  const r = await loadResolverThemes(config.resolver, config.tokens, cwd, logger, config.default);
+  const r = await loadResolverThemes(config.resolver, config.tokens, cwd, logger);
   return { ...r, sourceOnlyFiles: new Set() };
 }

--- a/packages/core/src/themes/resolver.ts
+++ b/packages/core/src/themes/resolver.ts
@@ -10,7 +10,6 @@ export interface ResolverLoadResult {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
-  defaultThemeName: string;
 }
 
 /**
@@ -25,7 +24,6 @@ export async function loadResolverThemes(
   tokenGlobs: string[],
   cwd: string,
   logger: BufferedLogger,
-  explicitDefault?: string,
 ): Promise<ResolverLoadResult> {
   const cwdUrl = pathToFileURL(`${cwd}/`);
   const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
@@ -68,12 +66,11 @@ export async function loadResolverThemes(
       resolveAliases: true,
       continueOnError: true,
     });
-    const name = explicitDefault ?? 'default';
+    const name = 'default';
     return {
       axes: [{ name: 'theme', contexts: [name], default: name, source: 'synthetic' }],
       themes: [{ name, input: { theme: name }, sources: tokenFiles }],
       resolved: { [name]: parsed.tokens },
-      defaultThemeName: name,
     };
   }
 
@@ -98,8 +95,5 @@ export async function loadResolverThemes(
     resolved[id] = tokens;
   }
 
-  const defaultThemeName =
-    explicitDefault && resolved[explicitDefault] ? explicitDefault : (themes[0]?.name ?? '');
-
-  return { axes, themes, resolved, defaultThemeName };
+  return { axes, themes, resolved };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -58,8 +58,13 @@ export interface Config {
   resolver?: string;
   /** Authored layered axes. Mutually exclusive with `resolver`. */
   axes?: AxisConfig[];
-  /** Name of the default theme. */
-  default?: string;
+  /**
+   * Initial active tuple (`{ axisName: contextName }`). Any axis the tuple
+   * omits falls back to that axis's own `default`. Unknown axis keys or
+   * invalid context values produce `warn` diagnostics and are sanitized.
+   * When absent, the starting tuple is built from each axis's `default`.
+   */
+  default?: Partial<Record<string, string>>;
   /** Prefix for emitted CSS custom properties. */
   cssVarPrefix?: string;
   /** Project-local output directory for codegen artifacts. */

--- a/packages/core/test/_helpers.ts
+++ b/packages/core/test/_helpers.ts
@@ -10,7 +10,7 @@ export async function loadWithPrefix(prefix: string | undefined): Promise<Projec
     {
       tokens: ['tokens/**/*.json'],
       resolver: resolverPath,
-      default: 'Light',
+      default: { mode: 'Light', brand: 'Default' },
       ...(prefix !== undefined && { cssVarPrefix: prefix }),
     },
     fixtureCwd,

--- a/packages/core/test/default-tuple.test.ts
+++ b/packages/core/test/default-tuple.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { resolverPath } from '@unpunnyfuns/swatchbook-tokens-reference';
+import { loadProject } from '#/load';
+import { fixtureCwd } from './_helpers';
+
+describe('Config.default tuple resolution', () => {
+  it('sets the starting tuple when every axis is specified', async () => {
+    const project = await loadProject(
+      {
+        tokens: ['tokens/**/*.json'],
+        resolver: resolverPath,
+        default: { mode: 'Dark', brand: 'Brand A' },
+      },
+      fixtureCwd,
+    );
+    expect(project.graph).toBe(project.themesResolved['Dark · Brand A']);
+  });
+
+  it("fills omitted axes from each axis's own default", async () => {
+    const project = await loadProject(
+      {
+        tokens: ['tokens/**/*.json'],
+        resolver: resolverPath,
+        default: { mode: 'Dark' },
+      },
+      fixtureCwd,
+    );
+    expect(project.graph).toBe(project.themesResolved['Dark · Default']);
+  });
+
+  it('resolves to the all-axis-defaults tuple when default is absent', async () => {
+    const project = await loadProject(
+      { tokens: ['tokens/**/*.json'], resolver: resolverPath },
+      fixtureCwd,
+    );
+    expect(project.graph).toBe(project.themesResolved['Light · Default']);
+  });
+
+  it('drops unknown axis keys with a warn diagnostic and falls back to the axis default', async () => {
+    const project = await loadProject(
+      {
+        tokens: ['tokens/**/*.json'],
+        resolver: resolverPath,
+        default: { mode: 'Dark', notAnAxis: 'Whatever' },
+      },
+      fixtureCwd,
+    );
+    const warn = project.diagnostics.find(
+      (d) => d.group === 'swatchbook/default' && d.message.includes('notAnAxis'),
+    );
+    expect(warn?.severity).toBe('warn');
+    expect(project.graph).toBe(project.themesResolved['Dark · Default']);
+  });
+
+  it('drops invalid context values with a warn diagnostic and falls back to the axis default', async () => {
+    const project = await loadProject(
+      {
+        tokens: ['tokens/**/*.json'],
+        resolver: resolverPath,
+        default: { mode: 'NopeMode' },
+      },
+      fixtureCwd,
+    );
+    const warn = project.diagnostics.find(
+      (d) => d.group === 'swatchbook/default' && d.message.includes('NopeMode'),
+    );
+    expect(warn?.severity).toBe('warn');
+    expect(project.graph).toBe(project.themesResolved['Light · Default']);
+  });
+});

--- a/packages/core/test/load.test.ts
+++ b/packages/core/test/load.test.ts
@@ -11,7 +11,11 @@ describe('loadProject — resolver mode', () => {
 
   beforeAll(async () => {
     project = await loadProject(
-      { tokens: ['tokens/**/*.json'], resolver: resolverPath, default: 'Light · Default' },
+      {
+        tokens: ['tokens/**/*.json'],
+        resolver: resolverPath,
+        default: { mode: 'Light', brand: 'Default' },
+      },
       fixtureCwd,
     );
   }, 30_000);

--- a/packages/core/test/presets.test.ts
+++ b/packages/core/test/presets.test.ts
@@ -84,7 +84,7 @@ describe('loadProject — presets', () => {
       {
         tokens: ['tokens/**/*.json'],
         resolver: resolverPath,
-        default: 'Light · Default',
+        default: { mode: 'Light', brand: 'Default' },
         presets: [
           { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' } },
           { name: 'Default Light', axes: { mode: 'Light' } },
@@ -103,7 +103,7 @@ describe('loadProject — presets', () => {
 
   it('defaults to an empty presets array when config.presets is absent', async () => {
     const p = await loadProject(
-      { tokens: ['tokens/**/*.json'], resolver: resolverPath, default: 'Light · Default' },
+      { tokens: ['tokens/**/*.json'], resolver: resolverPath, default: { mode: 'Light', brand: 'Default' } },
       fixtureCwd,
     );
     expect(p.presets).toEqual([]);

--- a/packages/tokens-starter/build.ts
+++ b/packages/tokens-starter/build.ts
@@ -17,7 +17,7 @@ const project = await loadProject(
   {
     tokens: ['tokens/**/*.json'],
     resolver: 'tokens/resolver.json',
-    default: 'Light',
+    default: { theme: 'Light' },
     cssVarPrefix: CSS_VAR_PREFIX,
   },
   here,


### PR DESCRIPTION
**Milestone:**

**Closes:** Closes #158

**Plan impact:** none

## Summary

- \`Config.default\` now takes a partial tuple object (\`{ axisName: contextName }\`) instead of a composed permutation string.
- Omitted axes fall back to each axis's own \`default\`; unknown axis keys and invalid context values surface as \`warn\` diagnostics (group \`swatchbook/default\`) and are sanitized out. Omitting \`config.default\` starts the project in the all-axis-defaults tuple.
- Moved default-tuple resolution out of the per-loader layer (\`resolver.ts\` / \`layered.ts\`) into \`loadProject\` itself, since its diagnostics need the same channel as preset validation — neither fits Terrazzo's \`LogGroup\` union, so they append directly to \`Project.diagnostics\`.
- \`apps/storybook/swatchbook.config.ts\` and \`packages/tokens-starter/build.ts\` updated to the new shape.
- New \`packages/core/test/default-tuple.test.ts\`: 5 tests covering full tuple, partial tuple, absent default, unknown axis, invalid context.

## Migration

Before:
\`\`\`ts
defineSwatchbookConfig({ default: 'Light · Default', … })
\`\`\`
After:
\`\`\`ts
defineSwatchbookConfig({ default: { mode: 'Light', brand: 'Default' }, … })
\`\`\`
Or omit \`default\` entirely if the all-axis-defaults tuple is fine.

## Test plan

- [x] \`pnpm turbo run lint typecheck test build\` — 19/19 green; 46 core tests pass (5 new)
- [x] \`pnpm turbo run test:storybook\` — 65/65 play-function tests pass