### PR TITLE
chore: declare sideEffects: false on all published packages

### DIFF
--- a/.changeset/side-effects-false.md
+++ b/.changeset/side-effects-false.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Declare `"sideEffects": false` on all three published packages. No CSS imports, no module-level work that isn't gated behind used-export reachability. Gives consumer bundlers permission to tree-shake unused exports more aggressively.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -55,6 +55,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -40,6 +40,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
   "files": [
     "dist"
   ],
+  "sideEffects": false,
   "scripts": {
     "build": "tsdown src/index.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
## Summary

Add \`"sideEffects": false\` to core, addon, and blocks. No CSS imports, no standalone module-level work — any module-level subscriptions live in modules whose exports are transitively used by every consumer, so tree-shaking them away wouldn't happen. Gives consumer bundlers license to drop unused exports.

Milestone: Maintenance
Closes: #247
Plan impact: none.

## Test plan

- [x] \`pnpm -r format\` — green.
- [ ] CI green.