### PR TITLE
feat(blocks): expose SwatchbookProvider for framework-free rendering

### DIFF
--- a/.changeset/swatchbook-provider.md
+++ b/.changeset/swatchbook-provider.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+Introduce `SwatchbookProvider` + `useSwatchbookData` + `ProjectSnapshot` for framework-free block rendering. Blocks no longer depend on the addon's `virtual:swatchbook/tokens` module when a provider is in the tree, which means they render in plain React apps, unit tests, and non-Storybook doc sites — just hand the provider a `ProjectSnapshot`. The addon's preview decorator now mounts the provider around every story automatically, so Storybook-side authors see no change. The virtual-module fallback stays in place during the transition.

--- a/apps/docs/docs/reference/blocks.mdx
+++ b/apps/docs/docs/reference/blocks.mdx
@@ -18,6 +18,8 @@ The addon must be registered in the same Storybook for the blocks to have data t
 
 ## Usage
 
+### Inside Storybook
+
 ```mdx
 import { ColorPalette, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
@@ -25,6 +27,27 @@ import { ColorPalette, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-b
 <TokenTable filter="size.sys.*" type="dimension" />
 <TokenDetail path="color.sys.accent.bg" />
 ```
+
+The addon's preview decorator wraps every story and docs render in a `SwatchbookProvider`, so no setup is required on the author's side.
+
+### Using blocks outside Storybook
+
+Blocks are pure presentation. Given a `ProjectSnapshot` — the shape the addon internally publishes into `virtual:swatchbook/tokens` — they render in any React tree: unit tests, standalone docs apps, custom tooling.
+
+```tsx
+import { SwatchbookProvider, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+import snapshot from './tokens-snapshot.json';
+
+export function TokenDocs() {
+  return (
+    <SwatchbookProvider value={snapshot}>
+      <TokenTable filter='color.sys.*' />
+    </SwatchbookProvider>
+  );
+}
+```
+
+`SwatchbookProvider` is the canonical entry point. The `virtual:swatchbook/tokens` module is the Storybook addon's internal wiring — do not import from it directly in consumer code.
 
 ## Blocks
 

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -10,6 +10,16 @@ export {
 } from '#/constants.ts';
 export { AxesContext, ThemeContext, useActiveAxes, useActiveTheme } from '#/theme-context.ts';
 export type { AddonOptions } from '#/options.ts';
+export {
+  type ProjectSnapshot,
+  SwatchbookContext,
+  useOptionalSwatchbookData,
+  type VirtualAxisShape,
+  type VirtualDiagnosticShape,
+  type VirtualPresetShape,
+  type VirtualThemeShape,
+  type VirtualTokenShape,
+} from '#/swatchbook-context.ts';
 
 /**
  * CSF Next factory. Consumers call this inside

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -19,6 +19,7 @@ import {
   PARAM_KEY,
   STYLE_ELEMENT_ID,
 } from '#/constants.ts';
+import { type ProjectSnapshot, SwatchbookContext } from '#/swatchbook-context.ts';
 import { AxesContext, ThemeContext } from '#/theme-context.ts';
 
 /** CSS var name with the active prefix applied. */
@@ -183,20 +184,37 @@ const themedDecorator: Decorator = (Story, context) => {
     if (value !== undefined) wrapperAttrs[`data-${axis.name}`] = value;
   }
 
+  const snapshot = useMemo<ProjectSnapshot>(
+    () => ({
+      axes: virtualAxes,
+      presets: virtualPresets,
+      themes,
+      themesResolved,
+      activeTheme: themeName,
+      activeAxes: tuple,
+      cssVarPrefix,
+      diagnostics,
+      css,
+    }),
+    [themeName, tuple],
+  );
+
   return (
-    <ThemeContext.Provider value={themeName}>
-      <AxesContext.Provider value={tuple}>
-        <div
-          {...wrapperAttrs}
-          style={{
-            padding: '1rem',
-            minHeight: '100%',
-          }}
-        >
-          <Story />
-        </div>
-      </AxesContext.Provider>
-    </ThemeContext.Provider>
+    <SwatchbookContext.Provider value={snapshot}>
+      <ThemeContext.Provider value={themeName}>
+        <AxesContext.Provider value={tuple}>
+          <div
+            {...wrapperAttrs}
+            style={{
+              padding: '1rem',
+              minHeight: '100%',
+            }}
+          >
+            <Story />
+          </div>
+        </AxesContext.Provider>
+      </ThemeContext.Provider>
+    </SwatchbookContext.Provider>
   );
 };
 

