### PR TITLE
fix(addon): polish toolbar and Design Tokens panel

### DIFF
--- a/.changeset/addon-ui-polish.md
+++ b/.changeset/addon-ui-polish.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Addon UI polish: restore the yinyang-style toolbar icon, drop the "Swatchbook" label from the toolbar button (tooltip still explains), and clear lingering `:focus` outlines from toolbar pills and Design Tokens panel tree rows. Also moves the Diagnostics section to the top of the Design Tokens panel so warnings and errors are visible without scrolling past the token tree. Closes #219 and #220.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -54,38 +54,17 @@ const EMPTY_PRESETS: readonly PresetEntry[] = [];
 const EMPTY_THEMES: ThemeEntry[] = [];
 
 /**
- * Root toolbar glyph — a 3-swatch stack chosen to read as "swatchbook"
- * at 14px and to look visually distinct from the previous per-axis chip
- * icon (single circle) so users notice the toolbar change.
+ * Root toolbar glyph — a split-circle ("yinyang") mark: a faint filled
+ * disc for the full-swatch silhouette, with a darker half-and-inset-disc
+ * path reading as a pair of theme variants swapped in place.
  */
 function SwatchbookIcon(): ReactElement {
   return h(
     'svg',
     { width: 14, height: 14, viewBox: '0 0 14 14', 'aria-hidden': true },
-    h('rect', {
-      x: 1,
-      y: 2,
-      width: 9,
-      height: 9,
-      rx: 1.5,
-      fill: 'currentColor',
-      opacity: 0.25,
-    }),
-    h('rect', {
-      x: 2.5,
-      y: 3.5,
-      width: 9,
-      height: 9,
-      rx: 1.5,
-      fill: 'currentColor',
-      opacity: 0.55,
-    }),
-    h('rect', {
-      x: 4,
-      y: 5,
-      width: 9,
-      height: 9,
-      rx: 1.5,
+    h('circle', { cx: 7, cy: 7, r: 6, fill: 'currentColor', opacity: 0.15 }),
+    h('path', {
+      d: 'M7 1a6 6 0 0 0 0 12 3 3 0 0 0 0-6 3 3 0 0 1 0-6Z',
       fill: 'currentColor',
     }),
   );
@@ -203,6 +182,7 @@ const OPTION_PILL_BASE: React.CSSProperties = {
   background: 'transparent',
   cursor: 'pointer',
   color: 'inherit',
+  outline: 'none',
 };
 
 const OPTION_PILL_ACTIVE: React.CSSProperties = {
@@ -554,7 +534,6 @@ function AxesToolbar(): ReactElement {
       onClick: () => setOpen((prev) => !prev),
     },
     h(SwatchbookIcon),
-    h('span', { style: { marginLeft: 6 } }, 'Swatchbook'),
   );
 
   const tooltipBody = h(PopoverBody, {

--- a/packages/addon/src/panel.tsx
+++ b/packages/addon/src/panel.tsx
@@ -128,6 +128,7 @@ const groupRowStyle: CSSProperties = {
   borderRadius: 4,
   cursor: 'pointer',
   userSelect: 'none',
+  outline: 'none',
 };
 
 const leafRowStyle: CSSProperties = {
@@ -144,6 +145,7 @@ const leafRowStyle: CSSProperties = {
   textAlign: 'left',
   fontFamily: 'inherit',
   fontSize: 'inherit',
+  outline: 'none',
 };
 
 const caretStyle: CSSProperties = {
@@ -435,6 +437,7 @@ export function DesignTokensPanel({ active }: PanelProps): ReactElement | null {
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value),
       }),
     ),
+    h(DiagnosticsSection, { diagnostics: payload.diagnostics }),
     h(
       ScrollArea,
       { vertical: true },
@@ -458,7 +461,6 @@ export function DesignTokensPanel({ active }: PanelProps): ReactElement | null {
               ),
             ),
           ),
-      h(DiagnosticsSection, { diagnostics: payload.diagnostics }),
     ),
   );
 }
@@ -575,8 +577,7 @@ const severityLabel: Record<DiagnosticSeverity, string> = {
 };
 
 const diagnosticsSectionStyle: CSSProperties = {
-  borderTop: '1px solid rgba(128,128,128,0.2)',
-  marginTop: 8,
+  borderBottom: '1px solid rgba(128,128,128,0.2)',
 };
 
 const diagnosticsSummaryStyle: CSSProperties = {


### PR DESCRIPTION
## Summary

- Restore the yinyang-style `SwatchbookIcon` in the toolbar; drop the "Swatchbook" label span (tooltip still explains).
- Add `outline: 'none'` to toolbar option pills and to the Design Tokens panel group/leaf row styles so the browser's default focus ring doesn't linger on previously-clicked controls.
- Move the Diagnostics section to the top of the Design Tokens panel so warnings and errors are visible without scrolling past the token tree. Auto-expand-on-warn-or-error and green "OK" summary semantics preserved.

## Test plan

- [x] `pnpm -r format`
- [x] `pnpm turbo run lint typecheck test build`
- [x] `pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook` (31 files, 126 tests passing)
- [ ] Visual: toolbar shows split-circle icon only, clicking pills leaves no stray ring, Design Tokens panel shows diagnostics banner above the tree.

Closes #219
Closes #220

Milestone: Maintenance
Plan impact: none