### PR TITLE
docs: audit and refresh documentation site for v0.1.0

### DIFF
--- a/apps/docs/docs/concepts/axes.mdx
+++ b/apps/docs/docs/concepts/axes.mdx
@@ -44,7 +44,7 @@ Each non-default tuple gets its own flat block (every var redeclared). The `:roo
 
 ## Independence
 
-Axes are independent. Selecting `mode=Dark` does not constrain `brand`; the resolver evaluates each modifier in `resolutionOrder` and each contributes its own layer stack. The toolbar reflects this by rendering one dropdown per axis rather than a single flat dropdown that lists every theme.
+Axes are independent. Selecting `mode=Dark` does not constrain `brand`; the resolver evaluates each modifier in `resolutionOrder` and each contributes its own layer stack. The toolbar popover reflects this by rendering one dropdown per axis rather than a single flat dropdown that lists every theme.
 
 ## Where axes come from
 

--- a/apps/docs/docs/concepts/diagnostics.mdx
+++ b/apps/docs/docs/concepts/diagnostics.mdx
@@ -36,7 +36,7 @@ interface Diagnostic {
 
 ## The panel
 
-The **Design Tokens** panel includes a collapsible diagnostics section beneath the token tree. It shows a green **OK** badge when the list is empty and auto-expands to list every diagnostic (severity + message + group/source) when there are warnings or errors.
+The **Design Tokens** panel includes a collapsible diagnostics section above the token tree (between the search input and the tree). It shows a green **OK** badge when the list is empty and auto-expands to list every diagnostic (severity + message + group/source) when there are warnings or errors.
 
 ## Interpreting them
 

--- a/apps/docs/docs/concepts/presets.mdx
+++ b/apps/docs/docs/concepts/presets.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # Presets
 
-A **preset** is a named combination of axis contexts — a shortcut to a useful tuple. Configured in `swatchbook.config.ts`, rendered as a row of pills next to the toolbar's axis dropdowns.
+A **preset** is a named combination of axis contexts — a shortcut to a useful tuple. Configured in `swatchbook.config.ts`, rendered as a row of pills at the top of the toolbar popover, above the axis dropdowns.
 
 ## Why
 
@@ -50,7 +50,7 @@ At load time, each preset is sanitized:
 - Invalid context values (`axes: { mode: 'NotARealContext' }`) produce a diagnostic and the key is dropped.
 - Sanitized presets stay in `Project.presets` — the pill still renders, it just resolves to fewer axis overrides than authored.
 
-The diagnostics show up in the addon's Design Tokens panel (diagnostics section) alongside any token-level issues.
+The diagnostics show up in the Design Tokens panel's diagnostics section (at the top of the panel) alongside any token-level issues.
 
 ## Config over localStorage
 

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -34,7 +34,7 @@ the resolver, so components style themselves against `color.sys.*` directly.
 
 ## Primitive palette
 
-<ColorPalette group="color.ref" />
+<ColorPalette filter="color.ref.*" />
 
 ## Semantic slots
 

--- a/apps/docs/docs/guides/multi-axis-walkthrough.mdx
+++ b/apps/docs/docs/guides/multi-axis-walkthrough.mdx
@@ -87,8 +87,8 @@ export default defineSwatchbookConfig({
 
 With the config live:
 
-- **Toolbar** renders two dropdowns: one labelled `mode`, one labelled `brand`. Each lists its contexts. The current selection shows next to the label.
-- **Design Tokens panel** shows a hierarchical tree of every resolved token for the active tuple. Switching the toolbar updates values live.
+- **Toolbar** shows a single Swatchbook icon button. Click it to open a popover containing two dropdowns (one labelled `mode`, one labelled `brand`), preset pills (if configured), and a color-format picker. Each dropdown lists its contexts.
+- **Design Tokens panel** shows a diagnostics summary at the top and a hierarchical tree of every resolved token for the active tuple beneath it. Switching the toolbar updates values live.
 - **CSS emission** generates:
   - `:root` with the default tuple (`Light · Default`).
   - `[data-mode="Dark"][data-brand="Default"] { … }`
@@ -110,7 +110,7 @@ export default defineSwatchbookConfig({
 });
 ```
 