--- a/packages/addon/src/swatchbook-context.ts
+++ b/packages/addon/src/swatchbook-context.ts
@@ -1,0 +1,79 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Typed shape of the addon's `virtual:swatchbook/tokens` module, duplicated
+ * as value-importable interfaces so consumers outside the addon's Vite
+ * plugin (unit tests, custom React apps) can construct a snapshot by hand.
+ *
+ * The ambient `declare module 'virtual:swatchbook/tokens'` declarations in
+ * `packages/addon/src/virtual.d.ts` describe the same payload; the two
+ * stay in sync by eye.
+ */
+export interface VirtualAxisShape {
+  name: string;
+  contexts: readonly string[];
+  default: string;
+  description?: string;
+  source: 'resolver' | 'synthetic';
+}
+
+export interface VirtualThemeShape {
+  name: string;
+  input: Record<string, string>;
+  sources: string[];
+}
+
+export interface VirtualDiagnosticShape {
+  severity: 'error' | 'warn' | 'info';
+  group: string;
+  message: string;
+  filename?: string;
+  line?: number;
+  column?: number;
+}
+
+export interface VirtualTokenShape {
+  $type?: string;
+  $value?: unknown;
+  $description?: string;
+  aliasOf?: string;
+  aliasChain?: readonly string[];
+  aliasedBy?: readonly string[];
+}
+
+export interface VirtualPresetShape {
+  name: string;
+  axes: Partial<Record<string, string>>;
+  description?: string;
+}
+
+/**
+ * Full project data read by blocks. Populated by the addon's preview
+ * decorator (from the virtual module) or constructed by hand in
+ * non-Storybook consumers.
+ */
+export interface ProjectSnapshot {
+  axes: readonly VirtualAxisShape[];
+  presets: readonly VirtualPresetShape[];
+  themes: readonly VirtualThemeShape[];
+  themesResolved: Record<string, Record<string, VirtualTokenShape>>;
+  activeTheme: string;
+  activeAxes: Readonly<Record<string, string>>;
+  cssVarPrefix: string;
+  diagnostics: readonly VirtualDiagnosticShape[];
+  css: string;
+}
+
+/**
+ * Context carrying the full {@link ProjectSnapshot}. `null` sentinel lets
+ * the blocks-side `useProject()` hook tell "provider present" from "fall
+ * back to the virtual module". The context itself lives in the addon
+ * package (not blocks) to keep the dependency graph acyclic — blocks
+ * already depends on addon; reversing that would break turbo's
+ * topological build order.
+ */
+export const SwatchbookContext = createContext<ProjectSnapshot | null>(null);
+
+export function useOptionalSwatchbookData(): ProjectSnapshot | null {
+  return useContext(SwatchbookContext);
+}

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -38,7 +38,11 @@ Requires `@unpunnyfuns/swatchbook-addon` to be registered in your Storybook conf
 
 Shared: every block accepts a `caption` override and renders against the addon's `var(--<prefix>-…)` output.
 
-## MDX example
+## Usage
+
+### Inside Storybook
+
+The addon's preview decorator wraps every story in a `SwatchbookProvider` for you, so MDX and story authors drop blocks in directly:
 
 ```mdx
 import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
@@ -56,6 +60,25 @@ import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-b
 <TokenDetail path="color.sys.accent.bg" />
 ```
 
