### PR TITLE
test(core): resolver edge-case coverage

### DIFF
--- a/packages/core/test/resolver-edge-cases.test.ts
+++ b/packages/core/test/resolver-edge-cases.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, expect, it } from 'vitest';
+import { loadProject } from '#/load';
+
+let workspace: string;
+
+beforeEach(() => {
+  workspace = mkdtempSync(join(tmpdir(), 'swatchbook-resolver-'));
+});
+
+afterEach(() => {
+  rmSync(workspace, { recursive: true, force: true });
+});
+
+function writeJSON(relPath: string, value: unknown): string {
+  const abs = join(workspace, relPath);
+  const dir = abs.substring(0, abs.lastIndexOf('/'));
+  if (dir) mkdirSync(dir, { recursive: true });
+  writeFileSync(abs, JSON.stringify(value, null, 2), 'utf8');
+  return abs;
+}
+
+it('surfaces an error when the resolver points at a file that does not exist', async () => {
+  await expect(
+    loadProject({ resolver: 'does-not-exist.json', default: {} }, workspace),
+  ).rejects.toThrow();
+});
+
+it('surfaces a diagnostic or error when a resolver $ref target is missing', async () => {
+  writeJSON('resolver.json', {
+    $schema: 'https://design-tokens.org/tr/2025/drafts/resolver/',
+    version: '2025.10',
+    sets: { ref: { sources: [{ $ref: './missing.json' }] } },
+    resolutionOrder: [{ $ref: '#/sets/ref' }],
+  });
+  await expect(loadProject({ resolver: 'resolver.json', default: {} }, workspace)).rejects.toThrow();
+});
+
+it('loads a minimal valid resolver with a single set and no modifiers', async () => {
+  writeJSON('tokens.json', {
+    color: { red: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } } },
+  });
+  writeJSON('resolver.json', {
+    $schema: 'https://design-tokens.org/tr/2025/drafts/resolver/',
+    version: '2025.10',
+    sets: { main: { sources: [{ $ref: './tokens.json' }] } },
+    resolutionOrder: [{ $ref: '#/sets/main' }],
+  });
+  const project = await loadProject({ resolver: 'resolver.json', default: {} }, workspace);
+  expect(project.themes.length).toBeGreaterThan(0);
+  expect(project.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+});
+
+it('loads a resolver with one modifier + two contexts (no override overlays)', async () => {
+  writeJSON('tokens.json', {
+    color: { red: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } } },
+  });
+  writeJSON('resolver.json', {
+    $schema: 'https://design-tokens.org/tr/2025/drafts/resolver/',
+    version: '2025.10',
+    sets: { main: { sources: [{ $ref: './tokens.json' }] } },
+    modifiers: {
+      mode: {
+        contexts: { Light: [], Dark: [] },
+        default: 'Light',
+      },
+    },
+    resolutionOrder: [{ $ref: '#/sets/main' }, { $ref: '#/modifiers/mode' }],
+  });
+  const project = await loadProject({ resolver: 'resolver.json', default: { mode: 'Light' } }, workspace);
+  const axis = project.axes.find((a) => a.name === 'mode');
+  expect(axis).toBeDefined();
+  expect(axis?.contexts).toEqual(['Light', 'Dark']);
+  expect(project.themes.length).toBe(2);
+});
+
+it('records sourceFiles for every file pulled through $ref', async () => {
+  writeJSON('tokens.json', {
+    color: { red: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } } },
+  });
+  const resolverPath = writeJSON('resolver.json', {
+    $schema: 'https://design-tokens.org/tr/2025/drafts/resolver/',
+    version: '2025.10',
+    sets: { main: { sources: [{ $ref: './tokens.json' }] } },
+    resolutionOrder: [{ $ref: '#/sets/main' }],
+  });
+  const project = await loadProject({ resolver: 'resolver.json', default: {} }, workspace);
+  expect(project.sourceFiles).toContain(join(workspace, 'tokens.json'));
+  // Resolver file itself may or may not land in sourceFiles depending on how
+  // Terrazzo reports its own input; the referenced target definitely should.
+  expect(resolverPath).toBeDefined();
+});


### PR DESCRIPTION
## Summary

Add \`packages/core/test/resolver-edge-cases.test.ts\` — 5 focused tests for resolver-loader paths not touched by the reference fixture: missing resolver file, missing \`\$ref\` target, minimal valid set-only resolver, set + modifier enumeration, sourceFiles recording.

Each test uses \`mkdtempSync\` + \`rmSync\` cleanup so temp fixtures don't leak.

Milestone: Maintenance
Closes: #249
Plan impact: none — test coverage only.

## Test plan

- [x] \`pnpm test --filter=@unpunnyfuns/swatchbook-core\` — green.
- [ ] CI green.