### PR TITLE
docs(storybook): add MDX showcase pages for remaining token types

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -15,7 +15,23 @@ export default definePreview({
     backgrounds: { disable: true },
     options: {
       storySort: {
-        order: ['Docs', ['Introduction', 'Colors', 'Typography', 'Tokens'], '*'],
+        order: [
+          'Docs',
+          [
+            'Introduction',
+            'Colors',
+            'Typography',
+            'Fonts',
+            'Dimensions',
+            'Shadows',
+            'Borders',
+            'Gradients',
+            'Motion',
+            'StrokeStyles',
+            'Tokens',
+          ],
+          '*',
+        ],
       },
     },
   },

--- a/apps/storybook/src/docs/Borders.mdx
+++ b/apps/storybook/src/docs/Borders.mdx
@@ -1,0 +1,20 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { BorderPreview, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title='Docs/Borders' />
+
+# Borders
+
+DTCG `border` tokens compose `width`, `style`, and `color` — emitted as a
+CSS `border` shorthand. Color typically aliases into `color.sys.border.*`
+so mode changes repaint the stroke.
+
+## System borders
+
+<BorderPreview filter='border.sys.*' />
+
+## Inspect a single token
+
+<TokenDetail path='border.sys.default' />
+
+<TokenDetail path='border.sys.focus' />

--- a/apps/storybook/src/docs/Dimensions.mdx
+++ b/apps/storybook/src/docs/Dimensions.mdx
@@ -1,0 +1,35 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { DimensionScale, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title='Docs/Dimensions' />
+
+# Dimensions
+
+DTCG `dimension` tokens are `{ value, unit }` objects — most of the scale
+is in `px` / `rem`. The reference fixture splits dimensions into two
+groups: **`space.sys.*`** (layout spacing) and **`radius.sys.*`** (border
+radii). Size primitives live under `size.ref.*`.
+
+## Spacing scale
+
+Width-driven bars, sorted numerically.
+
+<DimensionScale filter='space.sys.*' />
+
+## Radius scale
+
+Rendered as rounded squares so you can eyeball the corner curve.
+
+<DimensionScale filter='radius.sys.*' kind='radius' />
+
+## Raw size primitives
+
+Square samples sized directly from the token's `$value`.
+
+<DimensionScale filter='size.ref.*' kind='size' />
+
+## Inspect a single token
+
+<TokenDetail path='space.sys.md' />
+
+<TokenDetail path='radius.sys.md' />

--- a/apps/storybook/src/docs/Fonts.mdx
+++ b/apps/storybook/src/docs/Fonts.mdx
@@ -1,0 +1,30 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { FontFamilySample, FontWeightScale, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title='Docs/Fonts' />
+
+# Fonts
+
+Two primitive token types back every `typography.*` composite:
+**`fontFamily`** (a font stack — string or array) and **`fontWeight`**
+(a numeric weight). This page shows both separately; see
+[Typography](?path=/docs/docs-typography--docs) for the composites that
+combine them.
+
+## Font families
+
+Pangram rendered per `fontFamily` primitive.
+
+<FontFamilySample />
+
+## Font weights
+
+`Aa` rendered at every `fontWeight` primitive, sorted ascending.
+
+<FontWeightScale />
+
+## Inspect a single token
+
+<TokenDetail path='font.ref.family.sans' />
+
+<TokenDetail path='font.ref.weight.bold' />

--- a/apps/storybook/src/docs/Gradients.mdx
+++ b/apps/storybook/src/docs/Gradients.mdx
@@ -1,0 +1,21 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { GradientPalette, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title='Docs/Gradients' />
+
+# Gradients
+
+DTCG `gradient` tokens are arrays of `{ color, position }` stops. The
+rendering function — `linear-gradient` / `radial-gradient` / `conic-gradient`
+— is a choice the consumer makes at use-site; the token carries only the
+stops. This showcase uses `linear-gradient(to right, …)` for previews.
+
+## All gradients
+
+<GradientPalette />
+
+## Inspect a single token
+
+<TokenDetail path='gradient.ref.sunrise' />
+
+<TokenDetail path='gradient.ref.cool' />

--- a/apps/storybook/src/docs/Motion.mdx
+++ b/apps/storybook/src/docs/Motion.mdx
@@ -1,0 +1,31 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { MotionPreview, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title='Docs/Motion' />
+
+# Motion
+
+Three related DTCG types cover motion: **`duration`** (a time value),
+**`cubicBezier`** (a four-number easing array), and **`transition`** (a
+composite of duration + easing + optional delay). The addon respects
+`prefers-reduced-motion` — if the user has it set, the samples fall back
+to a textual placeholder.
+
+## System transitions
+
+Every `motion.sys.*` token animated against a horizontal track. The
+speed control is global to this block.
+
+<MotionPreview filter='motion.sys.*' />
+
+## Durations
+
+<MotionPreview filter='duration.*' />
+
+## Easings
+
+<MotionPreview filter='easing.*' />
+
+## Inspect a single token
+
+<TokenDetail path='motion.sys.enter' />

--- a/apps/storybook/src/docs/Shadows.mdx
+++ b/apps/storybook/src/docs/Shadows.mdx
@@ -1,0 +1,26 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { ShadowPreview, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title='Docs/Shadows' />
+
+# Shadows
+
+DTCG `shadow` tokens are either a single layer or an array of layers,
+each carrying `offsetX` / `offsetY` / `blur` / `spread` / `color` and an
+optional `inset` flag. Emitted CSS concatenates the layers into a single
+`box-shadow` value.
+
+## System shadows
+
+Every `shadow.sys.*` token applied to a surface rectangle. Switch the
+theme in the toolbar to see shadows redraw against dark surfaces.
+
+<ShadowPreview filter='shadow.sys.*' />
+
+## Inspect a single token
+
+Alias chain, per-layer breakdown, and the CSS var reference.
+
+<TokenDetail path='shadow.sys.md' />
+
+<TokenDetail path='shadow.sys.lg' />

--- a/apps/storybook/src/docs/StrokeStyles.mdx
+++ b/apps/storybook/src/docs/StrokeStyles.mdx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+import { StrokeStyleSample, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+
+<Meta title='Docs/StrokeStyles' />
+
+# Stroke styles
+
+DTCG `strokeStyle` covers the CSS `border-style` keywords (`solid`,
+`dashed`, `dotted`, `double`, etc.) plus richer object forms carrying
+explicit `dashArray` / `lineCap` for SVG strokes. String-form values
+render as a literal `border-style`; object-form tokens fall back to a
+textual display — there's no pure-CSS equivalent.
+
+## Stroke style primitives
+
+<StrokeStyleSample />
+
+## Inspect a single token
+
+<TokenDetail path='stroke.ref.style.dashed' />
+
+<TokenDetail path='stroke.ref.style.custom-dash' />


### PR DESCRIPTION
## Summary

Add 7 new MDX docs pages under \`apps/storybook/src/docs/\`, one per first-class DTCG \`\$type\` not already covered:

- Dimensions (space / radius / size)
- Shadows
- Borders
- Gradients
- Motion (transitions / durations / easings)
- Fonts (family + weight primitives)
- StrokeStyles

Each mirrors the \`Colors.mdx\` + \`Typography.mdx\` shape: short prose intro, the relevant block with a sensible filter, one or two \`<TokenDetail>\` inspectors.

Extend \`preview.tsx\` \`storySort\` so the Docs sidebar orders them sensibly: Introduction, Colors, Typography, Fonts, Dimensions, Shadows, Borders, Gradients, Motion, StrokeStyles, Tokens.

Milestone: Documentation
Closes: #298
Plan impact: none — docs only.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck --filter=storybook\` — green.
- [x] All 7 new pages registered in Storybook docs catalog.
- [ ] CI green.