### PR TITLE
feat(blocks): add gradient token rendering and refresh type-coverage audit

### DIFF
--- a/.changeset/gradient-token-rendering.md
+++ b/.changeset/gradient-token-rendering.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+Add `<GradientPalette filter? />` block for DTCG `gradient` tokens, and a `gradient` branch on `TokenDetail`'s composite preview. Samples default to `linear-gradient(to right, …)` since DTCG gradients are stop arrays and the gradient function is a rendering choice consumers make at use-site — if you need radial / conic previews, reach for a custom block.
+
+This closes the last spec-level `$type` gap the reference fixture was missing; Terrazzo-extension types (`boolean`, `string`, `link`) remain intentionally out of scope per `docs/type-coverage.md`.

--- a/apps/docs/docs/reference/blocks.mdx
+++ b/apps/docs/docs/reference/blocks.mdx
@@ -35,7 +35,7 @@ Single-token deep-dive. Renders:
 - Type + description.
 - Alias chain (forward) — e.g. `color.sys.accent.bg → color.ref.blue.700`.
 - Aliased-by tree (backward) — everything that transitively aliases this token.
-- Composite preview — for `typography`, `shadow`, `border`, `transition`, `dimension`, `duration`, `cubicBezier`, `fontFamily`, `fontWeight`, `strokeStyle`, `color`.
+- Composite preview — for `typography`, `shadow`, `border`, `transition`, `dimension`, `duration`, `cubicBezier`, `fontFamily`, `fontWeight`, `strokeStyle`, `gradient`, `color`.
 - Per-axis variance — values along whichever axes move the token.
 
 Props: `path: string`.
