### PR TITLE
ci: add Changesets release workflow with npm provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+# Prevent concurrent release runs — we don't want two Version Packages PRs
+# racing or a publish triggering while another is mid-flight.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    # Skip on the Changesets bot's own commits to avoid recursion; the
+    # changesets/action handles its own re-entry via the Version Packages PR.
+    if: github.repository == 'unpunnyfuns/swatchbook'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      # Required for npm provenance attestation (sigstore).
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create Version Packages PR or publish
+        uses: changesets/action@v1
+        with:
+          # `pnpm release` builds the three fixed-group packages and runs
+          # `changeset publish` — see package.json#scripts.
+          publish: pnpm release
+          version: pnpm version
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Opt into npm package provenance so published tarballs carry a
+          # sigstore attestation linking them back to this workflow run.
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

Wires up the first public release path.

- Push to `main` → Changesets GitHub Action either opens a "Version Packages" PR (when changesets are pending) or publishes to npm (when the Version Packages PR merges).
- `pnpm release` builds the three fixed-group packages (`core`, `addon`, `blocks`) then runs `changeset publish`.
- `id-token: write` permission + `NPM_CONFIG_PROVENANCE=true` opt into npm package provenance so published tarballs carry a sigstore attestation linking back to this workflow run.
- Concurrency group prevents racing release runs.

## Before first publish

Manual repo-side steps required before merging a Version Packages PR:

1. Create an **npm automation token** with publish scope for `@unpunnyfuns`.
2. Add it as the `NPM_TOKEN` repo secret.
3. Enable "Allow GitHub Actions to create and approve pull requests" under repo Settings → Actions → General → Workflow permissions (needed so the action can open the Version Packages PR).

Nothing to do for provenance beyond what's already in the workflow — sigstore attestation is free given `id-token: write` + the env var.

## Test plan

- [x] YAML parses (no `yamllint` in repo; visually verified indentation).
- [ ] Merge → workflow opens a Version Packages PR consuming the 36 queued changesets.
- [ ] After the Version Packages PR merges → workflow publishes `@unpunnyfuns/swatchbook-{core,addon,blocks}` at v0.1.0.

Closes #41
Milestone: Release
Plan impact: none