### PR TITLE
chore: add npm publish metadata to published packages

### DIFF
--- a/.changeset/publish-metadata.md
+++ b/.changeset/publish-metadata.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Add standard npm publish metadata — `license` (MIT), `repository`, `homepage`, `bugs`, `author`, `keywords` — to all three published packages. No runtime change; required for registry discoverability, npm provenance attestation, and legal clarity ahead of the v0.1.0 release.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -2,6 +2,24 @@
   "name": "@unpunnyfuns/swatchbook-addon",
   "version": "0.0.0",
   "description": "Storybook addon for DTCG design tokens — toolbar, panel, and useToken hook.",
+  "license": "MIT",
+  "author": "unpunnyfuns <unpunnyfuns@gmail.com>",
+  "homepage": "https://unpunnyfuns.github.io/swatchbook/",
+  "bugs": "https://github.com/unpunnyfuns/swatchbook/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unpunnyfuns/swatchbook.git",
+    "directory": "packages/addon"
+  },
+  "keywords": [
+    "storybook",
+    "storybook-addon",
+    "storybook-addons",
+    "design-tokens",
+    "dtcg",
+    "design-system",
+    "tokens"
+  ],
   "type": "module",
   "engines": {
     "node": ">=24.14.0"

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -2,6 +2,25 @@
   "name": "@unpunnyfuns/swatchbook-blocks",
   "version": "0.0.0",
   "description": "Storybook MDX doc blocks for DTCG design tokens — TokenTable, ColorPalette, TypographyScale, TokenDetail.",
+  "license": "MIT",
+  "author": "unpunnyfuns <unpunnyfuns@gmail.com>",
+  "homepage": "https://unpunnyfuns.github.io/swatchbook/",
+  "bugs": "https://github.com/unpunnyfuns/swatchbook/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unpunnyfuns/swatchbook.git",
+    "directory": "packages/blocks"
+  },
+  "keywords": [
+    "storybook",
+    "storybook-addon",
+    "storybook-blocks",
+    "design-tokens",
+    "dtcg",
+    "mdx",
+    "design-system",
+    "tokens"
+  ],
   "type": "module",
   "engines": {
     "node": ">=24.14.0"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,24 @@
   "name": "@unpunnyfuns/swatchbook-core",
   "version": "0.0.0",
   "description": "Framework-free core for loading and emitting DTCG design tokens.",
+  "license": "MIT",
+  "author": "unpunnyfuns <unpunnyfuns@gmail.com>",
+  "homepage": "https://unpunnyfuns.github.io/swatchbook/",
+  "bugs": "https://github.com/unpunnyfuns/swatchbook/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unpunnyfuns/swatchbook.git",
+    "directory": "packages/core"
+  },
+  "keywords": [
+    "design-tokens",
+    "dtcg",
+    "design-system",
+    "tokens",
+    "css-variables",
+    "terrazzo",
+    "typescript"
+  ],
   "type": "module",
   "engines": {
     "node": ">=24.14.0"


### PR DESCRIPTION
## Summary

- Fill in `license` (MIT), `author`, `homepage`, `bugs`, `repository` (with `directory` subpath), and `keywords` for `@unpunnyfuns/swatchbook-core`, `-addon`, and `-blocks`.
- LICENSE file already exists at repo root; this PR just declares it in each `package.json`.
- Required for npm provenance attestation (release workflow), registry discoverability, and legal clarity.

Milestone: Release
Closes #246
Plan impact: none — pre-v0.1.0 blocker cleanup from dossier #244.

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck test` — all green locally.
- [ ] CI green on PR.
- [ ] After merge, confirm Version Packages PR #231 regenerates with the queued patch bumps folded in.