### PR TITLE
fix(addon): close popover on preview clicks + fix toolbar loading race

### DIFF
--- a/.changeset/toolbar-preview-outside-click.md
+++ b/.changeset/toolbar-preview-outside-click.md
@@ -1,0 +1,8 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Fix two toolbar-popover papercuts:
+
+- Clicks inside the preview iframe now close the popover. The manager's document-level mousedown listener can't observe events inside the preview, so the preview now emits a channel event on mousedown and the popover listens for it.
+- Toolbar no longer stays stuck in its "loading…" state when the manager mounts after the preview's initial `INIT_EVENT` broadcast. Manager now sends an `INIT_REQUEST` on mount and the preview re-broadcasts in response, closing the timing race.

--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -17,3 +17,13 @@ export const STYLE_ELEMENT_ID = 'swatchbook-tokens';
 
 /** Channel event: preview → manager, carries theme list + mode. */
 export const INIT_EVENT = 'swatchbook/init';
+/** Channel event: manager → preview, asks preview to re-emit INIT_EVENT.
+ * Covers the race where the manager subscribes after the preview's
+ * initial broadcast — without it the toolbar stays in "loading…" until
+ * the user triggers anything that re-fires INIT_EVENT. */
+export const INIT_REQUEST_EVENT = 'swatchbook/init-request';
+/** Channel event: preview → manager, fires once per `mousedown` on the
+ * preview document. The toolbar popover listens for it so clicks landing
+ * inside the preview iframe close the popover — a plain document-level
+ * listener on the manager can't see iframe events. */
+export const PREVIEW_MOUSEDOWN_EVENT = 'swatchbook/preview-mousedown';

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -7,6 +7,8 @@ import {
   COLOR_FORMAT_GLOBAL_KEY,
   GLOBAL_KEY,
   INIT_EVENT,
+  INIT_REQUEST_EVENT,
+  PREVIEW_MOUSEDOWN_EVENT,
   PANEL_ID,
   TOOL_ID,
 } from '#/constants.ts';
@@ -433,6 +435,13 @@ function AxesToolbar(): ReactElement {
     const channel = addons.getChannel();
     const onInit = (next: InitPayload): void => setPayload(next);
     channel.on(INIT_EVENT, onInit);
+    /**
+     * Ask the preview to (re-)emit INIT_EVENT in case it already broadcast
+     * before this effect subscribed. Without this request, a late-mounting
+     * manager (story navigation, docs reload) can stay in "loading…" until
+     * the user triggers a globals change.
+     */
+    channel.emit(INIT_REQUEST_EVENT);
     return () => {
       channel.off(INIT_EVENT, onInit);
     };
@@ -541,8 +550,20 @@ function AxesToolbar(): ReactElement {
       if (target.closest('[data-testid="swatchbook-toolbar-popover"]')) return;
       setOpen(false);
     };
+    /**
+     * The manager's document-level listener above can't see mousedowns
+     * inside the preview iframe. Preview emits PREVIEW_MOUSEDOWN_EVENT on
+     * every mousedown over its own document; listen for it here so
+     * clicking the canvas / docs page also closes the popover.
+     */
+    const channel = addons.getChannel();
+    const onPreviewMouseDown = (): void => setOpen(false);
     document.addEventListener('mousedown', onDocMouseDown);
-    return () => document.removeEventListener('mousedown', onDocMouseDown);
+    channel.on(PREVIEW_MOUSEDOWN_EVENT, onPreviewMouseDown);
+    return () => {
+      document.removeEventListener('mousedown', onDocMouseDown);
+      channel.off(PREVIEW_MOUSEDOWN_EVENT, onPreviewMouseDown);
+    };
   }, [open]);
 
   if (axes.length === 0) {

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -27,6 +27,8 @@ import {
   DATA_THEME_ATTR,
   GLOBAL_KEY,
   INIT_EVENT,
+  INIT_REQUEST_EVENT,
+  PREVIEW_MOUSEDOWN_EVENT,
   PARAM_KEY,
   STYLE_ELEMENT_ID,
 } from '#/constants.ts';
@@ -319,6 +321,13 @@ function installGlobalAxisApplier(): void {
    */
   ensureStylesheet();
   broadcastInit();
+  /**
+   * If the manager subscribes to INIT_EVENT after our initial broadcast,
+   * it misses the payload and the toolbar stays in its "loading…" state
+   * until something else re-fires it. Honor an explicit request event so
+   * a late-mounting manager can ask for the payload.
+   */
+  channel.on(INIT_REQUEST_EVENT, broadcastInit);
   const apply = (globals: Record<string, unknown>): void => {
     ensureStylesheet();
     const tuple = resolveTuple(globals, {});
@@ -338,3 +347,20 @@ function installGlobalAxisApplier(): void {
 }
 
 installGlobalAxisApplier();
+
+/**
+ * Bridge `mousedown` inside the preview iframe to the manager via a
+ * dedicated channel event. The toolbar popover's outside-click listener
+ * runs on the manager's document, which can't observe mousedowns inside
+ * the preview; without this bridge, clicking the canvas leaves the
+ * popover open. Idempotent: fires at most once per real mousedown.
+ */
+function installPreviewMouseDownBridge(): void {
+  if (typeof document === 'undefined') return;
+  const channel = addons.getChannel();
+  document.addEventListener('mousedown', () => {
+    channel.emit(PREVIEW_MOUSEDOWN_EVENT);
+  });
+}
+
+installPreviewMouseDownBridge();


### PR DESCRIPTION
## Summary

Two related toolbar papercuts:

1. **Preview clicks didn't close the popover.** The popover's existing \`mousedown\` listener runs on the manager's document, which can't observe events inside the preview iframe. Preview now emits \`PREVIEW_MOUSEDOWN_EVENT\` on every \`mousedown\` over its own document; the popover listens alongside its existing listener. Clicking the canvas / MDX docs page now closes the popover.
2. **Toolbar could sit stuck on "loading…" until refresh.** The manager subscribes to \`INIT_EVENT\` in a \`useEffect\` — if the preview's module-level broadcast fires before that effect runs, the manager misses the payload and \`axes.length === 0\` keeps the toolbar in its disabled state. Fix: manager emits \`INIT_REQUEST_EVENT\` on mount; preview re-broadcasts in response.

Milestone: Maintenance
Closes: #302
Plan impact: none — UX fixes.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — all green.
- [ ] CI green.
- [ ] Manual verify: open Storybook, toolbar activates on first render; click inside canvas while popover is open → closes.