### PR TITLE
chore(storybook): add parity stories for extracted blocks and TokenDetail subcomponents

### DIFF
--- a/apps/storybook/src/stories/BorderSample.stories.tsx
+++ b/apps/storybook/src/stories/BorderSample.stories.tsx
@@ -1,0 +1,15 @@
+import { BorderSample } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/Samples/BorderSample',
+  component: BorderSample,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const Default = meta.story({ args: { path: 'border.sys.default' } });
+export const Focus = meta.story({ args: { path: 'border.sys.focus' } });

--- a/apps/storybook/src/stories/DimensionBar.stories.tsx
+++ b/apps/storybook/src/stories/DimensionBar.stories.tsx
@@ -1,0 +1,17 @@
+import { DimensionBar } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/Samples/DimensionBar',
+  component: DimensionBar,
+  argTypes: {
+    path: { control: 'text' },
+    kind: { control: { type: 'inline-radio' }, options: ['length', 'radius', 'size'] },
+  },
+});
+
+export default meta;
+
+export const SpaceMd = meta.story({ args: { path: 'space.sys.md' } });
+export const SpaceLg = meta.story({ args: { path: 'space.sys.lg' } });
+export const RadiusLg = meta.story({ args: { path: 'radius.sys.lg', kind: 'radius' } });

--- a/apps/storybook/src/stories/ShadowSample.stories.tsx
+++ b/apps/storybook/src/stories/ShadowSample.stories.tsx
@@ -1,0 +1,14 @@
+import { ShadowSample } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/Samples/ShadowSample',
+  component: ShadowSample,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const Default = meta.story({ args: { path: 'shadow.sys.md' } });

--- a/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
@@ -1,0 +1,15 @@
+import { AliasChain } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail/AliasChain',
+  component: AliasChain,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const AccentBg = meta.story({ args: { path: 'color.sys.accent.bg' } });
+export const SpaceMd = meta.story({ args: { path: 'space.sys.md' } });

--- a/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
@@ -1,0 +1,15 @@
+import { AliasedBy } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail/AliasedBy',
+  component: AliasedBy,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const RefNeutralZero = meta.story({ args: { path: 'color.ref.neutral.0' } });
+export const RefBlue500 = meta.story({ args: { path: 'color.ref.blue.500' } });

--- a/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
@@ -1,0 +1,15 @@
+import { AxisVariance } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail/AxisVariance',
+  component: AxisVariance,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const AccentBg = meta.story({ args: { path: 'color.sys.accent.bg' } });
+export const SurfaceDefault = meta.story({ args: { path: 'color.sys.surface.default' } });

--- a/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
@@ -1,0 +1,18 @@
+import { CompositeBreakdown } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail/CompositeBreakdown',
+  component: CompositeBreakdown,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const Typography = meta.story({ args: { path: 'typography.sys.heading' } });
+export const Shadow = meta.story({ args: { path: 'shadow.sys.md' } });
+export const Border = meta.story({ args: { path: 'border.sys.default' } });
+export const Transition = meta.story({ args: { path: 'motion.sys.enter' } });
+export const Gradient = meta.story({ args: { path: 'gradient.ref.sunrise' } });

--- a/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
@@ -1,0 +1,20 @@
+import { CompositePreview } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail/CompositePreview',
+  component: CompositePreview,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const Color = meta.story({ args: { path: 'color.sys.accent.bg' } });
+export const Shadow = meta.story({ args: { path: 'shadow.sys.md' } });
+export const Border = meta.story({ args: { path: 'border.sys.default' } });
+export const Transition = meta.story({ args: { path: 'motion.sys.enter' } });
+export const Typography = meta.story({ args: { path: 'typography.sys.body' } });
+export const Gradient = meta.story({ args: { path: 'gradient.ref.sunrise' } });
+export const StrokeStyle = meta.story({ args: { path: 'stroke.ref.style.custom-dash' } });

--- a/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
@@ -1,0 +1,18 @@
+import { TokenHeader } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail/TokenHeader',
+  component: TokenHeader,
+  argTypes: {
+    path: { control: 'text' },
+    heading: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const Default = meta.story({ args: { path: 'color.sys.accent.bg' } });
+export const WithHeading = meta.story({
+  args: { path: 'typography.sys.heading', heading: 'Heading typography' },
+});

--- a/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
@@ -1,0 +1,15 @@
+import { TokenUsageSnippet } from '@unpunnyfuns/swatchbook-blocks';
+import preview from '../../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/TokenDetail/TokenUsageSnippet',
+  component: TokenUsageSnippet,
+  argTypes: {
+    path: { control: 'text' },
+  },
+});
+
+export default meta;
+
+export const Color = meta.story({ args: { path: 'color.sys.accent.bg' } });
+export const Space = meta.story({ args: { path: 'space.sys.md' } });


### PR DESCRIPTION
**Milestone:** Storybook review and config simplification

**Closes:** Closes #197

**Plan impact:** none

## Summary

Audit of `apps/storybook/src/stories/` found that PRs #174 (TokenDetail split) and #175 (sample primitives) added 10 new public components to `@unpunnyfuns/swatchbook-blocks` but only `MotionSample` got a standalone story. The other 9 were exercised only transitively through `BlockAssertions` play-functions or the parent block stories.

Added a minimal display story per newcomer:

- `Blocks/Samples/ShadowSample`
- `Blocks/Samples/BorderSample`
- `Blocks/Samples/DimensionBar`
- `Blocks/TokenDetail/TokenHeader`
- `Blocks/TokenDetail/AliasChain`
- `Blocks/TokenDetail/AliasedBy`
- `Blocks/TokenDetail/CompositePreview`
- `Blocks/TokenDetail/CompositeBreakdown`
- `Blocks/TokenDetail/AxisVariance`
- `Blocks/TokenDetail/TokenUsageSnippet`

TokenDetail subcomponents live under a `token-detail/` subfolder to keep the sidebar navigable.

No assertion coverage added — `BlockAssertions.stories.tsx` already owns that. Test count went 82 → 110 because Storybook Test auto-mounts each exported story as a smoke test.

Titles, sidebar ordering, and the `Blocks/` / `Components/` / `Hooks/` / `Tests/` / `Docs/` split all already follow a consistent convention — no renames or reorganization needed beyond adding the missing stories.

## Test plan

- [x] `pnpm turbo run lint typecheck test build` green (19/19)
- [x] `pnpm turbo run test:storybook` green (110/110; was 82/82)