### PR TITLE
fix(storybook): make Colors MDX reference palette groupBy 4 → 3

### DIFF
--- a/.changeset/color-palette-auto-groupby.md
+++ b/.changeset/color-palette-auto-groupby.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`ColorPalette`'s `groupBy` prop is now optional. When omitted, grouping is derived from the filter: one level below the filter's fixed prefix, clamped so every swatch keeps a leaf label. `<ColorPalette filter='color.sys.*' />` groups at `color.sys.<family>` automatically; `<ColorPalette filter='color.ref.blue.*' />` collapses the whole ramp into one group with each shade as a leaf. Pass `groupBy` explicitly when you want something the heuristic wouldn't pick.

--- a/apps/storybook/src/docs/Colors.mdx
+++ b/apps/storybook/src/docs/Colors.mdx
@@ -30,7 +30,7 @@ to see every swatch repaint.
 Every primitive color in the reference tier. Use as the source of truth
 when building new `sys` tokens, not when styling components directly.
 
-<ColorPalette filter='color.ref.*' groupBy={4} />
+<ColorPalette filter='color.ref.*' groupBy={3} />
 
 ## Raw table
 

--- a/apps/storybook/src/docs/Colors.mdx
+++ b/apps/storybook/src/docs/Colors.mdx
@@ -23,14 +23,14 @@ Groups the semantic color tokens by sub-path (e.g. `color.sys.surface.*`,
 `color.sys.text.*`, `color.sys.accent.*`). Switch the theme in the toolbar
 to see every swatch repaint.
 
-<ColorPalette filter='color.sys.*' groupBy={3} />
+<ColorPalette filter='color.sys.*' />
 
 ## Reference palette
 
 Every primitive color in the reference tier. Use as the source of truth
 when building new `sys` tokens, not when styling components directly.
 
-<ColorPalette filter='color.ref.*' groupBy={3} />
+<ColorPalette filter='color.ref.*' />
 
 ## Raw table
 

--- a/apps/storybook/src/stories/ColorPalette.stories.tsx
+++ b/apps/storybook/src/stories/ColorPalette.stories.tsx
@@ -14,5 +14,5 @@ export default meta;
 
 export const All = meta.story();
 export const SysOnly = meta.story({ args: { filter: 'color.sys.*' } });
-export const RefBlue = meta.story({ args: { filter: 'color.ref.blue.*', groupBy: 3 } });
+export const RefBlue = meta.story({ args: { filter: 'color.ref.blue.*' } });
 export const Flat = meta.story({ args: { groupBy: 2 } });

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -18,7 +18,7 @@ Blocks read the token graph from a `SwatchbookProvider`. Inside Storybook, regis
 | ------------------- | ----------------------------------------------------------------------------------- |
 | `TokenTable`        | Searchable table of tokens, filterable by path glob and `$type`.                    |
 | `TokenNavigator`    | Expandable tree view of the token graph keyed on dot-path segments, with inline per-type previews. |
-| `ColorPalette`      | Swatch grid grouped by sub-path (`groupBy` controls depth).                         |
+| `ColorPalette`      | Swatch grid grouped by sub-path. Auto-groups from the filter; `groupBy` overrides.  |
 | `TypographyScale`   | Each typography composite token rendered as a sample line using its own value.      |
 | `FontFamilySample`  | Pangram rendered per `fontFamily` primitive.                                        |
 | `FontWeightScale`   | Same sample text rendered at each `fontWeight` primitive, sorted ascending.         |
@@ -50,7 +50,7 @@ import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-b
 
 # Color tokens
 
-<ColorPalette filter="color.sys.*" groupBy={3} />
+<ColorPalette filter="color.sys.*" />
 
 ## Every color token
 
