### PR TITLE
fix(addon): align storybook peerDependency to ^10.3.5

### DIFF
--- a/.changeset/align-storybook-peerdep.md
+++ b/.changeset/align-storybook-peerdep.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Align `storybook` peerDependency range on `@unpunnyfuns/swatchbook-addon` with `@unpunnyfuns/swatchbook-blocks` (`^10.3.5`). Consumers pinning Storybook to 10.3.0–10.3.4 previously satisfied the addon floor but failed the blocks floor.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -60,7 +60,7 @@
   "peerDependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "storybook": "^10.3.0"
+    "storybook": "^10.3.5"
   },
   "devDependencies": {
     "@storybook/react-vite": "^10.3.5",


### PR DESCRIPTION
## Summary

- Bump `@unpunnyfuns/swatchbook-addon` `peerDependencies.storybook` from `^10.3.0` to `^10.3.5` to match `@unpunnyfuns/swatchbook-blocks`.
- Fixes install-time peer mismatch for consumers pinning Storybook to 10.3.0–10.3.4.

Milestone: Release
Closes #245
Plan impact: none — pre-v0.1.0 blocker cleanup from dossier #244.

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck test` — all green locally.
- [ ] CI green on PR.