### PR TITLE
fix(blocks): seed channel globals on init for first-render correctness

### DIFF
--- a/.changeset/seed-channel-globals-on-init.md
+++ b/.changeset/seed-channel-globals-on-init.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Fix MDX blocks rendering defaults for one frame when the toolbar's URL-persisted selection is non-default. Storybook stores toolbar state in `?globals=…`, so deeplinking or reloading with e.g. `swatchbookColorFormat:rgb` already has `rgb` in the preview's `userGlobals`, but `SET_GLOBALS` — the event that carries it on init — fired before our listener subscribed. Subscribe at module load and re-add the `setGlobals` handler so first render matches the persisted selection.

--- a/packages/blocks/src/internal/channel-globals.ts
+++ b/packages/blocks/src/internal/channel-globals.ts
@@ -59,15 +59,24 @@ function ensureSubscribed(): void {
     }
   };
   /**
-   * Intentionally not listening to `setGlobals` here. It fires once on
-   * preview init carrying the current user globals — if any updates have
-   * happened the manager re-emits `updateGlobals` for us. Listening to
-   * `setGlobals` added no coverage in practice and risks overwriting a
-   * just-toggled value with the pre-toggle snapshot in edge-case orderings.
+   * `setGlobals` fires once on preview init carrying the URL-persisted user
+   * globals (Storybook stores toolbar selections in `?globals=…`). Without
+   * this listener, deeplinking to an MDX page with a non-default axis tuple
+   * or color format renders defaults for one frame before the first
+   * `updateGlobals` arrives. `emitGlobals()` reads from `userGlobals.get()`
+   * (current state), so the payload is never stale — safe to handle.
    */
   channel.on('globalsUpdated', onGlobals);
   channel.on('updateGlobals', onGlobals);
+  channel.on('setGlobals', onGlobals);
 }
+
+/**
+ * Subscribe at module load so the `SET_GLOBALS` emission from preview init
+ * lands in our snapshot before any block renders. Running `useSyncExternalStore`'s
+ * `subscribe` lazily on first hook call would miss the event in most cases.
+ */
+ensureSubscribed();
 
 function subscribe(cb: () => void): () => void {
   ensureSubscribed();


### PR DESCRIPTION
## Summary

- Subscribe to the globals channel at module load (was lazy-via-\`useSyncExternalStore\` before).
- Re-add \`setGlobals\` listener; the preview's \`emitGlobals()\` always carries current user globals, not stale factory defaults, so my earlier concern was unfounded.

## Why

Storybook persists toolbar selections in \`?globals=…\`. Deeplinking to an MDX page with a non-default color format or axis tuple boots the preview with those values already in \`userGlobals\` and fires \`SET_GLOBALS\` carrying them. Our lazy subscription happened after the emission, so the first render of a block used the fallback defaults and flashed to the correct value only on the next channel event.

Milestone: Maintenance
Closes: #282
Plan impact: none — polish.

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks\` — green.
- [x] Storybook story tests for color-format variants + theme switch + useToken pass.
- [ ] CI green.
- [ ] Manual verify: URL with \`?globals=swatchbookColorFormat:rgb\` loaded on an MDX page renders rgb without flicker.