### PR TITLE
fix(addon): aria-label on design tokens panel search input

### DIFF
--- a/.changeset/panel-search-aria-label.md
+++ b/.changeset/panel-search-aria-label.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Add an explicit `aria-label="Search tokens"` to the Design Tokens panel's search input. Placeholder text alone doesn't satisfy WCAG 2.1 4.1.2 (Name, Role, Value) — screen readers now announce the field's purpose.

--- a/packages/addon/src/panel.tsx
+++ b/packages/addon/src/panel.tsx
@@ -433,6 +433,7 @@ export function DesignTokensPanel({ active }: PanelProps): ReactElement | null {
         style: searchInputStyle,
         type: 'search',
         placeholder: `Search ${tokenCount} tokens in ${themeName}…`,
+        'aria-label': 'Search tokens',
         value: query,
         onChange: (e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value),
       }),


### PR DESCRIPTION
## Summary

Add \`aria-label="Search tokens"\` to the Design Tokens panel's search input. Placeholder text doesn't satisfy WCAG 2.1 4.1.2 — screen readers need an explicit accessible name.

Milestone: Maintenance
Closes: #252
Plan impact: none.

## Test plan

- [x] \`pnpm -r format\` — green.
- [ ] CI green.