+### Outside Storybook
+
+Blocks are pure presentation — given a `ProjectSnapshot` they render without any Storybook or Vite plugin. Mount a `SwatchbookProvider` at the top of your tree:
+
+```tsx
+import { SwatchbookProvider, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+import snapshot from './tokens-snapshot.json';
+
+export function TokenDocs() {
+  return (
+    <SwatchbookProvider value={snapshot}>
+      <TokenTable filter='color.sys.*' />
+    </SwatchbookProvider>
+  );
+}
+```
+
+`SwatchbookProvider` is the canonical integration point. The `virtual:swatchbook/tokens` module is the Storybook addon's internal wiring, not a public API.
+
 ## Props
 
 ```ts
@@ -69,7 +92,8 @@ import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-b
 
 - ✅ React to the active swatchbook theme — switching in the toolbar updates resolved values live, even on MDX docs pages.
 - ✅ Compose multiple blocks per MDX page — each mounts independently.
-- ❌ Don't run outside Storybook's preview/docs iframe — blocks rely on the addon's virtual token module.
+- ✅ Render blocks outside Storybook by wrapping them in `SwatchbookProvider` with a hand-built or loaded `ProjectSnapshot`.
+- ❌ Don't import from `virtual:swatchbook/tokens` directly — it's the addon's internal wiring, not a public API. Use `SwatchbookProvider` instead.
 - ❌ Don't use `useGlobals` / `useArgs` from `storybook/preview-api` inside custom blocks you write — those are story-only hooks and throw in docs context. Subscribe to `addons.getChannel()` directly for globals reactivity.
 
 ## See also

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -27,9 +27,11 @@
   "scripts": {
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src",
-    "format": "oxfmt -c ../../.oxfmtrc.json src",
-    "format:check": "oxfmt --check -c ../../.oxfmtrc.json src"
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
+    "format": "oxfmt -c ../../.oxfmtrc.json src test",
+    "format:check": "oxfmt --check -c ../../.oxfmtrc.json src test"
   },
   "dependencies": {
     "@unpunnyfuns/swatchbook-addon": "workspace:*"
@@ -40,11 +42,15 @@
     "storybook": "^10.3.5"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
+    "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "storybook": "^10.3.5",
     "tsdown": "^0.21.9",
-    "typescript": "^6.0.0"
+    "typescript": "^6.0.0",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -7,6 +7,19 @@ export { FontFamilySample, type FontFamilySampleProps } from '#/FontFamilySample
 export { FontWeightScale, type FontWeightScaleProps } from '#/FontWeightScale.tsx';
 export { GradientPalette, type GradientPaletteProps } from '#/GradientPalette.tsx';
 export { MotionPreview, type MotionPreviewProps, type MotionSpeed } from '#/MotionPreview.tsx';
+export {
+  SwatchbookProvider,
+  type SwatchbookProviderProps,
+  useSwatchbookData,
+} from '#/provider.tsx';
+export type {
+  ProjectSnapshot,
+  VirtualAxis,
+  VirtualDiagnostic,
+  VirtualPreset,
+  VirtualTheme,
+  VirtualToken,
+} from '#/types.ts';
 export { MotionSample, type MotionSampleProps } from '#/motion-preview/MotionSample.tsx';
 export { ShadowPreview, type ShadowPreviewProps } from '#/ShadowPreview.tsx';
 export { ShadowSample, type ShadowSampleProps } from '#/shadow-preview/ShadowSample.tsx';

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { addons } from 'storybook/preview-api';
+import { useOptionalSwatchbookData } from '@unpunnyfuns/swatchbook-addon';
 import { useActiveAxes, useActiveTheme } from '@unpunnyfuns/swatchbook-addon/hooks';
 import {
   axes as virtualAxes,
@@ -9,18 +10,17 @@ import {
   themes,
   themesResolved,
 } from 'virtual:swatchbook/tokens';
+import type { ProjectSnapshot, VirtualAxis, VirtualTheme, VirtualToken } from '#/types.ts';
 
-type VirtualTokens = typeof themesResolved;
-type ResolvedTokens = VirtualTokens[string];
-type VirtualAxes = typeof virtualAxes;
+type ResolvedTokens = Record<string, VirtualToken>;
 
 export interface ProjectData {
   activeTheme: string;
   activeAxes: Record<string, string>;
-  axes: VirtualAxes;
-  themes: typeof themes;
+  axes: readonly VirtualAxis[];
+  themes: readonly VirtualTheme[];
   resolved: ResolvedTokens;
-  themesResolved: VirtualTokens;
+  themesResolved: Record<string, ResolvedTokens>;
   cssVarPrefix: string;
 }
 
@@ -28,7 +28,7 @@ const STYLE_ELEMENT_ID = 'swatchbook-tokens';
 const GLOBAL_KEY = 'swatchbookTheme';
 const AXES_GLOBAL_KEY = 'swatchbookAxes';
 
-function ensureStylesheet(): void {
+function ensureStylesheet(css: string): void {
   if (typeof document === 'undefined') return;
   let style = document.getElementById(STYLE_ELEMENT_ID) as HTMLStyleElement | null;
   if (!style) {
@@ -36,21 +36,24 @@ function ensureStylesheet(): void {
     style.id = STYLE_ELEMENT_ID;
     document.head.appendChild(style);
   }
-  if (style.textContent !== generatedCss) style.textContent = generatedCss;
+  if (style.textContent !== css) style.textContent = css;
 }
 
 interface GlobalsPayload {
   globals?: Record<string, unknown>;
 }
 
-function defaultTuple(): Record<string, string> {
+function defaultTuple(axes: readonly VirtualAxis[]): Record<string, string> {
   const out: Record<string, string> = {};
-  for (const axis of virtualAxes) out[axis.name] = axis.default;
+  for (const axis of axes) out[axis.name] = axis.default;
   return out;
 }
 
-function tupleForName(name: string): Record<string, string> | undefined {
-  const match = themes.find((t) => t.name === name);
+function tupleForName(
+  themesList: readonly VirtualTheme[],
+  name: string,
+): Record<string, string> | undefined {
+  const match = themesList.find((t) => t.name === name);
   return match?.input;
 }
 
@@ -62,32 +65,57 @@ function tuplesEqual(a: Record<string, string>, b: Record<string, string>): bool
   return true;
 }
 
-function nameForTuple(tuple: Record<string, string>): string | undefined {
-  const match = themes.find((t) => tuplesEqual(t.input as Record<string, string>, tuple));
+function nameForTuple(
+  themesList: readonly VirtualTheme[],
+  tuple: Record<string, string>,
+): string | undefined {
+  const match = themesList.find((t) => tuplesEqual(t.input as Record<string, string>, tuple));
   return match?.name;
 }
 
+function snapshotToData(snapshot: ProjectSnapshot): ProjectData {
+  return {
+    activeTheme: snapshot.activeTheme,
+    activeAxes: { ...snapshot.activeAxes },
+    axes: snapshot.axes,
+    themes: snapshot.themes,
+    themesResolved: snapshot.themesResolved,
+    resolved: snapshot.themesResolved[snapshot.activeTheme] ?? {},
+    cssVarPrefix: snapshot.cssVarPrefix,
+  };
+}
+
 /**
- * One-stop hook for block components. Self-mounts the virtual module's
- * per-theme CSS (so blocks work in MDX/autodocs, not just inside a story
- * where the addon's decorator runs) and tracks the active tuple via
- * Storybook's `globalsUpdated` channel event.
+ * Reads project data either from a mounted {@link SwatchbookProvider}
+ * (preferred — the addon's preview decorator installs one around every
+ * story) or — as a back-compat fallback — directly from the virtual
+ * module plus Storybook globals.
  *
- * Can't use `useGlobals` from `storybook/preview-api` — that's a story
- * hook that throws "Storybook preview hooks can only be called inside
- * decorators and story functions" when called from MDX doc blocks.
+ * The fallback path is what makes the hook safe to call from MDX doc
+ * blocks and autodocs renders where no story is active. It self-mounts
+ * the virtual module's per-theme CSS and tracks the active tuple via the
+ * `globalsUpdated` channel event; {@link useGlobals} from
+ * `storybook/preview-api` would throw outside a story render.
  */
 export function useProject(): ProjectData {
+  const snapshot = useOptionalSwatchbookData();
+  const fallback = useVirtualModuleFallback(snapshot === null);
+  return snapshot !== null ? snapshotToData(snapshot) : fallback;
+}
+
+function useVirtualModuleFallback(enabled: boolean): ProjectData {
   const contextTheme = useActiveTheme();
   const contextAxes = useActiveAxes();
   const [channelTheme, setChannelTheme] = useState<string | null>(null);
   const [channelAxes, setChannelAxes] = useState<Record<string, string> | null>(null);
 
   useEffect(() => {
-    ensureStylesheet();
-  }, []);
+    if (!enabled) return;
+    ensureStylesheet(generatedCss);
+  }, [enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     const channel = addons.getChannel();
     const onGlobals = (payload: GlobalsPayload): void => {
       const nextTheme = payload.globals?.[GLOBAL_KEY];
@@ -103,15 +131,16 @@ export function useProject(): ProjectData {
       channel.off('globalsUpdated', onGlobals);
       channel.off('updateGlobals', onGlobals);
     };
-  }, []);
+  }, [enabled]);
 
   const hasContextAxes = Object.keys(contextAxes).length > 0;
   const activeAxes: Record<string, string> = hasContextAxes
     ? { ...contextAxes }
-    : (channelAxes ?? defaultTuple());
+    : (channelAxes ?? defaultTuple(virtualAxes));
 
-  const derivedName = nameForTuple(activeAxes);
-  const fallbackTupleName = channelTheme && tupleForName(channelTheme) ? channelTheme : null;
+  const derivedName = nameForTuple(themes, activeAxes);
+  const fallbackTupleName =
+    channelTheme && tupleForName(themes, channelTheme) ? channelTheme : null;
   const activeTheme =
     contextTheme ||
     derivedName ||
@@ -140,7 +169,6 @@ export function makeCssVar(path: string, prefix: string): string {
 export function globMatch(path: string, glob: string | undefined): boolean {
   if (!glob) return true;
   if (glob === '*' || glob === '**') return true;
-  // Accept simple `prefix.*` patterns plus exact matches.
   if (glob.endsWith('.*')) return path.startsWith(`${glob.slice(0, -2)}.`);
   if (glob.endsWith('**')) return path.startsWith(glob.slice(0, -2));
   return path === glob || path.startsWith(`${glob}.`);

--- a/packages/blocks/src/provider.tsx
+++ b/packages/blocks/src/provider.tsx
@@ -1,0 +1,46 @@
+import type { ReactElement, ReactNode } from 'react';
+import {
+  type ProjectSnapshot,
+  SwatchbookContext,
+  useOptionalSwatchbookData,
+} from '@unpunnyfuns/swatchbook-addon';
+
+export type { ProjectSnapshot };
+
+export interface SwatchbookProviderProps {
+  value: ProjectSnapshot;
+  children: ReactNode;
+}
+
+/**
+ * Wraps a tree of blocks with the token data they need to render.
+ *
+ * The Storybook addon's preview decorator mounts this automatically, so
+ * story/MDX authors typically never see it. Outside Storybook — unit
+ * tests, custom React apps, non-Storybook doc sites — consumers construct
+ * a {@link ProjectSnapshot} (often imported from a JSON file) and wrap
+ * their blocks in this provider.
+ *
+ * The underlying React context lives in the addon package so the
+ * workspace dep graph stays acyclic (blocks already depends on addon;
+ * the reverse would break turbo's topological build order).
+ */
+export function SwatchbookProvider({ value, children }: SwatchbookProviderProps): ReactElement {
+  return <SwatchbookContext.Provider value={value}>{children}</SwatchbookContext.Provider>;
+}
+
+/**
+ * Read the current {@link ProjectSnapshot}. Throws if called outside a
+ * {@link SwatchbookProvider}; blocks that need to fall back to the
+ * virtual module go through the internal `useProject()` hook instead.
+ */
+export function useSwatchbookData(): ProjectSnapshot {
+  const value = useOptionalSwatchbookData();
+  if (!value) {
+    throw new Error(
+      '[swatchbook-blocks] useSwatchbookData() called outside <SwatchbookProvider>. ' +
+        'Wrap your tree in <SwatchbookProvider value={snapshot}> or render inside a Storybook story.',
+    );
+  }
+  return value;
+}

--- a/packages/blocks/src/types.ts
+++ b/packages/blocks/src/types.ts
@@ -1,0 +1,15 @@
+/**
+ * Shared data shapes re-exported from `@unpunnyfuns/swatchbook-addon`.
+ * The addon owns the canonical declarations (adjacent to the Vite plugin
+ * that emits the matching runtime payload); blocks re-exposes them under
+ * friendlier names so consumers importing from
+ * `@unpunnyfuns/swatchbook-blocks` don't also have to pull from addon.
+ */
+export {
+  type ProjectSnapshot,
+  type VirtualAxisShape as VirtualAxis,
+  type VirtualDiagnosticShape as VirtualDiagnostic,
+  type VirtualPresetShape as VirtualPreset,
+  type VirtualThemeShape as VirtualTheme,
+  type VirtualTokenShape as VirtualToken,
+} from '@unpunnyfuns/swatchbook-addon';

--- a/packages/blocks/test/token-table.test.tsx
+++ b/packages/blocks/test/token-table.test.tsx
@@ -1,0 +1,100 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { type ProjectSnapshot, SwatchbookProvider, TokenTable } from '#/index.ts';
+
+function makeSnapshot(): ProjectSnapshot {
+  return {
+    axes: [
+      {
+        name: 'mode',
+        contexts: ['light', 'dark'],
+        default: 'light',
+        source: 'resolver',
+      },
+    ],
+    presets: [],
+    themes: [
+      { name: 'Light', input: { mode: 'light' }, sources: [] },
+      { name: 'Dark', input: { mode: 'dark' }, sources: [] },
+    ],
+    themesResolved: {
+      Light: {
+        'color.sys.text': {
+          $type: 'color',
+          $value: { hex: '#111111' },
+          $description: 'Primary text.',
+        },
+        'color.sys.surface': {
+          $type: 'color',
+          $value: { hex: '#ffffff' },
+          $description: 'Default surface.',
+        },
+        'space.sys.md': {
+          $type: 'dimension',
+          $value: { value: 16, unit: 'px' },
+        },
+      },
+      Dark: {},
+    },
+    activeTheme: 'Light',
+    activeAxes: { mode: 'light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+}
+
+describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders TokenTable rows from a hand-built snapshot', () => {
+    const snapshot = makeSnapshot();
+
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable />
+      </SwatchbookProvider>,
+    );
+
+    const table = screen.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+    expect(rows.length).toBe(4);
+
+    expect(within(table).getByText('color.sys.text')).toBeDefined();
+    expect(within(table).getByText('color.sys.surface')).toBeDefined();
+    expect(within(table).getByText('space.sys.md')).toBeDefined();
+
+    expect(within(table).getByText('var(--sb-color-sys-text)')).toBeDefined();
+  });
+
+  it('honors the filter prop to narrow to a path subtree', () => {
+    const snapshot = makeSnapshot();
+
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable filter='color.sys.*' />
+      </SwatchbookProvider>,
+    );
+
+    const table = screen.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+    expect(rows.length).toBe(3);
+
+    expect(within(table).queryByText('space.sys.md')).toBeNull();
+  });
+
+  it('renders the empty state when the filter matches nothing', () => {
+    const snapshot = makeSnapshot();
+
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable filter='typography.sys.*' />
+      </SwatchbookProvider>,
+    );
+
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getByText('No tokens match this filter.')).toBeDefined();
+  });
+});

--- a/packages/blocks/test/virtual-stub.ts
+++ b/packages/blocks/test/virtual-stub.ts
@@ -1,0 +1,14 @@
+/**
+ * Empty stand-in for `virtual:swatchbook/tokens`. The provider-first path
+ * exercised in tests never reads these exports; the stub just lets
+ * `#/internal/use-project.ts`'s module-level imports resolve when no
+ * addon Vite plugin is in the pipeline.
+ */
+export const axes = [] as const;
+export const presets = [] as const;
+export const themes = [] as const;
+export const defaultTheme = null;
+export const themesResolved = {};
+export const diagnostics = [] as const;
+export const css = '';
+export const cssVarPrefix = '';

