### PR TITLE
ci: switch to npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-      # Required for npm provenance attestation (sigstore).
+      # Required for npm trusted publishing — GitHub's OIDC token is
+      # exchanged for a short-lived publish token; no NPM_TOKEN secret
+      # needed. Also covers provenance attestation (sigstore).
       id-token: write
     steps:
       - uses: actions/checkout@v6
@@ -36,6 +38,10 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
+      # Node 24 ships npm 10.x; trusted publishing needs >= 11.5.1.
+      - name: Upgrade npm for trusted publishing
+        run: npm install --global npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - name: Create Version Packages PR or publish
@@ -51,12 +57,8 @@ jobs:
           title: 'chore(release): version packages'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # setup-node with registry-url writes an .npmrc containing
-          # `_authToken=${NODE_AUTH_TOKEN}`, and that file wins over the
-          # one changesets/action writes to ~/.npmrc. Without this, npm
-          # expands NODE_AUTH_TOKEN to empty and the registry returns 404.
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Opt into npm package provenance so published tarballs carry a
-          # sigstore attestation linking them back to this workflow run.
+          # Trusted publishing is configured on npm for all three
+          # packages — no NPM_TOKEN / NODE_AUTH_TOKEN needed; npm picks
+          # up the GitHub OIDC token via id-token: write and exchanges
+          # it for a short-lived publish token at publish time.
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Summary

- Drop \`NPM_TOKEN\` / \`NODE_AUTH_TOKEN\` from the changesets step's env.
- Add a pre-step upgrading npm to latest — Node 24 ships npm 10.x; trusted publishing needs ≥ 11.5.1.
- Keep \`id-token: write\` (already granted — same permission trusted publishing consumes).
- Keep \`NPM_CONFIG_PROVENANCE: true\` (layered on trusted-publish releases).

Trusted publishing is configured on npm for all three packages: \`core\`, \`addon\`, \`blocks\`. GitHub's OIDC token is exchanged for a short-lived publish token at publish time, so no long-lived secret is needed.

Milestone: Maintenance
Closes: #289
Plan impact: none — CI-only.

## Test plan

- [ ] CI green on PR.
- [ ] After merge, the next Release run on main exercises trusted-publish flow. If anything goes wrong, \`NPM_TOKEN\` secret is still available as fallback until it's revoked.
- [ ] Once verified, revoke \`NPM_TOKEN\` on the repo settings page.