### PR TITLE
chore: tidy npm keywords on addon + blocks

### DIFF
--- a/.changeset/package-keywords-tidy.md
+++ b/.changeset/package-keywords-tidy.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Tidy npm keywords: drop `storybook-addon` from `@unpunnyfuns/swatchbook-blocks` (it's a companion doc-block library, not an addon), and add broader discovery terms `design` and `style` to `@unpunnyfuns/swatchbook-addon`.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -19,7 +19,6 @@
     "design-system",
     "design",
     "style",
-    "organize",
     "tokens"
   ],
   "type": "module",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -19,6 +19,7 @@
     "design-system",
     "design",
     "style",
+    "organize",
     "tokens"
   ],
   "type": "module",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -20,7 +20,6 @@
     "design-system",
     "design",
     "style",
-    "organize",
     "tokens"
   ],
   "type": "module",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -13,7 +13,6 @@
   },
   "keywords": [
     "storybook-addon",
-    "storybook-addons",
     "storybook",
     "design-tokens",
     "dtcg",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -20,6 +20,7 @@
     "design-system",
     "design",
     "style",
+    "organize",
     "tokens"
   ],
   "type": "module",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -12,9 +12,9 @@
     "directory": "packages/addon"
   },
   "keywords": [
-    "storybook",
     "storybook-addon",
     "storybook-addons",
+    "storybook",
     "design-tokens",
     "dtcg",
     "design-system",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -18,6 +18,8 @@
     "design-tokens",
     "dtcg",
     "design-system",
+    "design",
+    "style",
     "tokens"
   ],
   "type": "module",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -13,7 +13,6 @@
   },
   "keywords": [
     "storybook",
-    "storybook-addon",
     "storybook-blocks",
     "design-tokens",
     "dtcg",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -12,8 +12,9 @@
     "directory": "packages/blocks"
   },
   "keywords": [
-    "storybook",
+    "storybook-addon",
     "storybook-blocks",
+    "storybook",
     "design-tokens",
     "dtcg",
     "mdx",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -19,6 +19,7 @@
     "dtcg",
     "mdx",
     "design-system",
+    "organize",
     "tokens"
   ],
   "type": "module",


### PR DESCRIPTION
## Summary

- **blocks**: drop \`storybook-addon\` — this package is the companion doc-block library, not an addon in its own right.
- **addon**: add \`design\` and \`style\` for broader discovery alongside the existing \`design-system\` / \`design-tokens\`.

Milestone: Maintenance
Closes: #284
Plan impact: none — metadata only.