### PR TITLE
docs: refresh plan.md and CLAUDE.md for release prep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,31 +4,28 @@ Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfun
 
 ## Start here
 
-- Design doc: `docs/plan.md` — milestones M0–M9, package responsibilities, decisions locked in.
+- Design doc: `docs/plan.md` — current state summary, package responsibilities, scope areas, decisions locked in.
 - Decision log: `docs/decisions.md` — append-only ADR-lite for changes made during execution.
 - Terrazzo spike: `docs/terrazzo-notes.md` — what `@terrazzo/parser` gives us and what core still owns.
 - Future plans: `docs/future.md` — ideas deliberately deferred past v0.1.0, with the *why* preserved so we don't re-litigate.
 
 ## Current milestone
 
-`Current: between milestones` — Full DTCG type parity with Terrazzo closed 2026-04-18 (issues #176, #179, #189, #190 all landed): gradient type shipped with fixture + block + TokenDetail preview; strokeStyle gained a TokenDetail SVG preview; color tokens got a two-surface contrast swatch; composite types (typography/shadow/border/transition/gradient) render a labelled sub-value breakdown. Documentation site live at https://unpunnyfuns.github.io/swatchbook/. Open feature milestones: **Split large doc blocks** (#22 — #174/#175), **Drop package-name prefixes from headers** (#24 — #181), **Three-axis fixture + disable-axis config** (#25 — #182/#183), **Rendered output views** (#27 — #186/#187). Release stays on hold.
+`Current: prepping v0.1.0 release` — remaining work tracked in the **Release** milestone: publish workflow in CI with npm token + provenance (issue #41), then cut v0.1.0 with tag + release notes (issue #42). Feature work feeding into the release has already landed: full DTCG type parity with Terrazzo, consolidated toolbar (PR #213) and Design Tokens panel (PR #218), toolbar polish (PR #221), `disabledAxes` config surface (PR #206), `SwatchbookProvider` for framework-free rendering (PR #201), `TokenNavigator` block (PR #210), consumer-output panel (PR #209), color value format switcher (PR #208). Documentation site live at https://unpunnyfuns.github.io/swatchbook/.
 
 Update this line when a milestone closes. See the matching GitHub milestones for per-issue state.
 
 ### Milestone taxonomy
 
-GitHub milestones are scope buckets, not a sequence. Originally prefixed `M0`–`M13` when the work was ordered around a v0.1.0 release; prefixes dropped once release was postponed indefinitely (iterating on features > shipping versions).
+GitHub milestones are scope buckets, not a sequence. Originally prefixed `M0`–`M13` when the work was ordered around a v0.1.0 release; prefixes were dropped during the feature push and re-focused now that we're cutting v0.1.0.
 
 Two active tracks:
 
-- **Feature milestones** — named scope areas in `docs/plan.md` (*Foundation*, *Core*, *Doc blocks*, *DTCG comprehension visualizations*, *Multi-axis theming UX*, …). Pick one to be "current"; the line above names it. No implied ordering beyond what `docs/plan.md` describes.
+- **Feature milestones** — named scope areas in `docs/plan.md` (*Foundation*, *Core*, *Doc blocks*, *DTCG comprehension visualizations*, *Multi-axis theming UX*, …). Pick one to be "current" when we're pushing on features; the line above names what's active. No implied ordering beyond what `docs/plan.md` describes.
 - **Maintenance** — hygiene, refactors, CI polish, deferred cleanups. Drained opportunistically; never blocks a feature milestone.
+- **Release** — Changesets versioning, publish workflow, cutting tags. **Active** for v0.1.0 — see the "Current milestone" line.
 
-One dormant track:
-
-- **Release** — Changesets versioning, publish workflow, cutting tags. **On hold** until release timing is explicitly decided. Issues originally scoped here sit unassigned for now.
-
-When filing an issue: feature work → the relevant scope milestone. Repo hygiene → *Maintenance*. Release plumbing → leave unassigned; we'll re-adopt the *Release* milestone when we're ready to ship.
+When filing an issue: feature work → the relevant scope milestone. Repo hygiene → *Maintenance*. Release plumbing → the *Release* milestone.
 
 ## Project conventions
 
@@ -98,7 +95,7 @@ claude
 
 - **Versioning:** [Changesets](https://github.com/changesets/changesets). Config in `.changeset/config.json`. The three published packages — `@unpunnyfuns/swatchbook-core`, `@unpunnyfuns/swatchbook-addon`, `@unpunnyfuns/swatchbook-blocks` — are grouped as `fixed`: they always carry the same version and release together. Private workspaces (root, `apps/storybook`, `tokens-reference`) and the iceboxed `tokens-starter` are listed under `ignore` so they never appear in bump prompts or get published.
 - **Writing a changeset:** any PR with a user-visible change to the fixed-group packages runs `pnpm changeset` locally, picks the bump type (`patch` / `minor` / `major`), and commits the generated `.changeset/*.md` alongside the change. Purely internal refactors and doc-only PRs can skip it.
-- **Publishing flow:** on `main`, Changesets' GitHub Action opens a "Version Packages" PR that consumes queued `.changeset/*.md` entries, bumps `package.json` versions, and regenerates `CHANGELOG.md`. Merging that PR runs `pnpm release` (builds + `changeset publish`) which pushes tags to GitHub and publishes to npm. See `.github/workflows/release.yml` (to land under M9).
+- **Publishing flow:** on `main`, Changesets' GitHub Action opens a "Version Packages" PR that consumes queued `.changeset/*.md` entries, bumps `package.json` versions, and regenerates `CHANGELOG.md`. Merging that PR runs `pnpm release` (builds + `changeset publish`) which pushes tags to GitHub and publishes to npm. See `.github/workflows/release.yml` (lands under the Release milestone via issue #41).
 
 ## Plan governance
 

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,5 +1,13 @@
 # Swatchbook — Storybook addon for DTCG design tokens
 
+## Current state
+
+**Prepping v0.1.0 release.** The feature surface targeted for the first public cut has landed: DTCG loading + emission (core), live theme switching with multi-axis resolvers (addon), the full doc-block set (`TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail` with composite previews, `DimensionScale`, `ShadowPreview`, `BorderPreview`, `MotionPreview`, `TokenNavigator`), comprehension visualizations for every DTCG primitive + composite type (including gradient and strokeStyle), Storybook interaction tests, consolidated toolbar + Design Tokens panel, `SwatchbookProvider` for framework-free rendering, consumer-output panel with CSS/JSON/JS/TS tabs, color value format switcher, and `disabledAxes` config surface. Documentation site live at https://unpunnyfuns.github.io/swatchbook/.
+
+**Remaining for v0.1.0:** publish pipeline — Changesets publish workflow in CI (npm token + provenance, issue #41) and cutting the tag + release notes (issue #42). Tracked under the **Release** milestone.
+
+**Feature work past v0.1.0** lives under open feature milestones (Documentation, Rendered output views and human-readable color formats, Presentation/connection split for blocks, Token navigator block) and `docs/future.md`. Live state for every scope bucket: https://github.com/unpunnyfuns/swatchbook/milestones.
+
 ## Mission
 
 **An addon and tools to help people visualize their future design token projects using Storybook.**
@@ -33,7 +41,10 @@ This keeps the addon narrow, keeps the value shareable across the DTCG ecosystem
 - **Rendering blocks** cover DTCG types: `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail` (with composite previews for typography / shadow / border / transition), `DimensionScale`, `ShadowPreview`, `BorderPreview`, `MotionPreview`. Gaps in type coverage are tracked as their own scope bucket.
 - **Single-axis resolvers** get clean theme names automatically. Multi-axis resolvers use Terrazzo's permutation IDs — a known rough edge, addressed in the multi-axis theming milestone.
 
-**Release cadence: deferred.** Iterating on features takes priority over shipping versions to npm. Packages stay unpublished until we explicitly decide to ship; `@unpunnyfuns/swatchbook-tokens` is iceboxed (see `docs/decisions.md`).
+**Release cadence: v0.1.0 in flight.** The three published packages (`@unpunnyfuns/swatchbook-core`, `-addon`, `-blocks`) are grouped as `fixed` under Changesets and will release together. `@unpunnyfuns/swatchbook-tokens` stays iceboxed (see `docs/decisions.md`). Remaining release work is tracked under the Release milestone — see "Current state" above.
+
+<details>
+<summary><strong>Scaffold-era context and repo layout</strong> (historical — decisions captured, current state has moved on)</summary>
 
 ## Context
 
@@ -120,6 +131,8 @@ swatchbook/
       vitest.config.ts              # Storybook Test (project: 'storybook')
       package.json                  # private, not published
 ```
+
+</details>
 
 ## Package responsibilities
 
@@ -216,7 +229,8 @@ Doc blocks consumable from MDX. Each block reads the same virtual token graph.
 
 All blocks are presentational; theme state comes from Storybook globals via `useGlobals()` so they react to the toolbar.
 
-## Critical files to create
+<details>
+<summary><strong>Critical files to create</strong> (scaffold-era — files now exist)</summary>
 
 - `packages/core/src/parse.ts` — glue to `@terrazzo/parser`. Must handle DTCG `$type` inheritance and `{alias}` references through the parser's resolver.
 - `packages/core/src/themes/normalize.ts` — converges layered / DTCG-resolver / Tokens-Studio-manifest inputs into one `Theme[]`. Core's most complex file.
@@ -226,13 +240,15 @@ All blocks are presentational; theme state comes from Storybook globals via `use
 - `packages/addon/src/controls/color.tsx` — study Storybook's built-in `ColorControl` for the registration contract.
 - `packages/blocks/src/TokenTable.tsx` — reference implementation the other blocks follow.
 
+</details>
+
 ## Dependencies
 
 - `@terrazzo/parser` — DTCG parsing, alias resolution, validation
 - `storybook@^10.3` (peer), `@storybook/react` (peer), `@storybook/manager-api`, `@storybook/preview-api`, `@storybook/components`, `@storybook/theming`, `@storybook/icons`
 - `react`, `react-dom` (peer)
 - `apps/storybook` dev deps: `storybook@^10.3`, `@storybook/react-vite`, `@storybook/addon-vitest`, `@storybook/addon-mcp`, `@vitest/browser`, `playwright`, `vite`
-- Root dev deps: `turbo`, `typescript`, `tsup`, `vitest`, `oxlint`, `oxfmt`
+- Root dev deps: `turbo`, `typescript`, `tsdown`, `vitest`, `oxlint`, `oxfmt`
 
 ## Token packages
 
@@ -354,7 +370,7 @@ export default defineConfig({
 
 ## Build / release
 
-- Each publishable package builds with `tsup` (ESM + CJS + `.d.ts`).
+- Each publishable package builds with `tsdown` (rolldown-powered), ESM-only + `.d.ts`. See `CLAUDE.md` project conventions.
 - **Turborepo** handles orchestration and caching:
   - `turbo run build` — topological, with `core` → `blocks`/`addon` → `apps/storybook` dependency graph.
   - `turbo run test` — runs Vitest in every package (unit tests).
@@ -377,7 +393,7 @@ Token-loading problems should be *visible*, not silent. Pipeline:
 
 ## Workspace root
 
-Root `package.json` uses `"swatchbook"` with `"private": true` — the plain unscoped name, matching the project's identity and the repo slug. Originally scaffolded as `swatchbook-monorepo` to hedge for a published meta-package; renamed during M9 once it was clear the scoped `@unpunnyfuns/swatchbook-*` package set is the public face and no meta-package is planned. See `docs/decisions.md` (2026-04-17 entry).
+Root `package.json` uses `"swatchbook"` with `"private": true` — the plain unscoped name, matching the project's identity and the repo slug. Originally scaffolded as `swatchbook-monorepo` to hedge for a published meta-package; renamed once it was clear the scoped `@unpunnyfuns/swatchbook-*` package set is the public face and no meta-package is planned. See `docs/decisions.md` (2026-04-17 entry).
 
 ## CI
 
@@ -426,9 +442,9 @@ The plan is the **design doc**; GitHub milestones/issues are the **tracker**. Do
 
 ### Tracking state
 
-- GitHub milestones **M0–M9** created at scaffold, names matching this plan.
+- GitHub milestones are scope buckets, named to match the sections in this plan (originally prefixed `M0–M13` while the plan was ordered around v0.1.0; prefixes were dropped during the long feature push and re-focused as we cut v0.1.0). See the [milestones page](https://github.com/unpunnyfuns/swatchbook/milestones) for live state.
 - One issue per "Work" bullet under each milestone. Each issue links back to the relevant `docs/plan.md` section anchor.
-- Root README carries a one-line `Current: Mx — <goal>` status that updates when a milestone closes.
+- `CLAUDE.md` carries a one-line `Current: …` status that updates when the active track moves.
 
 ### Branch & PR workflow
 
@@ -460,9 +476,12 @@ Two mechanisms:
 - **Append to `decisions.md`** for: tactical choices that don't change the design intent (e.g. "picked `tsup` over `unbuild` because of X"), post-merge observations, deprecations.
 - **Neither** for: day-to-day implementation details — those live in commit messages and issue comments.
 
-## Milestones
+## Completed milestones
 
-Each milestone has a single measurable demo step. Progress is tracked by which milestones are green.
+Every milestone below has shipped — contents preserved for trail and to keep the original design intent readable. Live state (including the per-issue breakdown) lives on the [GitHub milestones page](https://github.com/unpunnyfuns/swatchbook/milestones?state=closed). Open tracks are summarized in "Current state" at the top of this file.
+
+<details>
+<summary>History</summary>
 
 ### Foundation ✅
 **Goal:** Empty but fully wired monorepo; scope of core is confirmed; governance in place.
@@ -635,7 +654,9 @@ Beyond spec convergence, four scope areas deepen the "easier to understand DTCG"
 
 **Exit:** A token of any DTCG type has a dedicated visual inside at least one block or `TokenDetail` preview. No fallback-to-text for a type we haven't considered.
 
-### Further out
+</details>
+
+## Further out
 
 Out of scope as named milestones but worth capturing the shape:
 
@@ -646,7 +667,6 @@ Out of scope as named milestones but worth capturing the shape:
 - **Token-aware Storybook controls** (`swatchbook-color` argType etc.) — originally a planned milestone; dropped after mission tightening (authoring ergonomics, not overview).
 - **Component ↔ token reverse index.** Reads consumer stylesheets to build usage maps. Explicitly external-code analysis — outside our mission line.
 - **Graph analysis** (orphans, duplicate values, depth distributions, health scores) — belongs in Terrazzo, not here. Open a conversation if it's needed; contribute upstream.
-- **Release cadence.** Changesets versioning, publish workflow, tag cutting. Deferred by decision; re-adopt when we're ready to ship.
 
 ## Verification
 


### PR DESCRIPTION
## Summary

- **docs/plan.md** — adds a "Current state" section at the top summarizing what's shipped for v0.1.0 and what remains (publish pipeline in CI via issue #41, cutting the tag via issue #42). Collapses scaffold-era context/repo-layout/critical-files and the M0-through-DTCG-spec-convergence milestone list into `<details>` blocks so readers land on live state without scrolling past bootstrap notes. Updates the "Release cadence: deferred" line to reflect v0.1.0 in flight. Swaps stale `tsup` references for `tsdown` (the active bundler) and de-M9s the workspace-root note.
- **CLAUDE.md** — rewrites the "Current milestone" line from "between milestones" to "prepping v0.1.0 release" and names the remaining Release-milestone issues. Adjusts the milestone-taxonomy section to mark Release as active (not on hold). Points "Start here" at the current plan.md shape instead of "milestones M0–M9". Refreshes the release workflow reference to cite issue #41 rather than M9.

Package responsibilities, Plan governance, Verification, Dev environment sections left untouched (still accurate). Storybook addon gotchas all verified as still load-bearing post-consolidated-toolbar (PR #213) and Design Tokens panel (PR #218) — no changes needed there.

Closes #222
Milestone: Maintenance
Plan impact: update included

## Test plan

- [ ] Reviewer confirms the "Current state" summary in `docs/plan.md` matches what's actually shipped
- [ ] Reviewer confirms the "Current milestone" line in `CLAUDE.md` names the right remaining work for v0.1.0
- [ ] Markdown renders cleanly on GitHub (details/summary blocks collapse as expected)