### PR TITLE
feat(core): disabledAxes config surface to suppress declared axes

### DIFF
--- a/.changeset/disabled-axes-config.md
+++ b/.changeset/disabled-axes-config.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+New `Config.disabledAxes?: string[]` suppresses declared axes from the toolbar, CSS emission, and theme enumeration without editing the resolver. Each listed axis pins to its `default` context: `Project.axes` drops it, `Project.themes` collapses to the default-context slice, CSS emission stops including it in compound selectors, and the addon's toolbar skips the dropdown. The tokens panel shows a small pinned indicator so the suppression stays visible. Unknown axis names surface as `warn` diagnostics (group `swatchbook/disabled-axes`) and are ignored. Filtered-out names land on the new `Project.disabledAxes: string[]` for downstream tooling. Config-level only — no runtime toggle.

--- a/apps/docs/docs/concepts/axes.mdx
+++ b/apps/docs/docs/concepts/axes.mdx
@@ -79,6 +79,10 @@ export const DarkBrandA = meta.story({
 
 Omit an axis and it falls back to that axis's default. Invalid axis keys or context values are silently ignored (the decorator falls back to defaults). The legacy `parameters.swatchbook.theme: 'Composed Name'` form still works but axes tuples are preferred.
 
+## Disabling an axis
+
+A resolver may declare more modifiers than a given Storybook wants to surface — e.g. a work-in-progress `contrast` variant, or an experimental `density` mode. Rather than editing the resolver, list the axis name in `config.disabledAxes` and the project behaves as if that axis didn't exist for this session: no toolbar dropdown, no extra CSS blocks, and the axis is pinned to its `default` context in the active tuple. The tokens panel still shows a faint pinned indicator so the suppression isn't invisible. See the [`disabledAxes`](../reference/config#disabledaxes-string) field in the config reference for details.
+
 ## See also
 
 - [Presets](./presets) — name common tuples and render them as toolbar pills.

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -138,6 +138,20 @@ Partial tuples are legal — omitted axes resolve to the axis's `default` when t
 
 See [Presets](../concepts/presets) for the runtime UX.
 
+### `disabledAxes?: string[]`
+
+Axis names to suppress from this Storybook session. Each listed axis is **pinned to its `default` context**: the toolbar dropdown disappears, the axis drops out of `Project.axes`, non-default tuples fold away, and CSS emission stops including the axis in compound selectors. The tokens panel still shows a small pinned indicator so authors don't forget the modifier is being suppressed.
+
+```ts
+defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  disabledAxes: ['contrast'],
+  cssVarPrefix: 'ds',
+});
+```
+
+Config-level only — there's no runtime toggle. Disabling an axis is the cleanest way to hide a work-in-progress modifier (or an experimental axis you don't want surfaced yet) without editing the resolver document. Unknown axis names produce `warn` diagnostics (group `swatchbook/disabled-axes`) and are ignored; the filtered list lands on `Project.disabledAxes` for downstream tooling.
+
 ## See also
 
 - [Theming inputs](../concepts/theming-inputs) — when to pick resolver vs layered.

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -21,6 +21,10 @@ export default defineMain({
         config: {
           resolver: resolverPath,
           default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+          // Uncomment to suppress the `contrast` axis from this Storybook —
+          // the toolbar dropdown disappears, CSS emission drops it from
+          // compound selectors, and the tokens panel shows a pinned indicator.
+          // disabledAxes: ['contrast'],
           cssVarPrefix: 'sb',
           presets: [
             {

--- a/packages/addon/src/panel.tsx
+++ b/packages/addon/src/panel.tsx
@@ -40,6 +40,7 @@ interface VirtualDiagnostic {
 
 interface InitPayload {
   axes: VirtualAxis[];
+  disabledAxes: readonly string[];
   themes: VirtualTheme[];
   defaultTheme: string | null;
   themesResolved: Record<string, Record<string, VirtualToken>>;
@@ -221,6 +222,16 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
   const axisIndicatorText = axes
     .map((axis) => `${axis.name}: ${tuple[axis.name] ?? axis.default}`)
     .join('  ·  ');
+  const disabledAxes = payload?.disabledAxes ?? [];
+  /**
+   * Disabled axes don't appear in `axes` (filtered at load time) so their
+   * values aren't in `tuple` either. The surviving themes still carry the
+   * pinned value on their `input`, so pick any theme and read it out.
+   */
+  const pinnedSample = themes[0]?.input ?? {};
+  const disabledIndicatorText = disabledAxes
+    .map((name) => `${name}: ${pinnedSample[name] ?? '?'} · pinned`)
+    .join('  ·  ');
 
   return h(
     'div',
@@ -236,6 +247,15 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
             'data-testid': 'tokens-panel-axis-indicator',
           },
           axisIndicatorText,
+        ),
+      disabledAxes.length > 0 &&
+        h(
+          'div',
+          {
+            style: { ...axisIndicatorStyle, opacity: 0.5 },
+            'data-testid': 'tokens-panel-disabled-axes-indicator',
+          },
+          disabledIndicatorText,
         ),
       h('input', {
         style: searchInputStyle,

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -7,6 +7,7 @@ import {
   cssVarPrefix,
   defaultTheme,
   diagnostics,
+  disabledAxes as virtualDisabledAxes,
   presets as virtualPresets,
   themes,
   themesResolved,
@@ -69,6 +70,19 @@ function setRootAxes(themeName: string, tuple: Readonly<Record<string, string>>)
       root.setAttribute(`data-${axis.name}`, value);
     }
   }
+  /**
+   * Disabled axes aren't in `virtualAxes`, but CSS may still reference their
+   * pinned value on compound selectors in extension code. Read the value
+   * from any surviving theme's `input` — every theme that survived filtering
+   * carries the same pinned context for each disabled axis.
+   */
+  const pinnedSample = themes[0]?.input;
+  if (pinnedSample) {
+    for (const name of virtualDisabledAxes) {
+      const value = pinnedSample[name];
+      if (value !== undefined) root.setAttribute(`data-${name}`, value);
+    }
+  }
 }
 
 /**
@@ -80,6 +94,7 @@ function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(INIT_EVENT, {
     axes: virtualAxes,
+    disabledAxes: virtualDisabledAxes,
     presets: virtualPresets,
     themes,
     defaultTheme,
@@ -183,10 +198,18 @@ const themedDecorator: Decorator = (Story, context) => {
     const value = tuple[axis.name];
     if (value !== undefined) wrapperAttrs[`data-${axis.name}`] = value;
   }
+  const pinnedSample = themes[0]?.input;
+  if (pinnedSample) {
+    for (const name of virtualDisabledAxes) {
+      const value = pinnedSample[name];
+      if (value !== undefined) wrapperAttrs[`data-${name}`] = value;
+    }
+  }
 
   const snapshot = useMemo<ProjectSnapshot>(
     () => ({
       axes: virtualAxes,
+      disabledAxes: virtualDisabledAxes,
       presets: virtualPresets,
       themes,
       themesResolved,

--- a/packages/addon/src/swatchbook-context.ts
+++ b/packages/addon/src/swatchbook-context.ts
@@ -54,6 +54,8 @@ export interface VirtualPresetShape {
  */
 export interface ProjectSnapshot {
   axes: readonly VirtualAxisShape[];
+  /** Axis names suppressed via `config.disabledAxes` — pinned to their defaults, hidden from the toolbar. */
+  disabledAxes: readonly string[];
   presets: readonly VirtualPresetShape[];
   themes: readonly VirtualThemeShape[];
   themesResolved: Record<string, Record<string, VirtualTokenShape>>;

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -44,6 +44,7 @@ declare module 'virtual:swatchbook/tokens' {
   }
 
   export const axes: readonly VirtualAxis[];
+  export const disabledAxes: readonly string[];
   export const presets: readonly VirtualPreset[];
   export const themes: readonly VirtualTheme[];
   export const defaultTheme: string | null;

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -45,6 +45,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
         `/* swatchbook virtual module — generated */`,
         `export const axes = ${JSON.stringify(project.axes)};`,
         `export const presets = ${JSON.stringify(project.presets)};`,
+        `export const disabledAxes = ${JSON.stringify(project.disabledAxes)};`,
         `export const themes = ${JSON.stringify(project.themes)};`,
         `export const defaultTheme = ${JSON.stringify(project.themes[0]?.name ?? null)};`,
         `export const themesResolved = ${JSON.stringify(project.themesResolved)};`,

--- a/packages/blocks/test/token-table.test.tsx
+++ b/packages/blocks/test/token-table.test.tsx
@@ -12,6 +12,7 @@ function makeSnapshot(): ProjectSnapshot {
         source: 'resolver',
       },
     ],
+    disabledAxes: [],
     presets: [],
     themes: [
       { name: 'Light', input: { mode: 'light' }, sources: [] },

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -113,6 +113,21 @@ export default defineSwatchbookConfig({
 
 Each preset names a partial tuple; any axis the preset omits resolves to that axis's `default` when applied. `loadProject` validates presets: unknown axis keys and invalid context values surface as `warn` diagnostics and are sanitized out, but the preset stays in `Project.presets` (an empty preset is still a valid tuple).
 
+## Disabling axes
+
+`config.disabledAxes` suppresses declared axes from the toolbar, CSS emission, and theme enumeration — each listed axis is pinned to its `default` context and drops out of `Project.axes`. Useful when the resolver declares a work-in-progress modifier you don't want surfaced yet, without editing the resolver document.
+
+```ts
+export default defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  disabledAxes: ['contrast'],
+});
+```
+
+- Disabled names land on `Project.disabledAxes` so panels and blocks can still indicate the axis exists but is pinned.
+- Unknown axis names produce `warn` diagnostics (group `swatchbook/disabled-axes`) and are ignored.
+- Config-level only — there's no runtime toggle.
+
 ## CSS emission
 
 Multi-axis projects emit one `:root` block with the default-tuple values, plus one block per non-default combination of axis contexts keyed on a compound attribute selector in `Project.axes` order:

--- a/packages/core/src/disabled-axes.ts
+++ b/packages/core/src/disabled-axes.ts
@@ -1,0 +1,42 @@
+import type { Axis, Diagnostic } from '#/types.ts';
+
+export interface DisabledAxesValidationResult {
+  names: string[];
+  diagnostics: Diagnostic[];
+}
+
+/**
+ * Validate + sanitize the user-supplied `config.disabledAxes` list against
+ * the project's axes. Unknown axis names produce `warn` diagnostics and are
+ * dropped; the surviving names are what gets filtered out of
+ * `Project.axes`, `Project.themes`, and CSS emission.
+ *
+ * Mirrors the shape of `validatePresets` so the two validation surfaces
+ * feel identical to authors reading diagnostics.
+ */
+export function validateDisabledAxes(
+  raw: string[] | undefined,
+  axes: Axis[],
+): DisabledAxesValidationResult {
+  const diagnostics: Diagnostic[] = [];
+  if (!raw || raw.length === 0) return { names: [], diagnostics };
+
+  const known = new Set(axes.map((a) => a.name));
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const name of raw) {
+    if (seen.has(name)) continue;
+    seen.add(name);
+    if (!known.has(name)) {
+      diagnostics.push({
+        severity: 'warn',
+        group: 'swatchbook/disabled-axes',
+        message: `Config \`disabledAxes\` references unknown axis "${name}" — dropped.`,
+      });
+      continue;
+    }
+    names.push(name);
+  }
+
+  return { names, diagnostics };
+}

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,8 +1,17 @@
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
+import { validateDisabledAxes } from '#/disabled-axes.ts';
 import { validatePresets } from '#/presets.ts';
 import { resolveDefaultTuple } from '#/themes/default.ts';
 import { normalizeThemes } from '#/themes/normalize.ts';
-import { permutationID, type Config, type Project, type ResolvedTheme } from '#/types.ts';
+import {
+  permutationID,
+  type Axis,
+  type Config,
+  type Project,
+  type ResolvedTheme,
+  type Theme,
+  type TokenMap,
+} from '#/types.ts';
 
 /**
  * Load a swatchbook project from a config. Themes are eagerly resolved,
@@ -17,32 +26,79 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   const logger = new BufferedLogger({ level: 'warn' });
   const normalized = await normalizeThemes(config, cwd, logger);
 
+  const { names: disabledAxes, diagnostics: disabledDiagnostics } = validateDisabledAxes(
+    config.disabledAxes,
+    normalized.axes,
+  );
+
+  const {
+    axes: filteredAxes,
+    themes: filteredThemes,
+    resolved: filteredResolved,
+  } = applyDisabledAxes(normalized.axes, normalized.themes, normalized.resolved, disabledAxes);
+
   const { tuple: defaultTuple, diagnostics: defaultDiagnostics } = resolveDefaultTuple(
     config.default,
-    normalized.axes,
+    filteredAxes,
   );
   const computedDefault = permutationID(defaultTuple);
-  const defaultThemeName = normalized.resolved[computedDefault]
+  const defaultThemeName = filteredResolved[computedDefault]
     ? computedDefault
-    : (normalized.themes[0]?.name ?? '');
+    : (filteredThemes[0]?.name ?? '');
 
-  const graph = normalized.resolved[defaultThemeName] ?? {};
+  const graph = filteredResolved[defaultThemeName] ?? {};
 
-  const { presets, diagnostics: presetDiagnostics } = validatePresets(
-    config.presets,
-    normalized.axes,
-  );
+  const { presets, diagnostics: presetDiagnostics } = validatePresets(config.presets, filteredAxes);
 
   return {
     config,
-    axes: normalized.axes,
+    axes: filteredAxes,
+    disabledAxes,
     presets,
-    themes: normalized.themes,
-    themesResolved: normalized.resolved,
+    themes: filteredThemes,
+    themesResolved: filteredResolved,
     graph,
     sourceFiles: normalized.sourceFiles,
-    diagnostics: [...toDiagnostics(logger), ...defaultDiagnostics, ...presetDiagnostics],
+    diagnostics: [
+      ...toDiagnostics(logger),
+      ...disabledDiagnostics,
+      ...defaultDiagnostics,
+      ...presetDiagnostics,
+    ],
   };
+}
+
+/**
+ * Project `disabledAxes` onto the loader output: drop disabled axes from
+ * the axis list, keep only the themes whose disabled-axis values equal
+ * their axis defaults, and prune `resolved` to the surviving theme names.
+ * Returns the original triple unchanged when `disabled` is empty.
+ */
+function applyDisabledAxes(
+  axes: Axis[],
+  themes: Theme[],
+  resolved: Record<string, TokenMap>,
+  disabled: string[],
+): { axes: Axis[]; themes: Theme[]; resolved: Record<string, TokenMap> } {
+  if (disabled.length === 0) return { axes, themes, resolved };
+
+  const disabledSet = new Set(disabled);
+  const axisDefaults = new Map<string, string>();
+  for (const axis of axes) axisDefaults.set(axis.name, axis.default);
+
+  const filteredAxes = axes.filter((a) => !disabledSet.has(a.name));
+  const filteredThemes = themes.filter((theme) => {
+    for (const name of disabled) {
+      if (theme.input[name] !== axisDefaults.get(name)) return false;
+    }
+    return true;
+  });
+  const surviving = new Set(filteredThemes.map((t) => t.name));
+  const filteredResolved: Record<string, TokenMap> = {};
+  for (const [name, tokens] of Object.entries(resolved)) {
+    if (surviving.has(name)) filteredResolved[name] = tokens;
+  }
+  return { axes: filteredAxes, themes: filteredThemes, resolved: filteredResolved };
 }
 
 /** Fetch the resolved tokens for a named theme. Throws if the name is unknown. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -83,6 +83,15 @@ export interface Config {
   outDir?: string;
   /** Named tuple presets — rendered as quick-select pills in the toolbar. */
   presets?: Preset[];
+  /**
+   * Axis names to suppress from the toolbar and CSS emission. Each listed
+   * axis is pinned to its `default` context: it disappears from
+   * `Project.axes`, its tuples collapse into the default-context slice, and
+   * emitted CSS drops it from the compound selector. Unknown names produce
+   * `warn` diagnostics (group `swatchbook/disabled-axes`) and are ignored.
+   * Config-level only — no runtime toggle.
+   */
+  disabledAxes?: string[];
 }
 
 export type DiagnosticSeverity = 'error' | 'warn' | 'info';
@@ -104,6 +113,14 @@ export interface Diagnostic {
 export interface Project {
   config: Config;
   axes: Axis[];
+  /**
+   * Axis names suppressed via `config.disabledAxes`. Validated against the
+   * resolver's axis list at load time — unknown names are dropped here and
+   * surface as `warn` diagnostics. Downstream tooling (panels, blocks) can
+   * read this to indicate that a modifier exists in the resolver but is
+   * pinned to its default for this session.
+   */
+  disabledAxes: string[];
   /** Validated + sanitized presets from `config.presets`. Empty if unset. */
   presets: Preset[];
   themes: Theme[];

--- a/packages/core/test/disabled-axes.test.ts
+++ b/packages/core/test/disabled-axes.test.ts
@@ -1,0 +1,115 @@
+import { dirname } from 'node:path';
+import { beforeAll, expect, it } from 'vitest';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens-reference';
+import { projectCss } from '#/emit';
+import { loadProject } from '#/load';
+import { validateDisabledAxes } from '#/disabled-axes';
+import type { Axis, Project } from '#/types';
+
+const fixtureCwd = dirname(tokensDir);
+
+const axes: Axis[] = [
+  { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'resolver' },
+  {
+    name: 'brand',
+    contexts: ['Default', 'Brand A'],
+    default: 'Default',
+    source: 'resolver',
+  },
+  {
+    name: 'contrast',
+    contexts: ['Normal', 'High'],
+    default: 'Normal',
+    source: 'resolver',
+  },
+];
+
+it('validateDisabledAxes passes a known axis name through unchanged', () => {
+  const { names, diagnostics } = validateDisabledAxes(['contrast'], axes);
+  expect(names).toEqual(['contrast']);
+  expect(diagnostics).toEqual([]);
+});
+
+it('validateDisabledAxes drops unknown names with a warn diagnostic', () => {
+  const { names, diagnostics } = validateDisabledAxes(['contrast', 'density'], axes);
+  expect(names).toEqual(['contrast']);
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.severity).toBe('warn');
+  expect(diagnostics[0]?.group).toBe('swatchbook/disabled-axes');
+  expect(diagnostics[0]?.message).toMatch(/unknown axis "density"/);
+});
+
+it('validateDisabledAxes dedupes repeated entries silently', () => {
+  const { names, diagnostics } = validateDisabledAxes(['contrast', 'contrast'], axes);
+  expect(names).toEqual(['contrast']);
+  expect(diagnostics).toEqual([]);
+});
+
+it('validateDisabledAxes returns empty arrays when input is undefined', () => {
+  const { names, diagnostics } = validateDisabledAxes(undefined, axes);
+  expect(names).toEqual([]);
+  expect(diagnostics).toEqual([]);
+});
+
+// beforeAll is a perf escape hatch: loadProject over the reference fixture
+// takes ~1s; per-test reload would blow the default timeout. All `loadProject`
+// specs below read from the same filtered project.
+let project: Project;
+let css: string;
+
+beforeAll(async () => {
+  project = await loadProject(
+    {
+      tokens: ['tokens/**/*.json'],
+      resolver: resolverPath,
+      disabledAxes: ['contrast'],
+      default: { mode: 'Light', brand: 'Default' },
+      cssVarPrefix: 'sb',
+    },
+    fixtureCwd,
+  );
+  css = projectCss(project);
+}, 30_000);
+
+it('filters disabled axes out of Project.axes', () => {
+  expect(project.axes.map((a) => a.name)).toEqual(['mode', 'brand']);
+});
+
+it('carries the filtered-out names on Project.disabledAxes', () => {
+  expect(project.disabledAxes).toEqual(['contrast']);
+});
+
+it('filters themes down to the ones where disabled axes equal their default', () => {
+  expect(project.themes).toHaveLength(4);
+  for (const theme of project.themes) {
+    expect(theme.input['contrast']).toBe('Normal');
+  }
+});
+
+it('emits CSS with no data-contrast selectors', () => {
+  expect(css).not.toMatch(/data-contrast/);
+});
+
+it('keys themesResolved on the surviving theme names', () => {
+  const keys = Object.keys(project.themesResolved).toSorted();
+  const themeNames = project.themes.map((t) => t.name).toSorted();
+  expect(keys).toEqual(themeNames);
+});
+
+it('surfaces a warn diagnostic when disabledAxes references an unknown axis', async () => {
+  const p = await loadProject(
+    {
+      tokens: ['tokens/**/*.json'],
+      resolver: resolverPath,
+      disabledAxes: ['contrast', 'density'],
+      default: { mode: 'Light', brand: 'Default' },
+    },
+    fixtureCwd,
+  );
+  expect(p.disabledAxes).toEqual(['contrast']);
+  const warn = p.diagnostics.find(
+    (d) => d.group === 'swatchbook/disabled-axes' && d.severity === 'warn',
+  );
+  expect(warn).toBeDefined();
+  expect(warn?.message).toMatch(/unknown axis "density"/);
+});


### PR DESCRIPTION
**Milestone:** Three-axis fixture + disable-axis config

**Closes:** Closes #183

**Plan impact:** none

## Summary

- New `Config.disabledAxes?: string[]` pins listed axes to their `default` context and hides them from the toolbar, CSS emission, and theme enumeration — no resolver edits required.
- Core filters `Project.axes`, `Project.themes`, and `Project.themesResolved` to the surviving slice; filtered names land on new `Project.disabledAxes: string[]`. Unknown names surface as `warn` diagnostics (group `swatchbook/disabled-axes`) via `validateDisabledAxes`, mirroring `validatePresets`.
- Addon plumbs `disabledAxes` through the virtual module, init payload, and `ProjectSnapshot`. The tokens panel renders a faint pinned indicator (`contrast: Normal · pinned`) so the suppression stays visible; the decorator still writes `data-<disabled>=<pinned>` on the root so any consumer CSS keyed on it keeps matching.
- Reference Storybook's `main.ts` gains a commented-out `disabledAxes: ['contrast']` example; docs add a `disabledAxes` field in the config reference and a paragraph in the axes concept.
- Changeset: minor bump on `@unpunnyfuns/swatchbook-core` and `@unpunnyfuns/swatchbook-addon`.

## Test plan

- [x] New `packages/core/test/disabled-axes.test.ts` covers validator (unknown/dedupe/empty) + end-to-end filtering (axes, themes, CSS, diagnostics) — 10 tests.
- [x] `pnpm -r format && pnpm turbo run lint typecheck test build` green.
- [x] `pnpm turbo run test:storybook` green (110/110).