### PR TITLE
fix(blocks): preserve channel-derived globals across mdx remounts

### DIFF
--- a/.changeset/mdx-remount-preserves-channel-state.md
+++ b/.changeset/mdx-remount-preserves-channel-state.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Fix MDX-rendered blocks flickering back to default values one frame after an axis or color-format change. Storybook force-rerenders the docs container on every `updateGlobals`, which remounts the MDX-embedded blocks and reset their local `useState` trackers. Lift the channel-derived globals (axes / theme / color format) to a module-level store consumed via `useSyncExternalStore` so the values survive remounts, and drop the `setGlobals` listener that could overwrite a just-toggled value with the pre-toggle snapshot in edge orderings.

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -1,6 +1,6 @@
-import { createContext, useContext, useEffect, useState } from 'react';
-import { addons } from 'storybook/preview-api';
-import { COLOR_FORMATS, type ColorFormat } from '#/internal/format-color.ts';
+import { createContext, useContext } from 'react';
+import { useChannelGlobals } from '#/internal/channel-globals.ts';
+import type { ColorFormat } from '#/internal/format-color.ts';
 
 /**
  * Typed shape of the addon's `virtual:swatchbook/tokens` module, duplicated
@@ -119,38 +119,8 @@ export function useActiveAxes(): Readonly<Record<string, string>> {
  */
 export const ColorFormatContext = createContext<ColorFormat | null>(null);
 
-const COLOR_FORMAT_GLOBAL_KEY = 'swatchbookColorFormat';
-
-interface GlobalsPayload {
-  globals?: Record<string, unknown>;
-}
-
-function isColorFormat(value: unknown): value is ColorFormat {
-  return typeof value === 'string' && (COLOR_FORMATS as readonly string[]).includes(value);
-}
-
 export function useColorFormat(): ColorFormat {
   const contextValue = useContext(ColorFormatContext);
-  const [channelFormat, setChannelFormat] = useState<ColorFormat | null>(null);
-
-  const fallbackEnabled = contextValue === null;
-
-  useEffect(() => {
-    if (!fallbackEnabled) return;
-    const channel = addons.getChannel();
-    const onGlobals = (payload: GlobalsPayload): void => {
-      const next = payload.globals?.[COLOR_FORMAT_GLOBAL_KEY];
-      if (isColorFormat(next)) setChannelFormat(next);
-    };
-    channel.on('globalsUpdated', onGlobals);
-    channel.on('updateGlobals', onGlobals);
-    channel.on('setGlobals', onGlobals);
-    return () => {
-      channel.off('globalsUpdated', onGlobals);
-      channel.off('updateGlobals', onGlobals);
-      channel.off('setGlobals', onGlobals);
-    };
-  }, [fallbackEnabled]);
-
-  return contextValue ?? channelFormat ?? 'hex';
+  const channelGlobals = useChannelGlobals();
+  return contextValue ?? channelGlobals.format ?? 'hex';
 }

