### PR TITLE
docs: rewrite conventions and guides for the two-layer token model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,13 +61,13 @@ When filing an issue: feature work → the relevant scope milestone. Repo hygien
   - **No nested `describe`.** One `describe` per file at most, as a file-level grouping. If you feel the urge to nest, split files instead.
   - **No `beforeEach`** for cosmetic shared setup. Write an inline `setup()` helper and have each test call it; duplicating a line or two beats the "what is `user` here?" hunt.
   - **`beforeAll` is a perf escape hatch**, not a grouping tool. Acceptable only when the shared setup is genuinely expensive (e.g. `loadProject` takes ~1s so running it per-test would blow the timeout) and the alternative would be a meaningful regression. Annotate the reason inline.
-  - Prose over jargon in test names: `` it('resolves deep alias chains (cmp → sys → ref)') `` beats `` it('resolves') `` inside nested describes.
+  - Prose over jargon in test names: `` it('resolves alias chains (sys → ref)') `` beats `` it('resolves') `` inside nested describes.
 - **Pre-commit checks (always, no exceptions):** before running `git commit`, run
   ```
   pnpm -r format && pnpm turbo run lint typecheck test
   ```
   Format changes to already-staged files land as noisy follow-up commits; CI fails on lint/typecheck/test regressions. Running all four locally catches every class before the push. If something is too slow, scope with `--filter=<pkg>` — don't skip.
-- **Design tokens:** ref → sys → cmp pyramid. Components never alias ref directly.
+- **Design tokens:** ref → sys only. Variation lives in modes on sys (i.e., resolver modifiers like `mode`, `brand`, `contrast`), which already handle the component specialization a `cmp` layer would attempt. Component-layer tokens are an explicit anti-pattern here — they double the token count for every axis without expressive gain; components alias `sys` directly.
 - **TypeScript:** strict, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` on.
 - **READMEs:** module name + one-liner; structure table; TypeScript examples with imports; ✅/❌ for do's/don'ts.
 

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -28,8 +28,9 @@ import { ColorPalette, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 
 # Colors
 
-Our color system has three tiers: primitives in `color.ref`, semantic slots in
-`color.sys`, and component-scoped values in `cmp.*.color*`.
+Our color system has two tiers: primitives in `color.ref` and semantic slots
+in `color.sys`. Semantic slots carry mode- and brand-varied values through
+the resolver, so components style themselves against `color.sys.*` directly.
 
 ## Primitive palette
 

--- a/apps/docs/docs/guides/multi-axis-walkthrough.mdx
+++ b/apps/docs/docs/guides/multi-axis-walkthrough.mdx
@@ -14,7 +14,6 @@ Step-by-step setup of a two-axis theming model — `mode × brand` — using the
 tokens/
   ref/            # raw primitives — color palettes, size scale, font families
   sys/            # semantic slots — color.sys.surface.default → {color.ref.neutral.0}
-  cmp/            # component-scoped — cmp.button.bg → {color.sys.accent.bg}
   themes/
     light.json    # Light mode overrides of sys
     dark.json     # Dark mode overrides of sys
@@ -22,7 +21,7 @@ tokens/
   resolver.json
 ```
 
