### PR TITLE
fix(addon): pill border uses longhand so theme can't leak through

### DIFF
--- a/.changeset/pill-border-longhand.md
+++ b/.changeset/pill-border-longhand.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Actually kill the pill's stray border color after deselection. Previous `outline: none` + `boxShadow: none` + `onMouseDown: preventDefault` attempts all missed the root cause: `OPTION_PILL_BASE` used the `border` shorthand, so when React transitioned active → inactive it *removed* the `borderColor` inline-style key rather than updating its value — letting Storybook's theme's own `border-color` rule paint the button white. Switching to explicit `borderWidth` / `borderStyle` / `borderColor` longhands keeps `borderColor` permanently in the inline style, so every transition is a value change.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -178,7 +178,13 @@ const OPTION_PILL_BASE: React.CSSProperties = {
   borderRadius: 4,
   fontSize: 12,
   lineHeight: '18px',
-  border: '1px solid transparent',
+  // Longhand border properties (not the `border` shorthand) so
+  // active → inactive only updates `borderColor`'s value instead of
+  // *removing* the key from inline style. Removing it lets Storybook's
+  // theme paint a stray border-color on the previously-selected pill.
+  borderWidth: 1,
+  borderStyle: 'solid',
+  borderColor: 'transparent',
   background: 'transparent',
   cursor: 'pointer',
   color: 'inherit',


### PR DESCRIPTION
## Summary

Three prior attempts missed the root cause of the stale border:

- PR #221 added `outline: none` — didn't touch the border.
- PR #235 added `boxShadow: none` — didn't touch the border.
- PR #237 added `onMouseDown: preventDefault` — didn't touch the border.

The real issue: `OPTION_PILL_BASE` used the `border: '1px solid transparent'` shorthand, and `OPTION_PILL_ACTIVE` tacked on `borderColor: 'rgba(0, 122, 255, 0.45)'`. When React transitioned from ACTIVE back to BASE, it *removed* the `borderColor` key from inline style (since BASE didn't declare it as a longhand). With the longhand removed, Storybook's theme's own `border-color` CSS rule on the button element won — painting the deselected pill white.

Fix: split the border into `borderWidth` / `borderStyle` / `borderColor` longhands in BASE. Now `borderColor` is permanently an inline-style property; active/inactive transitions update its value rather than adding/removing the key.

## Aside

Comment in the PR: why inline styles at all instead of styled-components / the Storybook theme system? Historical inertia — the rest of the addon's manager uses inline styles and we hadn't pulled the thread yet. Worth a follow-up PR to adopt `storybook/theming`'s `styled` properly so the manager picks up the active Storybook theme automatically and we stop fighting its CSS.

## Test plan

- [ ] Click Dark, click Light — Dark reverts to no visible border.
- [ ] Same check on Brand / Contrast / Color format pills.
- [ ] Tab through pills — keyboard focus still reads correctly.

Closes #239
Milestone: Maintenance
Plan impact: none