### PR TITLE
fix(addon): broadcast init from module level so mdx pages wake the toolbar

### DIFF
--- a/.changeset/mdx-toolbar-loading.md
+++ b/.changeset/mdx-toolbar-loading.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Fix the Swatchbook toolbar sitting in its disabled `loading…` state on MDX docs pages. `broadcastInit()` — the event that ships the virtual-module payload to the manager so the toolbar can render axes — was called inside the decorator's `useEffect`, so it never fired on bare MDX pages that don't render a story. Hoist the init (and `ensureStylesheet()`) to the module-level installer alongside the axis-attrs subscription so they run on preview load regardless of decorator state. Follow-up to the same-shape fix in v0.1.2.

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -311,6 +311,14 @@ export const initialGlobals: NonNullable<Preview['initialGlobals']> = {
 function installGlobalAxisApplier(): void {
   if (typeof document === 'undefined') return;
   const channel = addons.getChannel();
+  /**
+   * Inject the stylesheet and emit the init payload once on module load so
+   * the manager's toolbar populates and CSS vars are available even when no
+   * story/decorator ever runs (bare MDX docs pages). Without these, the
+   * toolbar sits in its disabled "loading…" state and nothing is styled.
+   */
+  ensureStylesheet();
+  broadcastInit();
   const apply = (globals: Record<string, unknown>): void => {
     ensureStylesheet();
     const tuple = resolveTuple(globals, {});


### PR DESCRIPTION
## Summary

- Move \`broadcastInit()\` and the initial \`ensureStylesheet()\` call out of \`themedDecorator\`'s \`useEffect\` and into the module-level \`installGlobalAxisApplier()\` introduced by PR #273.
- Same-shape follow-up fix: the decorator only runs inside story renders, so bare MDX docs pages never received the init payload and the toolbar sat in its disabled \"loading…\" state (\`axes.length === 0\` guard in \`AxesToolbar\`).
- Decorator's useEffect still runs on stories (existing tests pass) — it's now a no-op for init/stylesheet, which the module-level installer already handles.

Milestone: Maintenance
Closes: #275
Plan impact: none — bug fix.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — 18/18 green.
- [x] Storybook story tests for theme switching + presets pass.
- [ ] CI green.
- [ ] Manual verify: open an MDX docs page without a \`<Story />\`, confirm the toolbar is interactive (not stuck on "loading…"), switch axes, see colors change.