### PR TITLE
fix(blocks): sort token paths numerically across all blocks

### DIFF
--- a/.changeset/numeric-path-sort.md
+++ b/.changeset/numeric-path-sort.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Sort token paths numerically so `color.ref.blue.50` comes before `color.ref.blue.100` instead of after. All block sorts now use `localeCompare(..., { numeric: true })`. Also corrected the `ColorPalette` `RefBlue` story's `groupBy` from `4` to `3` so every ramp shade groups under `color.ref.blue` instead of one swatch per row.

--- a/apps/storybook/src/stories/ColorPalette.stories.tsx
+++ b/apps/storybook/src/stories/ColorPalette.stories.tsx
@@ -14,5 +14,5 @@ export default meta;
 
 export const All = meta.story();
 export const SysOnly = meta.story({ args: { filter: 'color.sys.*' } });
-export const RefBlue = meta.story({ args: { filter: 'color.ref.blue.*', groupBy: 4 } });
+export const RefBlue = meta.story({ args: { filter: 'color.ref.blue.*', groupBy: 3 } });
 export const Flat = meta.story({ args: { groupBy: 2 } });

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -129,7 +129,7 @@ export function BorderPreview({ filter = 'border', caption }: BorderPreviewProps
         value: (token.$value ?? {}) as BorderValue,
       });
     }
-    collected.sort((a, b) => a.path.localeCompare(b.path));
+    collected.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
     return collected;
   }, [resolved, filter, cssVarPrefix]);
 

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -108,7 +108,7 @@ export function ColorPalette({
         if (token.$type !== 'color') return false;
         return globMatch(path, filter);
       })
-      .toSorted(([a], [b]) => a.localeCompare(b));
+      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }));
 
     for (const [path, token] of entries) {
       const segments = path.split('.');
@@ -126,7 +126,9 @@ export function ColorPalette({
       bucket.set(groupKey, list);
     }
 
-    return [...bucket.entries()].toSorted(([a], [b]) => a.localeCompare(b));
+    return [...bucket.entries()].toSorted(([a], [b]) =>
+      a.localeCompare(b, undefined, { numeric: true }),
+    );
   }, [resolved, filter, groupBy, cssVarPrefix, colorFormat]);
 
   const totalCount = groups.reduce((acc, [, swatches]) => acc + swatches.length, 0);

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -138,7 +138,7 @@ export function DimensionScale({
     }
     collected.sort((a, b) => {
       if (Number.isFinite(a.pxValue) && Number.isFinite(b.pxValue)) return a.pxValue - b.pxValue;
-      return a.path.localeCompare(b.path);
+      return a.path.localeCompare(b.path, undefined, { numeric: true });
     });
     return collected;
   }, [resolved, filter, cssVarPrefix]);

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -94,7 +94,7 @@ export function FontFamilySample({
         if (token.$type !== 'fontFamily') return false;
         return globMatch(path, filter);
       })
-      .toSorted(([a], [b]) => a.localeCompare(b))
+      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
       .map(([path, token]) => ({
         path,
         cssVar: makeCssVar(path, cssVarPrefix),

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -106,7 +106,7 @@ export function FontWeightScale({
     }
     collected.sort((a, b) => {
       if (Number.isFinite(a.weight) && Number.isFinite(b.weight)) return a.weight - b.weight;
-      return a.path.localeCompare(b.path);
+      return a.path.localeCompare(b.path, undefined, { numeric: true });
     });
     return collected;
   }, [resolved, filter, cssVarPrefix]);

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -142,7 +142,7 @@ export function GradientPalette({
         stops: asStops(token.$value),
       });
     }
-    collected.sort((a, b) => a.path.localeCompare(b.path));
+    collected.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
     return collected;
   }, [resolved, filter, cssVarPrefix]);
 

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -158,7 +158,7 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
     }
     collected.sort((a, b) => {
       if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
-      return a.path.localeCompare(b.path);
+      return a.path.localeCompare(b.path, undefined, { numeric: true });
     });
     return collected;
   }, [resolved, filter, cssVarPrefix]);

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -153,7 +153,7 @@ export function ShadowPreview({ filter = 'shadow', caption }: ShadowPreviewProps
         layers: asLayers(token.$value),
       });
     }
-    collected.sort((a, b) => a.path.localeCompare(b.path));
+    collected.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
     return collected;
   }, [resolved, filter, cssVarPrefix]);
 

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -109,7 +109,7 @@ export function StrokeStyleSample({
         if (token.$type !== 'strokeStyle') return false;
         return globMatch(path, filter);
       })
-      .toSorted(([a], [b]) => a.localeCompare(b))
+      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
       .map(([path, token]) => ({
         path,
         cssVar: makeCssVar(path, cssVarPrefix),

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -224,7 +224,7 @@ function buildTree(resolved: Record<string, VirtualToken>, root: string | undefi
 function sortTree(node: GroupNode): void {
   node.children.sort((a, b) => {
     if (a.kind !== b.kind) return a.kind === 'group' ? -1 : 1;
-    return a.segment.localeCompare(b.segment);
+    return a.segment.localeCompare(b.segment, undefined, { numeric: true });
   });
   for (const c of node.children) {
     if (c.kind === 'group') sortTree(c);

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -104,7 +104,7 @@ export function TokenTable({
         if (type && token.$type !== type) return false;
         return true;
       })
-      .toSorted(([a], [b]) => a.localeCompare(b));
+      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }));
     return entries.map(([path, token]) => {
       const isColor = token.$type === 'color';
       const color = isColor ? formatColor(token.$value, colorFormat) : null;

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -116,7 +116,7 @@ export function TypographyScale({
         if (token.$type !== 'typography') return false;
         return globMatch(path, filter);
       })
-      .toSorted(([a], [b]) => a.localeCompare(b))
+      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
       .map(([path, token]) => {
         const value = token.$value;
         if (!value || typeof value !== 'object') {

--- a/packages/blocks/src/token-detail/AliasedBy.tsx
+++ b/packages/blocks/src/token-detail/AliasedBy.tsx
@@ -92,7 +92,7 @@ function sortPaths(paths: readonly string[]): string[] {
   return paths.toSorted((a, b) => {
     const ra = GROUP_RANK[a.split('.')[0] ?? ''] ?? 2;
     const rb = GROUP_RANK[b.split('.')[0] ?? ''] ?? 2;
-    return ra !== rb ? ra - rb : a.localeCompare(b);
+    return ra !== rb ? ra - rb : a.localeCompare(b, undefined, { numeric: true });
   });
 }
 


### PR DESCRIPTION
## Summary

String sort on dot-paths placed `color.ref.blue.100` before `color.ref.blue.50` (and the same pattern everywhere else). Switched every block's comparator to `localeCompare(..., { numeric: true })`. Also corrected the `ColorPalette` `RefBlue` story's `groupBy: 4 → 3` so the ref ramp groups under `color.ref.blue` instead of giving every shade its own group row.

Files touched: all block-level sorts in `packages/blocks/src/` (ColorPalette, TokenTable, TokenNavigator, TypographyScale, DimensionScale, FontWeightScale, FontFamilySample, MotionPreview, ShadowPreview, BorderPreview, GradientPalette, StrokeStyleSample, token-detail/AliasedBy) plus the one story fix.

Closes #214
Milestone: Maintenance
Plan impact: none