-The toolbar now renders pills next to the dropdowns. Clicking a pill writes the full tuple; the pill highlights when the current state matches.
+The toolbar popover now renders pills above the dropdowns. Clicking a pill writes the full tuple; the pill highlights when the current state matches.
 
 ## 6. A third axis
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -7,7 +7,7 @@ sidebar_position: 1
 
 # Swatchbook
 
-A Storybook addon for documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/). It parses your token files through [Terrazzo](https://terrazzo.app/), composes themes through a resolver or layered configuration, and renders a live documentation surface inside your Storybook — searchable token panel, per-axis theme switcher, tuple-aware `TokenDetail` blocks, `ColorPalette`, `TypographyScale`, and more.
+A Storybook addon for documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/). It parses your token files through [Terrazzo](https://terrazzo.app/), composes themes through a resolver or layered configuration, and renders a live documentation surface inside your Storybook — searchable token panel, consolidated theme switcher, tuple-aware `TokenDetail` blocks, `ColorPalette`, `TypographyScale`, and more.
 
 ## Who it's for
 
@@ -15,9 +15,9 @@ Design-system authors who already have DTCG tokens (or are in the process of aut
 
 ## What the addon gives you
 
-- **Toolbar** — one dropdown per modifier axis, preset pills for named combinations.
-- **Design Tokens panel** — hierarchical tree of every token in the active theme, searchable. Click a leaf to copy its `var(--…)` reference. A collapsible diagnostics section at the bottom surfaces invalid tokens, broken aliases, and type mismatches with severity and location.
-- **Doc blocks** — `TokenDetail`, `TokenTable`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, motion/shadow/border previews. Embed them in MDX stories.
+- **Toolbar** — a single Swatchbook icon button opens a popover with preset pills, one dropdown per modifier axis, and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`) that controls how blocks display colors.
+- **Design Tokens panel** — a diagnostics summary at the top (green `OK` badge when clean; auto-expands on warnings or errors) followed by a searchable hierarchical tree of every token in the active theme. Click a leaf to copy its `var(--…)` reference.
+- **Doc blocks** — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, motion/shadow/border previews. Embed them in MDX stories.
 - **`useToken` hook** — typed lookups from component code, reactive to the active theme.
 
 ## See it live

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -10,13 +10,13 @@ Takes ~5 minutes if you already have a Storybook project.
 
 ## Install
 
-Install the addon for the toolbar, Design Tokens panel (tree + diagnostics), preview decorator, and `useToken()` hook:
+Install the addon for the toolbar, Design Tokens panel (diagnostics + tree), preview decorator, and `useToken()` hook:
 
 ```bash
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
-Install the blocks package too if you want the MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, and the block-side hooks):
+Install the blocks package too if you want the MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `SwatchbookProvider`, and the block-side hooks):
 
 ```bash
 npm install -D @unpunnyfuns/swatchbook-blocks
@@ -58,7 +58,7 @@ export default definePreview({
 });
 ```
 
-If you'd rather keep the config in its own file (useful when the same config is consumed by a CLI or CI lint outside Storybook), write a `swatchbook.config.ts` and point at it with `options.configPath: '../swatchbook.config.ts'` — see [config reference](./reference/config) for details.
+Inline `config` is the primary path. If you'd rather keep the config in its own file (useful when the same config is consumed by a CLI or CI lint outside Storybook), write a `swatchbook.config.ts` and point at it with `options.configPath: '../swatchbook.config.ts'` — see [config reference](./reference/config) for details.
 
 Start Storybook:
 
@@ -68,8 +68,8 @@ pnpm storybook
 
 ## What you should see
 
-- **Toolbar**: one dropdown per modifier in your resolver. If you've written a single `theme` modifier with `Light`/`Dark` contexts, you get one dropdown; if you have `mode × brand`, you get two.
-- **Design Tokens panel** (bottom panel): hierarchical tree of every token your resolver yields, searchable. A diagnostics section beneath shows a green "OK" badge if your tokens are clean, or auto-expands to list warnings and errors.
+- **Toolbar**: a single Swatchbook icon button in the top bar. Click it to open a popover containing preset pills, one dropdown per modifier in your resolver, and a color-format picker. If you've written a single `theme` modifier with `Light`/`Dark` contexts, you get one dropdown inside the popover; if you have `mode × brand`, you get two. Escape or outside-click closes it.
+- **Design Tokens panel** (bottom panel): a diagnostics summary at the top — green "OK" badge if your tokens are clean, auto-expands to list warnings and errors — followed by a searchable hierarchical tree of every token your resolver yields.
 
 Switch themes from the toolbar; the panel's resolved values update live.
 

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Addon
 
-Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config at build time via `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, registers a preview decorator + manager toolbar + the Design Tokens panel, and ships a `useToken` hook.
+Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config at build time via `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, registers a preview decorator + manager toolbar + the Design Tokens panel, and ships a `useToken` hook. Block-side hooks (`useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`) live in `@unpunnyfuns/swatchbook-blocks`.
 
 ## Install
 
@@ -14,13 +14,34 @@ Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
-This gives you the toolbar, Design Tokens panel (hierarchical tree view + diagnostics), preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks` — install it alongside if you want them.
+This gives you the toolbar, Design Tokens panel (diagnostics summary + hierarchical tree view), preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks` — install it alongside if you want them.
 
 Peer requirements: Storybook 10.3+ on the Vite builder, React 18+.
 
 ## Registration
 
-The addon is a CSF Next preview addon. Register it in your `preview.ts`:
+Register the addon in `main.ts#addons` with your config (inline `config` preferred; `configPath` also works — see the [config reference](./config)):
+
+```ts title=".storybook/main.ts"
+import { defineMain } from '@storybook/react-vite/node';
+
+export default defineMain({
+  framework: '@storybook/react-vite',
+  addons: [
+    {
+      name: '@unpunnyfuns/swatchbook-addon',
+      options: {
+        config: {
+          resolver: 'tokens/resolver.json',
+          cssVarPrefix: 'ds',
+        },
+      },
+    },
+  ],
+});
+```
+
+Then opt the preview into the addon's annotations (CSF Next factory) in `preview.ts`:
 
 ```ts title=".storybook/preview.ts"
 import { definePreview } from '@storybook/react-vite';
@@ -31,13 +52,11 @@ export default definePreview({
 });
 ```
 
-No entry in `main.ts#addons` — the preview annotation is the full registration.
-
 ## What it registers
 
-- **Preview decorator** — reads the active axis tuple, writes `data-<axis>="<context>"` attributes on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager.
-- **Toolbar tool** — one `IconButton` per axis with contexts as picks, plus preset pills.
-- **Design Tokens panel** — hierarchical tree of every token in the active theme (searchable, click a leaf to copy its `var(--…)` reference), with a collapsible diagnostics section beneath that auto-expands on warnings/errors.
+- **Preview decorator** — reads the active axis tuple, writes `data-<axis>="<context>"` attributes (plus `data-theme="<composed id>"`) on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager.
+- **Toolbar tool** — a single Swatchbook `IconButton`. Clicking opens a popover containing preset pills, one dropdown per axis, and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`). Escape and outside-click close it.
+- **Design Tokens panel** — a collapsible diagnostics section at the top (auto-expands on warnings/errors, green `OK` badge when clean) followed by a searchable hierarchical tree of every token in the active theme (click a leaf to copy its `var(--…)` reference).
 
 ## Globals
 
@@ -45,8 +64,9 @@ No entry in `main.ts#addons` — the preview annotation is the full registration
 | --- | --- | --- |
 | `swatchbookAxes` | `Record<string, string>` | Active tuple. Preferred input. |
 | `swatchbookTheme` | `string` | Composed permutation ID. Back-compat companion. |
+| `swatchbookColorFormat` | `'hex' \| 'rgb' \| 'hsl' \| 'oklch' \| 'raw'` | Display-only color format consumed by the blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`). Does **not** affect emitted CSS. Default `hex`. |
 
-The toolbar writes both in lockstep so legacy consumers keep working.
+The toolbar writes `swatchbookAxes` and `swatchbookTheme` in lockstep so legacy consumers keep working. `swatchbookColorFormat` is toggled from the color-format picker in the popover; `hex` falls back to space-separated `rgb()` (flagged with a ⚠ warning marker) for colors outside sRGB gamut.
 
 ## Per-story overrides
 
@@ -64,7 +84,7 @@ export const DarkBrandA = meta.story({
 
 ## Hooks
 
-Exposed under `@unpunnyfuns/swatchbook-addon/hooks`.
+The addon exposes exactly one hook, under `@unpunnyfuns/swatchbook-addon/hooks`.
 
 ### `useToken(path)`
 
@@ -81,18 +101,11 @@ function Brand() {
 
 Paths autocomplete from the generated `.swatchbook/tokens.d.ts`. Add `"include": [".swatchbook/**/*.d.ts"]` to your consumer tsconfig.
 
-### `useActiveTheme()` / `useActiveAxes()`
+### Block-side hooks live in `@unpunnyfuns/swatchbook-blocks`
 
-Exposed from `@unpunnyfuns/swatchbook-blocks` — see the [blocks reference](./blocks.mdx). `useActiveTheme()` returns the current composed permutation ID as a string; `useActiveAxes()` returns the active tuple as `Readonly<Record<string, string>>`.
+`useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the contexts that back them (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) are exported from `@unpunnyfuns/swatchbook-blocks` — see the [blocks reference](./blocks). They are **not** re-exported from the addon; import them from blocks.
 
