### PR TITLE
refactor(addon): consolidate tokens + diagnostics into Design Tokens panel

### DIFF
--- a/.changeset/design-tokens-panel.md
+++ b/.changeset/design-tokens-panel.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+Consolidate the addon's `Swatchbook tokens` and `Swatchbook diagnostics` panels into a single `Design Tokens` panel. The primary content is now a hierarchical tree of the active theme's tokens (expand/collapse groups, type pill + inline value/color-swatch preview, click a leaf to copy its `var(--…)` reference, search filter across paths). Diagnostics live in a collapsible section beneath the tree — collapsed with a green "OK" badge when clean, auto-expanded with a severity summary when warnings or errors are present. The `PANEL_TOKENS_TAB` / `PANEL_DIAGNOSTICS_TAB` constants are removed; use the new `PANEL_ID = 'swatchbook/design-tokens'` if you're wiring panel focus programmatically.

--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@ Monorepo published under the `@unpunnyfuns` scope.
 | Package | Purpose |
 | --- | --- |
 | [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Wraps Terrazzo's parser and DTCG 2025.10 resolver; emits CSS variables and TypeScript types. |
-| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Preset wires core into Vite via a virtual module, the toolbar renders one dropdown per modifier axis, the panels browse tokens and diagnostics, and `useToken()` gives typed reads from stories. |
+| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Preset wires core into Vite via a virtual module, the toolbar renders one dropdown per modifier axis, the Design Tokens panel browses the resolved graph with inline diagnostics, and `useToken()` gives typed reads from stories. |
 | [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks for Storybook docs pages. Per-type rendering — color swatches, dimension bars, typography samples, composite previews, per-token detail with the full alias chain. |
 | [`@unpunnyfuns/swatchbook-tokens`](./packages/tokens-starter) | Minimal DTCG starter set (iceboxed past v0.1.0 — see `docs/decisions.md`). |
 
 ## Install
 
-Install the addon for the toolbar, tokens + diagnostics panels, preview decorator, and `useToken()` hook:
+Install the addon for the toolbar, Design Tokens panel (tree + diagnostics), preview decorator, and `useToken()` hook:
 
 ```sh
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core

--- a/apps/docs/docs/concepts/axes.mdx
+++ b/apps/docs/docs/concepts/axes.mdx
@@ -81,7 +81,7 @@ Omit an axis and it falls back to that axis's default. Invalid axis keys or cont
 
 ## Disabling an axis
 
-A resolver may declare more modifiers than a given Storybook wants to surface — e.g. a work-in-progress `contrast` variant, or an experimental `density` mode. Rather than editing the resolver, list the axis name in `config.disabledAxes` and the project behaves as if that axis didn't exist for this session: no toolbar dropdown, no extra CSS blocks, and the axis is pinned to its `default` context in the active tuple. The tokens panel still shows a faint pinned indicator so the suppression isn't invisible. See the [`disabledAxes`](../reference/config#disabledaxes-string) field in the config reference for details.
+A resolver may declare more modifiers than a given Storybook wants to surface — e.g. a work-in-progress `contrast` variant, or an experimental `density` mode. Rather than editing the resolver, list the axis name in `config.disabledAxes` and the project behaves as if that axis didn't exist for this session: no toolbar dropdown, no extra CSS blocks, and the axis is pinned to its `default` context in the active tuple. The Design Tokens panel still shows a faint pinned indicator so the suppression isn't invisible. See the [`disabledAxes`](../reference/config#disabledaxes-string) field in the config reference for details.
 
 ## See also
 

--- a/apps/docs/docs/concepts/diagnostics.mdx
+++ b/apps/docs/docs/concepts/diagnostics.mdx
@@ -36,7 +36,7 @@ interface Diagnostic {
 
 ## The panel
 
-The Diagnostics panel shows every diagnostic grouped by severity, with a green **OK** badge when the list is empty. Clicking a diagnostic with a `filename`/`line` jumps to the source if your Storybook has the right URL handler; otherwise it's shown as text.
+The **Design Tokens** panel includes a collapsible diagnostics section beneath the token tree. It shows a green **OK** badge when the list is empty and auto-expands to list every diagnostic (severity + message + group/source) when there are warnings or errors.
 
 ## Interpreting them
 
@@ -66,4 +66,4 @@ Future work may add a `strict` config flag that bakes this in. Track in [issues]
 
 ## See also
 
-- [Quickstart](../quickstart) — getting to a clean Diagnostics panel is the first milestone.
+- [Quickstart](../quickstart) — getting to a clean diagnostics section is the first milestone.

--- a/apps/docs/docs/concepts/presets.mdx
+++ b/apps/docs/docs/concepts/presets.mdx
@@ -50,7 +50,7 @@ At load time, each preset is sanitized:
 - Invalid context values (`axes: { mode: 'NotARealContext' }`) produce a diagnostic and the key is dropped.
 - Sanitized presets stay in `Project.presets` — the pill still renders, it just resolves to fewer axis overrides than authored.
 
-The diagnostics show up in the addon's Diagnostics panel alongside any token-level issues.
+The diagnostics show up in the addon's Design Tokens panel (diagnostics section) alongside any token-level issues.
 
 ## Config over localStorage
 

--- a/apps/docs/docs/guides/multi-axis-walkthrough.mdx
+++ b/apps/docs/docs/guides/multi-axis-walkthrough.mdx
@@ -88,7 +88,7 @@ export default defineSwatchbookConfig({
 With the config live:
 
 - **Toolbar** renders two dropdowns: one labelled `mode`, one labelled `brand`. Each lists its contexts. The current selection shows next to the label.
-- **Tokens panel** lists every resolved token for the active tuple. Switching the toolbar updates values live.
+- **Design Tokens panel** shows a hierarchical tree of every resolved token for the active tuple. Switching the toolbar updates values live.
 - **CSS emission** generates:
   - `:root` with the default tuple (`Light · Default`).
   - `[data-mode="Dark"][data-brand="Default"] { … }`

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -16,8 +16,7 @@ Design-system authors who already have DTCG tokens (or are in the process of aut
 ## What the addon gives you
 
 - **Toolbar** — one dropdown per modifier axis, preset pills for named combinations.
-- **Tokens panel** — searchable, filterable, grouped by `$type`. Click a token to copy its `var(--…)` reference.
-- **Diagnostics panel** — invalid tokens, broken aliases, type mismatches surface with severity and location.
+- **Design Tokens panel** — hierarchical tree of every token in the active theme, searchable. Click a leaf to copy its `var(--…)` reference. A collapsible diagnostics section at the bottom surfaces invalid tokens, broken aliases, and type mismatches with severity and location.
 - **Doc blocks** — `TokenDetail`, `TokenTable`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, motion/shadow/border previews. Embed them in MDX stories.
 - **`useToken` hook** — typed lookups from component code, reactive to the active theme.
 

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -10,7 +10,7 @@ Takes ~5 minutes if you already have a Storybook project.
 
 ## Install
 
-Install the addon for the toolbar, tokens + diagnostics panels, preview decorator, and `useToken()` hook:
+Install the addon for the toolbar, Design Tokens panel (tree + diagnostics), preview decorator, and `useToken()` hook:
 
 ```bash
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
@@ -69,8 +69,7 @@ pnpm storybook
 ## What you should see
 
 - **Toolbar**: one dropdown per modifier in your resolver. If you've written a single `theme` modifier with `Light`/`Dark` contexts, you get one dropdown; if you have `mode × brand`, you get two.
-- **Tokens panel** (bottom panel): every token your resolver yields, grouped by `$type`, searchable.
-- **Diagnostics panel**: empty with a green "OK" badge if your tokens are clean.
+- **Design Tokens panel** (bottom panel): hierarchical tree of every token your resolver yields, searchable. A diagnostics section beneath shows a green "OK" badge if your tokens are clean, or auto-expands to list warnings and errors.
 
 Switch themes from the toolbar; the panel's resolved values update live.
 

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Addon
 
-Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config at build time via `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, registers a preview decorator + manager toolbar + panels, and ships a `useToken` hook.
+Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config at build time via `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, registers a preview decorator + manager toolbar + the Design Tokens panel, and ships a `useToken` hook.
 
 ## Install
 
@@ -14,7 +14,7 @@ Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
-This gives you the toolbar, tokens + diagnostics panels, preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks` — install it alongside if you want them.
+This gives you the toolbar, Design Tokens panel (hierarchical tree view + diagnostics), preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks` — install it alongside if you want them.
 
 Peer requirements: Storybook 10.3+ on the Vite builder, React 18+.
 
@@ -37,7 +37,7 @@ No entry in `main.ts#addons` — the preview annotation is the full registration
 
 - **Preview decorator** — reads the active axis tuple, writes `data-<axis>="<context>"` attributes on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager.
 - **Toolbar tool** — one `IconButton` per axis with contexts as picks, plus preset pills.
-- **Panels** — Tokens (searchable list, grouped by `$type`) and Diagnostics.
+- **Design Tokens panel** — hierarchical tree of every token in the active theme (searchable, click a leaf to copy its `var(--…)` reference), with a collapsible diagnostics section beneath that auto-expands on warnings/errors.
 
 ## Globals
 

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -140,7 +140,7 @@ See [Presets](../concepts/presets) for the runtime UX.
 
 ### `disabledAxes?: string[]`
 
-Axis names to suppress from this Storybook session. Each listed axis is **pinned to its `default` context**: the toolbar dropdown disappears, the axis drops out of `Project.axes`, non-default tuples fold away, and CSS emission stops including the axis in compound selectors. The tokens panel still shows a small pinned indicator so authors don't forget the modifier is being suppressed.
+Axis names to suppress from this Storybook session. Each listed axis is **pinned to its `default` context**: the toolbar dropdown disappears, the axis drops out of `Project.axes`, non-default tuples fold away, and CSS emission stops including the axis in compound selectors. The Design Tokens panel still shows a small pinned indicator so authors don't forget the modifier is being suppressed.
 
 ```ts
 defineSwatchbookConfig({

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -23,7 +23,7 @@ export default defineMain({
           default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
           // Uncomment to suppress the `contrast` axis from this Storybook —
           // the toolbar dropdown disappears, CSS emission drops it from
-          // compound selectors, and the tokens panel shows a pinned indicator.
+          // compound selectors, and the Design Tokens panel shows a pinned indicator.
           // disabledAxes: ['contrast'],
           cssVarPrefix: 'sb',
           presets: [

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,6 +1,6 @@
 # Addon
 
-Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus tokens and diagnostics panels, and ships a `useToken()` hook with typed paths.
+Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus a unified Design Tokens panel (hierarchical tree + diagnostics), and ships a `useToken()` hook with typed paths.
 
 > **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) via `@unpunnyfuns/swatchbook-core`.
 
@@ -10,7 +10,7 @@ Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
-This gives you the toolbar, tokens + diagnostics panels, preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks) live in the sibling package — add it alongside if you want them:
+This gives you the toolbar, Design Tokens panel (hierarchical tree view with diagnostics), preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks) live in the sibling package — add it alongside if you want them:
 
 ```sh
 npm install @unpunnyfuns/swatchbook-blocks

--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -1,8 +1,6 @@
 export const ADDON_ID = 'swatchbook';
 export const TOOL_ID = `${ADDON_ID}/theme-switcher`;
-export const PANEL_ID = `${ADDON_ID}/panel`;
-export const PANEL_TOKENS_TAB = `${ADDON_ID}/tokens`;
-export const PANEL_DIAGNOSTICS_TAB = `${ADDON_ID}/diagnostics`;
+export const PANEL_ID = `${ADDON_ID}/design-tokens`;
 export const PARAM_KEY = 'swatchbook';
 /** Canonical active-theme global: composed permutation ID (string). Read by toolbar, panel, blocks. */
 export const GLOBAL_KEY = 'swatchbookTheme';

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -7,11 +7,10 @@ import {
   COLOR_FORMAT_GLOBAL_KEY,
   GLOBAL_KEY,
   INIT_EVENT,
-  PANEL_DIAGNOSTICS_TAB,
-  PANEL_TOKENS_TAB,
+  PANEL_ID,
   TOOL_ID,
 } from '#/constants.ts';
-import { DiagnosticsPanel, TokensPanel } from '#/panel.tsx';
+import { DesignTokensPanel } from '#/panel.tsx';
 
 /**
  * Use explicit `React.createElement` rather than JSX so the manager bundle
@@ -465,17 +464,10 @@ addons.register(ADDON_ID, () => {
     render: () => h(AxesToolbar),
   });
 
-  addons.add(PANEL_TOKENS_TAB, {
+  addons.add(PANEL_ID, {
     type: types.PANEL,
-    title: 'Swatchbook tokens',
+    title: 'Design Tokens',
     match: ({ viewMode }) => viewMode === 'story',
-    render: ({ active }) => h(TokensPanel, { active: !!active }),
-  });
-
-  addons.add(PANEL_DIAGNOSTICS_TAB, {
-    type: types.PANEL,
-    title: 'Swatchbook diagnostics',
-    match: ({ viewMode }) => viewMode === 'story',
-    render: ({ active }) => h(DiagnosticsPanel, { active: !!active }),
+    render: ({ active }) => h(DesignTokensPanel, { active: !!active }),
   });
 });

--- a/packages/addon/src/panel.tsx
+++ b/packages/addon/src/panel.tsx
@@ -1,13 +1,20 @@
-import React, { useEffect, useMemo, useState, type ReactElement } from 'react';
-import { addons, useGlobals } from 'storybook/manager-api';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent,
+  type ReactElement,
+} from 'react';
 import { Placeholder, ScrollArea } from 'storybook/internal/components';
+import { addons, useGlobals } from 'storybook/manager-api';
 import { AXES_GLOBAL_KEY, GLOBAL_KEY, INIT_EVENT } from '#/constants.ts';
 
 /** `React.createElement` alias so the manager bundle avoids `react/jsx-runtime`. */
 const h = React.createElement;
 
 interface VirtualToken {
-  id: string;
   $type?: string;
   $value?: unknown;
   $description?: string;
@@ -61,7 +68,7 @@ function usePayload(): InitPayload | null {
   return payload;
 }
 
-function makeCssVar(path: string, prefix: string): string {
+function makeCssVarName(path: string, prefix: string): string {
   const tail = path.replaceAll('.', '-');
   return prefix ? `--${prefix}-${tail}` : `--${tail}`;
 }
@@ -80,50 +87,117 @@ function formatValue(value: unknown): string {
   if (typeof value === 'string' || typeof value === 'number') return String(value);
   if (typeof value === 'object') {
     const v = value as Record<string, unknown>;
-    // Color with hex
     if (typeof v['hex'] === 'string') return v['hex'] as string;
-    // Dimension / duration { value, unit }
     if ('value' in v && 'unit' in v) return `${String(v['value'])}${String(v['unit'])}`;
-    // Fallback: JSON-ish single line
     return JSON.stringify(value).slice(0, 80);
   }
   return String(value);
 }
 
-const rowStyle: React.CSSProperties = {
-  display: 'grid',
-  gridTemplateColumns: '1fr auto',
-  gap: 12,
-  padding: '6px 12px',
-  fontSize: 12,
-  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
-  borderBottom: '1px solid rgba(128,128,128,0.12)',
-  cursor: 'pointer',
+const containerStyle: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  height: '100%',
 };
 
-const pathStyle: React.CSSProperties = { overflow: 'hidden', textOverflow: 'ellipsis' };
-const valueStyle: React.CSSProperties = { opacity: 0.7, whiteSpace: 'nowrap' };
-const groupHeaderStyle: React.CSSProperties = {
-  padding: '8px 12px',
-  fontSize: 10,
-  textTransform: 'uppercase',
-  letterSpacing: 0.5,
-  opacity: 0.6,
-  position: 'sticky',
-  top: 0,
-  background: 'inherit',
-};
-const searchBarStyle: React.CSSProperties = {
+const headerStyle: CSSProperties = {
   padding: '8px 12px',
   borderBottom: '1px solid rgba(128,128,128,0.2)',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
 };
-const axisIndicatorStyle: React.CSSProperties = {
+
+const axisIndicatorStyle: CSSProperties = {
   fontSize: 11,
   fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace',
   opacity: 0.7,
-  marginBottom: 6,
 };
-const searchInputStyle: React.CSSProperties = {
+
+const treeWrapperStyle: CSSProperties = {
+  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+  fontSize: 12,
+  padding: 8,
+};
+
+const groupRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 6,
+  padding: '4px 6px',
+  borderRadius: 4,
+  cursor: 'pointer',
+  userSelect: 'none',
+};
+
+const leafRowStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+  padding: '4px 6px',
+  borderRadius: 4,
+  cursor: 'pointer',
+  border: 'none',
+  background: 'transparent',
+  color: 'inherit',
+  width: '100%',
+  textAlign: 'left',
+  fontFamily: 'inherit',
+  fontSize: 'inherit',
+};
+
+const caretStyle: CSSProperties = {
+  display: 'inline-block',
+  width: 12,
+  textAlign: 'center',
+  opacity: 0.6,
+};
+
+const treeUlStyle: CSSProperties = { listStyle: 'none', margin: 0, padding: 0 };
+
+const nestedUlStyle: CSSProperties = {
+  listStyle: 'none',
+  margin: 0,
+  paddingLeft: 18,
+  borderLeft: '1px solid rgba(128,128,128,0.2)',
+};
+
+const typePillStyle: CSSProperties = {
+  display: 'inline-block',
+  padding: '1px 6px',
+  borderRadius: 4,
+  fontSize: 10,
+  letterSpacing: 0.5,
+  textTransform: 'uppercase',
+  background: 'rgba(128,128,128,0.15)',
+};
+
+const valueStyle: CSSProperties = {
+  marginLeft: 'auto',
+  opacity: 0.7,
+  fontSize: 11,
+  maxWidth: '40%',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  whiteSpace: 'nowrap',
+};
+
+const countStyle: CSSProperties = {
+  marginLeft: 'auto',
+  fontSize: 11,
+  opacity: 0.7,
+};
+
+const swatchStyle: CSSProperties = {
+  display: 'inline-block',
+  width: 14,
+  height: 14,
+  borderRadius: 3,
+  border: '1px solid rgba(128,128,128,0.3)',
+  marginLeft: 8,
+};
+
+const searchInputStyle: CSSProperties = {
   width: '100%',
   padding: '4px 8px',
   fontSize: 12,
@@ -133,27 +207,102 @@ const searchInputStyle: React.CSSProperties = {
   color: 'inherit',
 };
 
-function groupByType(tokens: Record<string, VirtualToken>): Map<string, VirtualToken[]> {
-  const groups = new Map<string, VirtualToken[]>();
-  for (const [path, token] of Object.entries(tokens)) {
-    const type = token.$type ?? 'unknown';
-    const arr = groups.get(type) ?? [];
-    arr.push({ ...token, id: path });
-    groups.set(type, arr);
+interface LeafNode {
+  kind: 'leaf';
+  segment: string;
+  path: string;
+  token: VirtualToken;
+}
+
+interface GroupNode {
+  kind: 'group';
+  segment: string;
+  path: string;
+  children: TreeNode[];
+}
+
+type TreeNode = LeafNode | GroupNode;
+
+function buildTree(resolved: Record<string, VirtualToken>): TreeNode[] {
+  const rootNode: GroupNode = { kind: 'group', segment: '', path: '', children: [] };
+  for (const [path, token] of Object.entries(resolved)) {
+    const segments = path.split('.');
+    let node: GroupNode = rootNode;
+    for (let i = 0; i < segments.length - 1; i += 1) {
+      const seg = segments[i] as string;
+      const prefix = segments.slice(0, i + 1).join('.');
+      let child = node.children.find(
+        (c): c is GroupNode => c.kind === 'group' && c.segment === seg,
+      );
+      if (!child) {
+        child = { kind: 'group', segment: seg, path: prefix, children: [] };
+        node.children.push(child);
+      }
+      node = child;
+    }
+    const leafSegment = segments[segments.length - 1] as string;
+    node.children.push({ kind: 'leaf', segment: leafSegment, path, token });
   }
-  // Sort groups by name, tokens within each group by path.
-  return new Map(
-    [...groups.entries()]
-      .toSorted(([a], [b]) => a.localeCompare(b))
-      .map(([k, v]) => [k, v.toSorted((a, b) => a.id.localeCompare(b.id))]),
-  );
+  sortTree(rootNode);
+  return rootNode.children;
+}
+
+function sortTree(node: GroupNode): void {
+  node.children.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === 'group' ? -1 : 1;
+    return a.segment.localeCompare(b.segment);
+  });
+  for (const c of node.children) {
+    if (c.kind === 'group') sortTree(c);
+  }
+}
+
+function collectInitialExpanded(nodes: TreeNode[], remainingDepth: number, out: Set<string>): void {
+  if (remainingDepth <= 0) return;
+  for (const node of nodes) {
+    if (node.kind !== 'group') continue;
+    out.add(node.path);
+    collectInitialExpanded(node.children, remainingDepth - 1, out);
+  }
+}
+
+function countLeaves(node: TreeNode): number {
+  if (node.kind === 'leaf') return 1;
+  let n = 0;
+  for (const c of node.children) n += countLeaves(c);
+  return n;
+}
+
+function filterTree(nodes: TreeNode[], query: string): TreeNode[] {
+  if (!query) return nodes;
+  const out: TreeNode[] = [];
+  for (const node of nodes) {
+    if (node.kind === 'leaf') {
+      if (node.path.toLowerCase().includes(query)) out.push(node);
+      continue;
+    }
+    const filteredChildren = filterTree(node.children, query);
+    if (filteredChildren.length > 0) {
+      out.push({ ...node, children: filteredChildren });
+    }
+  }
+  return out;
+}
+
+function collectAllGroupPaths(nodes: TreeNode[], out: Set<string>): void {
+  for (const node of nodes) {
+    if (node.kind === 'group') {
+      out.add(node.path);
+      collectAllGroupPaths(node.children, out);
+    }
+  }
 }
 
 interface PanelProps {
   active: boolean;
 }
 
-export function TokensPanel({ active }: PanelProps): ReactElement | null {
+export function DesignTokensPanel({ active }: PanelProps): ReactElement | null {
   const payload = usePayload();
   const [globals] = useGlobals();
   const [query, setQuery] = useState('');
@@ -197,17 +346,45 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
   const tokens = useMemo(() => payload?.themesResolved[themeName] ?? {}, [payload, themeName]);
   const tokenCount = Object.keys(tokens).length;
 
-  const grouped = useMemo(() => groupByType(tokens), [tokens]);
+  const tree = useMemo(() => buildTree(tokens), [tokens]);
   const lowerQuery = query.toLowerCase();
-  const filtered = useMemo(() => {
-    if (!lowerQuery) return grouped;
-    const out = new Map<string, VirtualToken[]>();
-    for (const [type, list] of grouped) {
-      const matches = list.filter((t) => t.id.toLowerCase().includes(lowerQuery));
-      if (matches.length > 0) out.set(type, matches);
-    }
+  const filtered = useMemo(() => filterTree(tree, lowerQuery), [tree, lowerQuery]);
+
+  const initialExpanded = useMemo(() => {
+    const out = new Set<string>();
+    collectInitialExpanded(tree, 1, out);
     return out;
-  }, [grouped, lowerQuery]);
+  }, [tree]);
+
+  const [expanded, setExpanded] = useState<Set<string>>(initialExpanded);
+  useEffect(() => {
+    setExpanded(initialExpanded);
+  }, [initialExpanded]);
+
+  // When searching, expand every matching group so hits are visible.
+  const displayExpanded = useMemo(() => {
+    if (!lowerQuery) return expanded;
+    const all = new Set<string>();
+    collectAllGroupPaths(filtered, all);
+    return all;
+  }, [expanded, filtered, lowerQuery]);
+
+  const toggle = useCallback((path: string): void => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  }, []);
+
+  const handleLeafClick = useCallback(
+    (path: string) => {
+      const varName = makeCssVarName(path, prefix);
+      void copy(`var(${varName})`);
+    },
+    [prefix],
+  );
 
   if (!active) return null;
 
@@ -215,19 +392,12 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
     return h(Placeholder, null, 'Waiting for swatchbook preview…');
   }
 
-  const totalMatches = [...filtered.values()].reduce((n, l) => n + l.length, 0);
-
   const showAxisIndicator =
     axes.length > 1 || (axes.length === 1 && axes[0]?.source !== 'synthetic');
   const axisIndicatorText = axes
     .map((axis) => `${axis.name}: ${tuple[axis.name] ?? axis.default}`)
     .join('  ·  ');
   const disabledAxes = payload?.disabledAxes ?? [];
-  /**
-   * Disabled axes don't appear in `axes` (filtered at load time) so their
-   * values aren't in `tuple` either. The surviving themes still carry the
-   * pinned value on their `input`, so pick any theme and read it out.
-   */
   const pinnedSample = themes[0]?.input ?? {};
   const disabledIndicatorText = disabledAxes
     .map((name) => `${name}: ${pinnedSample[name] ?? '?'} · pinned`)
@@ -235,16 +405,16 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
 
   return h(
     'div',
-    { style: { display: 'flex', flexDirection: 'column', height: '100%' } },
+    { style: containerStyle },
     h(
       'div',
-      { style: searchBarStyle },
+      { style: headerStyle },
       showAxisIndicator &&
         h(
           'div',
           {
             style: axisIndicatorStyle,
-            'data-testid': 'tokens-panel-axis-indicator',
+            'data-testid': 'design-tokens-panel-axis-indicator',
           },
           axisIndicatorText,
         ),
@@ -253,7 +423,7 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
           'div',
           {
             style: { ...axisIndicatorStyle, opacity: 0.5 },
-            'data-testid': 'tokens-panel-disabled-axes-indicator',
+            'data-testid': 'design-tokens-panel-disabled-axes-indicator',
           },
           disabledIndicatorText,
         ),
@@ -268,35 +438,131 @@ export function TokensPanel({ active }: PanelProps): ReactElement | null {
     h(
       ScrollArea,
       { vertical: true },
-      totalMatches === 0
-        ? h(Placeholder, null, 'No tokens match this filter.')
-        : [...filtered.entries()].map(([type, list]) =>
+      filtered.length === 0
+        ? h(Placeholder, null, query ? 'No tokens match this filter.' : 'No tokens in this theme.')
+        : h(
+            'div',
+            { style: treeWrapperStyle },
             h(
-              'section',
-              { key: type },
-              h('header', { style: groupHeaderStyle }, type, ` · ${list.length}`),
-              list.map((token) => {
-                const cssVar = makeCssVar(token.id, prefix);
-                return h(
-                  'button',
-                  {
-                    key: token.id,
-                    type: 'button',
-                    style: rowStyle,
-                    title: `Click to copy var(${cssVar})`,
-                    onClick: () => void copy(`var(${cssVar})`),
-                  },
-                  h('span', { style: pathStyle }, token.id),
-                  h('span', { style: valueStyle }, formatValue(token.$value)),
-                );
-              }),
+              'ul',
+              { style: treeUlStyle, role: 'tree' },
+              filtered.map((node) =>
+                h(TreeRow, {
+                  key: node.path || node.segment,
+                  node,
+                  expanded: displayExpanded,
+                  onToggle: toggle,
+                  onLeafClick: handleLeafClick,
+                  prefix,
+                }),
+              ),
             ),
           ),
+      h(DiagnosticsSection, { diagnostics: payload.diagnostics }),
     ),
   );
 }
 
-const severityStyle: Record<DiagnosticSeverity, React.CSSProperties> = {
+interface TreeRowProps {
+  node: TreeNode;
+  expanded: Set<string>;
+  onToggle(path: string): void;
+  onLeafClick(path: string): void;
+  prefix: string;
+}
+
+function TreeRow({ node, expanded, onToggle, onLeafClick, prefix }: TreeRowProps): ReactElement {
+  if (node.kind === 'leaf') {
+    return h(LeafRow, { node, onLeafClick, prefix });
+  }
+  const isOpen = expanded.has(node.path);
+  const onKey = (e: KeyboardEvent<HTMLDivElement>): void => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      onToggle(node.path);
+    }
+  };
+  return h(
+    'li',
+    { role: 'treeitem', 'aria-expanded': isOpen },
+    h(
+      'div',
+      {
+        role: 'button',
+        tabIndex: 0,
+        style: groupRowStyle,
+        onClick: () => onToggle(node.path),
+        onKeyDown: onKey,
+        'data-path': node.path,
+        'data-testid': 'design-tokens-panel-group',
+      },
+      h('span', { style: caretStyle, 'aria-hidden': true }, isOpen ? '▾' : '▸'),
+      h('span', null, node.segment),
+      h('span', { style: countStyle }, countLeaves(node)),
+    ),
+    isOpen &&
+      h(
+        'ul',
+        { style: nestedUlStyle, role: 'group' },
+        node.children.map((c) =>
+          h(TreeRow, {
+            key: c.path || c.segment,
+            node: c,
+            expanded,
+            onToggle,
+            onLeafClick,
+            prefix,
+          }),
+        ),
+      ),
+  );
+}
+
+interface LeafRowProps {
+  node: LeafNode;
+  onLeafClick(path: string): void;
+  prefix: string;
+}
+
+function LeafRow({ node, onLeafClick, prefix }: LeafRowProps): ReactElement {
+  const type = node.token.$type ?? '';
+  const value = node.token.$value;
+  const displayValue = formatValue(value);
+  const isColor = type === 'color' && typeof value === 'object' && value !== null;
+  const colorPreview =
+    isColor && typeof (value as Record<string, unknown>)['hex'] === 'string'
+      ? ((value as Record<string, unknown>)['hex'] as string)
+      : null;
+
+  const varName = makeCssVarName(node.path, prefix);
+
+  return h(
+    'li',
+    { role: 'treeitem' },
+    h(
+      'button',
+      {
+        type: 'button',
+        style: leafRowStyle,
+        onClick: () => onLeafClick(node.path),
+        title: `Click to copy var(${varName})`,
+        'data-path': node.path,
+        'data-testid': 'design-tokens-panel-leaf',
+      },
+      h('span', { style: caretStyle, 'aria-hidden': true }, '•'),
+      h('span', null, node.segment),
+      type && h('span', { style: typePillStyle }, type),
+      h('span', { style: valueStyle }, displayValue),
+      colorPreview &&
+        h('span', {
+          style: { ...swatchStyle, background: colorPreview },
+          'aria-hidden': true,
+        }),
+    ),
+  );
+}
+
+const severityStyle: Record<DiagnosticSeverity, CSSProperties> = {
   error: { color: '#d64545' },
   warn: { color: '#b08900' },
   info: { opacity: 0.6 },
@@ -308,25 +574,37 @@ const severityLabel: Record<DiagnosticSeverity, string> = {
   info: 'INFO',
 };
 
-const diagnosticRowStyle: React.CSSProperties = {
+const diagnosticsSectionStyle: CSSProperties = {
+  borderTop: '1px solid rgba(128,128,128,0.2)',
+  marginTop: 8,
+};
+
+const diagnosticsSummaryStyle: CSSProperties = {
+  padding: '10px 12px',
+  fontSize: 12,
+  cursor: 'pointer',
+  userSelect: 'none',
+  listStyle: 'none',
+  display: 'flex',
+  alignItems: 'center',
+  gap: 8,
+};
+
+const diagnosticRowStyle: CSSProperties = {
   display: 'grid',
   gridTemplateColumns: '60px 1fr',
   gap: 12,
   padding: '8px 12px',
   fontSize: 12,
-  borderBottom: '1px solid rgba(128,128,128,0.12)',
+  borderTop: '1px solid rgba(128,128,128,0.12)',
 };
 
-export function DiagnosticsPanel({ active }: PanelProps): ReactElement | null {
-  const payload = usePayload();
+interface DiagnosticsSectionProps {
+  diagnostics: readonly VirtualDiagnostic[];
+}
 
-  if (!active) return null;
-
-  if (!payload) {
-    return h(Placeholder, null, 'Waiting for swatchbook preview…');
-  }
-
-  const counts = payload.diagnostics.reduce(
+function DiagnosticsSection({ diagnostics }: DiagnosticsSectionProps): ReactElement {
+  const counts = diagnostics.reduce(
     (acc, d) => {
       acc[d.severity] = (acc[d.severity] ?? 0) + 1;
       return acc;
@@ -334,50 +612,64 @@ export function DiagnosticsPanel({ active }: PanelProps): ReactElement | null {
     { error: 0, warn: 0, info: 0 } as Record<DiagnosticSeverity, number>,
   );
 
-  if (payload.diagnostics.length === 0) {
-    return h(
-      Placeholder,
-      null,
-      h('strong', null, 'All clear ✓'),
-      h('span', { style: { display: 'block', marginTop: 8, opacity: 0.7 } }, 'No diagnostics.'),
-    );
-  }
+  const hasErrorsOrWarnings = counts.error > 0 || counts.warn > 0;
+
+  const summaryText = (() => {
+    if (diagnostics.length === 0) return '✔ OK · no diagnostics';
+    const parts: string[] = [];
+    if (counts.error > 0) parts.push(`✖ ${counts.error} error${counts.error === 1 ? '' : 's'}`);
+    if (counts.warn > 0) parts.push(`⚠ ${counts.warn} warning${counts.warn === 1 ? '' : 's'}`);
+    if (counts.info > 0) parts.push(`${counts.info} info`);
+    return parts.join(' · ');
+  })();
+
+  const summaryColor = (() => {
+    if (diagnostics.length === 0) return '#30a46c';
+    if (counts.error > 0) return '#d64545';
+    if (counts.warn > 0) return '#b08900';
+    return 'inherit';
+  })();
 
   return h(
-    'div',
-    { style: { display: 'flex', flexDirection: 'column', height: '100%' } },
+    'details',
+    {
+      style: diagnosticsSectionStyle,
+      open: hasErrorsOrWarnings,
+      'data-testid': 'design-tokens-panel-diagnostics',
+    },
     h(
-      'header',
-      { style: { ...searchBarStyle, display: 'flex', gap: 16, fontSize: 11 } },
-      h('span', severityStyle.error, `${counts.error} errors`),
-      h('span', severityStyle.warn, `${counts.warn} warnings`),
-      h('span', severityStyle.info, `${counts.info} info`),
+      'summary',
+      { style: { ...diagnosticsSummaryStyle, color: summaryColor, fontWeight: 600 } },
+      h('span', null, 'Diagnostics'),
+      h('span', { style: { fontWeight: 400 } }, summaryText),
     ),
-    h(
-      ScrollArea,
-      { vertical: true },
-      payload.diagnostics.map((d, i) =>
-        h(
+    diagnostics.length === 0
+      ? null
+      : h(
           'div',
-          { key: `${d.group}-${i}`, style: diagnosticRowStyle },
-          h(
-            'span',
-            { style: { ...severityStyle[d.severity], fontWeight: 600, fontSize: 10 } },
-            severityLabel[d.severity],
-          ),
-          h(
-            'div',
-            null,
-            h('div', null, d.message),
-            (d.filename || d.group) &&
+          null,
+          diagnostics.map((d, i) =>
+            h(
+              'div',
+              { key: `${d.group}-${i}`, style: diagnosticRowStyle },
+              h(
+                'span',
+                { style: { ...severityStyle[d.severity], fontWeight: 600, fontSize: 10 } },
+                severityLabel[d.severity],
+              ),
               h(
                 'div',
-                { style: { opacity: 0.5, fontSize: 10, marginTop: 4 } },
-                [d.group, d.filename, d.line ? `:${d.line}` : ''].filter(Boolean).join(' · '),
+                null,
+                h('div', null, d.message),
+                (d.filename || d.group) &&
+                  h(
+                    'div',
+                    { style: { opacity: 0.5, fontSize: 10, marginTop: 4 } },
+                    [d.group, d.filename, d.line ? `:${d.line}` : ''].filter(Boolean).join(' · '),
+                  ),
               ),
+            ),
           ),
         ),
-      ),
-    ),
   );
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -88,7 +88,7 @@ const css = projectCss(project);
 const dts = emitTypes(project);
 ```
 
-`project.diagnostics` is always populated — severity is `'error' | 'warn' | 'info'`. The addon surfaces these in its Diagnostics panel; your own pipeline can inspect / `throw` on `severity === 'error'` as fits.
+`project.diagnostics` is always populated — severity is `'error' | 'warn' | 'info'`. The addon surfaces these in its Design Tokens panel (diagnostics section); your own pipeline can inspect / `throw` on `severity === 'error'` as fits.
 
 ## Axes and theme naming
 


### PR DESCRIPTION
## Summary

- One `Design Tokens` panel replaces the separate `Swatchbook tokens` and `Swatchbook diagnostics` panels.
- Primary view: a hierarchical tree of the active theme's tokens — expand/collapse groups, leaf-count badges, type pill, inline value display with a color swatch for `color` tokens, path-substring search, click a leaf to copy `var(--…)`. Matches the `TokenNavigator` block's interaction model.
- Secondary view: diagnostics in a `<details>` beneath the tree — collapsed with a green "OK" badge when clean, auto-expanded with a severity summary ("✖ N errors · ⚠ N warnings") when anything fires.
- Drops `PANEL_TOKENS_TAB` / `PANEL_DIAGNOSTICS_TAB`; new stable id `PANEL_ID = 'swatchbook/design-tokens'`.

## Surprises

The task brief suggested mounting `<TokenNavigator />` from `@unpunnyfuns/swatchbook-blocks` behind a panel-local `SwatchbookContext.Provider`. That turned out to be non-viable: `TokenNavigator` transitively imports `virtual:swatchbook/tokens` (via `use-project.ts`), which is a preview-side Vite virtual module — our Vite plugin only runs against the preview config (`viteFinal`), not the manager bundle. The top-level virtual import would fail to resolve when Storybook bundles the manager, breaking the whole addon.

Rather than reshape blocks to tolerate a manager-side mount (splitting out a panel-safe entry point, guarding the virtual import, exposing a context-only navigator, etc.), we ported a compact tree into `panel.tsx` that reads straight from the existing `INIT_EVENT` channel payload — the same data source the old two panels already used. Visual/interaction parity with `TokenNavigator` for the subset that makes sense in the bottom panel (no heavy per-type previews like `<ShadowSample>` — those need the preview's injected CSS variables to render). Future work: if the navigator ever becomes the panel's dedicated surface, introduce a manager-safe entry point in blocks that doesn't import the virtual module at all.

No new play-function tests: panels live in the manager iframe, outside `canvasElement`, so Storybook's Test runner can't reach them.

Milestone: Maintenance
Closes #216
Plan impact: none

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck test build` green.
- [x] `pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook` green (127 tests, 31 files).
- [ ] Manual: open Storybook, confirm the single `Design Tokens` panel, tree expansion, search filter, leaf click copies the CSS var, diagnostics section toggles correctly.