### PR TITLE
refactor(blocks): extract shared surface/caption/empty style constants

### DIFF
--- a/.changeset/extract-shared-block-styles.md
+++ b/.changeset/extract-shared-block-styles.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Extract the `wrapper` / `caption` / `empty` inline styles (plus the monospace stack and default border strings) shared across block components into `#/internal/styles.ts`. Pure refactor — no visible rendering change; each block's remaining `const styles = { ... }` now references the shared constants instead of re-declaring them.

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -1,6 +1,13 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface BorderPreviewProps {
@@ -14,26 +21,16 @@ export interface BorderPreviewProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(160px, 220px) 140px 1fr',
     gap: 16,
     alignItems: 'center',
     padding: '14px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -42,14 +39,14 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     opacity: 0.7,
   } satisfies CSSProperties,
@@ -59,7 +56,7 @@ const styles = {
     justifyContent: 'center',
   } satisfies CSSProperties,
   breakdown: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     display: 'grid',
     gridTemplateColumns: 'auto 1fr',
@@ -68,11 +65,6 @@ const styles = {
   } satisfies CSSProperties,
   breakdownKey: {
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
-  } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
   } satisfies CSSProperties,
 };
 

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -2,6 +2,13 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/internal/format-color.ts';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface ColorPaletteProps {
@@ -28,24 +35,14 @@ export interface ColorPaletteProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies React.CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies React.CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   group: {
     marginBottom: 20,
   } satisfies React.CSSProperties,
   groupHeader: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
@@ -58,7 +55,7 @@ const styles = {
     gap: 8,
   } satisfies React.CSSProperties,
   card: {
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    border: BORDER_DEFAULT,
     borderRadius: 6,
     overflow: 'hidden',
     display: 'flex',
@@ -76,18 +73,13 @@ const styles = {
     gap: 2,
   } satisfies React.CSSProperties,
   leaf: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies React.CSSProperties,
   value: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     opacity: 0.7,
-  } satisfies React.CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
   } satisfies React.CSSProperties,
 };
 

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -1,6 +1,13 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
 import { DimensionBar, type DimensionKind } from '#/dimension-scale/DimensionBar.tsx';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export type { DimensionKind };
@@ -25,26 +32,16 @@ export interface DimensionScaleProps {
 const MAX_RENDER_PX = 480;
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
     gap: 16,
     alignItems: 'center',
     padding: '10px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -53,14 +50,14 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   specs: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     opacity: 0.7,
   } satisfies CSSProperties,
