### PR TITLE
fix(addon): also neutralize box-shadow focus ring on toolbar pills

### DIFF
--- a/.changeset/pill-focus-boxshadow.md
+++ b/.changeset/pill-focus-boxshadow.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Kill the stray focus ring that stuck on previously-clicked toolbar pills. `outline: none` alone wasn't enough — Storybook's button theme paints a `box-shadow`-based focus ring on `:focus`, which inline style overrides. Added `boxShadow: 'none'` to the pill base.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -183,6 +183,7 @@ const OPTION_PILL_BASE: React.CSSProperties = {
   cursor: 'pointer',
   color: 'inherit',
   outline: 'none',
+  boxShadow: 'none',
 };
 
 const OPTION_PILL_ACTIVE: React.CSSProperties = {


### PR DESCRIPTION
## Summary

PR #221 added `outline: 'none'` to `OPTION_PILL_BASE` but the stray white ring on previously-clicked pills persisted. Root cause: Storybook's button theme paints a **`box-shadow`-based focus ring** on `:focus`, which the outline rule doesn't touch. Added `boxShadow: 'none'` to the pill base style.

## Test plan

- [ ] Open a story, click Dark (gets blue border), click Light — Dark's border reverts to transparent with no ring left behind.

Closes #234
Milestone: Maintenance
Plan impact: none