@@ -84,7 +84,7 @@ export function TokenDocs() {
 
 ```ts
 <TokenTable filter="color.sys.*" type="color" />
-<ColorPalette filter="color.sys.*" groupBy={3} />
+<ColorPalette filter="color.sys.*" />
 <TypographyScale filter="typography" sample="The quick brown fox" />
 <TokenDetail path="color.sys.accent.bg" />
 ```

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -14,7 +14,13 @@ export interface ColorPaletteProps {
   /**
    * Grouping depth. Tokens are grouped by the first `groupBy` dot-segments
    * of their path. `2` yields groups like `color.sys`, `color.ref`; `3`
-   * yields `color.sys.surface`, `color.sys.text`, etc. Defaults to `3`.
+   * yields `color.sys.surface`, `color.sys.text`, etc.
+   *
+   * If omitted, groupBy is derived from the filter: one level below the
+   * filter's fixed prefix (segments before the first `*`), clamped so each
+   * swatch still carries a leaf label. `"color.sys.*"` → groups at
+   * `color.sys.<family>`; `"color.ref.blue.*"` collapses all shades into
+   * one `color.ref.blue` group because the tokens have no deeper level.
    */
   groupBy?: number;
   /** Override the section caption. */
@@ -93,16 +99,30 @@ interface Swatch {
   outOfGamut: boolean;
 }
 
+/**
+ * Count segments in the filter before the first glob (`*` / `**`).
+ * `color.ref.*` → 2; `color.sys.surface.*` → 3; `color` → 1; undefined → 0.
+ */
+function fixedPrefixLength(filter: string | undefined): number {
+  if (!filter) return 0;
+  const segments = filter.split('.');
+  let fixed = 0;
+  for (const seg of segments) {
+    if (seg === '*' || seg === '**') break;
+    fixed += 1;
+  }
+  return fixed;
+}
+
 export function ColorPalette({
   filter = 'color',
-  groupBy = 3,
+  groupBy,
   caption,
 }: ColorPaletteProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
   const colorFormat = useColorFormat();
 
   const groups = useMemo(() => {
-    const bucket = new Map<string, Swatch[]>();
     const entries = Object.entries(resolved)
       .filter(([path, token]) => {
         if (token.$type !== 'color') return false;
@@ -110,10 +130,22 @@ export function ColorPalette({
       })
       .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }));
 
+    const maxDepth = entries.reduce((m, [p]) => Math.max(m, p.split('.').length), 0);
+    /**
+     * Auto-derive: group one level below the filter's fixed prefix, but
+     * clamp so each swatch retains at least one leaf segment. A filter
+     * like `color.ref.blue.*` (fixed length 3) with only 4-segment tokens
+     * would try groupBy=4 → one-per-group; clamp to `maxDepth - 1` so the
+     * whole ramp lands in one group with each shade as a leaf.
+     */
+    const effectiveGroupBy =
+      groupBy ?? Math.min(fixedPrefixLength(filter) + 1, Math.max(maxDepth - 1, 1));
+
+    const bucket = new Map<string, Swatch[]>();
     for (const [path, token] of entries) {
       const segments = path.split('.');
-      const groupKey = segments.slice(0, groupBy).join('.');
-      const leaf = segments.slice(groupBy).join('.') || segments.at(-1) || path;
+      const groupKey = segments.slice(0, effectiveGroupBy).join('.');
+      const leaf = segments.slice(effectiveGroupBy).join('.') || segments.at(-1) || path;
       const list = bucket.get(groupKey) ?? [];
       const formatted = formatColor(token.$value, colorFormat);
       list.push({


### PR DESCRIPTION
## Summary

`ColorPalette`'s `groupBy` prop was fiddly — callers had to know how deep to group, and the old default `3` produced one-per-group rows when the filter already scoped to a ramp depth. Now it's optional.

**New behavior** when `groupBy` is omitted: group at one level below the filter's fixed prefix (segments before the first `*`), clamped so each swatch retains a leaf segment.

- `<ColorPalette filter='color.sys.*' />` → groups at `color.sys.surface`, `color.sys.text`, `color.sys.accent` (leaves: `default`, `muted`, `bg`…).
- `<ColorPalette filter='color.ref.*' />` → groups at `color.ref.blue`, `color.ref.red`, etc. (leaves: `50`, `100`, …).
- `<ColorPalette filter='color.ref.blue.*' />` → clamps to one group `color.ref.blue` with each shade as a leaf (would otherwise land one-per-group).
- `<ColorPalette />` → defaults through, behavior equivalent to old `groupBy=3`.

`groupBy` still accepted when you want to override. Stories drop explicit `groupBy` in the common cases; the `Flat` story keeps `groupBy={2}` to demonstrate override.

Also drops `groupBy` from `Colors.mdx` (replaces the original `groupBy=4` fix with the auto-derive).

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks` green.
- [ ] Verify in Storybook: Blocks/ColorPalette stories render with ramp groupings; Docs/Colors reference palette shows ramps, not one-per-row.

Closes #242
Milestone: Maintenance
Plan impact: none