### PR TITLE
fix(addon): skip pill focus on mouse click to clear stale focus border

### DIFF
--- a/.changeset/pill-focus-no-take.md
+++ b/.changeset/pill-focus-no-take.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Stop the toolbar popover's pills from taking focus on mouse click. Storybook's theme applies a `:focus` border-color rule that stuck on the previously-clicked pill even with `outline: none` and `boxShadow: none` overrides — cleaner fix is to skip focus-on-click with `onMouseDown: preventDefault`. Keyboard tabbing still focuses pills normally.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -226,6 +226,11 @@ function OptionPill({ label, active, title, onClick, trailing }: OptionPillProps
       type: 'button',
       title,
       onClick,
+      // Skip focus on mouse click so Storybook's `:focus` border-color
+      // theming doesn't stick on the previously-clicked pill. Keyboard
+      // tabbing still lands focus normally — preventDefault on mousedown
+      // only blocks the implicit focus-on-click behavior.
+      onMouseDown: (event) => event.preventDefault(),
       style: active ? OPTION_PILL_ACTIVE : OPTION_PILL_BASE,
     },
     label,


### PR DESCRIPTION
## Summary

Previous attempts (PR #221 outline, PR #235 boxShadow) didn't catch the real culprit: Storybook's button theme paints a \`:focus\` **border-color** rule that sticks on the previously-clicked pill. Cleaner fix: don't let the pill take focus on mouse click in the first place.

\`onMouseDown: (e) => e.preventDefault()\` blocks the browser's implicit focus-on-click behavior without affecting keyboard focus. Tabbing still lands focus normally.

## Test plan

- [ ] Open the toolbar popover, click Dark, click Light — Dark reverts to transparent with no lingering border.
- [ ] Tab into the popover — pills still receive keyboard focus and show the theme's focus ring as intended for a11y.

Closes #236
Milestone: Maintenance
Plan impact: none