### PR TITLE
fix(addon): close toolbar popover on outside mousedown

### DIFF
--- a/.changeset/toolbar-outside-click.md
+++ b/.changeset/toolbar-outside-click.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Fix the Swatchbook toolbar popover not closing on outside click. `WithTooltipPure`'s built-in `closeOnOutsideClick` misses the case of clicks that land outside the portaled popover; add a document-level `mousedown` listener while open that closes unless the click is inside the trigger wrapper or the popover body.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -526,6 +526,25 @@ function AxesToolbar(): ReactElement {
     return () => document.removeEventListener('keydown', onDocKey);
   }, [open]);
 
+  /**
+   * `WithTooltipPure`'s built-in `closeOnOutsideClick` misses some cases
+   * (portaled popover + manager iframe boundaries). Belt-and-suspenders:
+   * close when the user mouses down anywhere that isn't the trigger wrapper
+   * or the popover body.
+   */
+  useEffect(() => {
+    if (!open) return;
+    const onDocMouseDown = (e: MouseEvent): void => {
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      if (bodyRef.current?.contains(target)) return;
+      if (target.closest('[data-testid="swatchbook-toolbar-popover"]')) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', onDocMouseDown);
+    return () => document.removeEventListener('mousedown', onDocMouseDown);
+  }, [open]);
+
   if (axes.length === 0) {
     return h(
       IconButton,


### PR DESCRIPTION
## Summary

Add a document-level \`mousedown\` listener while the Swatchbook toolbar popover is open. Closes it when the click lands outside both the trigger wrapper and the popover body (matched via \`data-testid="swatchbook-toolbar-popover"\`). \`WithTooltipPure\`'s built-in \`closeOnOutsideClick\` doesn't catch every case — portaled content + manager iframe boundaries seem to interfere — so this is a belt-and-suspenders supplement that mirrors our existing Escape-to-close listener.

Milestone: Maintenance
Closes: #286
Plan impact: none — UX fix.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — green on addon + storybook app.
- [ ] CI green.
- [ ] Manual verify: open toolbar popover, click anywhere outside → popover closes.