### PR TITLE
feat(core): make config.tokens optional when resolver is set

### DIFF
--- a/.changeset/optional-tokens-when-resolver.md
+++ b/.changeset/optional-tokens-when-resolver.md
@@ -1,0 +1,8 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+`Config.tokens` is now optional when `config.resolver` is set. The resolver's own `$ref` targets fully determine what gets loaded, and `Project.sourceFiles` exposes every file touched so the addon's Vite plugin can derive HMR watch paths without a parallel `tokens` glob. Supplying `tokens` alongside `resolver` still works — the watch paths union with the resolver-derived set, useful when you want HMR to watch broader directories than the resolver references.
+
+Plain-parse (no resolver, no axes) and layered (`axes` set) modes still require `tokens` — the loader has no other starting point. Configs that omit `resolver`, `axes`, AND `tokens` now throw a descriptive error at load time.

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -1,8 +1,7 @@
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
-import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
+import { resolverPath } from '@unpunnyfuns/swatchbook-tokens-reference';
 
 export default defineSwatchbookConfig({
-  tokens: [`${tokensDir}/**/*.json`],
   resolver: resolverPath,
   default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'sb',

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,5 +1,6 @@
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import type { Plugin } from 'vite';
 import { RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from '#/constants.ts';
 
@@ -11,8 +12,8 @@ export interface SwatchbookPluginOptions {
 /**
  * Vite plugin that serves the virtual `virtual:swatchbook/tokens` module —
  * a single source of truth for themes, resolved token maps, per-theme CSS,
- * and diagnostics. Watches the token files + manifest/resolver for changes
- * and invalidates the module so HMR reloads the preview with fresh data.
+ * and diagnostics. Watches the token files + resolver for changes and
+ * invalidates the module so HMR reloads the preview with fresh data.
  */
 export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions): Plugin {
   let project: Project | undefined;
@@ -54,7 +55,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
     },
 
     configureServer(server) {
-      const watchPaths = collectWatchPaths(config, cwd);
+      const watchPaths = collectWatchPaths(config, project, cwd);
       for (const p of watchPaths) server.watcher.add(p);
 
       const invalidate = async (): Promise<void> => {
@@ -79,18 +80,29 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
   };
 }
 
-function collectWatchPaths(config: Config, cwd: string): string[] {
+/**
+ * Collect the set of filesystem paths the dev server should watch for
+ * HMR. When `config.tokens` is set, use its globs (stripped to their
+ * base directories) — users opt in to broader watching this way. When
+ * absent, use the resolver file + every `$ref` target it pulled in, as
+ * tracked on `project.sourceFiles` — which stays correct as the resolver
+ * evolves without requiring a parallel `tokens` glob.
+ */
+function collectWatchPaths(config: Config, project: Project | undefined, cwd: string): string[] {
   const paths: string[] = [];
-  for (const glob of config.tokens) {
-    // Strip the glob portion and watch the base directory.
-    const base = glob.replace(/\/\*.*$/, '').replace(/\/[^/]*\*.*$/, '');
-    paths.push(resolveFromCwd(base, cwd));
+  if (config.tokens && config.tokens.length > 0) {
+    for (const glob of config.tokens) {
+      const base = glob.replace(/\/\*.*$/, '').replace(/\/[^/]*\*.*$/, '');
+      paths.push(resolveFromCwd(base, cwd));
+    }
+  } else if (project?.sourceFiles) {
+    for (const file of project.sourceFiles) paths.push(dirname(file));
   }
   if (config.resolver) paths.push(resolveFromCwd(config.resolver, cwd));
   return [...new Set(paths)];
 }
 
 function resolveFromCwd(p: string, cwd: string): string {
-  if (p.startsWith('/')) return p;
-  return `${cwd}/${p}`;
+  if (isAbsolute(p)) return p;
+  return resolvePath(cwd, p);
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,14 +29,17 @@ pnpm add @unpunnyfuns/swatchbook-core
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 
 export default defineSwatchbookConfig({
-  tokens: ['tokens/**/*.json'],
   resolver: 'tokens/resolver.json',
   default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'sb',
 });
 ```
 
-The resolver file is the spec-defined document describing how token sets compose into named themes — see [the DTCG 2025.10 resolver draft](https://design-tokens.org/tr/2025/drafts/resolver/).
+The resolver file is the spec-defined document describing how token sets compose into named themes — see [the DTCG 2025.10 resolver draft](https://design-tokens.org/tr/2025/drafts/resolver/). Every token file the resolver references via `$ref` is loaded automatically; the addon's Vite plugin derives HMR watch paths from that set, so no separate `tokens` glob is needed for resolver-backed projects.
+
+If you want HMR to watch a directory broader than the resolver references directly — say, to pick up a new token file the moment it's added — supply `tokens: ['tokens/**/*.json']` alongside `resolver` and the plugin will union the two.
+
+Projects without a resolver (plain-parse or layered-axes) still need `tokens` — the loader has nothing to start from otherwise.
 
 `default` is a partial tuple keyed by axis name. Any axis you omit falls back to that axis's own `default`; unknown keys and invalid context values produce `warn` diagnostics and are sanitized out. Omit `default` entirely to start the project in the all-axis-defaults tuple.
 

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -40,6 +40,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     themes: normalized.themes,
     themesResolved: normalized.resolved,
     graph,
+    sourceFiles: normalized.sourceFiles,
     diagnostics: [...toDiagnostics(logger), ...defaultDiagnostics, ...presetDiagnostics],
   };
 }

--- a/packages/core/src/themes/layered.ts
+++ b/packages/core/src/themes/layered.ts
@@ -9,6 +9,7 @@ export interface LayeredLoadResult {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
+  sourceFiles: string[];
 }
 
 /**
@@ -84,13 +85,15 @@ export async function loadLayeredThemes(
 
   const themes: Theme[] = [];
   const resolved: Record<string, TokenMap> = {};
+  const sourceSet = new Set<string>();
   for (const { input, allFiles, tokens } of perTuple) {
     const id = permutationID(input);
     themes.push({ name: id, input: { ...input }, sources: allFiles });
     resolved[id] = tokens;
+    for (const f of allFiles) sourceSet.add(f);
   }
 
-  return { axes, themes, resolved };
+  return { axes, themes, resolved, sourceFiles: [...sourceSet].toSorted() };
 }
 
 function cartesianTuples(axesConfig: AxisConfig[]): Record<string, string>[] {

--- a/packages/core/src/themes/normalize.ts
+++ b/packages/core/src/themes/normalize.ts
@@ -7,14 +7,16 @@ export interface NormalizedThemes {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
+  sourceFiles: string[];
   /** Files loaded as source-only (not emitted to CSS). Reserved for future use. */
   sourceOnlyFiles: Set<string>;
 }
 
 /**
  * Realize themes from the config. Exactly one of `resolver` or `axes` may
- * be set; if neither is set, we fall back to a single synthetic axis
- * containing the plain-parsed token files.
+ * be set; when neither is set, we fall back to a single synthetic axis
+ * containing the plain-parsed token files (which then must be supplied
+ * via `config.tokens`).
  */
 export async function normalizeThemes(
   config: Config,
@@ -26,6 +28,11 @@ export async function normalizeThemes(
   }
 
   if (config.axes) {
+    if (!config.tokens || config.tokens.length === 0) {
+      throw new Error(
+        'swatchbook: config with `axes` must also supply `tokens` (the base token files the overlays layer onto).',
+      );
+    }
     const r = await loadLayeredThemes(config.axes, config.tokens, cwd, logger);
     return { ...r, sourceOnlyFiles: new Set() };
   }

--- a/packages/core/src/themes/resolver.ts
+++ b/packages/core/src/themes/resolver.ts
@@ -10,6 +10,7 @@ export interface ResolverLoadResult {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
+  sourceFiles: string[];
 }
 
 /**
@@ -18,32 +19,40 @@ export interface ResolverLoadResult {
  * Terrazzo's `loadResolver` scans the provided input list for a resolver
  * document, normalizes it, then lets us enumerate permutations via
  * `resolver.listPermutations()` and realize each with `resolver.apply()`.
+ *
+ * We intercept Terrazzo's `$ref` fetch callback so every file it pulls in
+ * gets recorded on `sourceFiles`. The addon's Vite plugin uses that list
+ * for HMR watch paths when the consumer's config doesn't supply an
+ * explicit `tokens` glob.
  */
 export async function loadResolverThemes(
   resolverPath: string | undefined,
-  tokenGlobs: string[],
+  tokenGlobs: string[] | undefined,
   cwd: string,
   logger: BufferedLogger,
 ): Promise<ResolverLoadResult> {
   const cwdUrl = pathToFileURL(`${cwd}/`);
   const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
 
-  const tokenFiles = await collectGlobbedFiles(tokenGlobs, cwd);
+  const tokenFiles = tokenGlobs ? await collectGlobbedFiles(tokenGlobs, cwd) : [];
+  const refFiles = new Set<string>();
 
   const req = async (url: URL): Promise<string> => {
     const filename = url.protocol === 'file:' ? fileURLToPath(url) : url.toString();
+    if (url.protocol === 'file:') refFiles.add(filename);
     return readFile(filename, 'utf8');
   };
 
   let loaded: Awaited<ReturnType<typeof loadResolver>> | undefined;
+  let resolverAbsolute: string | undefined;
   if (resolverPath) {
-    const absolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
+    resolverAbsolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
     // `loadResolver` expects the resolver file alone as input and fetches
     // referenced token files via `req`. Passing tokens up front triggers
     // "Resolver must be the only input" errors.
     const resolverInput = {
-      filename: pathToFileURL(absolute),
-      src: await readFile(absolute, 'utf8'),
+      filename: pathToFileURL(resolverAbsolute),
+      src: await readFile(resolverAbsolute, 'utf8'),
     };
     loaded = await loadResolver([resolverInput], {
       config: terrazzoConfig,
@@ -54,6 +63,11 @@ export async function loadResolverThemes(
 
   if (!loaded?.resolver) {
     // Fall back to plain parse; no resolver found.
+    if (tokenFiles.length === 0) {
+      throw new Error(
+        'swatchbook config must specify `resolver`, `axes`, or non-empty `tokens`. None were set.',
+      );
+    }
     const tokenInputs = await Promise.all(
       tokenFiles.map(async (filename) => ({
         filename: pathToFileURL(filename),
@@ -71,6 +85,7 @@ export async function loadResolverThemes(
       axes: [{ name: 'theme', contexts: [name], default: name, source: 'synthetic' }],
       themes: [{ name, input: { theme: name }, sources: tokenFiles }],
       resolved: { [name]: parsed.tokens },
+      sourceFiles: tokenFiles,
     };
   }
 
@@ -95,5 +110,11 @@ export async function loadResolverThemes(
     resolved[id] = tokens;
   }
 
-  return { axes, themes, resolved };
+  const sourceFiles = [...refFiles];
+  if (resolverAbsolute) sourceFiles.push(resolverAbsolute);
+  // If the consumer supplied explicit globs, take their union — they may
+  // want HMR to watch directories broader than the resolver references.
+  for (const f of tokenFiles) if (!sourceFiles.includes(f)) sourceFiles.push(f);
+
+  return { axes, themes, resolved, sourceFiles: sourceFiles.toSorted() };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,8 +52,20 @@ export interface AxisConfig {
 
 /** Swatchbook configuration. Supply either `resolver` or `axes`, not both. */
 export interface Config {
-  /** Glob patterns for base DTCG token files. */
-  tokens: string[];
+  /**
+   * Glob patterns for base DTCG token files.
+   *
+   * Required when neither `resolver` nor `axes` is set (plain-parse mode),
+   * and when `axes` is set (the layered loader needs a base token list).
+   *
+   * Optional when `resolver` is set: the resolver's own `$ref` targets
+   * fully determine which files get loaded, and the addon's Vite plugin
+   * derives HMR watch paths from the resolved source list. Supplying
+   * `tokens` alongside `resolver` overrides the watch path derivation —
+   * useful when you want HMR to watch directories broader than the
+   * resolver references directly.
+   */
+  tokens?: string[];
   /** Path to a DTCG 2025.10 resolver file. Mutually exclusive with `axes`. */
   resolver?: string;
   /** Authored layered axes. Mutually exclusive with `resolver`. */
@@ -99,6 +111,14 @@ export interface Project {
   themesResolved: Record<string, TokenMap>;
   /** Default theme's resolved tokens — convenience for global views. */
   graph: TokenMap;
+  /**
+   * Absolute paths of every file loaded while building the project —
+   * the resolver file (if any), every `$ref` target it pulled in, every
+   * overlay file the layered loader concatenated, or every globbed file
+   * the plain-parse fallback consumed. Consumers use this for file-watching
+   * (the addon's Vite plugin does exactly that).
+   */
+  sourceFiles: string[];
   diagnostics: Diagnostic[];
 }
 

--- a/packages/core/test/source-files.test.ts
+++ b/packages/core/test/source-files.test.ts
@@ -1,0 +1,46 @@
+import { dirname, resolve as resolvePath } from 'node:path';
+import { expect, it } from 'vitest';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
+import { loadProject } from '#/load';
+import { fixtureCwd } from './_helpers';
+
+it('populates sourceFiles with every $ref target when config.tokens is omitted', async () => {
+  const project = await loadProject({ resolver: resolverPath }, fixtureCwd);
+
+  expect(project.sourceFiles.length).toBeGreaterThan(5);
+  expect(project.sourceFiles).toContain(resolverPath);
+  expect(project.sourceFiles).toContain(resolvePath(tokensDir, 'ref/color.palette.json'));
+  expect(project.sourceFiles).toContain(resolvePath(tokensDir, 'sys/color.json'));
+  expect(project.sourceFiles).toContain(resolvePath(tokensDir, 'themes/light.json'));
+});
+
+it('augments sourceFiles with explicit tokens globs when both are supplied', async () => {
+  const project = await loadProject(
+    { resolver: resolverPath, tokens: ['tokens/**/*.json'] },
+    fixtureCwd,
+  );
+
+  // Every source file is inside the fixture's tokens tree.
+  const fixtureRoot = dirname(tokensDir);
+  for (const file of project.sourceFiles) {
+    expect(file.startsWith(fixtureRoot)).toBe(true);
+  }
+  expect(project.sourceFiles).toContain(resolverPath);
+});
+
+it('throws when config has neither resolver, axes, nor tokens', async () => {
+  await expect(loadProject({}, fixtureCwd)).rejects.toThrow(
+    /must specify `resolver`, `axes`, or non-empty `tokens`/,
+  );
+});
+
+it('throws when config.axes is set without config.tokens', async () => {
+  await expect(
+    loadProject(
+      {
+        axes: [{ name: 'mode', contexts: { Light: [] }, default: 'Light' }],
+      },
+      fixtureCwd,
+    ),
+  ).rejects.toThrow(/`axes` must also supply `tokens`/);
+});


### PR DESCRIPTION
**Milestone:** Maintenance

**Closes:** Closes #160

**Plan impact:** none

## Summary

- `Config.tokens` is now optional when `config.resolver` is set. The resolver's own `$ref` targets fully determine which files get loaded, so the parallel glob was redundant.
- `loadResolverThemes` intercepts Terrazzo's `$ref` fetch callback and records every file pulled in. The new `Project.sourceFiles: string[]` exposes them. Layered + synthetic-fallback paths populate the same list from their own file enumeration.
- The addon's Vite plugin (`packages/addon/src/virtual/plugin.ts`) prefers `config.tokens` globs when supplied (back-compat, plus an opt-in to broader watching) and falls back to `dirname` of every `Project.sourceFiles` entry. HMR behavior identical either way.
- `apps/storybook/swatchbook.config.ts` drops its `tokens` line to demo the new shape; the core README example updates to match.
- Validation: configs with neither `resolver`, `axes`, nor `tokens` now throw at load time. `axes` still requires `tokens` (the layered loader has nothing to layer onto otherwise).
- 4 new tests cover resolver-only, resolver+tokens union, and both throw-when-missing branches.

## Test plan

- [x] `pnpm turbo run lint typecheck test build` green (19 tasks; core 50/50)
- [x] `pnpm turbo run test:storybook` green (story tests unchanged)