### PR TITLE
fix(addon,blocks): write axis attrs from module-level channel sub

### DIFF
--- a/.changeset/mdx-axis-attrs.md
+++ b/.changeset/mdx-axis-attrs.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Fix axis switching on MDX docs pages. The addon's preview decorator wrote `data-<axis>` attributes to `<html>` from inside the story wrapper — so bare MDX pages (no `<Story />`) had no ancestor carrying the tuple, the per-tuple CSS selectors never matched, and colors stayed on `:root` defaults no matter what the toolbar did. Subscribe to the channel at module level and write the same attrs independent of any decorator run, and pick up `setGlobals` in the blocks' fallback so the "Active tuple" indicator reflects the current selection on first render.

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -295,3 +295,38 @@ export const initialGlobals: NonNullable<Preview['initialGlobals']> = {
   [AXES_GLOBAL_KEY]: buildInitialAxes(),
   [COLOR_FORMAT_GLOBAL_KEY]: 'hex',
 };
+
+/**
+ * Module-level channel subscription: writes the active tuple's attributes
+ * onto `<html>` regardless of whether a story decorator is rendering.
+ *
+ * The {@link themedDecorator} already sets these inside story renders, but
+ * it never runs on MDX docs pages that embed blocks without `<Story />`.
+ * Without attrs on an ancestor, the per-tuple CSS selectors
+ * (`[data-mode="Dark"][data-brand="…"]`) don't match and everything falls
+ * back to the `:root` default tuple — so colors stay defaults even after
+ * the toolbar switches axes. Subscribing globally fixes MDX docs at the
+ * cost of one idempotent redundant write per story render.
+ */
+function installGlobalAxisApplier(): void {
+  if (typeof document === 'undefined') return;
+  const channel = addons.getChannel();
+  const apply = (globals: Record<string, unknown>): void => {
+    ensureStylesheet();
+    const tuple = resolveTuple(globals, {});
+    const match = themes.find((t) => {
+      const input = t.input as Record<string, string>;
+      return Object.keys(input).every((k) => input[k] === tuple[k]);
+    });
+    const themeName = match?.name ?? defaultTheme ?? themes[0]?.name ?? 'Light';
+    setRootAxes(themeName, tuple);
+  };
+  const onGlobals = (payload: { globals?: Record<string, unknown> }): void => {
+    if (payload.globals) apply(payload.globals);
+  };
+  channel.on('globalsUpdated', onGlobals);
+  channel.on('setGlobals', onGlobals);
+  channel.on('updateGlobals', onGlobals);
+}
+
+installGlobalAxisApplier();

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -126,9 +126,11 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     };
     channel.on('globalsUpdated', onGlobals);
     channel.on('updateGlobals', onGlobals);
+    channel.on('setGlobals', onGlobals);
     return () => {
       channel.off('globalsUpdated', onGlobals);
       channel.off('updateGlobals', onGlobals);
+      channel.off('setGlobals', onGlobals);
     };
   }, [enabled]);
 


### PR DESCRIPTION
## Summary

- Addon's \`themedDecorator\` only runs inside story renders, so bare MDX docs pages that embed blocks (\`<TokenDetail>\`, \`<ColorPalette>\`, …) without a \`<Story />\` had no ancestor carrying \`data-<axis>\` attributes. Per-tuple CSS selectors (\`[data-mode="Dark"]...\`) never matched; colors stayed on \`:root\` defaults regardless of toolbar state.
- Add a module-level channel subscription in \`packages/addon/src/preview.tsx\` that writes the same attrs + ensures the stylesheet independent of any decorator run. Idempotent when a decorator is also running.
- Pick up \`setGlobals\` in the blocks' \`useProject\` fallback listener so the "Active tuple" indicator on \`<ConsumerOutput>\` reflects the current selection on first MDX render, not just after a toolbar toggle.

Milestone: Maintenance
Closes: #272
Plan impact: none — bug fix.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — 18/18 green.
- [x] Storybook story tests for theme-switching + \`useToken\` reactivity all pass.
- [ ] CI green.
- [ ] Manual verify: open an MDX docs page with \`<TokenDetail>\`, toggle axes in the toolbar → colors actually change, "Active tuple" label updates.