### PR TITLE
chore: downgrade pre-1.0 major changesets to minor for v0.1.0

### DIFF
--- a/.changeset/default-tuple-object.md
+++ b/.changeset/default-tuple-object.md
@@ -1,5 +1,5 @@
 ---
-'@unpunnyfuns/swatchbook-core': major
+'@unpunnyfuns/swatchbook-core': minor
 ---
 
 `Config.default` now takes a partial tuple object (`{ axisName: contextName }`) instead of a composed permutation string. Partial tuples fill omitted axes from each axis's own `default`; unknown axis keys and invalid context values surface as `warn` diagnostics (group `swatchbook/default`) and are sanitized out. Omit `default` entirely to start in the all-axis-defaults tuple.

--- a/.changeset/drop-layered-theming.md
+++ b/.changeset/drop-layered-theming.md
@@ -1,7 +1,7 @@
 ---
-'@unpunnyfuns/swatchbook-core': major
-'@unpunnyfuns/swatchbook-addon': major
-'@unpunnyfuns/swatchbook-blocks': major
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': minor
+'@unpunnyfuns/swatchbook-blocks': minor
 ---
 
 Drop the explicit-layers theming input. The DTCG 2025.10 resolver is now the sole theming input — `Config.themes`, the `ThemeConfig` type, and `resolveThemingMode` are all gone. Consumers with a layered config must move to a `resolver.json`.

--- a/.changeset/drop-manifest-support.md
+++ b/.changeset/drop-manifest-support.md
@@ -1,7 +1,7 @@
 ---
-'@unpunnyfuns/swatchbook-core': major
-'@unpunnyfuns/swatchbook-addon': major
-'@unpunnyfuns/swatchbook-blocks': major
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': minor
+'@unpunnyfuns/swatchbook-blocks': minor
 ---
 
 Drop Tokens Studio `$themes` manifest support. The DTCG 2025.10 resolver is now the spec-native theming input; consumers using a manifest should convert to a `resolver.json` (the transformation is mechanical). `Config.manifest` is removed, `resolveThemingMode` returns `'layered' | 'resolver'`, and `themingMode` on the virtual module narrows accordingly. `@unpunnyfuns/swatchbook-tokens-reference` no longer exports `manifestPath`.

--- a/.changeset/invert-blocks-addon-dep.md
+++ b/.changeset/invert-blocks-addon-dep.md
@@ -1,6 +1,6 @@
 ---
-'@unpunnyfuns/swatchbook-blocks': major
-'@unpunnyfuns/swatchbook-addon': major
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
 ---
 
 **Breaking.** `SwatchbookProvider`, `SwatchbookContext`, `ThemeContext`, `AxesContext`, `useSwatchbookData`, `useOptionalSwatchbookData`, `useActiveTheme`, `useActiveAxes`, and the `Virtual*Shape` / `ProjectSnapshot` types now live exclusively in `@unpunnyfuns/swatchbook-blocks`. They are no longer exported from `@unpunnyfuns/swatchbook-addon` — import them from `@unpunnyfuns/swatchbook-blocks` directly. Workspace dep graph runs addon → blocks, which is the direction it was always meant to. Closes issue #202.


### PR DESCRIPTION
## Summary

The first Version Packages PR (#231) bumped everything to `1.0.0` because four queued changesets are typed as `major`. From `0.0.0`, that's the semver-resolved jump. None of these changes broke a published API — the packages have never been published. Downgrading to `minor` lands the first release at `0.1.0`, which is the honest framing for a first public preview.

Files touched:

- `.changeset/default-tuple-object.md` (core)
- `.changeset/drop-layered-theming.md` (core/addon/blocks)
- `.changeset/drop-manifest-support.md` (core/addon/blocks)
- `.changeset/invert-blocks-addon-dep.md` (addon/blocks)

## Test plan

- [ ] Merge → Release workflow regenerates the Version Packages PR (#231) at `0.1.0`.
- [ ] Confirm all three fixed-group packages in the new PR show `@unpunnyfuns/swatchbook-{core,addon,blocks}@0.1.0`.

Closes #232
Milestone: Release
Plan impact: none