@@ -70,6 +70,12 @@ Same "Aa" sample at each `fontWeight` primitive, sorted ascending. Props: `sampl
 ### `<StrokeStyleSample />`
 
 Border rendered per `strokeStyle` primitive. String-form styles (`solid`, `dashed`, `dotted`, `double`) render as `border-style`; object-form (with `dashArray` / `lineCap`) renders a textual fallback.
+
+### `<GradientPalette filter? />`
+
+Wide sample per `gradient` token with the stop list as a sidebar. Samples use `linear-gradient(to right, …)` by default — DTCG gradients are stop arrays, and the gradient function is a rendering choice the consumer makes at use-site. If you want radial/conic previews here, open an issue.
+
+Props: `filter?: string` — path glob (`"gradient.ref.*"`, etc.).
 
 ## Reactivity
 

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -4,6 +4,7 @@ import {
   DimensionScale,
   FontFamilySample,
   FontWeightScale,
+  GradientPalette,
   MotionPreview,
   ShadowPreview,
   StrokeStyleSample,
@@ -112,6 +113,27 @@ export const ShadowPreviewRenders = meta.story({
     expect(
       withShadow.length,
       'at least one sample must resolve to a non-none box-shadow',
+    ).toBeGreaterThan(0);
+  },
+});
+
+/**
+ * `GradientPalette` renders gradient tokens with a `linear-gradient`
+ * sample each. At least one sample must resolve to a non-empty background
+ * that includes `gradient` (the computed shorthand).
+ */
+export const GradientPaletteRenders = meta.story({
+  render: () => <GradientPalette filter='gradient.ref.*' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'div[aria-hidden="true"]');
+    const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
+    const withGradient = samples.filter((el) => {
+      const bg = getComputedStyle(el).backgroundImage;
+      return bg && bg.includes('gradient');
+    });
+    expect(
+      withGradient.length,
+      'at least one sample must resolve to a linear-gradient background',
     ).toBeGreaterThan(0);
   },
 });

--- a/apps/storybook/src/stories/GradientPalette.stories.tsx
+++ b/apps/storybook/src/stories/GradientPalette.stories.tsx
@@ -1,0 +1,15 @@
+import { GradientPalette } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/GradientPalette',
+  component: GradientPalette,
+  argTypes: {
+    filter: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const AllGradients = meta.story();
+export const RefGradients = meta.story({ args: { filter: 'gradient.ref.*' } });

--- a/apps/storybook/src/stories/TokenDetail.stories.tsx
+++ b/apps/storybook/src/stories/TokenDetail.stories.tsx
@@ -17,4 +17,5 @@ export const SysAccent = meta.story({ args: { path: 'color.sys.text.accent' } })
 export const AccentBg = meta.story({ args: { path: 'color.sys.accent.bg' } });
 export const SpaceMd = meta.story({ args: { path: 'space.sys.md' } });
 export const TypographyBody = meta.story({ args: { path: 'typography.sys.body' } });
+export const Gradient = meta.story({ args: { path: 'gradient.ref.sunrise' } });
 export const Missing = meta.story({ args: { path: 'color.does.not.exist' } });

--- a/docs/type-coverage.md
+++ b/docs/type-coverage.md
@@ -1,39 +1,46 @@
 # DTCG type coverage
 
-Inventory of how each DTCG 2025.10 `$type` is rendered visually in swatchbook. "Visual rendering" means a dedicated block or a TokenDetail composite preview — not a raw text value in `TokenTable`. Anything that bottoms out in text is a gap, because the mission is to *show* what a token means, not just print its value.
+Inventory of how each DTCG 2025.10 `$type` is rendered visually in swatchbook. "Visual rendering" means a dedicated block or a `TokenDetail` composite preview — not a raw text value in `TokenTable`. Anything that bottoms out in text is a gap, because the mission is to *show* what a token means, not just print its value.
 
-Audit last run: 2026-04-18 (refreshed after the milestone closed). File any new gaps against the **DTCG type coverage** milestone.
+Scope is DTCG-spec types only. Terrazzo also parses `boolean`, `string`, and `link` tokens — those are Terrazzo-specific extensions, not in the spec, and intentionally out of scope.
+
+Audit last run: 2026-04-18 (refreshed alongside the **Full DTCG type parity with Terrazzo** milestone).
 
 ## Coverage matrix
 
 | `$type` | In `tokens-reference` | Dedicated block | `TokenDetail` preview |
 | --- | --- | --- | --- |
-| `color` | ✅ ref / sys / cmp | `ColorPalette` (grid) | swatch + hex |
-| `dimension` | ✅ sys / cmp | `DimensionScale` (length / radius / size) | bar ✅ |
+| `color` | ✅ ref / sys | `ColorPalette` (grid) | swatch + hex |
+| `dimension` | ✅ sys | `DimensionScale` (length / radius / size) | bar ✅ |
 | `fontFamily` | ✅ ref only | `FontFamilySample` | sample text ✅ |
 | `fontWeight` | ✅ ref only | `FontWeightScale` | sample text ✅ |
 | `duration` | ✅ ref only | `MotionPreview` | animated ball ✅ |
 | `cubicBezier` | ✅ ref only | `MotionPreview` | animated ball ✅ |
 | `number` | ✅ ref only | — (text-only, acceptable) | — |
 | `strokeStyle` | ✅ ref only | `StrokeStyleSample` | — (text-only) |
+| `gradient` | ✅ ref only | `GradientPalette` | linear-gradient sample ✅ |
 | `typography` | ✅ sys | `TypographyScale` | pangram sample ✅ |
-| `shadow` | ✅ sys / cmp | `ShadowPreview` | box-shadow card ✅ |
-| `border` | ✅ sys / cmp | `BorderPreview` | border card ✅ |
-| `transition` | ✅ sys / cmp | `MotionPreview` | animated ball ✅ |
+| `shadow` | ✅ sys | `ShadowPreview` | box-shadow card ✅ |
+| `border` | ✅ sys | `BorderPreview` | border card ✅ |
+| `transition` | ✅ sys | `MotionPreview` | animated ball ✅ |
 
 ## Status
 
-All DTCG 2025.10 primitives and composites now have either a dedicated block, a `TokenDetail` preview, or both. `number` tokens render as raw values in `TokenTable` — defensible because opacities / line-heights / z-index slots have no meaningful visual beyond the number itself. The `strokeStyle` object form (`{ dashArray, lineCap }`) falls back to a textual notice in `StrokeStyleSample`; if we later add SVG stroke rendering, this doc should be updated.
+Every DTCG 2025.10 `$type` has a dedicated block, a `TokenDetail` preview, or both. `number` renders as raw text in `TokenTable` — acceptable because opacities, line-heights, and z-index slots have no meaningful visual beyond the number itself. The `strokeStyle` object form (`{ dashArray, lineCap }`) falls back to a textual notice in `StrokeStyleSample`; SVG stroke rendering is a future-work candidate.
+
+## Out-of-scope types (Terrazzo extensions)
+
+Terrazzo exposes `boolean`, `string`, and `link` in addition to the spec types. These aren't part of DTCG 2025.10 and don't appear in our reference fixture. Rendering them would duplicate Terrazzo's extension surface without adding spec-consumer value.
 
 ## Method
 
 For each type:
 
-1. `$type` present in `packages/tokens-reference/tokens/**`? (`grep '"\$type": "<name>"'`)
-2. Which block(s) filter on that type? (`grep '\\$type !== '`)
+1. `$type` present in `packages/tokens-reference/tokens/**`? (`grep '"$type": "<name>"'`)
+2. Which block(s) filter on that type? (`grep '$type !== '`)
 3. Does `TokenDetail`'s `CompositePreview` have a branch? (`packages/blocks/src/TokenDetail.tsx`)
 4. If only `TokenTable` shows it → gap.
 
 ## Follow-ups
 
-Gap issues filed under the **DTCG type coverage** milestone. Each one closes by (a) surfacing the type in at least one visual block, and where applicable (b) extending `TokenDetail`'s `CompositePreview`, and (c) ensuring the reference fixture exercises it.
+Gap issues go under the **Full DTCG type parity with Terrazzo** milestone. Each one closes by (a) surfacing the type in at least one visual block, and where applicable (b) extending `TokenDetail`'s `CompositePreview`, and (c) ensuring the reference fixture exercises it.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -22,6 +22,7 @@ Requires `@unpunnyfuns/swatchbook-addon` to be registered in your Storybook conf
 | `FontFamilySample`  | Pangram rendered per `fontFamily` primitive.                                        |
 | `FontWeightScale`   | Same sample text rendered at each `fontWeight` primitive, sorted ascending.         |
 | `StrokeStyleSample` | Border rendered per `strokeStyle` primitive.                                        |
+| `GradientPalette`   | Wide swatch per `gradient` token with stop breakdown (linear-gradient default).      |
 | `TokenDetail`       | Single-token inspector — type, value, alias chain, aliased-by tree, per-axis variance, composite preview. |
 
 Shared: every block accepts a `caption` override and renders against the addon's `var(--<prefix>-…)` output.

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -1,0 +1,192 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useMemo } from 'react';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface GradientPaletteProps {
+  /**
+   * Token-path filter. Defaults to every `gradient` token. Use e.g.
+   * `"gradient.ref.*"` or `"gradient.sys.accent"` to scope.
+   */
+  filter?: string;
+  /** Override the caption. */
+  caption?: string;
+}
+
+const styles = {
+  wrapper: {
+    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
+    color: 'var(--sb-color-sys-text-default, CanvasText)',
+    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    padding: 12,
+    borderRadius: 6,
+  } satisfies CSSProperties,
+  caption: {
+    padding: '4px 0 12px',
+    opacity: 0.7,
+    fontSize: 12,
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(180px, 240px) 1fr minmax(140px, 220px)',
+    gap: 16,
+    alignItems: 'center',
+    padding: '16px 0',
+    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+  } satisfies CSSProperties,
+  meta: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+    minWidth: 0,
+  } satisfies CSSProperties,
+  path: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
+  cssVar: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+  sample: {
+    height: 56,
+    borderRadius: 6,
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+  } satisfies CSSProperties,
+  stops: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 11,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 2,
+  } satisfies CSSProperties,
+  stopRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+  } satisfies CSSProperties,
+  stopSwatch: {
+    width: 10,
+    height: 10,
+    borderRadius: 2,
+    border: '1px solid var(--sb-color-sys-border-default, rgba(0,0,0,0.1))',
+    flex: '0 0 auto',
+  } satisfies CSSProperties,
+  stopPosition: {
+    opacity: 0.6,
+  } satisfies CSSProperties,
+  empty: {
+    padding: '24px 12px',
+    textAlign: 'center',
+    opacity: 0.6,
+  } satisfies CSSProperties,
+};
+
+interface GradientStop {
+  color?: {
+    colorSpace?: string;
+    components?: readonly number[];
+    alpha?: number;
+  };
+  position?: number;
+}
+
+interface Row {
+  path: string;
+  cssVar: string;
+  stops: GradientStop[];
+}
+
+function asStops(raw: unknown): GradientStop[] {
+  if (!Array.isArray(raw)) return [];
+  return raw as GradientStop[];
+}
+
+const pct = (n: number): string => `${(n * 100).toFixed(3)}%`;
+
+function stopCssColor(stop: GradientStop): string {
+  const color = stop.color;
+  if (!color || !Array.isArray(color.components) || color.components.length < 3) {
+    return 'transparent';
+  }
+  const [r, g, b] = color.components;
+  if (r === undefined || g === undefined || b === undefined) return 'transparent';
+  const alpha = color.alpha ?? 1;
+  return alpha === 1
+    ? `rgb(${pct(r)} ${pct(g)} ${pct(b)})`
+    : `rgb(${pct(r)} ${pct(g)} ${pct(b)} / ${alpha})`;
+}
+
+function stopKey(path: string, stop: GradientStop, fallback: number): string {
+  return `${path}|${stop.position ?? fallback}|${stopCssColor(stop)}`;
+}
+
+export function GradientPalette({
+  filter = 'gradient',
+  caption,
+}: GradientPaletteProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+
+  const rows = useMemo(() => {
+    const collected: Row[] = [];
+    for (const [path, token] of Object.entries(resolved)) {
+      if (token.$type !== 'gradient') continue;
+      if (!globMatch(path, filter)) continue;
+      collected.push({
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        stops: asStops(token.$value),
+      });
+    }
+    collected.sort((a, b) => a.path.localeCompare(b.path));
+    return collected;
+  }, [resolved, filter, cssVarPrefix]);
+
+  const captionText =
+    caption ??
+    `${rows.length} gradient${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div data-theme={activeTheme} style={styles.wrapper}>
+        <div style={styles.empty}>No gradient tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-theme={activeTheme} style={styles.wrapper}>
+      <div style={styles.caption}>{captionText}</div>
+      {rows.map((row) => (
+        <div key={row.path} style={styles.row}>
+          <div style={styles.meta}>
+            <span style={styles.path}>{row.path}</span>
+            <span style={styles.cssVar}>{row.cssVar}</span>
+          </div>
+          <div
+            style={{ ...styles.sample, background: `linear-gradient(to right, ${row.cssVar})` }}
+            aria-hidden
+          />
+          <div style={styles.stops}>
+            {row.stops.map((stop, i) => (
+              <div key={stopKey(row.path, stop, i)} style={styles.stopRow}>
+                <span
+                  style={{ ...styles.stopSwatch, background: stopCssColor(stop) }}
+                  aria-hidden
+                />
+                <span>{stopCssColor(stop)}</span>
+                <span style={styles.stopPosition}>
+                  @ {((stop.position ?? 0) * 100).toFixed(0)}%
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -139,6 +139,12 @@ const styles = {
     background: 'var(--sb-color-sys-surface-raised, transparent)',
     borderRadius: 6,
   } satisfies CSSProperties,
+  gradientSample: {
+    width: 220,
+    height: 56,
+    borderRadius: 6,
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+  } satisfies CSSProperties,
   fontFamilySample: {
     padding: '4px 0',
     fontSize: 22,
@@ -372,6 +378,18 @@ function CompositePreview({
     // Synthesize a transition at a fixed duration so the easing curve is
     // perceptible on its own.
     return <TransitionSample transition={`left 800ms ${cssVar}`} />;
+  }
+  if (type === 'gradient') {
+    // Terrazzo emits gradient tokens as a raw stop list (e.g.
+    // `rgb(…) 0%, rgb(…) 100%`) without wrapping them in a gradient
+    // function — consumers pick linear/radial/conic at use-site. Default
+    // to linear-gradient for a preview.
+    return (
+      <div
+        style={{ ...styles.gradientSample, background: `linear-gradient(to right, ${cssVar})` }}
+        aria-hidden
+      />
+    );
   }
   return null;
 }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -3,6 +3,7 @@ export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
 export { DimensionScale, type DimensionKind, type DimensionScaleProps } from '#/DimensionScale.tsx';
 export { FontFamilySample, type FontFamilySampleProps } from '#/FontFamilySample.tsx';
 export { FontWeightScale, type FontWeightScaleProps } from '#/FontWeightScale.tsx';
+export { GradientPalette, type GradientPaletteProps } from '#/GradientPalette.tsx';
 export { MotionPreview, type MotionPreviewProps, type MotionSpeed } from '#/MotionPreview.tsx';
 export { ShadowPreview, type ShadowPreviewProps } from '#/ShadowPreview.tsx';
 export { StrokeStyleSample, type StrokeStyleSampleProps } from '#/StrokeStyleSample.tsx';

--- a/packages/tokens-reference/tokens/ref/gradient.json
+++ b/packages/tokens-reference/tokens/ref/gradient.json
@@ -1,0 +1,31 @@
+{
+  "gradient": {
+    "ref": {
+      "$type": "gradient",
+      "$description": "Raw gradient primitives. DTCG gradients are stop arrays; CSS rendering defaults to linear-gradient — consumers can place them on any gradient-function property they need.",
+      "sunrise": {
+        "$description": "Warm yellow-to-violet sweep.",
+        "$value": [
+          { "color": { "colorSpace": "srgb", "components": [0.992, 0.878, 0.278] }, "position": 0 },
+          { "color": { "colorSpace": "srgb", "components": [0.937, 0.267, 0.267] }, "position": 0.55 },
+          { "color": { "colorSpace": "srgb", "components": [0.486, 0.227, 0.929] }, "position": 1 }
+        ]
+      },
+      "cool": {
+        "$description": "Cool blue-to-green sweep.",
+        "$value": [
+          { "color": { "colorSpace": "srgb", "components": [0.114, 0.306, 0.847] }, "position": 0 },
+          { "color": { "colorSpace": "srgb", "components": [0.376, 0.647, 0.980] }, "position": 0.5 },
+          { "color": { "colorSpace": "srgb", "components": [0.525, 0.937, 0.675] }, "position": 1 }
+        ]
+      },
+      "surface-fade": {
+        "$description": "Neutral-to-dark scrim, useful for overlays.",
+        "$value": [
+          { "color": { "colorSpace": "srgb", "components": [1, 1, 1] }, "position": 0 },
+          { "color": { "colorSpace": "srgb", "components": [0.067, 0.094, 0.153] }, "position": 1 }
+        ]
+      }
+    }
+  }
+}

--- a/packages/tokens-reference/tokens/resolver.json
+++ b/packages/tokens-reference/tokens/resolver.json
@@ -12,7 +12,8 @@
         { "$ref": "./ref/font.json" },
         { "$ref": "./ref/motion.json" },
         { "$ref": "./ref/stroke.json" },
-        { "$ref": "./ref/number.json" }
+        { "$ref": "./ref/number.json" },
+        { "$ref": "./ref/gradient.json" }
       ]
     },
     "sys": {


### PR DESCRIPTION
**Milestone:** Full DTCG type parity with Terrazzo

**Closes:** Closes #176, Closes #179

**Plan impact:** none

## Summary

Closes the milestone in one PR — the only spec-level gap was `gradient`, and the audit doc refresh pairs naturally with the fixture + rendering change.

- **Fixture** — `packages/tokens-reference/tokens/ref/gradient.json` adds `sunrise`, `cool`, `surface-fade`. Stops authored in DTCG object notation (`{ colorSpace, components }`) because string-form colors are deprecated in Terrazzo 2.x.
- **New block** — `<GradientPalette filter? />` renders a wide sample per gradient token with a stop breakdown. Linear-gradient by default (the DTCG spec's gradient type is just stop arrays — the gradient function is a render-time choice).
- **TokenDetail** — composite preview gains a `gradient` branch.
- **Audit** — `docs/type-coverage.md` refreshed with the full coverage matrix; Terrazzo-specific extensions (`boolean`, `string`, `link`) called out as explicitly out of scope.
- **Docs + README** — blocks reference page and README updated; TokenDetail composite list mentions `gradient`.
- **Tests** — two new `GradientPalette` stories, a `TokenDetail.Gradient` variant, and a `GradientPaletteRenders` play-function assertion.

## Test plan

- [x] `pnpm turbo run lint typecheck test build` green (19/19)
- [x] `pnpm turbo run test:storybook` green (73/73; was 69/69)