### PR TITLE
fix(ci): use pnpm run so release workflow hits scripts, not built-ins

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,12 @@ jobs:
       - name: Create Version Packages PR or publish
         uses: changesets/action@v1
         with:
-          # `pnpm release` builds the three fixed-group packages and runs
-          # `changeset publish` — see package.json#scripts.
-          publish: pnpm release
-          version: pnpm version
+          # `pnpm run <script>` disambiguates from pnpm's built-ins
+          # (`pnpm version` would hit the built-in and silently no-op).
+          # `version` → `changeset version`; `release` builds the three
+          # fixed-group packages and runs `changeset publish`.
+          publish: pnpm run release
+          version: pnpm run version
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'
         env:


### PR DESCRIPTION
## Summary

The release workflow from PR #228 failed on first run: \`version: pnpm version\` in the Changesets action invoked pnpm's built-in \`pnpm version\` command (which no-ops without a semver arg) instead of the \`version\` script in root package.json (\`changeset version\`). No files changed, no commits to PR, "No commits between main and changeset-release/main" from the GitHub API.

Fix: \`pnpm run version\` / \`pnpm run release\` to disambiguate from the built-ins.

## Test plan

- [ ] Merge → workflow opens the Version Packages PR consuming the queued changesets.

Closes #229
Milestone: Release
Plan impact: none