### PR TITLE
feat(tokens-reference): extend fixture with contrast axis

### DIFF
--- a/.changeset/three-axis-fixture.md
+++ b/.changeset/three-axis-fixture.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+The bundled `tokens-reference` fixture gains a `contrast` axis (`Normal` / `High`), composing with `mode` and `brand` for 8 total themes. The `High` context thickens borders and swaps the focus ring to a high-contrast yellow; surfaces and accents stay owned by `mode` and `brand`. A new `A11y High Contrast` preset demonstrates the composition. Consumers of the fixture see three toolbar dropdowns and three-segment theme names (e.g. `Light · Default · Normal`).

--- a/apps/docs/docs/guides/multi-axis-walkthrough.mdx
+++ b/apps/docs/docs/guides/multi-axis-walkthrough.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Multi-axis walkthrough
 
-Step-by-step setup of a two-axis theming model — `mode × brand` — using the resolver input. The [live Storybook](/swatchbook/storybook/) runs exactly this fixture; open it in a second tab and cross-reference as you read.
+Step-by-step setup of a multi-axis theming model — `mode × brand × contrast` — using the resolver input. The walkthrough builds it up in stages, starting with `mode × brand` and adding `contrast` at the end. The [live Storybook](/swatchbook/storybook/) runs the full three-axis fixture; open it in a second tab and cross-reference as you read.
 
 ## 1. The token layout
 
@@ -114,7 +114,20 @@ The toolbar now renders pills next to the dropdowns. Clicking a pill writes the 
 
 ## 6. A third axis
 
