### PR TITLE
fix(ci): set NODE_AUTH_TOKEN for setup-node's .npmrc in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # setup-node with registry-url writes an .npmrc containing
+          # `_authToken=${NODE_AUTH_TOKEN}`, and that file wins over the
+          # one changesets/action writes to ~/.npmrc. Without this, npm
+          # expands NODE_AUTH_TOKEN to empty and the registry returns 404.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # Opt into npm package provenance so published tarballs carry a
           # sigstore attestation linking them back to this workflow run.
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Add \`NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}\` to the changesets step's \`env:\` block.

## Why

Every v0.1.0 publish attempt 404'd on \`PUT https://registry.npmjs.org/@unpunnyfuns%2f...\` despite \`NPM_TOKEN\` being set and \`npm whoami\` working with the same token locally.

Root cause: \`actions/setup-node@v6\` with \`registry-url\` writes \`/tmp/.npmrc\` containing:

\`\`\`
//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}
\`\`\`

…and sets \`NPM_CONFIG_USERCONFIG\` to that path, overriding the \`~/.npmrc\` that \`changesets/action\` writes from \`NPM_TOKEN\`. Since \`NODE_AUTH_TOKEN\` wasn't in the step's env, npm expanded it to empty and the registry returned 404 (the auth failure code npm returns to avoid leaking scope existence).

Milestone: Release
Closes: #263
Plan impact: unblocks v0.1.0 publish.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, the push-to-main Release run retries publish and succeeds.