### PR TITLE
feat(blocks): color swatch and composite breakdown in TokenDetail

### DIFF
--- a/.changeset/color-swatch-and-composite-breakdown.md
+++ b/.changeset/color-swatch-and-composite-breakdown.md
@@ -1,0 +1,8 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`TokenDetail` grows two new visuals.
+
+- **Color swatch** — opening a `color` token now shows a two-surface swatch (the token on a light and dark backdrop) in the composite preview area, alongside the existing inline swatch next to the resolved value line. Lets viewers gut-check contrast without leaving the detail pane.
+- **Composite sub-value breakdown** — `typography`, `shadow`, `border`, `transition`, and `gradient` tokens now render a labelled field list underneath the composite preview. Shadow breakdowns group multi-layer tokens with a "Layer N" header; gradient breakdowns list each stop by position percentage.

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -216,6 +216,64 @@ export const TokenDetailStrokeStyleObject = meta.story({
 });
 
 /**
+ * `TokenDetail` for a color token renders a two-surface swatch in the
+ * composite preview area (on top of the existing inline swatch + value
+ * line). Assert both swatches exist and carry a non-transparent background.
+ */
+export const TokenDetailColorSwatch = meta.story({
+  render: () => <TokenDetail path='color.sys.accent.bg' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const swatches = [
+      ...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"] > div'),
+    ];
+    expect(
+      swatches.length,
+      'color composite preview must render inner swatch cells',
+    ).toBeGreaterThanOrEqual(2);
+  },
+});
+
+/**
+ * Composite types show a labelled sub-value breakdown alongside the
+ * rendered preview. Typography breakdown lists fontFamily, fontSize,
+ * fontWeight, lineHeight, and optionally letterSpacing.
+ */
+export const TokenDetailCompositeBreakdownTypography = meta.story({
+  render: () => <TokenDetail path='typography.sys.heading' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const body = canvasElement.textContent ?? '';
+    for (const key of ['fontFamily', 'fontSize', 'fontWeight', 'lineHeight']) {
+      expect(body, `breakdown must list ${key}`).toContain(key);
+    }
+  },
+});
+
+export const TokenDetailCompositeBreakdownShadow = meta.story({
+  render: () => <TokenDetail path='shadow.sys.md' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const body = canvasElement.textContent ?? '';
+    for (const key of ['color', 'offsetX', 'offsetY', 'blur']) {
+      expect(body, `shadow breakdown must list ${key}`).toContain(key);
+    }
+  },
+});
+
+export const TokenDetailCompositeBreakdownGradient = meta.story({
+  render: () => <TokenDetail path='gradient.ref.sunrise' />,
+  play: async ({ canvasElement }) => {
+    await waitForContent(canvasElement, 'h3');
+    const body = canvasElement.textContent ?? '';
+    // The fixture's `sunrise` gradient has stops at 0, 0.55, 1.
+    expect(body, 'gradient breakdown must label the 0% stop').toContain('0%');
+    expect(body, 'gradient breakdown must label the 55% stop').toContain('55%');
+    expect(body, 'gradient breakdown must label the 100% stop').toContain('100%');
+  },
+});
+
+/**
  * `TypographyScale` must render one row per typography token with the
  * sample text visible.
  */