-## Contexts
-
-Exposed from `@unpunnyfuns/swatchbook-blocks`.
-
-- `ThemeContext` — React context carrying the composed permutation ID.
-- `AxesContext` — React context carrying the tuple.
-
-Both are populated by the preview decorator and consumed by `useActiveTheme` / `useActiveAxes`. You can also consume them directly for non-hook call sites.
+The preview decorator mounts a `SwatchbookProvider` (from blocks) that populates every context, so those hooks just work wherever the addon is registered.
 
 ## Exported constants
 

--- a/apps/docs/docs/reference/blocks.mdx
+++ b/apps/docs/docs/reference/blocks.mdx
@@ -14,7 +14,9 @@ Published as `@unpunnyfuns/swatchbook-blocks`. MDX-embeddable doc blocks. Each b
 npm install -D @unpunnyfuns/swatchbook-blocks
 ```
 
-Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these blocks — its preview decorator mounts a `SwatchbookProvider` that the blocks read from. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly.
+Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these blocks — its preview decorator mounts a `SwatchbookProvider` (exported from this package) that the blocks read from. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly.
+
+`SwatchbookProvider`, `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the backing contexts (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) are exported from **`@unpunnyfuns/swatchbook-blocks` only**. The addon does not re-export them.
 
 ## Usage
 
@@ -23,7 +25,7 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```mdx
 import { ColorPalette, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette group="color.sys" />
+<ColorPalette filter="color.sys.*" />
 <TokenTable filter="size.sys.*" type="dimension" />
 <TokenDetail path="color.sys.accent.bg" />
 ```
@@ -55,11 +57,13 @@ export function TokenDocs() {
 
 Single-token deep-dive. Renders:
 
-- Type + description.
+- Header: heading, `$type` pill, cssVar reference, description.
+- Composite preview — for `typography`, `shadow`, `border`, `transition`, `dimension`, `duration`, `cubicBezier`, `fontFamily`, `fontWeight`, `strokeStyle`, `gradient`, `color`.
+- Composite breakdown — labelled sub-value grid for composite types.
 - Alias chain (forward) — e.g. `color.sys.accent.bg → color.ref.blue.700`.
 - Aliased-by tree (backward) — everything that transitively aliases this token.
-- Composite preview — for `typography`, `shadow`, `border`, `transition`, `dimension`, `duration`, `cubicBezier`, `fontFamily`, `fontWeight`, `strokeStyle`, `gradient`, `color`.
 - Per-axis variance — values along whichever axes move the token.
+- Consumer output — a two-row summary of **Path** and **CSS var** for the active token, each with a copy button (see `<ConsumerOutput />`).
 
 Props: `path: string`, `heading?: string`.
 
@@ -93,6 +97,12 @@ Per-axis value table. Collapses to a single row when the value is constant, a ve
 
 Copy-ready `color: var(--…);` reference snippet.
 
+### `<ConsumerOutput path />`
+
+Compact two-row summary of the token's consumer-facing outputs: the token's dot-path and its CSS custom property name (`var(--…)`). Each row has its own copy-to-clipboard button. Displays the active axis tuple above the rows when more than one axis is in play.
+
+Props: `path: string`.
+
 ### `<TokenNavigator root? initiallyExpanded? onSelect? />`
 
 Expandable tree view of the token graph, keyed on dot-path segments. Complements the flat `TokenTable` and the typed `ColorPalette` with an explorable hierarchy. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value fallback for types without a preview primitive).
