### PR TITLE
refactor(blocks): extract sample primitives from preview blocks

### DIFF
--- a/.changeset/extract-sample-primitives.md
+++ b/.changeset/extract-sample-primitives.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+Extract per-token sample primitives from `MotionPreview`, `ShadowPreview`, `BorderPreview`, and `DimensionScale`. Each preview block's single-token renderer is now exported standalone so MDX authors can embed just one sample: `MotionSample`, `ShadowSample`, `BorderSample`, and `DimensionBar` — each takes a `path: string` prop (and `DimensionBar` also accepts `kind`, `MotionSample` accepts `speed` / `runKey`). The parent blocks are unchanged in DOM output and props; they're now thin iterators that filter, sort, and map over the extracted sample.

--- a/apps/docs/docs/reference/blocks.mdx
+++ b/apps/docs/docs/reference/blocks.mdx
@@ -101,6 +101,30 @@ Same "Aa" sample at each `fontWeight` primitive, sorted ascending. Props: `sampl
 
 Border rendered per `strokeStyle` primitive. String-form styles (`solid`, `dashed`, `dotted`, `double`) render as `border-style`; object-form (with `dashArray` / `lineCap`) renders a textual fallback.
 
+### `<MotionSample path speed? runKey? />`
+
+Standalone per-token animated sample (the animated ball + track from `MotionPreview`). Accepts any `transition`, `duration`, or `cubicBezier` token path. Respects `prefers-reduced-motion`.
+
+Props: `path: string`, `speed?: 0.25 | 0.5 | 1 | 2` (default `1`), `runKey?: number` (change to force a restart).
+
+### `<ShadowSample path />`
+
+Standalone per-token shadow sample (the surface rectangle with `box-shadow` from `ShadowPreview`).
+
+Props: `path: string`.
+
+### `<BorderSample path />`
+
+Standalone per-token border sample (the surface rectangle with `border` from `BorderPreview`).
+
+Props: `path: string`.
+
+### `<DimensionBar path kind? />`
+
+Standalone per-token dimension visual (the bar / square / radius sample from `DimensionScale`).
+
+Props: `path: string`, `kind?: 'length' | 'radius' | 'size'` (default `'length'`).
+
 ### `<GradientPalette filter? />`
 
 Wide sample per `gradient` token with the stop list as a sidebar. Samples use `linear-gradient(to right, …)` by default — DTCG gradients are stop arrays, and the gradient function is a rendering choice the consumer makes at use-site. If you want radial/conic previews here, open an issue.

--- a/apps/storybook/src/stories/MotionSample.stories.tsx
+++ b/apps/storybook/src/stories/MotionSample.stories.tsx
@@ -1,0 +1,15 @@
+import { MotionSample } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/MotionSample',
+  component: MotionSample,
+  argTypes: {
+    path: { control: 'text' },
+    speed: { control: { type: 'inline-radio' }, options: [0.25, 0.5, 1, 2] },
+  },
+});
+
+export default meta;
+
+export const Default = meta.story({ args: { path: 'motion.sys.enter' } });

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -23,6 +23,10 @@ Requires `@unpunnyfuns/swatchbook-addon` to be registered in your Storybook conf
 | `FontWeightScale`   | Same sample text rendered at each `fontWeight` primitive, sorted ascending.         |
 | `StrokeStyleSample` | Border rendered per `strokeStyle` primitive.                                        |
 | `GradientPalette`   | Wide swatch per `gradient` token with stop breakdown (linear-gradient default).      |
+| `MotionSample`      | Animated ball + track for one `transition` / `duration` / `cubicBezier` token. Accepts `speed` / `runKey`. |
+| `ShadowSample`      | Surface rectangle with one `shadow` token applied as `box-shadow`.                  |
+| `BorderSample`      | Surface rectangle with one `border` token applied as `border`.                      |
+| `DimensionBar`      | Width-driven bar (or square / radius sample, via `kind`) for one `dimension` token. |
 | `TokenDetail`       | Single-token inspector — composition of the subcomponents below. |
 | `TokenHeader`       | Heading + `$type` pill + cssVar + `$description`, or a missing-token empty state. |
 | `CompositePreview`  | Type-dispatched live preview (typography, shadow, border, transition, dimension, duration, cubicBezier, fontFamily, fontWeight, strokeStyle, gradient, color). |

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface BorderPreviewProps {
@@ -56,12 +57,6 @@ const styles = {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-  } satisfies CSSProperties,
-  sample: {
-    width: 120,
-    height: 56,
-    background: 'var(--sb-color-sys-surface-raised, transparent)',
-    borderRadius: 6,
   } satisfies CSSProperties,
   breakdown: {
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
@@ -160,7 +155,7 @@ export function BorderPreview({ filter = 'border', caption }: BorderPreviewProps
             <span style={styles.cssVar}>{row.cssVar}</span>
           </div>
           <div style={styles.sampleCell}>
-            <div style={{ ...styles.sample, border: row.cssVar }} aria-hidden />
+            <BorderSample path={row.path} />
           </div>
           <div style={styles.breakdown}>
             <span style={styles.breakdownKey}>width</span>

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -1,8 +1,9 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import { DimensionBar, type DimensionKind } from '#/dimension-scale/DimensionBar.tsx';
 import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
-export type DimensionKind = 'length' | 'radius' | 'size';
+export type { DimensionKind };
 
 export interface DimensionScaleProps {
   /**
@@ -68,24 +69,6 @@ const styles = {
     alignItems: 'center',
     minWidth: 0,
   } satisfies CSSProperties,
-  bar: {
-    height: 14,
-    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
-    borderRadius: 2,
-    minWidth: 1,
-  } satisfies CSSProperties,
-  radiusSample: {
-    width: 56,
-    height: 56,
-    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',
-  } satisfies CSSProperties,
-  sizeSample: {
-    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',
-    minWidth: 1,
-    minHeight: 1,
-  } satisfies CSSProperties,
   cssVar: {
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
     fontSize: 11,
@@ -115,9 +98,7 @@ interface Row {
 
 /**
  * Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
- * purpose of ordering and deciding whether to cap the rendered bar. Returns
- * `NaN` for units we can't reasonably approximate (ex / ch / %), which the
- * caller treats as "render at cssVar but don't cap or sort numerically".
+ * purpose of ordering and deciding whether to show a cap indicator.
  */
 function toPixels(raw: unknown): number {
   if (raw == null || typeof raw !== 'object') return Number.NaN;
@@ -184,7 +165,7 @@ export function DimensionScale({
             <span style={styles.specs}>{row.displayValue}</span>
           </div>
           <div style={styles.visualCell}>
-            {renderVisual(row, kind)}
+            <DimensionBar path={row.path} kind={kind} />
             {row.capped && <span style={styles.cap}>capped at {MAX_RENDER_PX}px</span>}
           </div>
           <span style={styles.cssVar}>{row.cssVar}</span>
@@ -192,22 +173,4 @@ export function DimensionScale({
       ))}
     </div>
   );
-}
-
-function renderVisual(row: Row, kind: DimensionKind): ReactElement {
-  const cappedValue = row.capped ? `${MAX_RENDER_PX}px` : row.cssVar;
-  switch (kind) {
-    case 'radius':
-      return <div style={{ ...styles.radiusSample, borderRadius: row.cssVar }} aria-hidden />;
-    case 'size':
-      return (
-        <div
-          style={{ ...styles.sizeSample, width: cappedValue, height: cappedValue }}
-          aria-hidden
-        />
-      );
-    case 'length':
-    default:
-      return <div style={{ ...styles.bar, width: cappedValue }} aria-hidden />;
-  }
 }

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -1,9 +1,14 @@
 import type { CSSProperties, ReactElement } from 'react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+import {
+  MotionSample,
+  type MotionSpeed,
+  resolveMotionSpec,
+} from '#/motion-preview/MotionSample.tsx';
 
-export type MotionSpeed = 0.25 | 0.5 | 1 | 2;
+export type { MotionSpeed };
 
 export interface MotionPreviewProps {
   /**
@@ -15,8 +20,6 @@ export interface MotionPreviewProps {
   caption?: string;
 }
 
-const DEFAULT_DURATION_MS = 300;
-const DEFAULT_EASING = 'cubic-bezier(0.2, 0, 0, 1)';
 const SPEEDS: MotionSpeed[] = [0.25, 0.5, 1, 2];
 
 const styles = {
@@ -96,22 +99,6 @@ const styles = {
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
-  track: {
-    position: 'relative',
-    height: 36,
-    background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.08))',
-    borderRadius: 18,
-    overflow: 'hidden',
-  } satisfies CSSProperties,
-  ball: {
-    position: 'absolute',
-    top: '50%',
-    width: 28,
-    height: 28,
-    marginTop: -14,
-    borderRadius: '50%',
-    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
-  } satisfies CSSProperties,
   cssVar: {
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
     fontSize: 11,
@@ -123,11 +110,6 @@ const styles = {
     textAlign: 'center',
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
-  reducedMotion: {
-    fontSize: 11,
-    color: 'var(--sb-color-sys-text-muted, CanvasText)',
-    fontStyle: 'italic',
-  } satisfies CSSProperties,
 };
 
 interface Row {
@@ -138,91 +120,15 @@ interface Row {
   kind: 'transition' | 'duration' | 'cubicBezier';
 }
 
-function extractDurationMs(raw: unknown): number {
-  if (raw == null) return Number.NaN;
-  if (typeof raw === 'object') {
-    const v = raw as { value?: unknown; unit?: unknown };
-    if (typeof v.value === 'number' && typeof v.unit === 'string') {
-      if (v.unit === 'ms') return v.value;
-      if (v.unit === 's') return v.value * 1000;
-    }
+function formatSpec(row: Row): string {
+  switch (row.kind) {
+    case 'transition':
+      return `transition · ${Math.round(row.durationMs)}ms · ${row.easing}`;
+    case 'duration':
+      return `duration · ${Math.round(row.durationMs)}ms`;
+    case 'cubicBezier':
+      return `cubicBezier · ${row.easing}`;
   }
-  return Number.NaN;
-}
-
-function extractCubicBezier(raw: unknown): string | null {
-  if (Array.isArray(raw) && raw.length === 4 && raw.every((n) => typeof n === 'number')) {
-    return `cubic-bezier(${raw.map((n) => Number(n).toFixed(3)).join(', ')})`;
-  }
-  return null;
-}
-
-function resolveSpec(
-  token: { $type?: string; $value?: unknown },
-  themeTokens: Record<string, { $value?: unknown }>,
-): Pick<Row, 'durationMs' | 'easing' | 'kind'> | null {
-  const type = token.$type;
-  if (type === 'transition') {
-    const v = (token.$value ?? {}) as {
-      duration?: unknown;
-      timingFunction?: unknown;
-    };
-    return {
-      kind: 'transition',
-      durationMs: asDuration(v.duration, themeTokens, DEFAULT_DURATION_MS),
-      easing: asEasing(v.timingFunction, themeTokens, DEFAULT_EASING),
-    };
-  }
-  if (type === 'duration') {
-    return {
-      kind: 'duration',
-      durationMs: extractDurationMs(token.$value),
-      easing: DEFAULT_EASING,
-    };
-  }
-  if (type === 'cubicBezier') {
-    const easing = extractCubicBezier(token.$value);
-    if (!easing) return null;
-    return { kind: 'cubicBezier', durationMs: DEFAULT_DURATION_MS, easing };
-  }
-  return null;
-}
-
-function asDuration(
-  raw: unknown,
-  themeTokens: Record<string, { $value?: unknown }>,
-  fallback: number,
-): number {
-  const direct = extractDurationMs(raw);
-  if (Number.isFinite(direct)) return direct;
-  if (typeof raw === 'string') {
-    // Alias strings like "{duration.ref.normal}" resolve to a reference in themeTokens.
-    const match = raw.match(/^\{([^}]+)\}$/);
-    if (match && match[1]) {
-      const referenced = themeTokens[match[1]];
-      const resolved = extractDurationMs(referenced?.$value);
-      if (Number.isFinite(resolved)) return resolved;
-    }
-  }
-  return fallback;
-}
-
-function asEasing(
-  raw: unknown,
-  themeTokens: Record<string, { $value?: unknown }>,
-  fallback: string,
-): string {
-  const direct = extractCubicBezier(raw);
-  if (direct) return direct;
-  if (typeof raw === 'string') {
-    const match = raw.match(/^\{([^}]+)\}$/);
-    if (match && match[1]) {
-      const referenced = themeTokens[match[1]];
-      const resolved = extractCubicBezier(referenced?.$value);
-      if (resolved) return resolved;
-    }
-  }
-  return fallback;
 }
 
 export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactElement {
@@ -238,12 +144,16 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
       if (!filter && !['transition', 'duration', 'cubicBezier'].includes(token.$type ?? '')) {
         continue;
       }
-      const spec = resolveSpec(token, resolved);
+      const kind = token.$type as Row['kind'] | undefined;
+      if (!kind) continue;
+      const spec = resolveMotionSpec(token, resolved);
       if (!spec) continue;
       collected.push({
         path,
         cssVar: makeCssVar(path, cssVarPrefix),
-        ...spec,
+        durationMs: spec.durationMs,
+        easing: spec.easing,
+        kind,
       });
     }
     collected.sort((a, b) => {
@@ -296,67 +206,10 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
             <span style={styles.path}>{row.path}</span>
             <span style={styles.specs}>{formatSpec(row)}</span>
           </div>
-          {reducedMotion ? (
-            <div style={styles.reducedMotion}>
-              Animation suppressed by `prefers-reduced-motion: reduce`.
-            </div>
-          ) : (
-            <MotionTrack row={row} speed={speed} runKey={run} />
-          )}
+          <MotionSample path={row.path} speed={speed} runKey={run} />
           <span style={styles.cssVar}>{row.cssVar}</span>
         </div>
       ))}
-    </div>
-  );
-}
-
-function formatSpec(row: Row): string {
-  switch (row.kind) {
-    case 'transition':
-      return `transition · ${Math.round(row.durationMs)}ms · ${row.easing}`;
-    case 'duration':
-      return `duration · ${Math.round(row.durationMs)}ms`;
-    case 'cubicBezier':
-      return `cubicBezier · ${row.easing}`;
-  }
-}
-
-function MotionTrack({
-  row,
-  speed,
-  runKey,
-}: {
-  row: Row;
-  speed: MotionSpeed;
-  runKey: number;
-}): ReactElement {
-  const [phase, setPhase] = useState<0 | 1>(0);
-  const scaledDuration = Math.max(1, row.durationMs / speed);
-
-  useEffect(() => {
-    // Reset to 0 on replay / speed change, then tick to 1 next frame so the
-    // transition actually plays (going 0 → 1 each cycle).
-    setPhase(0);
-    const id = requestAnimationFrame(() => setPhase(1));
-    const loop = window.setInterval(() => {
-      setPhase((p) => (p === 0 ? 1 : 0));
-    }, scaledDuration * 2);
-    return () => {
-      cancelAnimationFrame(id);
-      window.clearInterval(loop);
-    };
-  }, [scaledDuration, runKey, row.path]);
-
-  return (
-    <div style={styles.track}>
-      <div
-        style={{
-          ...styles.ball,
-          left: phase === 1 ? 'calc(100% - 32px)' : '4px',
-          transition: `left ${scaledDuration}ms ${row.easing}`,
-        }}
-        aria-hidden
-      />
     </div>
   );
 }

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 
 export interface ShadowPreviewProps {
   /**
@@ -57,13 +58,6 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'center',
     height: 96,
-  } satisfies CSSProperties,
-  sample: {
-    width: 120,
-    height: 56,
-    background: 'var(--sb-color-sys-surface-raised, #fff)',
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
-    borderRadius: 6,
   } satisfies CSSProperties,
   breakdown: {
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
@@ -185,7 +179,7 @@ export function ShadowPreview({ filter = 'shadow', caption }: ShadowPreviewProps
             <span style={styles.cssVar}>{row.cssVar}</span>
           </div>
           <div style={styles.sampleCell}>
-            <div style={{ ...styles.sample, boxShadow: row.cssVar }} aria-hidden />
+            <ShadowSample path={row.path} />
           </div>
           <div style={styles.breakdown}>
             {row.layers.length === 1

--- a/packages/blocks/src/border-preview/BorderSample.tsx
+++ b/packages/blocks/src/border-preview/BorderSample.tsx
@@ -1,0 +1,20 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface BorderSampleProps {
+  /** Full dot-path of the border token to preview. */
+  path: string;
+}
+
+const sampleStyle: CSSProperties = {
+  width: 120,
+  height: 56,
+  background: 'var(--sb-color-sys-surface-raised, transparent)',
+  borderRadius: 6,
+};
+
+export function BorderSample({ path }: BorderSampleProps): ReactElement {
+  const { cssVarPrefix } = useProject();
+  const cssVar = makeCssVar(path, cssVarPrefix);
+  return <div style={{ ...sampleStyle, border: cssVar }} aria-hidden />;
+}

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -1,0 +1,84 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export type DimensionKind = 'length' | 'radius' | 'size';
+
+export interface DimensionBarProps {
+  /** Full dot-path of the dimension token to preview. */
+  path: string;
+  /**
+   * Visualization kind:
+   * - `'length'` (default): horizontal bar whose width equals the token's dimension.
+   * - `'radius'`: 56×56 square with the token applied as `border-radius`.
+   * - `'size'`: a square sized to the token's dimension.
+   */
+  kind?: DimensionKind;
+}
+
+const MAX_RENDER_PX = 480;
+
+const styles = {
+  bar: {
+    height: 14,
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+    borderRadius: 2,
+    minWidth: 1,
+  } satisfies CSSProperties,
+  radiusSample: {
+    width: 56,
+    height: 56,
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',
+  } satisfies CSSProperties,
+  sizeSample: {
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',
+    minWidth: 1,
+    minHeight: 1,
+  } satisfies CSSProperties,
+};
+
+/**
+ * Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
+ * purpose of deciding whether to cap the rendered bar. Returns `NaN` for
+ * units we can't reasonably approximate (ex / ch / %), which the caller
+ * treats as "render at cssVar but don't cap".
+ */
+function toPixels(raw: unknown): number {
+  if (raw == null || typeof raw !== 'object') return Number.NaN;
+  const v = raw as { value?: unknown; unit?: unknown };
+  if (typeof v.value !== 'number' || typeof v.unit !== 'string') return Number.NaN;
+  switch (v.unit) {
+    case 'px':
+      return v.value;
+    case 'rem':
+    case 'em':
+      return v.value * 16;
+    default:
+      return Number.NaN;
+  }
+}
+
+export function DimensionBar({ path, kind = 'length' }: DimensionBarProps): ReactElement {
+  const { resolved, cssVarPrefix } = useProject();
+  const cssVar = makeCssVar(path, cssVarPrefix);
+  const token = resolved[path];
+  const pxValue = toPixels(token?.$value);
+  const capped = Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX;
+  const cappedValue = capped ? `${MAX_RENDER_PX}px` : cssVar;
+
+  switch (kind) {
+    case 'radius':
+      return <div style={{ ...styles.radiusSample, borderRadius: cssVar }} aria-hidden />;
+    case 'size':
+      return (
+        <div
+          style={{ ...styles.sizeSample, width: cappedValue, height: cappedValue }}
+          aria-hidden
+        />
+      );
+    case 'length':
+    default:
+      return <div style={{ ...styles.bar, width: cappedValue }} aria-hidden />;
+  }
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -1,11 +1,15 @@
 export { BorderPreview, type BorderPreviewProps } from '#/BorderPreview.tsx';
+export { BorderSample, type BorderSampleProps } from '#/border-preview/BorderSample.tsx';
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
 export { DimensionScale, type DimensionKind, type DimensionScaleProps } from '#/DimensionScale.tsx';
+export { DimensionBar, type DimensionBarProps } from '#/dimension-scale/DimensionBar.tsx';
 export { FontFamilySample, type FontFamilySampleProps } from '#/FontFamilySample.tsx';
 export { FontWeightScale, type FontWeightScaleProps } from '#/FontWeightScale.tsx';
 export { GradientPalette, type GradientPaletteProps } from '#/GradientPalette.tsx';
 export { MotionPreview, type MotionPreviewProps, type MotionSpeed } from '#/MotionPreview.tsx';
+export { MotionSample, type MotionSampleProps } from '#/motion-preview/MotionSample.tsx';
 export { ShadowPreview, type ShadowPreviewProps } from '#/ShadowPreview.tsx';
+export { ShadowSample, type ShadowSampleProps } from '#/shadow-preview/ShadowSample.tsx';
 export { StrokeStyleSample, type StrokeStyleSampleProps } from '#/StrokeStyleSample.tsx';
 export { TokenDetail, type TokenDetailProps } from '#/TokenDetail.tsx';
 export { AliasChain, type AliasChainProps } from '#/token-detail/AliasChain.tsx';

--- a/packages/blocks/src/motion-preview/MotionSample.tsx
+++ b/packages/blocks/src/motion-preview/MotionSample.tsx
@@ -1,0 +1,182 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
+import { useProject } from '#/internal/use-project.ts';
+
+export type MotionSpeed = 0.25 | 0.5 | 1 | 2;
+
+export interface MotionSampleProps {
+  /** Full dot-path of the motion token (`transition`, `duration`, or `cubicBezier`). */
+  path: string;
+  /** Playback speed multiplier. Defaults to `1`. */
+  speed?: MotionSpeed;
+  /**
+   * Change this value to force the animation to restart. Useful when an
+   * outer block exposes a "replay" button that should re-trigger every
+   * sample at once.
+   */
+  runKey?: number;
+}
+
+const DEFAULT_DURATION_MS = 300;
+const DEFAULT_EASING = 'cubic-bezier(0.2, 0, 0, 1)';
+
+const styles = {
+  track: {
+    position: 'relative',
+    height: 36,
+    background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.08))',
+    borderRadius: 18,
+    overflow: 'hidden',
+  } satisfies CSSProperties,
+  ball: {
+    position: 'absolute',
+    top: '50%',
+    width: 28,
+    height: 28,
+    marginTop: -14,
+    borderRadius: '50%',
+    background: 'var(--sb-color-sys-accent-bg, #3b82f6)',
+  } satisfies CSSProperties,
+  reducedMotion: {
+    fontSize: 11,
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+    fontStyle: 'italic',
+  } satisfies CSSProperties,
+};
+
+interface Spec {
+  durationMs: number;
+  easing: string;
+}
+
+function extractDurationMs(raw: unknown): number {
+  if (raw == null) return Number.NaN;
+  if (typeof raw === 'object') {
+    const v = raw as { value?: unknown; unit?: unknown };
+    if (typeof v.value === 'number' && typeof v.unit === 'string') {
+      if (v.unit === 'ms') return v.value;
+      if (v.unit === 's') return v.value * 1000;
+    }
+  }
+  return Number.NaN;
+}
+
+function extractCubicBezier(raw: unknown): string | null {
+  if (Array.isArray(raw) && raw.length === 4 && raw.every((n) => typeof n === 'number')) {
+    return `cubic-bezier(${raw.map((n) => Number(n).toFixed(3)).join(', ')})`;
+  }
+  return null;
+}
+
+function asDuration(
+  raw: unknown,
+  themeTokens: Record<string, { $value?: unknown }>,
+  fallback: number,
+): number {
+  const direct = extractDurationMs(raw);
+  if (Number.isFinite(direct)) return direct;
+  if (typeof raw === 'string') {
+    const match = raw.match(/^\{([^}]+)\}$/);
+    if (match && match[1]) {
+      const referenced = themeTokens[match[1]];
+      const resolved = extractDurationMs(referenced?.$value);
+      if (Number.isFinite(resolved)) return resolved;
+    }
+  }
+  return fallback;
+}
+
+function asEasing(
+  raw: unknown,
+  themeTokens: Record<string, { $value?: unknown }>,
+  fallback: string,
+): string {
+  const direct = extractCubicBezier(raw);
+  if (direct) return direct;
+  if (typeof raw === 'string') {
+    const match = raw.match(/^\{([^}]+)\}$/);
+    if (match && match[1]) {
+      const referenced = themeTokens[match[1]];
+      const resolved = extractCubicBezier(referenced?.$value);
+      if (resolved) return resolved;
+    }
+  }
+  return fallback;
+}
+
+export function resolveMotionSpec(
+  token: { $type?: string; $value?: unknown } | undefined,
+  themeTokens: Record<string, { $value?: unknown }>,
+): Spec | null {
+  if (!token) return null;
+  const type = token.$type;
+  if (type === 'transition') {
+    const v = (token.$value ?? {}) as {
+      duration?: unknown;
+      timingFunction?: unknown;
+    };
+    return {
+      durationMs: asDuration(v.duration, themeTokens, DEFAULT_DURATION_MS),
+      easing: asEasing(v.timingFunction, themeTokens, DEFAULT_EASING),
+    };
+  }
+  if (type === 'duration') {
+    const durationMs = extractDurationMs(token.$value);
+    if (!Number.isFinite(durationMs)) return null;
+    return { durationMs, easing: DEFAULT_EASING };
+  }
+  if (type === 'cubicBezier') {
+    const easing = extractCubicBezier(token.$value);
+    if (!easing) return null;
+    return { durationMs: DEFAULT_DURATION_MS, easing };
+  }
+  return null;
+}
+
+export function MotionSample({ path, speed = 1, runKey = 0 }: MotionSampleProps): ReactElement {
+  const { resolved } = useProject();
+  const reducedMotion = usePrefersReducedMotion();
+
+  const spec = useMemo(() => resolveMotionSpec(resolved[path], resolved), [resolved, path]);
+
+  const durationMs = spec?.durationMs ?? DEFAULT_DURATION_MS;
+  const easing = spec?.easing ?? DEFAULT_EASING;
+  const scaledDuration = Math.max(1, durationMs / speed);
+
+  const [phase, setPhase] = useState<0 | 1>(0);
+
+  useEffect(() => {
+    if (reducedMotion) return;
+    setPhase(0);
+    const id = requestAnimationFrame(() => setPhase(1));
+    const loop = window.setInterval(() => {
+      setPhase((p) => (p === 0 ? 1 : 0));
+    }, scaledDuration * 2);
+    return () => {
+      cancelAnimationFrame(id);
+      window.clearInterval(loop);
+    };
+  }, [scaledDuration, runKey, reducedMotion]);
+
+  if (reducedMotion) {
+    return (
+      <div style={styles.reducedMotion}>
+        Animation suppressed by `prefers-reduced-motion: reduce`.
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.track}>
+      <div
+        style={{
+          ...styles.ball,
+          left: phase === 1 ? 'calc(100% - 32px)' : '4px',
+          transition: `left ${scaledDuration}ms ${easing}`,
+        }}
+        aria-hidden
+      />
+    </div>
+  );
+}

--- a/packages/blocks/src/shadow-preview/ShadowSample.tsx
+++ b/packages/blocks/src/shadow-preview/ShadowSample.tsx
@@ -1,0 +1,21 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface ShadowSampleProps {
+  /** Full dot-path of the shadow token to preview. */
+  path: string;
+}
+
+const sampleStyle: CSSProperties = {
+  width: 120,
+  height: 56,
+  background: 'var(--sb-color-sys-surface-raised, #fff)',
+  border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+  borderRadius: 6,
+};
+
+export function ShadowSample({ path }: ShadowSampleProps): ReactElement {
+  const { cssVarPrefix } = useProject();
+  const cssVar = makeCssVar(path, cssVarPrefix);
+  return <div style={{ ...sampleStyle, boxShadow: cssVar }} aria-hidden />;
+}


### PR DESCRIPTION
**Milestone:** Split large doc blocks into composable subcomponents

**Closes:** Closes #175

**Plan impact:** none

## Summary

- Pull the per-token renderers out of `MotionPreview`, `ShadowPreview`, `BorderPreview`, and `DimensionScale` into standalone components (`MotionSample`, `ShadowSample`, `BorderSample`, `DimensionBar`) so MDX authors can embed a single sample.
- Each extracted sample exports a matching `Props` interface (`MotionSampleProps`, etc.) from `@unpunnyfuns/swatchbook-blocks`. `MotionSample` accepts optional `speed` / `runKey` (used by the parent block's shared controls); `DimensionBar` accepts optional `kind`.
- Parent blocks stay unchanged in DOM output and props — they're now thin iterators that filter, sort, and map over the extracted sample. No behavior change.
- Docs: Blocks table (`packages/blocks/README.md`) and reference page (`apps/docs/docs/reference/blocks.mdx`) gain entries for the four new samples. Minor changeset on `@unpunnyfuns/swatchbook-blocks` for the new exports.
- Added `MotionSample.stories.tsx` to exercise the standalone import end-to-end.

## Test plan

- [x] `pnpm turbo run lint typecheck test build` — 19/19 green
- [x] `pnpm turbo run test:storybook` — 82/82 (was 81/81; +1 for the new `MotionSample` story)
- [x] `BlockAssertions` play-function tests for Motion/Shadow/Border/Dimension stay green with no edits, confirming no DOM change