### PR TITLE
ci: accept 'Closes: #N' and bold-label forms in pr-lint regex

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -79,9 +79,9 @@ jobs:
             echo "::error::PR body is empty. Every code PR links an issue via 'Closes #N' (or 'Fixes' / 'Resolves')."
             exit 1
           fi
-          if echo "$BODY" | grep -qiE '(close[sd]?|fix(e[sd])?|resolve[sd]?|refs?) #[0-9]+'; then
+          if echo "$BODY" | grep -qiE '(close[sd]?|fix(e[sd])?|resolve[sd]?|refs?)[^a-z0-9#]{1,10}#[0-9]+'; then
             echo "Linked-issue reference found."
             exit 0
           fi
-          echo "::error::PR body must link an issue — include 'Closes #N', 'Fixes #N', 'Resolves #N', or 'Refs #N'. Open one first if needed: gh issue create --milestone \"Mx — …\" --title \"…\""
+          echo "::error::PR body must link an issue — include 'Closes #N' or 'Closes: #N' (same for Fixes/Resolves/Refs). Open one first if needed: gh issue create --milestone \"Mx — …\" --title \"…\""
           exit 1


### PR DESCRIPTION
## Summary

- Loosen the linked-issue regex in `.github/workflows/pr-lint.yml` so it accepts `Closes: #N` (colon), `**Closes:** #N` (bold-label form the PR template renders as), alongside the existing `Closes #N`.
- Same for `Fixes` / `Resolves` / `Refs`.
- Error message updated to mention the colon form.

Regex change: `(keyword) #[0-9]+` → `(keyword)[^a-z0-9#]{1,10}#[0-9]+`. The 1–10 bound keeps false positives out — prose like `close the window #42` still fails (separator too long).

Milestone: Maintenance
Closes: #259
Plan impact: none — tooling paper-cut.

## Test plan

- [x] Local regex sanity check across 10 common forms — all expected passes, prose rejected.
- [ ] CI green on this PR (the lint runs on itself).