-Ref → sys → cmp is the DTCG pyramid. Components alias sys (never ref directly) so a brand swap at sys propagates through every component that uses the accent.
+Two layers: `ref` (primitives) and `sys` (semantic slots aliased into ref). Component variation is carried by modes on sys — the resolver's `mode × brand` axes swap values at the sys level, and components alias sys directly. There's no `cmp` layer here by design: modes already handle the specialization a component layer would try to introduce, and every added layer multiplies the token count for every axis. See [Terrazzo's own guidance](https://terrazzo.app/docs/guides/architecture/) on keeping layers minimal.
 
 ## 2. The resolver
 
@@ -34,8 +33,7 @@ Two independent modifiers:
   "version": "2025.10",
   "sets": {
     "ref": { "sources": [{ "$ref": "./ref/color.palette.json" } /* , … */] },
-    "sys": { "sources": [{ "$ref": "./sys/color.json" } /* , … */] },
-    "cmp": { "sources": [{ "$ref": "./cmp/button.json" } /* , … */] }
+    "sys": { "sources": [{ "$ref": "./sys/color.json" } /* , … */] }
   },
   "modifiers": {
     "mode": {
@@ -58,7 +56,6 @@ Two independent modifiers:
   "resolutionOrder": [
     { "$ref": "#/sets/ref" },
     { "$ref": "#/sets/sys" },
-    { "$ref": "#/sets/cmp" },
     { "$ref": "#/modifiers/mode" },
     { "$ref": "#/modifiers/brand" }
   ]
@@ -68,8 +65,8 @@ Two independent modifiers:
 Key points:
 
 - `"Default": []` is a legal context — no override files, just the sys baseline.
-- `resolutionOrder` lists modifiers **after** sets: sys/cmp load first, mode/brand overlay on top.
-- `brand` appears after `mode` in `resolutionOrder`, so if both touch the same token path, brand wins. That's authoring intent — brand-a.json can override light.json for accent-only tweaks.
+- `resolutionOrder` lists modifiers **after** sets: ref/sys load first, mode/brand overlay on top.
+- `brand` appears after `mode` in `resolutionOrder`, so if both touch the same token path, brand wins. That's authoring intent — `brand-a.json` can override `light.json` for accent-only tweaks.
 
 ## 3. Config
 
@@ -79,12 +76,12 @@ import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 export default defineSwatchbookConfig({
   tokens: ['tokens/**/*.json'],
   resolver: 'tokens/resolver.json',
-  default: 'Light · Default',
+  default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'ds',
 });
 ```
 
-The `default` string is the composed tuple name — `<mode> · <brand>` for this project.
+`default` is a partial tuple keyed by axis name. Omit it entirely to start in the all-axis-defaults tuple; name any axis explicitly to override. Unknown keys and invalid values produce `warn` diagnostics and fall back to the axis default.
 
 ## 4. What Storybook shows
 
@@ -97,7 +94,7 @@ With the config live:
   - `[data-mode="Dark"][data-brand="Default"] { … }`
   - `[data-mode="Light"][data-brand="Brand A"] { … }`
   - `[data-mode="Dark"][data-brand="Brand A"] { … }`
-- **Components** (Button, Card, Input in the reference Storybook) repaint as you switch axes.
+- **Components** in the reference Storybook (Button, Card, Input) read `var(--ds-color-sys-*)` directly and repaint as you switch axes — no component-specific token plumbing needed.
 
 ## 5. Preset pills
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -23,7 +23,7 @@ Design-system authors who already have DTCG tokens (or are in the process of aut
 
 ## See it live
 
-The [live Storybook](/swatchbook/storybook/) runs the addon against this repo's [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference) fixture — a realistic multi-file DTCG pyramid with resolver-driven axes. Every block, panel, and toolbar control is wired up against those tokens.
+The [live Storybook](/swatchbook/storybook/) runs the addon against this repo's [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference) fixture — a multi-file DTCG token set with two layers (ref and sys) and resolver-driven axes. Every block, panel, and toolbar control is wired up against those tokens.
 
 ## How to read these docs
 

--- a/apps/docs/docs/reference/blocks.mdx
+++ b/apps/docs/docs/reference/blocks.mdx
@@ -33,7 +33,7 @@ import { ColorPalette, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-b
 Single-token deep-dive. Renders:
 
 - Type + description.
-- Alias chain (forward) — e.g. `cmp.button.bg → color.sys.accent.bg → color.ref.blue.500`.
+- Alias chain (forward) — e.g. `color.sys.accent.bg → color.ref.blue.700`.
 - Aliased-by tree (backward) — everything that transitively aliases this token.
 - Composite preview — for `typography`, `shadow`, `border`, `transition`, `dimension`, `duration`, `cubicBezier`, `fontFamily`, `fontWeight`, `strokeStyle`, `color`.
 - Per-axis variance — values along whichever axes move the token.

--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -246,3 +246,15 @@ Second, how to emit CSS for N axes: one block per cartesian tuple with compound 
 **Terrazzo already provides the axis primitives.** `Resolver.source.modifiers`, `listPermutations()`, `apply(input)`, and `getPermutationID(input)` model tuples and per-modifier contexts natively. `packages/core/src/themes/resolver.ts` already iterates permutations and stores the tuple on `Theme.input` — we simply never expose the modifier structure to `Project`, so downstream code keys on the flat permutation ID instead of the tuple. The multi-axis work is mostly plumbing: surface what Terrazzo gives us; route preview, toolbar, emission, and blocks through tuples. Not reinventing resolution.
 
 **Plan impact:** `docs/plan.md` Multi-axis section rewritten with concrete issue breakdown (#131–#138). CLAUDE.md current-milestone line updated. Per-context display-name extensions and modifier `description` labels (from the original milestone sketch) demoted to post-milestone follow-ups; saved tuple presets stay in scope as issue #138 but land as config (`defineConfig({ presets })`) rather than localStorage so they're reviewable and shared across teammates.
+
+---
+
+## 2026-04-18 — Two-layer token model: drop the `cmp` layer
+
+**Context:** The reference fixture and our CLAUDE.md convention prescribed a three-layer pyramid — `ref` → `sys` → `cmp`. Components aliased `cmp.*` tokens, which in turn aliased `sys.*`. In practice every `cmp` token in the fixture was a 1:1 pass-through of a `sys` token.
+
+**Decision:** Collapse to two layers (`ref` + `sys`). Components alias `sys` directly. `cmp` is called out as an anti-pattern in the CLAUDE.md convention.
+
+**Rationale:** From Terrazzo's architecture guidance: every token layer is multiplied by every mode (axis × context), so each additional layer compounds the token count exponentially. Atlassian reported hitting 37,000 tokens largely because of component-layer specialization. In our own fixture, modes on `sys` (the resolver's `mode × brand` axes) already carry the variation a `cmp` layer was trying to introduce — a button aliasing `color.sys.accent.bg` picks up each tuple's value for free. The cmp layer paid for complexity it didn't resolve.
+
+**Plan impact:** Milestone #20 (Two-layer token model) split into issues #164 (code: fixture, components, tests) and #165 (convention + docs). CLAUDE.md "Design tokens" line rewritten to name cmp as an anti-pattern explicitly. Docusaurus `multi-axis-walkthrough.mdx` rewritten around the 2-layer layout, linking out to Terrazzo's architecture guide. No package version bumps — `packages/tokens-reference` is private, no published consumer.


### PR DESCRIPTION
**Milestone:** Two-layer token model

**Closes:** Closes #165

**Plan impact:** decisions.md entry

## Summary

Paper trail for the cmp-layer removal (PR #166 carries the code change).

- `CLAUDE.md` design-tokens convention names cmp as an explicit anti-pattern.
- `apps/docs/docs/intro.mdx` drops the "pyramid" framing in favor of "two-layer with resolver-driven axes".
- `apps/docs/docs/guides/multi-axis-walkthrough.mdx` rewritten around ref + sys only, linking Terrazzo's architecture guide and explaining why cmp is absent.
- `apps/docs/docs/guides/authoring-doc-stories.mdx` narrative updated from three tiers to two.
- `apps/docs/docs/reference/blocks.mdx` alias-chain example uses the sys → ref shape.
- `docs/decisions.md` appends a 2026-04-18 entry with the rationale and cross-links #164 and #165.

## Merge order

Can merge independently of #166 — the docs describe the post-#166 state, but #166's code change is self-contained. If this lands first the docs reference a state not yet in code; either way is fine.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-docs build` green (broken-link warnings expected pre-deploy as before)