@@ -70,18 +67,13 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     opacity: 0.7,
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
-  } satisfies CSSProperties,
   cap: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 10,
     opacity: 0.6,
     marginLeft: 6,

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -1,5 +1,12 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface FontFamilySampleProps {
@@ -15,25 +22,15 @@ export interface FontFamilySampleProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
     gap: 16,
     alignItems: 'baseline',
     padding: '14px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -42,14 +39,14 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   stack: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
@@ -58,15 +55,11 @@ const styles = {
     lineHeight: 1.2,
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
-  } satisfies CSSProperties,
+  empty: emptyStyle,
 };
 
 interface Row {

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -1,5 +1,12 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface FontWeightScaleProps {
@@ -15,25 +22,16 @@ export interface FontWeightScaleProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
     gap: 16,
     alignItems: 'baseline',
     padding: '12px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -42,14 +40,14 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   value: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
@@ -58,14 +56,9 @@ const styles = {
     lineHeight: 1,
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
-  } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
   } satisfies CSSProperties,
 };
 

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -1,5 +1,13 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import {
+  BORDER_DEFAULT,
+  BORDER_FAINT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface GradientPaletteProps {
@@ -13,26 +21,16 @@ export interface GradientPaletteProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(180px, 240px) 1fr minmax(140px, 220px)',
     gap: 16,
     alignItems: 'center',
     padding: '16px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -41,24 +39,24 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     opacity: 0.7,
   } satisfies CSSProperties,
   sample: {
     height: 56,
     borderRadius: 6,
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    border: BORDER_FAINT,
   } satisfies CSSProperties,
   stops: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     display: 'flex',
     flexDirection: 'column',
@@ -77,11 +75,6 @@ const styles = {
     flex: '0 0 auto',
   } satisfies CSSProperties,
   stopPosition: {
-    opacity: 0.6,
-  } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
     opacity: 0.6,
   } satisfies CSSProperties,
 };

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo, useState } from 'react';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
+import { BORDER_DEFAULT, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 import {
   MotionSample,
@@ -23,14 +24,7 @@ export interface MotionPreviewProps {
 const SPEEDS: MotionSpeed[] = [0.25, 0.5, 1, 2];
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
   caption: {
     padding: '4px 0 4px',
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
@@ -49,7 +43,7 @@ const styles = {
     letterSpacing: 0.5,
   } satisfies CSSProperties,
   speedBtn: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     padding: '4px 8px',
     background: 'transparent',
@@ -79,7 +73,7 @@ const styles = {
     gap: 16,
     alignItems: 'center',
     padding: '14px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -88,19 +82,19 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   specs: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
     whiteSpace: 'nowrap',

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -1,5 +1,12 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 
@@ -14,26 +21,16 @@ export interface ShadowPreviewProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(160px, 220px) 140px 1fr',
     gap: 16,
     alignItems: 'center',
     padding: '16px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -42,14 +39,14 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     opacity: 0.7,
   } satisfies CSSProperties,
@@ -60,7 +57,7 @@ const styles = {
     height: 96,
   } satisfies CSSProperties,
   breakdown: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     display: 'grid',
     gridTemplateColumns: 'auto 1fr',
@@ -76,11 +73,6 @@ const styles = {
     letterSpacing: 0.5,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
     marginTop: 6,
-  } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
   } satisfies CSSProperties,
 };
 

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -1,5 +1,12 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface StrokeStyleSampleProps {
@@ -24,25 +31,16 @@ const STRING_STYLES = new Set([
 ]);
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
     gap: 16,
     alignItems: 'center',
     padding: '14px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -51,14 +49,14 @@ const styles = {
     minWidth: 0,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   value: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
@@ -69,19 +67,14 @@ const styles = {
     width: '100%',
   } satisfies CSSProperties,
   objectFallback: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
   cssVar: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
-  } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
   } satisfies CSSProperties,
 };
 

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -4,6 +4,7 @@ import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
 import { formatColor } from '#/internal/format-color.ts';
