### PR TITLE
docs: credit Terrazzo team instead of only Drew Powers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See the [documentation](https://unpunnyfuns.github.io/swatchbook/) for concepts,
 
 ## Credits
 
-Parses DTCG tokens through [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) — its parser, resolver evaluation, and alias resolution are the foundation this project builds on.
+Parses DTCG tokens through [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) — its parser, resolver evaluation, and alias resolution are the foundation this project builds on.
 
 ## Development
 

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -2,7 +2,7 @@
 
 Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus a unified Design Tokens panel (hierarchical tree + diagnostics), and ships a `useToken()` hook with typed paths.
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) via `@unpunnyfuns/swatchbook-core`.
+> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
 
 ## Install
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -2,7 +2,7 @@
 
 Published as `@unpunnyfuns/swatchbook-blocks`. Storybook MDX doc blocks for DTCG design tokens. React components for rendering token documentation inside `.mdx` pages or regular stories. Self-mount the addon's CSS and react to axis changes from the toolbar; work inside the docs container even though story decorators don't.
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow) via `@unpunnyfuns/swatchbook-core`.
+> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
 
 ## Install
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -152,7 +152,7 @@ Single-axis projects (one resolver modifier, or the synthetic `theme` axis) keep
 
 ## Credits
 
-Token parsing, alias resolution, and DTCG resolver evaluation are provided by [Terrazzo](https://terrazzo.app/) by [Drew Powers](https://github.com/drwpow). This package wraps those APIs into a Swatchbook-shaped project.
+Token parsing, alias resolution, and DTCG resolver evaluation are provided by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp). This package wraps those APIs into a Swatchbook-shaped project.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Four README files credit Terrazzo as "by [Drew Powers]" — Drew is the original author but the project has a team. Swap the attribution for \`by the [Terrazzo team](https://github.com/terrazzoapp)\` in root README, core README, addon README, and blocks README.

Milestone: Maintenance
Closes: #305
Plan impact: none.