### PR TITLE
docs: add a dedicated config reference page

### DIFF
--- a/.changeset/optional-tokens-when-resolver.md
+++ b/.changeset/optional-tokens-when-resolver.md
@@ -1,0 +1,8 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+`Config.tokens` is now optional when `config.resolver` is set. The resolver's own `$ref` targets fully determine what gets loaded, and `Project.sourceFiles` exposes every file touched so the addon's Vite plugin can derive HMR watch paths without a parallel `tokens` glob. Supplying `tokens` alongside `resolver` still works — the watch paths union with the resolver-derived set, useful when you want HMR to watch broader directories than the resolver references.
+
+Plain-parse (no resolver, no axes) and layered (`axes` set) modes still require `tokens` — the loader has no other starting point. Configs that omit `resolver`, `axes`, AND `tokens` now throw a descriptive error at load time.

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -1,0 +1,112 @@
+---
+id: config
+title: Config reference
+sidebar_position: 0
+---
+
+# `swatchbook.config.ts` reference
+
+Every field on the `Config` object, with the semantics `loadProject` applies at runtime.
+
+```ts title="swatchbook.config.ts"
+import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
+
+export default defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  default: { mode: 'Dark', brand: 'Brand A' },
+  cssVarPrefix: 'ds',
+  presets: [
+    { name: 'A11y High Contrast', axes: { mode: 'Light', contrast: 'High' } },
+  ],
+});
+```
+
+`defineSwatchbookConfig` is an identity helper — it gives you typed autocomplete on the object you pass in and returns it unchanged.
+
+## Picking a theming input
+
+Exactly three shapes are legal:
+
+- **Resolver** — `resolver: 'path/to/resolver.json'`. The DTCG-spec-native path; the file declares sets, modifiers, and resolutionOrder, and the modifiers become your axes. Recommended.
+- **Layered** — `axes: [...]` + `tokens: [...]`. For projects without a resolver document. You declare axes inline; each context names overlay files that layer onto the base `tokens`.
+- **Plain parse** — `tokens: [...]` alone. Single synthetic `theme` axis; every token loaded as one tuple. Useful for smoke-testing a token set before adopting a resolver.
+
+Setting `resolver` and `axes` at the same time is an error. Setting none of the three (no `resolver`, no `axes`, no `tokens`) throws at load time.
+
+## Fields
+
+### `tokens?: string[]`
+
+Glob patterns (relative to the config's cwd) for base DTCG token files.
+
+- **Resolver projects (`resolver` set)** — optional. The resolver's own `$ref` targets fully determine which files get loaded, and the addon's Vite plugin derives HMR watch paths from the resolved source list. Supplying `tokens` alongside `resolver` is still valid and unions the watch paths — useful when you want HMR to pick up files the resolver doesn't reference directly.
+- **Layered projects (`axes` set)** — required. The layered loader parses `[...base, ...overlayFilesInAxisOrder]` per tuple; without `tokens` there's nothing to layer onto.
+- **Plain-parse (no resolver, no axes)** — required. Every file matched by the globs gets parsed into the single synthetic theme.
+
+### `resolver?: string`
+
+Path to a [DTCG 2025.10 resolver](https://design-tokens.org/tr/2025/drafts/resolver/) document. Mutually exclusive with `axes`.
+
+Terrazzo normalizes the document, then Swatchbook enumerates permutations via `resolver.listPermutations()` and realizes each with `resolver.apply()`. One `Axis` surfaces per modifier; the resolver file itself and every `$ref` target it pulls in land on `Project.sourceFiles`.
+
+### `axes?: AxisConfig[]`
+
+Authored layered axes, for projects without a resolver. Mutually exclusive with `resolver`. Each `AxisConfig` has:
+
+```ts
+interface AxisConfig {
+  name: string;
+  description?: string;
+  contexts: Record<string, string[]>;
+  default: string;
+}
+```
+
+`contexts` is a map from context name to an ordered list of overlay files (paths or globs, relative to the config's cwd). An empty array is legal — it means "no override," which is the baseline for an axis that introduces nothing by default (`Default: []`).
+
+Themes are every combination of contexts across all axes. Last write wins on duplicate token paths across base + overlays; overlay files listed later in `axes` win over earlier ones.
+
+### `default?: Partial<Record<string, string>>`
+
+Initial active tuple, keyed by axis name. Partial is fine — any axis you omit falls back to that axis's own `default` at load time. Unknown axis keys and invalid context values produce `warn` diagnostics (group `swatchbook/default`) and are sanitized out.
+
+```ts
+// Every axis specified:
+default: { mode: 'Dark', brand: 'Brand A' }
+
+// Partial — omitted axes use their own defaults:
+default: { brand: 'Brand A' }
+
+// Omit entirely — starts in the all-axis-defaults tuple:
+// default: undefined
+```
+
+### `cssVarPrefix?: string`
+
+Prefix prepended to every emitted CSS variable. `color.sys.accent.bg` becomes `var(--<prefix>-color-sys-accent-bg)`; an empty string disables the prefix. Typical values are short and project-specific (`ds`, `sb`, `ui`).
+
+### `outDir?: string`
+
+Project-local directory for codegen artifacts (default `.swatchbook`). The addon preset writes `tokens.d.ts` here — add `"include": [".swatchbook/**/*.d.ts"]` to your tsconfig so `useToken()` autocompletes.
+
+### `presets?: Preset[]`
+
+Named tuple combinations rendered as quick-select pills next to the toolbar's axis dropdowns. Each `Preset` has:
+
+```ts
+interface Preset {
+  name: string;
+  axes: Partial<Record<string, string>>;
+  description?: string;
+}
+```
+
+Partial tuples are legal — omitted axes resolve to the axis's `default` when the preset is applied. `loadProject` validates presets: unknown axis keys and invalid context values surface as `warn` diagnostics (group `swatchbook/presets`) and are sanitized out, but the preset itself stays in `Project.presets` (an empty preset is still a valid tuple — it resolves to all defaults).
+
+See [Presets](../concepts/presets) for the runtime UX.
+
+## See also
+
+- [Theming inputs](../concepts/theming-inputs) — when to pick resolver vs layered.
+- [Axes](../concepts/axes) — the runtime model for selection.
+- [Reference: core](./core) — the loader APIs this config drives.

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -18,15 +18,14 @@ pnpm add @unpunnyfuns/swatchbook-core
 
 ### `defineSwatchbookConfig(config)`
 
-Identity helper for a typed `swatchbook.config.ts`. No runtime effect — just TypeScript ergonomics.
+Identity helper for a typed `swatchbook.config.ts`. No runtime effect — just TypeScript ergonomics. See the [Config reference](./config) for every field's semantics.
 
 ```ts
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 
 export default defineSwatchbookConfig({
-  tokens: ['tokens/**/*.json'],
   resolver: 'tokens/resolver.json',
-  default: 'Light',
+  default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'ds',
 });
 ```

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -25,7 +25,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Reference',
       collapsed: false,
-      items: ['reference/core', 'reference/addon', 'reference/blocks'],
+      items: ['reference/config', 'reference/core', 'reference/addon', 'reference/blocks'],
     },
   ],
 };

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -1,8 +1,7 @@
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
-import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
+import { resolverPath } from '@unpunnyfuns/swatchbook-tokens-reference';
 
 export default defineSwatchbookConfig({
-  tokens: [`${tokensDir}/**/*.json`],
   resolver: resolverPath,
   default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'sb',

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,5 +1,6 @@
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import type { Plugin } from 'vite';
 import { RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from '#/constants.ts';
 
@@ -11,8 +12,8 @@ export interface SwatchbookPluginOptions {
 /**
  * Vite plugin that serves the virtual `virtual:swatchbook/tokens` module —
  * a single source of truth for themes, resolved token maps, per-theme CSS,
- * and diagnostics. Watches the token files + manifest/resolver for changes
- * and invalidates the module so HMR reloads the preview with fresh data.
+ * and diagnostics. Watches the token files + resolver for changes and
+ * invalidates the module so HMR reloads the preview with fresh data.
  */
 export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions): Plugin {
   let project: Project | undefined;
@@ -54,7 +55,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
     },
 
     configureServer(server) {
-      const watchPaths = collectWatchPaths(config, cwd);
+      const watchPaths = collectWatchPaths(config, project, cwd);
       for (const p of watchPaths) server.watcher.add(p);
 
       const invalidate = async (): Promise<void> => {
@@ -79,18 +80,29 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
   };
 }
 
-function collectWatchPaths(config: Config, cwd: string): string[] {
+/**
+ * Collect the set of filesystem paths the dev server should watch for
+ * HMR. When `config.tokens` is set, use its globs (stripped to their
+ * base directories) — users opt in to broader watching this way. When
+ * absent, use the resolver file + every `$ref` target it pulled in, as
+ * tracked on `project.sourceFiles` — which stays correct as the resolver
+ * evolves without requiring a parallel `tokens` glob.
+ */
+function collectWatchPaths(config: Config, project: Project | undefined, cwd: string): string[] {
   const paths: string[] = [];
-  for (const glob of config.tokens) {
-    // Strip the glob portion and watch the base directory.
-    const base = glob.replace(/\/\*.*$/, '').replace(/\/[^/]*\*.*$/, '');
-    paths.push(resolveFromCwd(base, cwd));
+  if (config.tokens && config.tokens.length > 0) {
+    for (const glob of config.tokens) {
+      const base = glob.replace(/\/\*.*$/, '').replace(/\/[^/]*\*.*$/, '');
+      paths.push(resolveFromCwd(base, cwd));
+    }
+  } else if (project?.sourceFiles) {
+    for (const file of project.sourceFiles) paths.push(dirname(file));
   }
   if (config.resolver) paths.push(resolveFromCwd(config.resolver, cwd));
   return [...new Set(paths)];
 }
 
 function resolveFromCwd(p: string, cwd: string): string {
-  if (p.startsWith('/')) return p;
-  return `${cwd}/${p}`;
+  if (isAbsolute(p)) return p;
+  return resolvePath(cwd, p);
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -29,14 +29,17 @@ pnpm add @unpunnyfuns/swatchbook-core
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 
 export default defineSwatchbookConfig({
-  tokens: ['tokens/**/*.json'],
   resolver: 'tokens/resolver.json',
   default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'sb',
 });
 ```
 
-The resolver file is the spec-defined document describing how token sets compose into named themes — see [the DTCG 2025.10 resolver draft](https://design-tokens.org/tr/2025/drafts/resolver/).
+The resolver file is the spec-defined document describing how token sets compose into named themes — see [the DTCG 2025.10 resolver draft](https://design-tokens.org/tr/2025/drafts/resolver/). Every token file the resolver references via `$ref` is loaded automatically; the addon's Vite plugin derives HMR watch paths from that set, so no separate `tokens` glob is needed for resolver-backed projects.
+
+If you want HMR to watch a directory broader than the resolver references directly — say, to pick up a new token file the moment it's added — supply `tokens: ['tokens/**/*.json']` alongside `resolver` and the plugin will union the two.
+
+Projects without a resolver (plain-parse or layered-axes) still need `tokens` — the loader has nothing to start from otherwise.
 
 `default` is a partial tuple keyed by axis name. Any axis you omit falls back to that axis's own `default`; unknown keys and invalid context values produce `warn` diagnostics and are sanitized out. Omit `default` entirely to start the project in the all-axis-defaults tuple.
 

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -40,6 +40,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     themes: normalized.themes,
     themesResolved: normalized.resolved,
     graph,
+    sourceFiles: normalized.sourceFiles,
     diagnostics: [...toDiagnostics(logger), ...defaultDiagnostics, ...presetDiagnostics],
   };
 }

--- a/packages/core/src/themes/layered.ts
+++ b/packages/core/src/themes/layered.ts
@@ -9,6 +9,7 @@ export interface LayeredLoadResult {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
+  sourceFiles: string[];
 }
 
 /**
@@ -84,13 +85,15 @@ export async function loadLayeredThemes(
 
   const themes: Theme[] = [];
   const resolved: Record<string, TokenMap> = {};
+  const sourceSet = new Set<string>();
   for (const { input, allFiles, tokens } of perTuple) {
     const id = permutationID(input);
     themes.push({ name: id, input: { ...input }, sources: allFiles });
     resolved[id] = tokens;
+    for (const f of allFiles) sourceSet.add(f);
   }
 
-  return { axes, themes, resolved };
+  return { axes, themes, resolved, sourceFiles: [...sourceSet].toSorted() };
 }
 
 function cartesianTuples(axesConfig: AxisConfig[]): Record<string, string>[] {

--- a/packages/core/src/themes/normalize.ts
+++ b/packages/core/src/themes/normalize.ts
@@ -7,14 +7,16 @@ export interface NormalizedThemes {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
+  sourceFiles: string[];
   /** Files loaded as source-only (not emitted to CSS). Reserved for future use. */
   sourceOnlyFiles: Set<string>;
 }
 
 /**
  * Realize themes from the config. Exactly one of `resolver` or `axes` may
- * be set; if neither is set, we fall back to a single synthetic axis
- * containing the plain-parsed token files.
+ * be set; when neither is set, we fall back to a single synthetic axis
+ * containing the plain-parsed token files (which then must be supplied
+ * via `config.tokens`).
  */
 export async function normalizeThemes(
   config: Config,
@@ -26,6 +28,11 @@ export async function normalizeThemes(
   }
 
   if (config.axes) {
+    if (!config.tokens || config.tokens.length === 0) {
+      throw new Error(
+        'swatchbook: config with `axes` must also supply `tokens` (the base token files the overlays layer onto).',
+      );
+    }
     const r = await loadLayeredThemes(config.axes, config.tokens, cwd, logger);
     return { ...r, sourceOnlyFiles: new Set() };
   }

--- a/packages/core/src/themes/resolver.ts
+++ b/packages/core/src/themes/resolver.ts
@@ -10,6 +10,7 @@ export interface ResolverLoadResult {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
+  sourceFiles: string[];
 }
 
 /**
@@ -18,32 +19,40 @@ export interface ResolverLoadResult {
  * Terrazzo's `loadResolver` scans the provided input list for a resolver
  * document, normalizes it, then lets us enumerate permutations via
  * `resolver.listPermutations()` and realize each with `resolver.apply()`.
+ *
+ * We intercept Terrazzo's `$ref` fetch callback so every file it pulls in
+ * gets recorded on `sourceFiles`. The addon's Vite plugin uses that list
+ * for HMR watch paths when the consumer's config doesn't supply an
+ * explicit `tokens` glob.
  */
 export async function loadResolverThemes(
   resolverPath: string | undefined,
-  tokenGlobs: string[],
+  tokenGlobs: string[] | undefined,
   cwd: string,
   logger: BufferedLogger,
 ): Promise<ResolverLoadResult> {
   const cwdUrl = pathToFileURL(`${cwd}/`);
   const terrazzoConfig = defineTerrazzoConfig({}, { logger, cwd: cwdUrl });
 
-  const tokenFiles = await collectGlobbedFiles(tokenGlobs, cwd);
+  const tokenFiles = tokenGlobs ? await collectGlobbedFiles(tokenGlobs, cwd) : [];
+  const refFiles = new Set<string>();
 
   const req = async (url: URL): Promise<string> => {
     const filename = url.protocol === 'file:' ? fileURLToPath(url) : url.toString();
+    if (url.protocol === 'file:') refFiles.add(filename);
     return readFile(filename, 'utf8');
   };
 
   let loaded: Awaited<ReturnType<typeof loadResolver>> | undefined;
+  let resolverAbsolute: string | undefined;
   if (resolverPath) {
-    const absolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
+    resolverAbsolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
     // `loadResolver` expects the resolver file alone as input and fetches
     // referenced token files via `req`. Passing tokens up front triggers
     // "Resolver must be the only input" errors.
     const resolverInput = {
-      filename: pathToFileURL(absolute),
-      src: await readFile(absolute, 'utf8'),
+      filename: pathToFileURL(resolverAbsolute),
+      src: await readFile(resolverAbsolute, 'utf8'),
     };
     loaded = await loadResolver([resolverInput], {
       config: terrazzoConfig,
@@ -54,6 +63,11 @@ export async function loadResolverThemes(
 
   if (!loaded?.resolver) {
     // Fall back to plain parse; no resolver found.
+    if (tokenFiles.length === 0) {
+      throw new Error(
+        'swatchbook config must specify `resolver`, `axes`, or non-empty `tokens`. None were set.',
+      );
+    }
     const tokenInputs = await Promise.all(
       tokenFiles.map(async (filename) => ({
         filename: pathToFileURL(filename),
@@ -71,6 +85,7 @@ export async function loadResolverThemes(
       axes: [{ name: 'theme', contexts: [name], default: name, source: 'synthetic' }],
       themes: [{ name, input: { theme: name }, sources: tokenFiles }],
       resolved: { [name]: parsed.tokens },
+      sourceFiles: tokenFiles,
     };
   }
 
@@ -95,5 +110,11 @@ export async function loadResolverThemes(
     resolved[id] = tokens;
   }
 
-  return { axes, themes, resolved };
+  const sourceFiles = [...refFiles];
+  if (resolverAbsolute) sourceFiles.push(resolverAbsolute);
+  // If the consumer supplied explicit globs, take their union — they may
+  // want HMR to watch directories broader than the resolver references.
+  for (const f of tokenFiles) if (!sourceFiles.includes(f)) sourceFiles.push(f);
+
+  return { axes, themes, resolved, sourceFiles: sourceFiles.toSorted() };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -52,8 +52,20 @@ export interface AxisConfig {
 
 /** Swatchbook configuration. Supply either `resolver` or `axes`, not both. */
 export interface Config {
-  /** Glob patterns for base DTCG token files. */
-  tokens: string[];
+  /**
+   * Glob patterns for base DTCG token files.
+   *
+   * Required when neither `resolver` nor `axes` is set (plain-parse mode),
+   * and when `axes` is set (the layered loader needs a base token list).
+   *
+   * Optional when `resolver` is set: the resolver's own `$ref` targets
+   * fully determine which files get loaded, and the addon's Vite plugin
+   * derives HMR watch paths from the resolved source list. Supplying
+   * `tokens` alongside `resolver` overrides the watch path derivation —
+   * useful when you want HMR to watch directories broader than the
+   * resolver references directly.
+   */
+  tokens?: string[];
   /** Path to a DTCG 2025.10 resolver file. Mutually exclusive with `axes`. */
   resolver?: string;
   /** Authored layered axes. Mutually exclusive with `resolver`. */
@@ -99,6 +111,14 @@ export interface Project {
   themesResolved: Record<string, TokenMap>;
   /** Default theme's resolved tokens — convenience for global views. */
   graph: TokenMap;
+  /**
+   * Absolute paths of every file loaded while building the project —
+   * the resolver file (if any), every `$ref` target it pulled in, every
+   * overlay file the layered loader concatenated, or every globbed file
+   * the plain-parse fallback consumed. Consumers use this for file-watching
+   * (the addon's Vite plugin does exactly that).
+   */
+  sourceFiles: string[];
   diagnostics: Diagnostic[];
 }
 

--- a/packages/core/test/source-files.test.ts
+++ b/packages/core/test/source-files.test.ts
@@ -1,0 +1,46 @@
+import { dirname, resolve as resolvePath } from 'node:path';
+import { expect, it } from 'vitest';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
+import { loadProject } from '#/load';
+import { fixtureCwd } from './_helpers';
+
+it('populates sourceFiles with every $ref target when config.tokens is omitted', async () => {
+  const project = await loadProject({ resolver: resolverPath }, fixtureCwd);
+
+  expect(project.sourceFiles.length).toBeGreaterThan(5);
+  expect(project.sourceFiles).toContain(resolverPath);
+  expect(project.sourceFiles).toContain(resolvePath(tokensDir, 'ref/color.palette.json'));
+  expect(project.sourceFiles).toContain(resolvePath(tokensDir, 'sys/color.json'));
+  expect(project.sourceFiles).toContain(resolvePath(tokensDir, 'themes/light.json'));
+});
+
+it('augments sourceFiles with explicit tokens globs when both are supplied', async () => {
+  const project = await loadProject(
+    { resolver: resolverPath, tokens: ['tokens/**/*.json'] },
+    fixtureCwd,
+  );
+
+  // Every source file is inside the fixture's tokens tree.
+  const fixtureRoot = dirname(tokensDir);
+  for (const file of project.sourceFiles) {
+    expect(file.startsWith(fixtureRoot)).toBe(true);
+  }
+  expect(project.sourceFiles).toContain(resolverPath);
+});
+
+it('throws when config has neither resolver, axes, nor tokens', async () => {
+  await expect(loadProject({}, fixtureCwd)).rejects.toThrow(
+    /must specify `resolver`, `axes`, or non-empty `tokens`/,
+  );
+});
+
+it('throws when config.axes is set without config.tokens', async () => {
+  await expect(
+    loadProject(
+      {
+        axes: [{ name: 'mode', contexts: { Light: [] }, default: 'Light' }],
+      },
+      fixtureCwd,
+    ),
+  ).rejects.toThrow(/`axes` must also supply `tokens`/);
+});


### PR DESCRIPTION
**Milestone:** Documentation

**Closes:** Closes #161

**Plan impact:** none

## Summary

- New `apps/docs/docs/reference/config.mdx` — every `Config` field with the semantics `loadProject` applies: `tokens`, `resolver`, `axes`, `default`, `cssVarPrefix`, `outDir`, `presets`.
- Page leads with "Picking a theming input" (resolver vs layered vs plain-parse) so newcomers understand the three shapes before the field-by-field reference.
- `sidebars.ts` puts it first under **Reference** so readers land there before drilling into the `core` / `addon` / `blocks` APIs.
- `reference/core.mdx` `defineSwatchbookConfig` example updates to the post-#158 tuple-object `default` shape and cross-links to the new config page.

## Stacked on #169

Stacked on top of PR #169 (config.tokens optional) so the documented shape matches the post-#160 API. GitHub's merge UI will base this on main after #169 merges; the diff is doc-only and won't conflict.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-docs build` green (broken-link warnings are expected pre-deploy, same as every other docs PR)