+import { BORDER_DEFAULT, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
 import { formatValue, makeCssVar, useProject } from '#/internal/use-project.ts';
 import { MotionSample } from '#/motion-preview/MotionSample.tsx';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
@@ -44,14 +45,7 @@ interface GroupNode {
 type TreeNode = LeafNode | GroupNode;
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
   caption: {
     padding: '4px 0 12px',
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
@@ -66,7 +60,7 @@ const styles = {
     listStyle: 'none',
     margin: 0,
     paddingLeft: 18,
-    borderLeft: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderLeft: BORDER_DEFAULT,
   } satisfies CSSProperties,
   groupRow: {
     display: 'flex',
@@ -76,7 +70,7 @@ const styles = {
     borderRadius: 4,
     cursor: 'pointer',
     userSelect: 'none',
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies CSSProperties,
   leafRow: {
@@ -86,7 +80,7 @@ const styles = {
     padding: '4px 6px',
     borderRadius: 4,
     cursor: 'pointer',
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies CSSProperties,
   caret: {
@@ -96,7 +90,7 @@ const styles = {
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
   tail: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies CSSProperties,
   typePill: {

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/internal/format-color.ts';
+import { BORDER_FAINT, emptyStyle, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
 import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface TokenTableProps {
@@ -19,14 +20,8 @@ export interface TokenTableProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies React.CSSProperties,
+  wrapper: surfaceStyle,
+  empty: emptyStyle,
   caption: {
     captionSide: 'top',
     textAlign: 'left',
@@ -50,11 +45,11 @@ const styles = {
   } satisfies React.CSSProperties,
   td: {
     padding: '8px 12px',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    borderBottom: BORDER_FAINT,
     verticalAlign: 'top',
   } satisfies React.CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies React.CSSProperties,
   typePill: {
@@ -67,7 +62,7 @@ const styles = {
     background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.15))',
   } satisfies React.CSSProperties,
   value: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     opacity: 0.85,
     wordBreak: 'break-all',
@@ -80,11 +75,6 @@ const styles = {
     marginRight: 6,
     borderRadius: 3,
     border: '1px solid var(--sb-color-sys-border-default, rgba(0,0,0,0.1))',
-  } satisfies React.CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
   } satisfies React.CSSProperties,
 };
 

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -1,5 +1,12 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
+import {
+  BORDER_DEFAULT,
+  captionStyle,
+  emptyStyle,
+  MONO_STACK,
+  surfaceStyle,
+} from '#/internal/styles.ts';
 import { globMatch, useProject } from '#/internal/use-project.ts';
 
 export interface TypographyScaleProps {
@@ -15,25 +22,16 @@ export interface TypographyScaleProps {
 }
 
 const styles = {
-  wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
-    padding: 12,
-    borderRadius: 6,
-  } satisfies CSSProperties,
-  caption: {
-    padding: '4px 0 12px',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies CSSProperties,
+  wrapper: surfaceStyle,
+  caption: captionStyle,
+  empty: emptyStyle,
   row: {
     display: 'grid',
     gridTemplateColumns: 'minmax(160px, 220px) 1fr',
     gap: 16,
     alignItems: 'baseline',
     padding: '14px 0',
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    borderBottom: BORDER_DEFAULT,
   } satisfies CSSProperties,
   meta: {
     display: 'flex',
@@ -41,18 +39,13 @@ const styles = {
     gap: 2,
   } satisfies CSSProperties,
   path: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies CSSProperties,
   specs: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     opacity: 0.7,
-  } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    opacity: 0.6,
   } satisfies CSSProperties,
 };
 

--- a/packages/blocks/src/internal/styles.ts
+++ b/packages/blocks/src/internal/styles.ts
@@ -1,0 +1,28 @@
+import type { CSSProperties } from 'react';
+
+export const MONO_STACK = 'ui-monospace, SFMono-Regular, Menlo, monospace';
+
+export const BORDER_DEFAULT = '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))';
+
+export const BORDER_FAINT = '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))';
+
+export const surfaceStyle = {
+  fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
+  fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
+  color: 'var(--sb-color-sys-text-default, CanvasText)',
+  background: 'var(--sb-color-sys-surface-default, Canvas)',
+  padding: 12,
+  borderRadius: 6,
+} satisfies CSSProperties;
+
+export const captionStyle = {
+  padding: '4px 0 12px',
+  opacity: 0.7,
+  fontSize: 12,
+} satisfies CSSProperties;
+
+export const emptyStyle = {
+  padding: '24px 12px',
+  textAlign: 'center',
+  opacity: 0.6,
+} satisfies CSSProperties;

--- a/packages/blocks/src/token-detail/styles.ts
+++ b/packages/blocks/src/token-detail/styles.ts
@@ -1,18 +1,15 @@
 import type { CSSProperties } from 'react';
+import { BORDER_DEFAULT, BORDER_FAINT, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
 
 export const styles = {
   wrapper: {
-    fontFamily: 'var(--sb-typography-sys-body-font-family, system-ui)',
-    fontSize: 'var(--sb-typography-sys-body-font-size, 14px)',
-    color: 'var(--sb-color-sys-text-default, CanvasText)',
-    background: 'var(--sb-color-sys-surface-default, Canvas)',
+    ...surfaceStyle,
     padding: 16,
-    borderRadius: 6,
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    border: BORDER_DEFAULT,
   } satisfies CSSProperties,
   heading: {
     margin: 0,
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 16,
   } satisfies CSSProperties,
   subline: {
@@ -37,7 +34,7 @@ export const styles = {
     opacity: 0.85,
   } satisfies CSSProperties,
   sectionHeader: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 11,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
@@ -49,13 +46,13 @@ export const styles = {
     flexWrap: 'wrap',
     gap: 6,
     alignItems: 'center',
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies CSSProperties,
   chainNode: {
     padding: '2px 6px',
     borderRadius: 4,
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    border: BORDER_DEFAULT,
   } satisfies CSSProperties,
   arrow: {
     opacity: 0.5,
@@ -67,7 +64,7 @@ export const styles = {
     fontSize: 12,
   } satisfies CSSProperties,
   themeRow: {
-    borderBottom: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    borderBottom: BORDER_FAINT,
   } satisfies CSSProperties,
   themeCell: {
     padding: '6px 8px',
@@ -87,7 +84,7 @@ export const styles = {
     padding: '8px 10px',
     borderRadius: 4,
     background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.1))',
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     whiteSpace: 'pre',
     overflow: 'auto',
@@ -103,7 +100,7 @@ export const styles = {
     width: 140,
     height: 56,
     background: 'var(--sb-color-sys-surface-raised, #fff)',
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    border: BORDER_FAINT,
     borderRadius: 6,
   } satisfies CSSProperties,
   borderSample: {
@@ -116,7 +113,7 @@ export const styles = {
     width: 220,
     height: 56,
     borderRadius: 6,
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.15))',
+    border: BORDER_FAINT,
   } satisfies CSSProperties,
   strokeStyleLine: {
     height: 0,
@@ -130,7 +127,7 @@ export const styles = {
     color: 'var(--sb-color-sys-text-default, CanvasText)',
   } satisfies CSSProperties,
   strokeStyleFallback: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     color: 'var(--sb-color-sys-text-muted, CanvasText)',
   } satisfies CSSProperties,
@@ -139,7 +136,7 @@ export const styles = {
     gap: 1,
     borderRadius: 6,
     overflow: 'hidden',
-    border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.2))',
+    border: BORDER_DEFAULT,
     width: 220,
     height: 56,
   } satisfies CSSProperties,
@@ -152,7 +149,7 @@ export const styles = {
     boxShadow: 'inset 0 0 0 8px rgba(17, 17, 17, 0.9)',
   } satisfies CSSProperties,
   breakdownSection: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     display: 'grid',
     gridTemplateColumns: 'auto 1fr',
@@ -216,7 +213,7 @@ export const styles = {
     listStyle: 'none',
     margin: 0,
     padding: 0,
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
   } satisfies CSSProperties,
   aliasedByRow: {
@@ -240,7 +237,7 @@ export const styles = {
     fontSize: 11,
     opacity: 0.7,
     margin: '0 0 6px',
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
   } satisfies CSSProperties,
   consumerRow: {
     display: 'flex',
@@ -252,7 +249,7 @@ export const styles = {
     background: 'var(--sb-color-sys-surface-muted, rgba(128,128,128,0.1))',
   } satisfies CSSProperties,
   consumerRowLabel: {
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 10,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
@@ -262,7 +259,7 @@ export const styles = {
   } satisfies CSSProperties,
   consumerRowValue: {
     flex: 1,
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     fontSize: 12,
     whiteSpace: 'nowrap',
     overflow: 'auto',
@@ -270,7 +267,7 @@ export const styles = {
   consumerRowCopy: {
     padding: '3px 8px',
     fontSize: 11,
-    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontFamily: MONO_STACK,
     background: 'var(--sb-color-sys-surface-raised, Canvas)',
     color: 'var(--sb-color-sys-text-default, CanvasText)',
     border: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.3))',


### PR DESCRIPTION
## Summary

- Extract the three inline style shapes that every top-level block re-declares — `wrapper` (surface), `caption`, `empty` — plus the monospace font stack and default border strings, into `packages/blocks/src/internal/styles.ts`.
- Route `token-detail/styles.ts` through the same constants.
- No visible rendering change — extracted shapes match the majority values each call site already used.

Net diff: ~30 lines added (shared module) against ~160 lines removed across 14 files.

Milestone: Maintenance
Closes #257
Plan impact: none — dossier #244 cleanup, low-friction alternative to the CSS Modules migration proposal that was filed as #254 and closed in favour of this.

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck test` — all 18 tasks green locally.
- [x] Storybook story tests — 124/124 passing, including every block render + composition + token-detail assertion.
- [ ] CI green on PR.