### PR TITLE
fix(blocks): channel-fallback for useColorFormat on mdx pages

### DIFF
--- a/.changeset/mdx-color-format-fallback.md
+++ b/.changeset/mdx-color-format-fallback.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Fix the toolbar's color-format switcher (hex / rgb / hsl / oklch / raw) having no effect on blocks rendered in MDX docs pages. `useColorFormat()` was context-only, and the addon's preview decorator — which populates the context — doesn't run on bare MDX pages. Subscribe to `globalsUpdated` / `updateGlobals` / `setGlobals` as a fallback when no provider is mounted, mirroring `useProject()`'s existing pattern.

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -1,5 +1,6 @@
-import { createContext, useContext } from 'react';
-import type { ColorFormat } from '#/internal/format-color.ts';
+import { createContext, useContext, useEffect, useState } from 'react';
+import { addons } from 'storybook/preview-api';
+import { COLOR_FORMATS, type ColorFormat } from '#/internal/format-color.ts';
 
 /**
  * Typed shape of the addon's `virtual:swatchbook/tokens` module, duplicated
@@ -116,8 +117,40 @@ export function useActiveAxes(): Readonly<Record<string, string>> {
  * is safe to call from MDX doc blocks (where the preview-hooks context
  * isn't available).
  */
-export const ColorFormatContext = createContext<ColorFormat>('hex');
+export const ColorFormatContext = createContext<ColorFormat | null>(null);
+
+const COLOR_FORMAT_GLOBAL_KEY = 'swatchbookColorFormat';
+
+interface GlobalsPayload {
+  globals?: Record<string, unknown>;
+}
+
+function isColorFormat(value: unknown): value is ColorFormat {
+  return typeof value === 'string' && (COLOR_FORMATS as readonly string[]).includes(value);
+}
 
 export function useColorFormat(): ColorFormat {
-  return useContext(ColorFormatContext);
+  const contextValue = useContext(ColorFormatContext);
+  const [channelFormat, setChannelFormat] = useState<ColorFormat | null>(null);
+
+  const fallbackEnabled = contextValue === null;
+
+  useEffect(() => {
+    if (!fallbackEnabled) return;
+    const channel = addons.getChannel();
+    const onGlobals = (payload: GlobalsPayload): void => {
+      const next = payload.globals?.[COLOR_FORMAT_GLOBAL_KEY];
+      if (isColorFormat(next)) setChannelFormat(next);
+    };
+    channel.on('globalsUpdated', onGlobals);
+    channel.on('updateGlobals', onGlobals);
+    channel.on('setGlobals', onGlobals);
+    return () => {
+      channel.off('globalsUpdated', onGlobals);
+      channel.off('updateGlobals', onGlobals);
+      channel.off('setGlobals', onGlobals);
+    };
+  }, [fallbackEnabled]);
+
+  return contextValue ?? channelFormat ?? 'hex';
 }


### PR DESCRIPTION
## Summary

- \`useColorFormat()\` in \`packages/blocks/src/contexts.ts\` only read \`ColorFormatContext\`, populated by the addon's preview decorator — which doesn't run on bare MDX docs pages. Toolbar's format switcher (hex / rgb / hsl / oklch / raw) was dead on any block rendered in an \`.mdx\` file.
- Subscribe to \`globalsUpdated\` / \`updateGlobals\` / \`setGlobals\` as a fallback when no provider is mounted. Mirrors the pattern \`useProject()\` already uses for axes.
- Context type widens from \`ColorFormat\` to \`ColorFormat | null\` so the hook can distinguish "provider absent" from "provider deliberately set 'hex'". Decorator still passes a real \`ColorFormat\`; no consumer-visible API change.

Milestone: Maintenance
Closes: #277
Plan impact: none — parity fix for the MDX fallback story.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — green on blocks + addon.
- [x] Storybook story tests for all four color-format variants + theme-switch pass.
- [ ] CI green.
- [ ] Manual verify: open an MDX page with \`<ColorPalette>\`, cycle color format in the toolbar popover, value text updates.