--- a/docs/type-coverage.md
+++ b/docs/type-coverage.md
@@ -10,7 +10,7 @@ Audit last run: 2026-04-18 (refreshed alongside the **Full DTCG type parity with
 
 | `$type` | In `tokens-reference` | Dedicated block | `TokenDetail` preview |
 | --- | --- | --- | --- |
-| `color` | ✅ ref / sys | `ColorPalette` (grid) | swatch + hex |
+| `color` | ✅ ref / sys | `ColorPalette` (grid) | two-surface swatch + hex |
 | `dimension` | ✅ sys | `DimensionScale` (length / radius / size) | bar ✅ |
 | `fontFamily` | ✅ ref only | `FontFamilySample` | sample text ✅ |
 | `fontWeight` | ✅ ref only | `FontWeightScale` | sample text ✅ |
@@ -27,6 +27,8 @@ Audit last run: 2026-04-18 (refreshed alongside the **Full DTCG type parity with
 ## Status
 
 Every DTCG 2025.10 `$type` has a dedicated block, a `TokenDetail` preview, or both. `number` renders as raw text in `TokenTable` — acceptable because opacities, line-heights, and z-index slots have no meaningful visual beyond the number itself. `strokeStyle` object form (`{ dashArray, lineCap }`) renders faithfully inside `TokenDetail` as an SVG stroke; the standalone `StrokeStyleSample` block still shows a textual notice for object form — future polish.
+
+Composite types (`typography`, `shadow`, `border`, `transition`, `gradient`) also render a labelled sub-value breakdown underneath the composite preview in `TokenDetail`, so authors can see each field's resolved value without squinting at the raw object dump.
 
 ## Out-of-scope types (Terrazzo extensions)
 

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -161,6 +161,43 @@ const styles = {
     fontSize: 12,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
+  colorSwatchRow: {
+    display: 'flex',
+    gap: 1,
+    borderRadius: 6,
+    overflow: 'hidden',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    width: 220,
+    height: 56,
+  } satisfies CSSProperties,
+  colorSwatchLight: {
+    flex: 1,
+    boxShadow: 'inset 0 0 0 8px rgba(255, 255, 255, 0.9)',
+  } satisfies CSSProperties,
+  colorSwatchDark: {
+    flex: 1,
+    boxShadow: 'inset 0 0 0 8px rgba(17, 17, 17, 0.9)',
+  } satisfies CSSProperties,
+  breakdownSection: {
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontSize: 12,
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr',
+    columnGap: 12,
+    rowGap: 3,
+    marginTop: 6,
+  } satisfies CSSProperties,
+  breakdownKey: {
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+  } satisfies CSSProperties,
+  breakdownLayerHeader: {
+    gridColumn: '1 / -1',
+    fontSize: 10,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+    marginTop: 4,
+  } satisfies CSSProperties,
   fontFamilySample: {
     padding: '4px 0',
     fontSize: 22,
@@ -274,6 +311,7 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
 
       <div style={styles.sectionHeader}>Resolved value · {activeTheme}</div>
       <CompositePreview type={token.$type} cssVar={cssVar} rawValue={token.$value} />
+      <CompositeBreakdown type={token.$type} rawValue={token.$value} />
       <div style={styles.chain}>
         {isColor && <span style={{ ...styles.swatch, background: cssVar }} aria-hidden />}
         <span>{value}</span>
@@ -412,7 +450,175 @@ function CompositePreview({
   if (type === 'strokeStyle') {
     return <StrokeStylePreview value={rawValue} />;
   }
+  if (type === 'color') {
+    // Two stacked swatches on light + dark surfaces so out-of-gamut or
+    // low-contrast colors become visible against either background.
+    return (
+      <div style={styles.colorSwatchRow} aria-hidden>
+        <div style={{ ...styles.colorSwatchLight, background: cssVar }} />
+        <div style={{ ...styles.colorSwatchDark, background: cssVar }} />
+      </div>
+    );
+  }
   return null;
+}
+
+function CompositeBreakdown({
+  type,
+  rawValue,
+}: {
+  type: string | undefined;
+  rawValue: unknown;
+}): ReactElement | null {
+  if (!rawValue || typeof rawValue !== 'object') return null;
+
+  if (type === 'typography') {
+    const v = rawValue as Record<string, unknown>;
+    return renderKeyValueList([
+      ['fontFamily', formatFontFamily(v['fontFamily'])],
+      ['fontSize', formatDimensionValue(v['fontSize'])],
+      ['fontWeight', formatPrimitive(v['fontWeight'])],
+      ['lineHeight', formatPrimitive(v['lineHeight'])],
+      ['letterSpacing', formatDimensionValue(v['letterSpacing'])],
+    ]);
+  }
+
+  if (type === 'border') {
+    const v = rawValue as Record<string, unknown>;
+    return renderKeyValueList([
+      ['color', formatColorValue(v['color'])],
+      ['width', formatDimensionValue(v['width'])],
+      ['style', formatPrimitive(v['style'])],
+    ]);
+  }
+
+  if (type === 'transition') {
+    const v = rawValue as Record<string, unknown>;
+    return renderKeyValueList([
+      ['duration', formatDimensionValue(v['duration'])],
+      ['timingFunction', formatPrimitive(v['timingFunction'])],
+      ['delay', formatDimensionValue(v['delay'])],
+    ]);
+  }
+
+  if (type === 'shadow') {
+    const layers = Array.isArray(rawValue) ? rawValue : [rawValue];
+    const multi = layers.length > 1;
+    return (
+      <div style={styles.breakdownSection}>
+        {layers.map((layer, i) => {
+          const v = layer as Record<string, unknown>;
+          return (
+            <div key={shadowLayerKey(v, i)} style={{ display: 'contents' }}>
+              {multi && <div style={styles.breakdownLayerHeader}>Layer {i + 1}</div>}
+              <KeyValueRow label='color' value={formatColorValue(v['color'])} />
+              <KeyValueRow label='offsetX' value={formatDimensionValue(v['offsetX'])} />
+              <KeyValueRow label='offsetY' value={formatDimensionValue(v['offsetY'])} />
+              <KeyValueRow label='blur' value={formatDimensionValue(v['blur'])} />
+              <KeyValueRow label='spread' value={formatDimensionValue(v['spread'])} />
+              {'inset' in v && <KeyValueRow label='inset' value={formatPrimitive(v['inset'])} />}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (type === 'gradient') {
+    const stops = Array.isArray(rawValue) ? rawValue : [];
+    if (stops.length === 0) return null;
+    return (
+      <div style={styles.breakdownSection}>
+        {stops.map((stop, i) => {
+          const v = stop as Record<string, unknown>;
+          const position = typeof v['position'] === 'number' ? v['position'] : 0;
+          return (
+            <KeyValueRow
+              key={gradientStopKey(v, i)}
+              label={`${(position * 100).toFixed(0)}%`}
+              value={formatColorValue(v['color'])}
+            />
+          );
+        })}
+      </div>
+    );
+  }
+
+  return null;
+}
+
+function renderKeyValueList(rows: Array<[string, string | null]>): ReactElement {
+  return (
+    <div style={styles.breakdownSection}>
+      {rows
+        .filter(([, v]) => v !== null)
+        .map(([k, v]) => (
+          <KeyValueRow key={k} label={k} value={v ?? ''} />
+        ))}
+    </div>
+  );
+}
+
+function KeyValueRow({ label, value }: { label: string; value: string | null }): ReactElement {
+  return (
+    <>
+      <span style={styles.breakdownKey}>{label}</span>
+      <span>{value ?? '—'}</span>
+    </>
+  );
+}
+
+function formatPrimitive(v: unknown): string | null {
+  if (v == null) return null;
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return JSON.stringify(v);
+}
+
+function formatFontFamily(v: unknown): string | null {
+  if (v == null) return null;
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return v.map(String).join(', ');
+  return JSON.stringify(v);
+}
+
+function formatDimensionValue(v: unknown): string | null {
+  if (v == null) return null;
+  if (typeof v === 'string' || typeof v === 'number') return String(v);
+  if (typeof v === 'object') {
+    const d = v as { value?: unknown; unit?: unknown };
+    if (typeof d.value === 'number' && typeof d.unit === 'string') return `${d.value}${d.unit}`;
+  }
+  return JSON.stringify(v);
+}
+
+function shadowLayerKey(layer: Record<string, unknown>, fallback: number): string {
+  const parts = [
+    layer['color'],
+    layer['offsetX'],
+    layer['offsetY'],
+    layer['blur'],
+    layer['spread'],
+    layer['inset'],
+  ].map((p) => (p === undefined ? '' : JSON.stringify(p)));
+  return `shadow|${parts.join('|')}|${fallback}`;
+}
+
+function gradientStopKey(stop: Record<string, unknown>, fallback: number): string {
+  return `stop|${stop['position'] ?? fallback}|${JSON.stringify(stop['color'])}`;
+}
+
+function formatColorValue(v: unknown): string | null {
+  if (v == null) return null;
+  if (typeof v === 'string') return v;
+  if (typeof v === 'object') {
+    const c = v as { colorSpace?: unknown; components?: unknown; alpha?: unknown };
+    if (Array.isArray(c.components) && typeof c.colorSpace === 'string') {
+      const parts = c.components.map((n) => (typeof n === 'number' ? n.toFixed(3) : String(n)));
+      const alpha = typeof c.alpha === 'number' && c.alpha !== 1 ? ` / ${c.alpha}` : '';
+      return `${c.colorSpace}(${parts.join(' ')}${alpha})`;
+    }
+  }
+  return JSON.stringify(v);
 }
 
 const STROKE_STYLE_STRINGS = new Set([


### PR DESCRIPTION
**Milestone:** Full DTCG type parity with Terrazzo

**Closes:** Closes #190

**Plan impact:** none

## Summary

Two new visuals inside `TokenDetail`'s Resolved-value section.

- **Color swatch** — opening a `color` token renders a two-surface swatch (the token on a light backdrop and a dark backdrop, side-by-side) in the composite preview area, so contrast is gut-checkable without leaving the pane. The existing inline swatch next to the resolved-value text stays.
- **Composite sub-value breakdown** — `typography`, `shadow`, `border`, `transition`, `gradient` tokens now render a labelled field list underneath the composite preview:
  - Typography: `fontFamily / fontSize / fontWeight / lineHeight / letterSpacing`
  - Border: `color / width / style`
  - Transition: `duration / timingFunction / delay`
  - Shadow: per-layer `color / offsetX / offsetY / blur / spread / inset?` (multi-layer tokens get a "Layer N" header)
  - Gradient: one row per stop, labelled by position percentage

## Non-goals (out of scope here)

- **Extracting a shared `format-composite.ts` helper** and refactoring `ShadowPreview` to use it. Inline helpers inside `TokenDetail.tsx` for now — a larger refactor would fight with the upcoming #174 TokenDetail split.
- Changing the standalone block rendering.

## Test plan

- [x] `pnpm turbo run lint typecheck test build` green (19/19)
- [x] `pnpm turbo run test:storybook` green (81/81; was 77/77 with 4 new play-functions)