--- a/packages/blocks/src/internal/channel-globals.ts
+++ b/packages/blocks/src/internal/channel-globals.ts
@@ -1,0 +1,90 @@
+import { useSyncExternalStore } from 'react';
+import { addons } from 'storybook/preview-api';
+import { COLOR_FORMATS, type ColorFormat } from '#/internal/format-color.ts';
+
+/**
+ * Shared subscription to Storybook's globals channel, lifted out of React
+ * component state so the values survive docs-mode remounts.
+ *
+ * On MDX docs pages, Storybook force-rerenders the docs container on every
+ * `updateGlobals` (see `preview/runtime.js` → `onUpdateGlobals`), which
+ * unmounts and remounts any embedded blocks. A `useState(null)` initializer
+ * inside the block would reset to null on each remount — the symptom is a
+ * one-frame flicker to the correct value, then revert to the defaults.
+ * Module-level state persists; React reads it through `useSyncExternalStore`
+ * and stays concurrent-safe.
+ */
+
+export interface ChannelGlobals {
+  axes: Record<string, string> | null;
+  theme: string | null;
+  format: ColorFormat | null;
+}
+
+const AXES_GLOBAL_KEY = 'swatchbookAxes';
+const THEME_GLOBAL_KEY = 'swatchbookTheme';
+const COLOR_FORMAT_GLOBAL_KEY = 'swatchbookColorFormat';
+
+let snapshot: ChannelGlobals = { axes: null, theme: null, format: null };
+const listeners = new Set<() => void>();
+let subscribed = false;
+
+function isColorFormat(value: unknown): value is ColorFormat {
+  return typeof value === 'string' && (COLOR_FORMATS as readonly string[]).includes(value);
+}
+
+function ensureSubscribed(): void {
+  if (subscribed || typeof window === 'undefined') return;
+  subscribed = true;
+  const channel = addons.getChannel();
+  const onGlobals = (payload: { globals?: Record<string, unknown> }): void => {
+    const globals = payload.globals;
+    if (!globals) return;
+    let next = snapshot;
+    const nextAxes = globals[AXES_GLOBAL_KEY];
+    if (nextAxes && typeof nextAxes === 'object') {
+      next = { ...next, axes: nextAxes as Record<string, string> };
+    }
+    const nextTheme = globals[THEME_GLOBAL_KEY];
+    if (typeof nextTheme === 'string') {
+      next = { ...next, theme: nextTheme };
+    }
+    const nextFormat = globals[COLOR_FORMAT_GLOBAL_KEY];
+    if (isColorFormat(nextFormat)) {
+      next = { ...next, format: nextFormat };
+    }
+    if (next !== snapshot) {
+      snapshot = next;
+      for (const cb of listeners) cb();
+    }
+  };
+  /**
+   * Intentionally not listening to `setGlobals` here. It fires once on
+   * preview init carrying the current user globals — if any updates have
+   * happened the manager re-emits `updateGlobals` for us. Listening to
+   * `setGlobals` added no coverage in practice and risks overwriting a
+   * just-toggled value with the pre-toggle snapshot in edge-case orderings.
+   */
+  channel.on('globalsUpdated', onGlobals);
+  channel.on('updateGlobals', onGlobals);
+}
+
+function subscribe(cb: () => void): () => void {
+  ensureSubscribed();
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+function getSnapshot(): ChannelGlobals {
+  return snapshot;
+}
+
+function getServerSnapshot(): ChannelGlobals {
+  return snapshot;
+}
+
+export function useChannelGlobals(): ChannelGlobals {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
-import { addons } from 'storybook/preview-api';
+import { useEffect } from 'react';
 import { useActiveAxes, useActiveTheme, useOptionalSwatchbookData } from '#/contexts.ts';
+import { useChannelGlobals } from '#/internal/channel-globals.ts';
 import {
   axes as virtualAxes,
   css as generatedCss,
@@ -24,8 +24,6 @@ export interface ProjectData {
 }
 
 const STYLE_ELEMENT_ID = 'swatchbook-tokens';
-const GLOBAL_KEY = 'swatchbookTheme';
-const AXES_GLOBAL_KEY = 'swatchbookAxes';
 
 function ensureStylesheet(css: string): void {
   if (typeof document === 'undefined') return;
@@ -36,10 +34,6 @@ function ensureStylesheet(css: string): void {
     document.head.appendChild(style);
   }
   if (style.textContent !== css) style.textContent = css;
-}
-
-interface GlobalsPayload {
-  globals?: Record<string, unknown>;
 }
 
 function defaultTuple(axes: readonly VirtualAxis[]): Record<string, string> {
@@ -105,41 +99,20 @@ export function useProject(): ProjectData {
 function useVirtualModuleFallback(enabled: boolean): ProjectData {
   const contextTheme = useActiveTheme();
   const contextAxes = useActiveAxes();
-  const [channelTheme, setChannelTheme] = useState<string | null>(null);
-  const [channelAxes, setChannelAxes] = useState<Record<string, string> | null>(null);
+  const channelGlobals = useChannelGlobals();
 
   useEffect(() => {
     if (!enabled) return;
     ensureStylesheet(generatedCss);
   }, [enabled]);
 
-  useEffect(() => {
-    if (!enabled) return;
-    const channel = addons.getChannel();
-    const onGlobals = (payload: GlobalsPayload): void => {
-      const nextTheme = payload.globals?.[GLOBAL_KEY];
-      if (typeof nextTheme === 'string') setChannelTheme(nextTheme);
-      const nextAxes = payload.globals?.[AXES_GLOBAL_KEY];
-      if (nextAxes && typeof nextAxes === 'object') {
-        setChannelAxes(nextAxes as Record<string, string>);
-      }
-    };
-    channel.on('globalsUpdated', onGlobals);
-    channel.on('updateGlobals', onGlobals);
-    channel.on('setGlobals', onGlobals);
-    return () => {
-      channel.off('globalsUpdated', onGlobals);
-      channel.off('updateGlobals', onGlobals);
-      channel.off('setGlobals', onGlobals);
-    };
-  }, [enabled]);
-
   const hasContextAxes = Object.keys(contextAxes).length > 0;
   const activeAxes: Record<string, string> = hasContextAxes
     ? { ...contextAxes }
-    : (channelAxes ?? defaultTuple(virtualAxes));
+    : (channelGlobals.axes ?? defaultTuple(virtualAxes));
 
   const derivedName = nameForTuple(themes, activeAxes);
+  const channelTheme = channelGlobals.theme;
   const fallbackTupleName =
     channelTheme && tupleForName(themes, channelTheme) ? channelTheme : null;
   const activeTheme =


### PR DESCRIPTION
## Summary

- Lift the channel-derived globals (axes, theme, color format) from component-local \`useState\` to a module-level store in \`packages/blocks/src/internal/channel-globals.ts\`, consumed via \`useSyncExternalStore\`.
- Refactor \`useProject\` fallback + \`useColorFormat\` to read from the shared store.
- Drop the \`setGlobals\` listener — it added no coverage in practice and risked overwriting a just-toggled value with the pre-toggle snapshot in edge orderings.

## Why

Storybook force-rerenders the docs container on every \`updateGlobals\` (see \`preview/runtime.js\` → \`onUpdateGlobals\`: \`storyRenders.map(r => r.rerender())\`). On MDX pages the rerender unmounts + remounts the embedded blocks, wiping their local \`useState(null)\` trackers — symptom: text flickers to correct for one frame on toolbar switch, reverts to default. Module-level state survives remounts; \`useSyncExternalStore\` keeps it concurrent-safe.

Milestone: Maintenance
Closes: #280
Plan impact: none — bug fix.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — 18/18 green.
- [x] Storybook story tests: theme-switch (all variants), useToken reactivity, all four color-format variants — pass.
- [ ] CI green.
- [ ] Manual verify on an MDX page with \`<ColorPalette>\` / \`<TokenTable>\`: toggle axis → text stays at new value; toggle color format → text reformats and stays.