### PR TITLE
chore(storybook): move subcomponent and sample stories under Internals

### DIFF
--- a/apps/storybook/src/stories/BorderSample.stories.tsx
+++ b/apps/storybook/src/stories/BorderSample.stories.tsx
@@ -2,7 +2,7 @@ import { BorderSample } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/Samples/BorderSample',
+  title: 'Internals/Samples/BorderSample',
   component: BorderSample,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/DimensionBar.stories.tsx
+++ b/apps/storybook/src/stories/DimensionBar.stories.tsx
@@ -2,7 +2,7 @@ import { DimensionBar } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/Samples/DimensionBar',
+  title: 'Internals/Samples/DimensionBar',
   component: DimensionBar,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/MotionSample.stories.tsx
+++ b/apps/storybook/src/stories/MotionSample.stories.tsx
@@ -2,7 +2,7 @@ import { MotionSample } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/MotionSample',
+  title: 'Internals/Samples/MotionSample',
   component: MotionSample,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/ShadowSample.stories.tsx
+++ b/apps/storybook/src/stories/ShadowSample.stories.tsx
@@ -2,7 +2,7 @@ import { ShadowSample } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/Samples/ShadowSample',
+  title: 'Internals/Samples/ShadowSample',
   component: ShadowSample,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
@@ -2,7 +2,7 @@ import { AliasChain } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/AliasChain',
+  title: 'Internals/TokenDetail/AliasChain',
   component: AliasChain,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
@@ -2,7 +2,7 @@ import { AliasedBy } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/AliasedBy',
+  title: 'Internals/TokenDetail/AliasedBy',
   component: AliasedBy,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
@@ -2,7 +2,7 @@ import { AxisVariance } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/AxisVariance',
+  title: 'Internals/TokenDetail/AxisVariance',
   component: AxisVariance,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
@@ -2,7 +2,7 @@ import { CompositeBreakdown } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/CompositeBreakdown',
+  title: 'Internals/TokenDetail/CompositeBreakdown',
   component: CompositeBreakdown,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
@@ -2,7 +2,7 @@ import { CompositePreview } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/CompositePreview',
+  title: 'Internals/TokenDetail/CompositePreview',
   component: CompositePreview,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/ConsumerOutput.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/ConsumerOutput.stories.tsx
@@ -3,7 +3,7 @@ import { expect, userEvent, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/ConsumerOutput',
+  title: 'Internals/TokenDetail/ConsumerOutput',
   component: ConsumerOutput,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
@@ -2,7 +2,7 @@ import { TokenHeader } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/TokenHeader',
+  title: 'Internals/TokenDetail/TokenHeader',
   component: TokenHeader,
   argTypes: {
     path: { control: 'text' },

--- a/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
@@ -2,7 +2,7 @@ import { TokenUsageSnippet } from '@unpunnyfuns/swatchbook-blocks';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
-  title: 'Blocks/TokenDetail/TokenUsageSnippet',
+  title: 'Internals/TokenDetail/TokenUsageSnippet',
   component: TokenUsageSnippet,
   argTypes: {
     path: { control: 'text' },


### PR DESCRIPTION
## Summary

Splits the Storybook sidebar so composed, user-facing blocks stay prominent under `Blocks/` while internal subcomponents and sample primitives move under a new `Internals/` group.

- `Blocks/TokenDetail/*` subcomponents (TokenHeader, AliasChain, AliasedBy, CompositePreview, CompositeBreakdown, AxisVariance, TokenUsageSnippet, ConsumerOutput) retitled to `Internals/TokenDetail/*`.
- Sample primitives (ShadowSample, BorderSample, DimensionBar, MotionSample) retitled to `Internals/Samples/*`. MotionSample was previously at `Blocks/MotionSample` (flat, not under `Blocks/Samples/`) — moved alongside the others for consistency.
- Public composed blocks (TokenTable, ColorPalette, TokenDetail, TokenNavigator, TypographyScale, DimensionScale, MotionPreview, ShadowPreview, BorderPreview, GradientPalette) left at `Blocks/<Name>`.

Only `title:` strings in each story meta changed — no imports, args, play functions, or component code touched.

Closes #223
Milestone: Maintenance
Plan impact: none

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck test build` green
- [x] `pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook` green (126/126)
- [x] `pnpm turbo run build:storybook` — verified sidebar structure via `storybook-static/index.json` (10 `Blocks/*`, 4 `Internals/Samples/*`, 8 `Internals/TokenDetail/*`).