@@ -103,7 +113,7 @@ Props:
 - `initiallyExpanded?: number` — depth open on first render. `0` = all collapsed, `1` = top-level groups open (default), `2` = one level deeper, etc.
 - `onSelect?(path: string): void` — receives a leaf's full dot-path on click. When provided, the inline `<TokenDetail>` slide-over is suppressed and the consumer owns the follow-up UI; when omitted, clicking a leaf opens a fixed-position overlay with a full `<TokenDetail>` and a close button.
 
-### `<TokenTable filter? type? />`
+### `<TokenTable filter? type? showVar? caption? />`
 
 Filterable table. Columns: name, value, resolved, description.
 
@@ -111,12 +121,22 @@ Props:
 
 - `filter?: string` — path glob (`"color.sys.*"`, `"color.sys"`, or exact path).
 - `type?: string` — DTCG `$type` filter.
+- `showVar?: boolean` — show the CSS variable reference column. Default `true`.
+- `caption?: string` — override the table caption.
 
-### `<ColorPalette group? />`
+Rows sort numerically by dot-path, so `blue.50` lands before `blue.100`. Color cells are rendered through the active color-format global (`swatchbookColorFormat`).
 
-Swatch grid grouped by sub-path.
+### `<ColorPalette filter? groupBy? caption? />`
 
-Props: `group?: string` — path prefix (`"color.ref"`, `"color.sys.surface"`, …).
+Swatch grid grouped by dot-path prefix. Sorted numerically by path.
+
+Props:
+
+- `filter?: string` — path glob (`"color.ref.blue.*"`, `"color.sys.*"`, …). Default: every `color` token.
+- `groupBy?: number` — grouping depth. `2` yields groups like `color.sys`/`color.ref`; `3` yields `color.sys.surface`/`color.sys.text`, etc. Default `3`. Pick a depth where each group holds at least a handful of swatches — setting it too high (e.g. `groupBy={5}` on a three-segment path) produces one swatch per group.
+- `caption?: string` — override the section caption.
+
+Color values are rendered through the active color-format global (`swatchbookColorFormat`).
 
 ### `<TypographyScale />`
 
