### PR TITLE
test(storybook): add smoke-test play functions to block stories

### DIFF
--- a/apps/storybook/src/stories/BorderPreview.stories.tsx
+++ b/apps/storybook/src/stories/BorderPreview.stories.tsx
@@ -1,4 +1,5 @@
 import { BorderPreview } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -11,5 +12,13 @@ const meta = preview.meta({
 
 export default meta;
 
-export const SystemBorders = meta.story({ args: { filter: 'border.sys.*' } });
+export const SystemBorders = meta.story({
+  args: { filter: 'border.sys.*' },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const samples = canvasElement.querySelectorAll('[aria-hidden="true"]');
+      expect(samples.length, 'border preview must render at least one sample').toBeGreaterThan(0);
+    });
+  },
+});
 export const All = meta.story();

--- a/apps/storybook/src/stories/ColorPalette.stories.tsx
+++ b/apps/storybook/src/stories/ColorPalette.stories.tsx
@@ -1,4 +1,5 @@
 import { ColorPalette } from '@unpunnyfuns/swatchbook-blocks';
+import { waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -12,7 +13,22 @@ const meta = preview.meta({
 
 export default meta;
 
-export const All = meta.story();
-export const SysOnly = meta.story({ args: { filter: 'color.sys.*' } });
-export const RefBlue = meta.story({ args: { filter: 'color.ref.blue.*' } });
+async function assertPaletteRenders(canvas: HTMLElement): Promise<void> {
+  await waitFor(() => {
+    const section = canvas.querySelector('section');
+    if (!section) throw new Error('palette section not found');
+  });
+}
+
+export const All = meta.story({
+  play: async ({ canvasElement }) => assertPaletteRenders(canvasElement),
+});
+export const SysOnly = meta.story({
+  args: { filter: 'color.sys.*' },
+  play: async ({ canvasElement }) => assertPaletteRenders(canvasElement),
+});
+export const RefBlue = meta.story({
+  args: { filter: 'color.ref.blue.*' },
+  play: async ({ canvasElement }) => assertPaletteRenders(canvasElement),
+});
 export const Flat = meta.story({ args: { groupBy: 2 } });

--- a/apps/storybook/src/stories/DimensionScale.stories.tsx
+++ b/apps/storybook/src/stories/DimensionScale.stories.tsx
@@ -1,4 +1,5 @@
 import { DimensionScale } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -12,7 +13,20 @@ const meta = preview.meta({
 
 export default meta;
 
-export const SpaceSystem = meta.story({ args: { filter: 'space.sys.*' } });
+async function assertScaleRenders(canvas: HTMLElement): Promise<void> {
+  await waitFor(() => {
+    const bars = canvas.querySelectorAll('[aria-hidden="true"]');
+    expect(bars.length, 'scale must render at least one visual').toBeGreaterThan(0);
+  });
+}
+
+export const SpaceSystem = meta.story({
+  args: { filter: 'space.sys.*' },
+  play: async ({ canvasElement }) => assertScaleRenders(canvasElement),
+});
 export const RadiusSystem = meta.story({ args: { filter: 'radius.sys.*', kind: 'radius' } });
-export const SizeReferencePx = meta.story({ args: { filter: 'size.ref.*', kind: 'size' } });
+export const SizeReferencePx = meta.story({
+  args: { filter: 'size.ref.*', kind: 'size' },
+  play: async ({ canvasElement }) => assertScaleRenders(canvasElement),
+});
 export const All = meta.story();

--- a/apps/storybook/src/stories/GradientPalette.stories.tsx
+++ b/apps/storybook/src/stories/GradientPalette.stories.tsx
@@ -1,4 +1,5 @@
 import { GradientPalette } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -11,5 +12,12 @@ const meta = preview.meta({
 
 export default meta;
 
-export const AllGradients = meta.story();
+export const AllGradients = meta.story({
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const sample = canvasElement.querySelector('[aria-hidden="true"]');
+      expect(sample, 'at least one gradient sample should render').not.toBeNull();
+    });
+  },
+});
 export const RefGradients = meta.story({ args: { filter: 'gradient.ref.*' } });

--- a/apps/storybook/src/stories/MotionPreview.stories.tsx
+++ b/apps/storybook/src/stories/MotionPreview.stories.tsx
@@ -1,4 +1,5 @@
 import { MotionPreview } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -11,7 +12,17 @@ const meta = preview.meta({
 
 export default meta;
 
-export const SystemTransitions = meta.story({ args: { filter: 'motion.sys.*' } });
+export const SystemTransitions = meta.story({
+  args: { filter: 'motion.sys.*' },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const wrapper = canvasElement.querySelector('[data-theme]');
+      expect(wrapper?.textContent, 'motion preview should include at least one axis path').toMatch(
+        /motion\./,
+      );
+    });
+  },
+});
 export const Durations = meta.story({ args: { filter: 'duration.*' } });
 export const Easings = meta.story({ args: { filter: 'easing.*' } });
 export const All = meta.story();

--- a/apps/storybook/src/stories/ShadowPreview.stories.tsx
+++ b/apps/storybook/src/stories/ShadowPreview.stories.tsx
@@ -1,4 +1,5 @@
 import { ShadowPreview } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -11,5 +12,13 @@ const meta = preview.meta({
 
 export default meta;
 
-export const SystemShadows = meta.story({ args: { filter: 'shadow.sys.*' } });
+export const SystemShadows = meta.story({
+  args: { filter: 'shadow.sys.*' },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const samples = canvasElement.querySelectorAll('[aria-hidden="true"]');
+      expect(samples.length, 'shadow preview must render at least one sample').toBeGreaterThan(0);
+    });
+  },
+});
 export const All = meta.story();

--- a/apps/storybook/src/stories/TokenDetail.stories.tsx
+++ b/apps/storybook/src/stories/TokenDetail.stories.tsx
@@ -1,4 +1,5 @@
 import { TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -12,11 +13,27 @@ const meta = preview.meta({
 
 export default meta;
 
-export const SysSurface = meta.story({ args: { path: 'color.sys.surface.default' } });
+async function assertDetailRenders(canvas: HTMLElement, path: string): Promise<void> {
+  await waitFor(() => {
+    const heading = canvas.querySelector('h3, h2');
+    expect(heading?.textContent, 'token heading should contain the dot-path').toContain(path);
+  });
+}
+
+export const SysSurface = meta.story({
+  args: { path: 'color.sys.surface.default' },
+  play: async ({ canvasElement, args }) => assertDetailRenders(canvasElement, args.path as string),
+});
 export const SysAccent = meta.story({ args: { path: 'color.sys.text.accent' } });
-export const AccentBg = meta.story({ args: { path: 'color.sys.accent.bg' } });
+export const AccentBg = meta.story({
+  args: { path: 'color.sys.accent.bg' },
+  play: async ({ canvasElement, args }) => assertDetailRenders(canvasElement, args.path as string),
+});
 export const SpaceMd = meta.story({ args: { path: 'space.sys.md' } });
-export const TypographyBody = meta.story({ args: { path: 'typography.sys.body' } });
+export const TypographyBody = meta.story({
+  args: { path: 'typography.sys.body' },
+  play: async ({ canvasElement, args }) => assertDetailRenders(canvasElement, args.path as string),
+});
 export const Gradient = meta.story({ args: { path: 'gradient.ref.sunrise' } });
 export const StrokeStyleString = meta.story({ args: { path: 'stroke.ref.style.dashed' } });
 export const StrokeStyleObject = meta.story({ args: { path: 'stroke.ref.style.custom-dash' } });

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -1,4 +1,5 @@
 import { TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -28,8 +29,23 @@ const meta = preview.meta({
 
 export default meta;
 
-export const All = meta.story();
-export const ColorsOnly = meta.story({ args: { type: 'color' } });
+async function assertTableRenders(canvas: HTMLElement): Promise<void> {
+  await waitFor(() => {
+    const rows = canvas.querySelectorAll('tbody tr');
+    expect(rows.length, 'table must render at least one row').toBeGreaterThan(0);
+  });
+}
+
+export const All = meta.story({
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});
+export const ColorsOnly = meta.story({
+  args: { type: 'color' },
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});
 export const SysColors = meta.story({ args: { filter: 'color.sys.*' } });
 export const SysTypography = meta.story({ args: { filter: 'typography.sys.*' } });
-export const DimensionsOnly = meta.story({ args: { type: 'dimension' } });
+export const DimensionsOnly = meta.story({
+  args: { type: 'dimension' },
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});

--- a/apps/storybook/src/stories/TypographyScale.stories.tsx
+++ b/apps/storybook/src/stories/TypographyScale.stories.tsx
@@ -1,4 +1,5 @@
 import { TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -12,7 +13,17 @@ const meta = preview.meta({
 
 export default meta;
 
-export const All = meta.story();
+export const All = meta.story({
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const wrapper = canvasElement.querySelector('[data-theme]');
+      expect(
+        wrapper?.textContent,
+        'typography scale should include at least one typography path',
+      ).toMatch(/typography\./);
+    });
+  },
+});
 export const HeadingOnly = meta.story({ args: { filter: 'typography.sys.heading' } });
 export const Pangram = meta.story({
   args: { sample: 'Sphinx of black quartz, judge my vow — 0123456789' },


### PR DESCRIPTION
## Summary

Add minimal render-smoke play functions to the most-visible block story variants — ColorPalette, TokenTable, TokenDetail, GradientPalette, DimensionScale, MotionPreview, ShadowPreview, BorderPreview, TypographyScale. Each \`play\` waits for the block's expected content (section / row / swatch / sample) and asserts with a helpful message.

These complement \`BlockAssertions.stories.tsx\`'s composition-assurance tests; per-story plays catch regressions that are specific to the concrete args (filter, path, groupBy) used in the story files.

Intentionally skipped:
- Button / Card / Input — demo components, not swatchbook library code.
- Internal sample stories (\`BorderSample\`, \`DimensionBar\`, \`MotionSample\`, \`ShadowSample\`) — already covered transitively through their parent block stories.

Milestone: Maintenance
Closes: #251
Plan impact: none — test coverage only.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck --filter=storybook\` — green.
- [x] Storybook play-function run for all 16 touched stories — all pass.
- [ ] CI green.