-Adding a `contrast` modifier is additive — existing axes stay as-is, the total theme count grows from 4 to 8. For contrast to compose cleanly with mode and brand, each contrast override should only touch **contrast-specific** paths (borders, focus rings, text), letting mode handle surfaces and brand handle accents. See [axes](../concepts/axes) on why the CSS emission is flat rather than nested.
+The fixture now has a `contrast` modifier too, composing additively with `mode` and `brand` for a total of 8 themes. The overlay only touches **contrast-specific** paths — borders, focus rings, a couple of text slots — so it composes cleanly with mode (which owns surfaces) and brand (which owns accents):
+
+```json title="tokens/resolver.json"
+"contrast": {
+  "description": "Border + focus emphasis.",
+  "contexts": {
+    "Normal": [],
+    "High": [{ "$ref": "./themes/contrast-high.json" }]
+  },
+  "default": "Normal"
+}
+```
+
+`contrast` is appended to `resolutionOrder` after `brand`, so brand's accent stays dominant and contrast only reinforces where they don't collide. The [live Storybook](/swatchbook/storybook/) includes an **A11y High Contrast** preset that flips `contrast` to `High` on the Light baseline — open the preview and try it alongside the other two presets. See [axes](../concepts/axes) on why the CSS emission is flat rather than nested.
 
 ## See also
 

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -20,18 +20,23 @@ export default defineMain({
       options: {
         config: {
           resolver: resolverPath,
-          default: { mode: 'Light', brand: 'Default' },
+          default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
           cssVarPrefix: 'sb',
           presets: [
             {
               name: 'Default Light',
-              axes: { mode: 'Light', brand: 'Default' },
+              axes: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
               description: 'Baseline light mode with the stock accent.',
             },
             {
               name: 'Brand A Dark',
-              axes: { mode: 'Dark', brand: 'Brand A' },
+              axes: { mode: 'Dark', brand: 'Brand A', contrast: 'Normal' },
               description: 'Dark surfaces paired with the violet Brand A accent.',
+            },
+            {
+              name: 'A11y High Contrast',
+              axes: { mode: 'Light', contrast: 'High' },
+              description: 'High-contrast borders on the light baseline.',
             },
           ],
         },

--- a/apps/storybook/src/stories/Presets.stories.tsx
+++ b/apps/storybook/src/stories/Presets.stories.tsx
@@ -44,7 +44,7 @@ export const DefaultLightPreset = meta.story({
     if (!wrapper) throw new Error('story wrapper missing');
     await waitForAttr(wrapper, 'data-mode', 'Light');
     await waitForAttr(wrapper, 'data-brand', 'Default');
-    expect(wrapper.getAttribute('data-theme')).toBe('Light · Default');
+    expect(wrapper.getAttribute('data-theme')).toBe('Light · Default · Normal');
   },
 });
 
@@ -61,6 +61,6 @@ export const BrandADarkPreset = meta.story({
     if (!wrapper) throw new Error('story wrapper missing');
     await waitForAttr(wrapper, 'data-mode', 'Dark');
     await waitForAttr(wrapper, 'data-brand', 'Brand A');
-    expect(wrapper.getAttribute('data-theme')).toBe('Dark · Brand A');
+    expect(wrapper.getAttribute('data-theme')).toBe('Dark · Brand A · Normal');
   },
 });

--- a/apps/storybook/src/stories/ThemeSwitch.stories.tsx
+++ b/apps/storybook/src/stories/ThemeSwitch.stories.tsx
@@ -107,7 +107,7 @@ export const PerAxisDataAttrs = meta.story({
     if (!wrapper) throw new Error('expected story wrapper with data-mode attribute');
     expect(wrapper.getAttribute('data-mode')).toBe('Dark');
     expect(wrapper.getAttribute('data-brand')).toBe('Brand A');
-    expect(wrapper.getAttribute('data-theme')).toBe('Dark · Brand A');
+    expect(wrapper.getAttribute('data-theme')).toBe('Dark · Brand A · Normal');
     expect(document.documentElement.getAttribute('data-mode')).toBe('Dark');
     expect(document.documentElement.getAttribute('data-brand')).toBe('Brand A');
   },

--- a/packages/core/test/_helpers.ts
+++ b/packages/core/test/_helpers.ts
@@ -10,7 +10,7 @@ export async function loadWithPrefix(prefix: string | undefined): Promise<Projec
     {
       tokens: ['tokens/**/*.json'],
       resolver: resolverPath,
-      default: { mode: 'Light', brand: 'Default' },
+      default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
       ...(prefix !== undefined && { cssVarPrefix: prefix }),
     },
     fixtureCwd,

--- a/packages/core/test/css-sb-prefix.test.ts
+++ b/packages/core/test/css-sb-prefix.test.ts
@@ -55,7 +55,7 @@ it('emits every primitive + composite type covered by the fixture', () => {
 
 it('keeps sparse overrides: Dark flips surface, size scale identical', () => {
   const lightBlock = extractBlock(css, ':root');
-  const darkBlock = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default' }));
+  const darkBlock = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default', contrast: 'Normal' }));
   expect(lightBlock).toBeTruthy();
   expect(darkBlock).toBeTruthy();
   const lightSize = grep(lightBlock, '--sb-size-ref-400:');

--- a/packages/core/test/css-tuple-emit.test.ts
+++ b/packages/core/test/css-tuple-emit.test.ts
@@ -33,7 +33,7 @@ it('compound selector order matches Project.axes order', () => {
 
 it('redeclares every var per tuple (flat emission, not nested cascading)', () => {
   const lightDefault = extractBlock(css, ':root');
-  const darkDefault = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default' }));
+  const darkDefault = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default', contrast: 'Normal' }));
   expect(lightDefault).toBeTruthy();
   expect(darkDefault).toBeTruthy();
 
@@ -56,7 +56,7 @@ it('redeclares every var per tuple (flat emission, not nested cascading)', () =>
 
 it('holds brand-invariant tokens stable across mode at the same brand', () => {
   const lightDefault = extractBlock(css, ':root');
-  const darkDefault = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default' }));
+  const darkDefault = extractBlock(css, tupleSelector({ mode: 'Dark', brand: 'Default', contrast: 'Normal' }));
   const lightSize = grep(lightDefault, '--sb-size-ref-400:');
   const darkSize = grep(darkDefault, '--sb-size-ref-400:');
   expect(lightSize).toBeDefined();

--- a/packages/core/test/default-tuple.test.ts
+++ b/packages/core/test/default-tuple.test.ts
@@ -9,11 +9,11 @@ describe('Config.default tuple resolution', () => {
       {
         tokens: ['tokens/**/*.json'],
         resolver: resolverPath,
-        default: { mode: 'Dark', brand: 'Brand A' },
+        default: { mode: 'Dark', brand: 'Brand A', contrast: 'High' },
       },
       fixtureCwd,
     );
-    expect(project.graph).toBe(project.themesResolved['Dark · Brand A']);
+    expect(project.graph).toBe(project.themesResolved['Dark · Brand A · High']);
   });
 
   it("fills omitted axes from each axis's own default", async () => {
@@ -25,7 +25,7 @@ describe('Config.default tuple resolution', () => {
       },
       fixtureCwd,
     );
-    expect(project.graph).toBe(project.themesResolved['Dark · Default']);
+    expect(project.graph).toBe(project.themesResolved['Dark · Default · Normal']);
   });
 
   it('resolves to the all-axis-defaults tuple when default is absent', async () => {
@@ -33,7 +33,7 @@ describe('Config.default tuple resolution', () => {
       { tokens: ['tokens/**/*.json'], resolver: resolverPath },
       fixtureCwd,
     );
-    expect(project.graph).toBe(project.themesResolved['Light · Default']);
+    expect(project.graph).toBe(project.themesResolved['Light · Default · Normal']);
   });
 
   it('drops unknown axis keys with a warn diagnostic and falls back to the axis default', async () => {
@@ -49,7 +49,7 @@ describe('Config.default tuple resolution', () => {
       (d) => d.group === 'swatchbook/default' && d.message.includes('notAnAxis'),
     );
     expect(warn?.severity).toBe('warn');
-    expect(project.graph).toBe(project.themesResolved['Dark · Default']);
+    expect(project.graph).toBe(project.themesResolved['Dark · Default · Normal']);
   });
 
   it('drops invalid context values with a warn diagnostic and falls back to the axis default', async () => {
@@ -65,6 +65,6 @@ describe('Config.default tuple resolution', () => {
       (d) => d.group === 'swatchbook/default' && d.message.includes('NopeMode'),
     );
     expect(warn?.severity).toBe('warn');
-    expect(project.graph).toBe(project.themesResolved['Light · Default']);
+    expect(project.graph).toBe(project.themesResolved['Light · Default · Normal']);
   });
 });

--- a/packages/core/test/load.test.ts
+++ b/packages/core/test/load.test.ts
@@ -14,18 +14,22 @@ describe('loadProject — resolver mode', () => {
       {
         tokens: ['tokens/**/*.json'],
         resolver: resolverPath,
-        default: { mode: 'Light', brand: 'Default' },
+        default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
       },
       fixtureCwd,
     );
   }, 30_000);
 
-  it('enumerates the cartesian product of mode × brand', () => {
+  it('enumerates the cartesian product of mode × brand × contrast', () => {
     expect(project.themes.map((t) => t.name)).toEqual([
-      'Light · Default',
-      'Dark · Default',
-      'Light · Brand A',
-      'Dark · Brand A',
+      'Light · Default · Normal',
+      'Dark · Default · Normal',
+      'Light · Brand A · Normal',
+      'Dark · Brand A · Normal',
+      'Light · Default · High',
+      'Dark · Default · High',
+      'Light · Brand A · High',
+      'Dark · Brand A · High',
     ]);
     expect(Object.keys(project.graph).length).toBeGreaterThan(100);
   });
@@ -47,6 +51,14 @@ describe('loadProject — resolver mode', () => {
           'Accent palette. `Default` leaves sys alone; `Brand A` overrides the accent scale.',
         source: 'resolver',
       },
+      {
+        name: 'contrast',
+        contexts: ['Normal', 'High'],
+        default: 'Normal',
+        description:
+          'Border + focus emphasis. `Normal` leaves sys alone; `High` thickens borders and boosts the focus ring.',
+        source: 'resolver',
+      },
     ]);
   });
 
@@ -56,15 +68,15 @@ describe('loadProject — resolver mode', () => {
   });
 
   it('resolves alias chains (sys → ref)', () => {
-    const light = resolveTheme(project, 'Light · Default').tokens;
+    const light = resolveTheme(project, 'Light · Default · Normal').tokens;
     const accentBg = light['color.sys.accent.bg'];
     expect(accentBg).toBeDefined();
     expect(accentBg?.$type).toBe('color');
   });
 
   it('produces different surface values for Light vs Dark at the same brand', () => {
-    const light = resolveTheme(project, 'Light · Default').tokens['color.sys.surface.default'];
-    const dark = resolveTheme(project, 'Dark · Default').tokens['color.sys.surface.default'];
+    const light = resolveTheme(project, 'Light · Default · Normal').tokens['color.sys.surface.default'];
+    const dark = resolveTheme(project, 'Dark · Default · Normal').tokens['color.sys.surface.default'];
     expect(light).toBeDefined();
     expect(dark).toBeDefined();
     expect(JSON.stringify(light?.$value)).not.toEqual(JSON.stringify(dark?.$value));

--- a/packages/core/test/presets.test.ts
+++ b/packages/core/test/presets.test.ts
@@ -20,6 +20,12 @@ const axes: Axis[] = [
     default: 'Default',
     source: 'resolver',
   },
+  {
+    name: 'contrast',
+    contexts: ['Normal', 'High'],
+    default: 'Normal',
+    source: 'resolver',
+  },
 ];
 
 describe('validatePresets', () => {
@@ -84,7 +90,7 @@ describe('loadProject — presets', () => {
       {
         tokens: ['tokens/**/*.json'],
         resolver: resolverPath,
-        default: { mode: 'Light', brand: 'Default' },
+        default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
         presets: [
           { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' } },
           { name: 'Default Light', axes: { mode: 'Light' } },

--- a/packages/tokens-reference/tokens/resolver.json
+++ b/packages/tokens-reference/tokens/resolver.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/tr/2025/drafts/resolver/",
   "version": "2025.10",
   "name": "swatchbook-reference",
-  "description": "DTCG 2025.10 native resolver. Two layers (ref and sys) plus two independent modifiers — `mode` (light/dark baseline) and `brand` (default/Brand A accent) — compose into 4 named themes. Component variation is carried by modes on sys; no `cmp` layer.",
+  "description": "DTCG 2025.10 native resolver. Two layers (ref and sys) plus three independent modifiers — `mode` (light/dark baseline), `brand` (default/Brand A accent), and `contrast` (normal/high border + focus emphasis) — compose into 8 named themes. Component variation is carried by modes on sys; no `cmp` layer.",
   "sets": {
     "ref": {
       "description": "Raw primitives (loaded but not emitted).",
@@ -45,12 +45,21 @@
         "Brand A": [{ "$ref": "./themes/brand-a.json" }]
       },
       "default": "Default"
+    },
+    "contrast": {
+      "description": "Border + focus emphasis. `Normal` leaves sys alone; `High` thickens borders and boosts the focus ring.",
+      "contexts": {
+        "Normal": [],
+        "High": [{ "$ref": "./themes/contrast-high.json" }]
+      },
+      "default": "Normal"
     }
   },
   "resolutionOrder": [
     { "$ref": "#/sets/ref" },
     { "$ref": "#/sets/sys" },
     { "$ref": "#/modifiers/mode" },
-    { "$ref": "#/modifiers/brand" }
+    { "$ref": "#/modifiers/brand" },
+    { "$ref": "#/modifiers/contrast" }
   ]
 }

--- a/packages/tokens-reference/tokens/themes/contrast-high.json
+++ b/packages/tokens-reference/tokens/themes/contrast-high.json
@@ -1,0 +1,44 @@
+{
+  "color": {
+    "sys": {
+      "$type": "color",
+      "$description": "High-contrast overlay — strengthens borders and focus rings. Surfaces and accents stay in mode/brand's lane.",
+      "border": {
+        "default": { "$value": "{color.ref.neutral.700}" },
+        "strong":  { "$value": "{color.ref.neutral.900}" },
+        "focus":   { "$value": "{color.ref.yellow.500}" }
+      },
+      "text": {
+        "muted":  { "$value": "{color.ref.neutral.700}" },
+        "subtle": { "$value": "{color.ref.neutral.600}" }
+      }
+    }
+  },
+  "border": {
+    "sys": {
+      "$type": "border",
+      "$description": "High-contrast border widths — composite bumps to 2px default, 3px focus.",
+      "default": {
+        "$value": {
+          "color": "{color.sys.border.default}",
+          "width": { "value": 2, "unit": "px" },
+          "style": "solid"
+        }
+      },
+      "strong": {
+        "$value": {
+          "color": "{color.sys.border.strong}",
+          "width": { "value": 2, "unit": "px" },
+          "style": "solid"
+        }
+      },
+      "focus": {
+        "$value": {
+          "color": "{color.sys.border.focus}",
+          "width": { "value": 3, "unit": "px" },
+          "style": "solid"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Milestone:** Three-axis fixture + disable-axis config

**Closes:** Closes #182

**Plan impact:** none

## Summary

Extends the bundled `tokens-reference` fixture from `mode × brand` (4 themes) to `mode × brand × contrast` (8 themes). Additive: existing 2-axis paths keep their behavior; the new `contrast` modifier just stresses the multi-axis UI.

- New `tokens/themes/contrast-high.json` overlay with sparse overrides — border colors, focus-ring color, and composite border widths. Surfaces stay owned by `mode`; accents stay owned by `brand`.
- Resolver grows a third modifier `contrast: Normal | High` with `Normal` as default, appended to `resolutionOrder` after `brand`.
- Storybook gains an `A11y High Contrast` preset (`{ mode: 'Light', contrast: 'High' }`).
- Core tests updated to the three-segment theme names (e.g. `Light · Default · Normal`) and the extra axis entry.
- `apps/docs` multi-axis walkthrough rewritten from teaser-tense to present-tense with the live preset.
- Changeset: `@unpunnyfuns/swatchbook-addon` minor (public fixture surface).

## Test plan

- [x] `pnpm turbo run lint typecheck test build` all green
- [x] `pnpm turbo run test:storybook` — 110 tests pass
- [x] Core tests read 8 themes with composed 3-segment names
- [x] `ThemeSwitch` and `Presets` stories continue to pass under the new axis