--- a/packages/blocks/tsconfig.json
+++ b/packages/blocks/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": []
   },
-  "include": ["src"]
+  "include": ["src", "test", "vitest.config.ts"]
 }

--- a/packages/blocks/vitest.config.ts
+++ b/packages/blocks/vitest.config.ts
@@ -1,0 +1,19 @@
+import { fileURLToPath } from 'node:url';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      'virtual:swatchbook/tokens': fileURLToPath(
+        new URL('./test/virtual-stub.ts', import.meta.url),
+      ),
+    },
+  },
+  test: {
+    include: ['test/**/*.test.{ts,tsx}'],
+    environment: 'jsdom',
+    reporters: ['default'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
 
   apps/docs:
     dependencies:
@@ -144,7 +144,7 @@ importers:
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
 
   packages/addon:
     dependencies:
@@ -189,9 +189,18 @@ importers:
         specifier: workspace:*
         version: link:../addon
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       react:
         specifier: ^19.2.4
         version: 19.2.5
@@ -207,6 +216,9 @@ importers:
       typescript:
         specifier: ^6.0.0
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
 
   packages/core:
     dependencies:
@@ -234,7 +246,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
 
   packages/tokens-reference:
     devDependencies:
@@ -348,6 +360,21 @@ packages:
   '@algolia/requester-node-http@5.50.2':
     resolution: {integrity: sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==}
     engines: {node: '>= 14.0.0'}
+
+  '@asamuzakjp/css-color@5.1.11':
+    resolution: {integrity: sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@7.1.0':
+    resolution: {integrity: sha512-ASf825+5vsGuYWoyFyNsex2mNtPTXpCvYTR942+w/eNw7PqS0Lhl/PE1hC7bajneI3m/Oxi+yrP3vTOPxfwM8A==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/generational-cache@1.0.1':
+    resolution: {integrity: sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  '@asamuzakjp/nwsapi@2.3.9':
+    resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -943,6 +970,10 @@ packages:
   '@blazediff/core@1.9.1':
     resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
 
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
   '@changesets/apply-release-plan@7.1.0':
     resolution: {integrity: sha512-yq8ML3YS7koKQ/9bk1PqO0HMzApIFNwjlwCnwFEXMzNe8NpzeeYYKCmnhWJGkN8g7E51MnWaSbqRcTcdIxUgnQ==}
 
@@ -1019,12 +1050,23 @@ packages:
     resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
     engines: {node: '>=18'}
 
+  '@csstools/color-helpers@6.0.2':
+    resolution: {integrity: sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==}
+    engines: {node: '>=20.19.0'}
+
   '@csstools/css-calc@2.1.4':
     resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
 
   '@csstools/css-color-parser@3.1.0':
     resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
@@ -1033,15 +1075,40 @@ packages:
       '@csstools/css-parser-algorithms': ^3.0.5
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-color-parser@4.1.0':
+    resolution: {integrity: sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
   '@csstools/css-parser-algorithms@3.0.5':
     resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
     engines: {node: '>=18'}
     peerDependencies:
       '@csstools/css-tokenizer': ^3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@csstools/media-query-list-parser@4.0.3':
     resolution: {integrity: sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==}
@@ -1690,6 +1757,15 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@exodus/bytes@1.15.0':
+    resolution: {integrity: sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@hapi/hoek@9.3.0':
     resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
@@ -2924,6 +3000,21 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -3524,6 +3615,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
+
   big.js@5.2.2:
     resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
 
@@ -3936,6 +4030,10 @@ packages:
     resolution: {integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
   css-what@6.2.2:
     resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
     engines: {node: '>= 6'}
@@ -3982,6 +4080,10 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -4001,6 +4103,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -4621,6 +4726,10 @@ packages:
   hpack.js@2.1.6:
     resolution: {integrity: sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -4874,6 +4983,9 @@ packages:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
     engines: {node: '>=0.10.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regexp@1.0.0:
     resolution: {integrity: sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==}
     engines: {node: '>=0.10.0'}
@@ -4970,6 +5082,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@29.0.2:
+    resolution: {integrity: sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.0.0}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -5244,6 +5365,9 @@ packages:
 
   mdn-data@2.0.30:
     resolution: {integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
   media-typer@0.3.0:
     resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
@@ -5680,6 +5804,9 @@ packages:
 
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
+  parse5@8.0.0:
+    resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -6515,6 +6642,10 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -6826,6 +6957,9 @@ packages:
       '@swc/core': ^1.2.147
       webpack: '>=2'
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tapable@2.3.2:
     resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
     engines: {node: '>=6'}
@@ -6901,6 +7035,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@7.0.28:
+    resolution: {integrity: sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==}
+
+  tldts@7.0.28:
+    resolution: {integrity: sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==}
+    hasBin: true
+
   tmcp@1.19.3:
     resolution: {integrity: sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==}
 
@@ -6915,6 +7056,14 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tough-cookie@6.0.1:
+    resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   tree-dump@1.1.0:
     resolution: {integrity: sha512-rMuvhU4MCDbcbnleZTFezWsaZXRFemSqAM+7jPnzUl1fo9w3YEKOxAeui0fz3OI4EU4hf23iyA7uQRVko+UaBA==}
@@ -7007,6 +7156,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -7236,6 +7389,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
@@ -7245,6 +7402,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
 
   webpack-bundle-analyzer@4.10.2:
     resolution: {integrity: sha512-vJptkMm9pk5si4Bv922ZbKLV8UTT4zib4FPgXMhgzUny0bfDDkLXAVQs3ly3fS4/TN9ROFtb0NFrm04UXFE/Vw==}
@@ -7318,6 +7479,14 @@ packages:
     resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
     engines: {node: '>=0.8.0'}
 
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -7380,6 +7549,13 @@ packages:
   xml-js@1.6.11:
     resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
     hasBin: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -7524,6 +7700,26 @@ snapshots:
   '@algolia/requester-node-http@5.50.2':
     dependencies:
       '@algolia/client-common': 5.50.2
+
+  '@asamuzakjp/css-color@5.1.11':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@asamuzakjp/dom-selector@7.1.0':
+    dependencies:
+      '@asamuzakjp/generational-cache': 1.0.1
+      '@asamuzakjp/nwsapi': 2.3.9
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+
+  '@asamuzakjp/generational-cache@1.0.1': {}
+
+  '@asamuzakjp/nwsapi@2.3.9': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -8300,6 +8496,10 @@ snapshots:
 
   '@blazediff/core@1.9.1': {}
 
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
   '@changesets/apply-release-plan@7.1.0':
     dependencies:
       '@changesets/config': 3.1.3
@@ -8465,10 +8665,17 @@ snapshots:
 
   '@csstools/color-helpers@5.1.0': {}
 
+  '@csstools/color-helpers@6.0.2': {}
+
   '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
 
   '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -8477,11 +8684,28 @@ snapshots:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-color-parser@4.1.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.0.2
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
   '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
     dependencies:
       '@csstools/css-tokenizer': 3.0.4
 
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@csstools/media-query-list-parser@4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
     dependencies:
@@ -9659,6 +9883,8 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
+  '@exodus/bytes@1.15.0': {}
+
   '@hapi/hoek@9.3.0': {}
 
   '@hapi/topo@5.1.0':
@@ -10423,7 +10649,7 @@ snapshots:
       '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))(vitest@4.1.4)
       '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))(vitest@4.1.4)
       '@vitest/runner': 4.1.4
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
     transitivePeerDependencies:
       - react
       - react-dom
@@ -10759,6 +10985,16 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
     dependencies:
       '@testing-library/dom': 10.4.1
@@ -11032,7 +11268,7 @@ snapshots:
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
       playwright: 1.59.1
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -11048,7 +11284,7 @@ snapshots:
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
       ws: 8.20.0
     transitivePeerDependencies:
       - bufferutil
@@ -11068,7 +11304,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
     optionalDependencies:
       '@vitest/browser': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))(vitest@4.1.4)
 
@@ -11132,7 +11368,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11443,6 +11679,10 @@ snapshots:
   better-path-resolve@1.0.0:
     dependencies:
       is-windows: 1.0.2
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   big.js@5.2.2: {}
 
@@ -11863,6 +12103,11 @@ snapshots:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
   css-what@6.2.2: {}
 
   css.escape@1.5.1: {}
@@ -11932,6 +12177,13 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   debounce@1.2.1: {}
 
   debug@2.6.9:
@@ -11941,6 +12193,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -12666,6 +12920,12 @@ snapshots:
       readable-stream: 2.3.8
       wbuf: 1.7.3
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   html-escaper@2.0.2: {}
 
   html-minifier-terser@6.1.0:
@@ -12885,6 +13145,8 @@ snapshots:
     dependencies:
       isobject: 3.0.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regexp@1.0.0: {}
 
   is-stream@2.0.1: {}
@@ -12976,6 +13238,32 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@29.0.2:
+    dependencies:
+      '@asamuzakjp/css-color': 5.1.11
+      '@asamuzakjp/dom-selector': 7.1.0
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.0
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.3.5
+      parse5: 8.0.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.1
+      undici: 7.25.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -13332,6 +13620,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.0.30: {}
+
+  mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
 
@@ -13951,6 +14241,10 @@ snapshots:
       parse5: 7.3.0
 
   parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
+  parse5@8.0.0:
     dependencies:
       entities: 6.0.1
 
@@ -14930,6 +15224,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   schema-dts@1.1.5: {}
@@ -15301,6 +15599,8 @@ snapshots:
       '@swc/counter': 0.1.3
       webpack: 5.106.2(@swc/core@1.15.26)(esbuild@0.27.7)
 
+  symbol-tree@3.2.4: {}
+
   tapable@2.3.2: {}
 
   term-size@2.2.1: {}
@@ -15363,6 +15663,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@7.0.28: {}
+
+  tldts@7.0.28:
+    dependencies:
+      tldts-core: 7.0.28
+
   tmcp@1.19.3(typescript@6.0.3):
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -15380,6 +15686,14 @@ snapshots:
   toidentifier@1.0.1: {}
 
   totalist@3.0.1: {}
+
+  tough-cookie@6.0.1:
+    dependencies:
+      tldts: 7.0.28
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   tree-dump@1.1.0(tslib@2.8.1):
     dependencies:
@@ -15464,6 +15778,8 @@ snapshots:
       quansync: 1.0.0
 
   undici-types@7.19.2: {}
+
+  undici@7.25.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -15625,7 +15941,7 @@ snapshots:
       jiti: 2.6.1
       terser: 5.46.1
 
-  vitest@4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)):
+  vitest@4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
@@ -15652,8 +15968,13 @@ snapshots:
       '@vitest/browser-playwright': 4.1.4(playwright@1.59.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))(vitest@4.1.4)
       '@vitest/coverage-v8': 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
       '@vitest/ui': 4.1.4(vitest@4.1.4)
+      jsdom: 29.0.2
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
 
   watchpack@2.5.1:
     dependencies:
@@ -15665,6 +15986,8 @@ snapshots:
       minimalistic-assert: 1.0.1
 
   web-namespaces@2.0.1: {}
+
+  webidl-conversions@8.0.1: {}
 
   webpack-bundle-analyzer@4.10.2:
     dependencies:
@@ -15833,6 +16156,16 @@ snapshots:
 
   websocket-extensions@0.1.4: {}
 
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.0
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -15876,6 +16209,10 @@ snapshots:
   xml-js@1.6.11:
     dependencies:
       sax: 1.6.0
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
**Milestone:** Presentation/connection split for blocks

**Closes:** Closes #196

**Plan impact:** none

## Summary

- New exports from `@unpunnyfuns/swatchbook-blocks`: `SwatchbookProvider`, `useSwatchbookData`, `ProjectSnapshot` (+ the `Virtual*` shapes). Blocks now read from a React context instead of the addon's `virtual:swatchbook/tokens` module.
- The React context itself lives in the addon package (`swatchbook-context.ts`) to keep the workspace dep graph acyclic — blocks already depends on addon; reversing that direction breaks turbo's topological build order. Blocks re-exports the provider + types under a friendlier name.
- The addon's preview decorator now mounts `<SwatchbookProvider value={snapshot}>` around every story, so Storybook-side authors see no change. `ThemeContext`/`AxesContext` stay as-is (the toolbar/panel still read through them).
- Virtual-module fallback in `useProject()` kept in place: if no provider is present, blocks behave exactly as before (reads from the virtual module, tracks `globalsUpdated`, self-mounts the stylesheet). Dropping that fallback is a future major.
- README + `apps/docs/docs/reference/blocks.mdx` lead with the provider pattern and flag `virtual:swatchbook/tokens` as internal.

## Test plan

- [x] `pnpm turbo run lint typecheck test build` — 20/20 green (includes new `packages/blocks/test/token-table.test.tsx`)
- [x] `pnpm turbo run test:storybook` — 82/82 green
- [x] New vitest + RTL test renders `<SwatchbookProvider value={snapshot}><TokenTable /></SwatchbookProvider>` with zero addon/Vite/Storybook dependency at runtime (3 cases: full render, filter, empty state)
- [x] Changeset: `minor` bump on `@unpunnyfuns/swatchbook-blocks` + `@unpunnyfuns/swatchbook-addon`