@@ -158,18 +178,42 @@ Standalone per-token dimension visual (the bar / square / radius sample from `Di
 
 Props: `path: string`, `kind?: 'length' | 'radius' | 'size'` (default `'length'`).
 
-### `<GradientPalette filter? />`
+### `<GradientPalette filter? caption? />`
 
 Wide sample per `gradient` token with the stop list as a sidebar. Samples use `linear-gradient(to right, …)` by default — DTCG gradients are stop arrays, and the gradient function is a rendering choice the consumer makes at use-site. If you want radial/conic previews here, open an issue.
 
-Props: `filter?: string` — path glob (`"gradient.ref.*"`, etc.).
+Props:
+
+- `filter?: string` — path glob (`"gradient.ref.*"`, etc.). Defaults to every `gradient` token.
+- `caption?: string` — override the caption.
+
+## Hooks
+
+All hooks live in this package — they are **not** re-exported from `@unpunnyfuns/swatchbook-addon`. They read from the nearest `SwatchbookProvider` (mounted automatically by the addon's preview decorator inside Storybook).
+
+### `useSwatchbookData()`
+
+Returns the full `ProjectSnapshot` the provider is holding (themes, axes, presets, tokens, diagnostics, …). Useful for custom blocks that need graph-level information the canned blocks don't expose.
+
+### `useActiveTheme()`
+
+Returns the current composed permutation ID as a string (e.g. `"Dark · Brand A"`).
+
+### `useActiveAxes()`
+
+Returns the active tuple as `Readonly<Record<string, string>>`.
+
+### `useColorFormat()`
+
+Returns the active color format (`'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw'`) — the display setting toggled from the toolbar popover. Pair with `formatColor(value, format)` (also exported) to render colors the same way the built-in blocks do. `hex` falls back to space-separated `rgb()` for out-of-gamut colors, marked with a ⚠ warning.
 
 ## Reactivity
 
-All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render when the active axis tuple changes. This works both inside story renders and inside MDX doc blocks (where the preview HooksContext isn't available — we use the channel directly).
+All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render when the active axis tuple or color format changes. This works both inside story renders and inside MDX doc blocks (where the preview HooksContext isn't available — we use the channel directly).
 
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
 - ✅ Filter aggressively — `<TokenTable filter="color.sys.*" type="color" />` beats unfiltered tables for browsability.
-- ❌ Don't try to use blocks outside Storybook; they depend on the addon's virtual module. A framework-free variant may arrive later if there's demand.
+- ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
+- ❌ Don't import block-side hooks or contexts from `@unpunnyfuns/swatchbook-addon` — they live in this package only.

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -87,11 +87,15 @@ permutationID({ theme: 'Light' }); // → "Light"
 
 ```ts
 interface Config {
-  tokens: string[];
+  /** Required for plain-parse and layered; optional when `resolver` is set. */
+  tokens?: string[];
   resolver?: string; // mutually exclusive with `axes`
   axes?: AxisConfig[]; // mutually exclusive with `resolver`
   presets?: Preset[];
-  default?: string;
+  /** Partial tuple keyed by axis name — e.g. `{ mode: 'Dark', brand: 'Brand A' }`. Omitted axes fall back to each axis's own `default`. */
+  default?: Partial<Record<string, string>>;
+  /** Axis names to suppress from the toolbar and CSS emission; each is pinned to its default context. */
+  disabledAxes?: string[];
   cssVarPrefix?: string;
   outDir?: string;
 }
@@ -136,10 +140,14 @@ interface Axis {
 interface Project {
   config: Config;
   axes: Axis[];
+  /** Axis names suppressed via `config.disabledAxes` and validated against the resolver. */
+  disabledAxes: string[];
   presets: Preset[];
   themes: Theme[];
   themesResolved: Record<string, TokenMap>;
   graph: TokenMap; // default theme's resolved tokens
+  /** Absolute paths of every file loaded while building the project (resolver + `$ref` targets, overlay files, or globbed plain-parse files). */
+  sourceFiles: string[];
   diagnostics: Diagnostic[];
 }
 ```


### PR DESCRIPTION
## Summary

- Cross-referenced every MDX under `apps/docs/docs/` against current code and fixed drift accumulated since PRs #201/#207/#208/#209/#210/#211/#213/#218/#221, #162, #169, #204, #206.
- Toolbar: single Swatchbook icon-button popover (preset pills + per-axis dropdowns + color-format picker). Diagnostics section is at the TOP of the Design Tokens panel, not beneath the tree.
- Hooks location: only `useToken` on `@unpunnyfuns/swatchbook-addon`; `SwatchbookProvider`, `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and backing contexts are exported from `@unpunnyfuns/swatchbook-blocks` only.
- Addon registration: `main.ts#addons` with inline `options.config` is primary; `configPath` secondary.
- `reference/blocks.mdx`: document `ConsumerOutput`, add a full Hooks section, fix `ColorPalette` props (`filter` + `groupBy`, not the fictional `group`), add `TokenTable` / `GradientPalette` extras, note numeric path sort, and mark out-of-Storybook use as supported.
- `reference/core.mdx`: `Config.tokens` now optional when `resolver` is set; `Config.default` is `Partial<Record<axis, context>>`; `disabledAxes` on both `Config` and `Project`; `Project.sourceFiles`.
- `reference/addon.mdx`: documented `swatchbookColorFormat` global.

Milestone: Maintenance
Closes #238
Plan impact: none

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-docs build` succeeds locally (pre-existing `/swatchbook/storybook/` links resolve once the site is published alongside Storybook on GH Pages)
- [ ] Reviewer spot-checks any "Unchanged — worth a second look" items

## Unchanged — worth a second look

- `concepts/theming-inputs.mdx` keeps the layered-authored path as a live option. The `drop-layered-theming` changeset dropped `Config.themes` / `ThemeConfig`, but `Config.axes` + `AxisConfig` + `loadLayeredThemes` are still in `packages/core/src/themes/layered.ts`, so the layered input is current. Worth a fresh read to confirm we actually want to keep promoting it for v0.1.0.
- `concepts/axes.mdx` shows a hypothetical CSS block (`:root` + `[data-mode="Dark"][data-brand="…"]`) with hex color values; no adjustment to modern color-function syntax was needed because the example doesn't use `rgb()` / `hsl()` / `oklch()` functional colors.
- The `quickstart.mdx` "No resolver yet?" snippet calls `defineSwatchbookConfig` without importing it — this matches the existing style in the file and is likely intentional shorthand, but worth confirming.