### PR TITLE
fix: mark tokens-starter as private

### DIFF
--- a/packages/tokens-starter/package.json
+++ b/packages/tokens-starter/package.json
@@ -2,6 +2,7 @@
   "name": "@unpunnyfuns/swatchbook-tokens",
   "version": "0.0.0",
   "description": "Minimal DTCG design-token starter set for swatchbook consumers.",
+  "private": true,
   "type": "module",
   "engines": {
     "node": ">=24.14.0"
@@ -21,9 +22,6 @@
     "dist",
     "tokens"
   ],
-  "publishConfig": {
-    "access": "public"
-  },
   "scripts": {
     "build": "node --no-warnings --experimental-strip-types build.ts",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

- Add `"private": true` to `packages/tokens-starter/package.json`.
- Drop the now-dead `publishConfig.access: "public"` block.

## Why

The v0.1.0 publish run failed because `changeset publish` tried to push `@unpunnyfuns/swatchbook-tokens` to npm. Changesets' `ignore` array (in `.changeset/config.json`) only blocks version bumps — not publish attempts. Without `private: true`, the tool sees a publishable package and tries. Publishing tokens-starter has never been the intent — it's the iceboxed fixture (matching tokens-reference's existing `private: true`).

Unblocks the v0.1.0 publish retry. The main blocker is an npm scope/token issue on the maintainer side, tracked separately; this PR ensures that once the npm side is resolved, the publish won't fail again on a package we never meant to publish.

Milestone: Release
Closes: #261
Plan impact: none — publish-prep hygiene.

## Test plan

- [x] `pnpm -r format && pnpm turbo run lint typecheck --filter=@unpunnyfuns/swatchbook-tokens` — green.
- [ ] CI green on PR.
- [ ] After merge + npm fix, Release workflow re-attempts publish and skips tokens-starter.