### PR TITLE
docs: drop package-name prefixes from readme and reference headers

### DIFF
--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -1,12 +1,12 @@
 ---
 id: addon
-title: '@unpunnyfuns/swatchbook-addon'
+title: Addon
 sidebar_position: 2
 ---
 
-# `@unpunnyfuns/swatchbook-addon`
+# Addon
 
-Storybook addon. Loads your config at build time via `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, registers a preview decorator + manager toolbar + panels, and ships a `useToken` hook.
+Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config at build time via `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, registers a preview decorator + manager toolbar + panels, and ships a `useToken` hook.
 
 ## Install
 

--- a/apps/docs/docs/reference/blocks.mdx
+++ b/apps/docs/docs/reference/blocks.mdx
@@ -1,12 +1,12 @@
 ---
 id: blocks
-title: '@unpunnyfuns/swatchbook-blocks'
+title: Blocks
 sidebar_position: 3
 ---
 
-# `@unpunnyfuns/swatchbook-blocks`
+# Blocks
 
-MDX-embeddable doc blocks. Each block reads the active token graph from the addon's virtual module and reacts to axis changes.
+Published as `@unpunnyfuns/swatchbook-blocks`. MDX-embeddable doc blocks. Each block reads the active token graph from the addon's virtual module and reacts to axis changes.
 
 ## Install
 

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -1,12 +1,12 @@
 ---
 id: core
-title: '@unpunnyfuns/swatchbook-core'
+title: Core
 sidebar_position: 1
 ---
 
-# `@unpunnyfuns/swatchbook-core`
+# Core
 
-Framework-free DTCG loader. Parses token files via Terrazzo, resolves aliases, composes themes through a resolver or layered-axes config, and emits CSS variables + TypeScript types. No React, no Storybook dependency.
+Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses token files via Terrazzo, resolves aliases, composes themes through a resolver or layered-axes config, and emits CSS variables + TypeScript types. No React, no Storybook dependency.
 
 ## Install
 

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,6 +1,6 @@
-# @unpunnyfuns/swatchbook-addon
+# Addon
 
-Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus tokens and diagnostics panels, and ships a `useToken()` hook with typed paths.
+Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus tokens and diagnostics panels, and ships a `useToken()` hook with typed paths.
 
 > **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) via `@unpunnyfuns/swatchbook-core`.
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,6 +1,6 @@
-# @unpunnyfuns/swatchbook-blocks
+# Blocks
 
-Storybook MDX doc blocks for DTCG design tokens. React components for rendering token documentation inside `.mdx` pages or regular stories. Self-mount the addon's CSS and react to axis changes from the toolbar; work inside the docs container even though story decorators don't.
+Published as `@unpunnyfuns/swatchbook-blocks`. Storybook MDX doc blocks for DTCG design tokens. React components for rendering token documentation inside `.mdx` pages or regular stories. Self-mount the addon's CSS and react to axis changes from the toolbar; work inside the docs container even though story decorators don't.
 
 > **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) via `@unpunnyfuns/swatchbook-core`.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
-# @unpunnyfuns/swatchbook-core
+# Core
 
-Framework-free DTCG loader. Parses token files via [Terrazzo](https://terrazzo.app/), resolves aliases, composes themes through a DTCG 2025.10 resolver, and emits CSS variables and TypeScript types.
+Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses token files via [Terrazzo](https://terrazzo.app/), resolves aliases, composes themes through a DTCG 2025.10 resolver, and emits CSS variables and TypeScript types.
 
 > **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/).
 

--- a/packages/tokens-reference/README.md
+++ b/packages/tokens-reference/README.md
@@ -1,6 +1,6 @@
-# @unpunnyfuns/swatchbook-tokens-reference
+# Tokens reference
 
-Exhaustive DTCG 2025.10 pyramid used as swatchbook's internal test bed. Private — not published.
+Internal workspace package (`@unpunnyfuns/swatchbook-tokens-reference`). Exhaustive DTCG 2025.10 fixture used as swatchbook's internal test bed. Private — not published.
 
 ## Structure
 

--- a/packages/tokens-starter/README.md
+++ b/packages/tokens-starter/README.md
@@ -1,6 +1,6 @@
-# @unpunnyfuns/swatchbook-tokens
+# Tokens starter
 
-Minimal DTCG design-token starter set. Drop in for a working baseline; fork and extend.
+Published as `@unpunnyfuns/swatchbook-tokens`. Minimal DTCG design-token starter set. Drop in for a working baseline; fork and extend.
 
 > **Status:** iceboxed past v0.1.0 — see `docs/decisions.md` (2026-04-17 entry). The package currently exists as a build-pipeline smoke test for `@unpunnyfuns/swatchbook-core`, not a public starter. Pin from npm at your own risk until v0.1.0 ships; the shape below is the intent, not yet a contract.
 


### PR DESCRIPTION
**Milestone:** Drop package-name prefixes from visible headers

**Closes:** Closes #181

**Plan impact:** none

## Summary

Every README H1 and docs-site reference title shouted the fully-qualified `@unpunnyfuns/swatchbook-<name>` scope. Now:

| File | Before | After |
| --- | --- | --- |
| `packages/core/README.md` | `@unpunnyfuns/swatchbook-core` | `Core` |
| `packages/addon/README.md` | `@unpunnyfuns/swatchbook-addon` | `Addon` |
| `packages/blocks/README.md` | `@unpunnyfuns/swatchbook-blocks` | `Blocks` |
| `packages/tokens-reference/README.md` | `@unpunnyfuns/swatchbook-tokens-reference` | `Tokens reference` |
| `packages/tokens-starter/README.md` | `@unpunnyfuns/swatchbook-tokens` | `Tokens starter` |
| `apps/docs/docs/reference/core.mdx` | scoped | `Core` |
| `apps/docs/docs/reference/addon.mdx` | scoped | `Addon` |
| `apps/docs/docs/reference/blocks.mdx` | scoped | `Blocks` |

Each page keeps a "Published as \`@unpunnyfuns/swatchbook-<name>\`." line so the npm name remains discoverable where it matters. Install commands and import statements in code blocks still use the scoped name.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-docs build` green (broken-link warnings expected pre-deploy, same as every docs PR)