### PR TITLE
docs: promote Blocks in sidebar + intro

### DIFF
--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -15,9 +15,9 @@ Design-system authors who already have DTCG tokens (or are in the process of aut
 
 ## What the addon gives you
 
-- **Toolbar** — a single Swatchbook icon button opens a popover with preset pills, one dropdown per modifier axis, and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`) that controls how blocks display colors.
+- **Doc blocks** — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, motion/shadow/border previews. Once the addon is wired up, *authoring pages with these blocks is the primary day-to-day swatchbook interaction*. See the [blocks reference](./reference/blocks) and the [authoring guide](./guides/authoring-doc-stories).
+- **Toolbar** — a single Swatchbook icon button opens a popover with preset pills, one dropdown per modifier axis (so a reader can browse tokens in every context), and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`) that controls how blocks display colors.
 - **Design Tokens panel** — a diagnostics summary at the top (green `OK` badge when clean; auto-expands on warnings or errors) followed by a searchable hierarchical tree of every token in the active theme. Click a leaf to copy its `var(--…)` reference.
-- **Doc blocks** — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, motion/shadow/border previews. Embed them in MDX stories.
 - **`useToken` hook** — typed lookups from component code, reactive to the active theme.
 
 ## See it live
@@ -28,8 +28,8 @@ The [live Storybook](/swatchbook/storybook/) runs the addon against this repo's 
 
 - **[Quickstart](./quickstart)** — install, configure, run.
 - **Concepts** — the mental model: theming inputs, axes, presets, diagnostics.
-- **Guides** — walkthroughs for multi-axis setup and authoring doc stories with the blocks.
-- **Reference** — API surface per published package (`core`, `addon`, `blocks`).
+- **Guides** — start with [authoring doc stories with the blocks](./guides/authoring-doc-stories); the [multi-axis walkthrough](./guides/multi-axis-walkthrough) covers one-time setup.
+- **Reference** — API surface per published package (`blocks`, `addon`, `core`, `config`).
 
 ## What these docs assume
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -27,9 +27,10 @@ The [live Storybook](/swatchbook/storybook/) runs the addon against this repo's 
 ## How to read these docs
 
 - **[Quickstart](./quickstart)** — install, configure, run.
+- **Blocks** — the MDX doc blocks you'll spend most of your time with: the [reference](./reference/blocks) lists what's available and the [authoring guide](./guides/authoring-doc-stories) walks through composing them.
 - **Concepts** — the mental model: theming inputs, axes, presets, diagnostics.
-- **Guides** — start with [authoring doc stories with the blocks](./guides/authoring-doc-stories); the [multi-axis walkthrough](./guides/multi-axis-walkthrough) covers one-time setup.
-- **Reference** — API surface per published package (`blocks`, `addon`, `core`, `config`).
+- **Guides** — the [multi-axis walkthrough](./guides/multi-axis-walkthrough) covers one-time setup.
+- **Reference** — API surface for the remaining packages (`addon`, `core`, `config`).
 
 ## What these docs assume
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -19,13 +19,17 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Guides',
       collapsed: false,
-      items: ['guides/multi-axis-walkthrough', 'guides/authoring-doc-stories'],
+      items: ['guides/authoring-doc-stories', 'guides/multi-axis-walkthrough'],
     },
     {
       type: 'category',
       label: 'Reference',
       collapsed: false,
-      items: ['reference/config', 'reference/core', 'reference/addon', 'reference/blocks'],
+      // Blocks lead — after initial setup, authoring pages with blocks is
+      // the primary day-to-day swatchbook interaction. Addon is peer-of-
+      // blocks; core is for build-time consumers; config is rarely read
+      // end-to-end so it goes last.
+      items: ['reference/blocks', 'reference/addon', 'reference/core', 'reference/config'],
     },
   ],
 };

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -4,6 +4,17 @@ const sidebars: SidebarsConfig = {
   docs: [
     'intro',
     'quickstart',
+    // Blocks promoted to the top level. After initial setup, authoring
+    // pages with the doc blocks is the primary swatchbook interaction —
+    // the reference (what's available) and the authoring guide (how to
+    // compose them) land right below the quickstart rather than buried
+    // under Reference / Guides.
+    {
+      type: 'category',
+      label: 'Blocks',
+      collapsed: false,
+      items: ['reference/blocks', 'guides/authoring-doc-stories'],
+    },
     {
       type: 'category',
       label: 'Concepts',
@@ -19,17 +30,13 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Guides',
       collapsed: false,
-      items: ['guides/authoring-doc-stories', 'guides/multi-axis-walkthrough'],
+      items: ['guides/multi-axis-walkthrough'],
     },
     {
       type: 'category',
       label: 'Reference',
       collapsed: false,
-      // Blocks lead — after initial setup, authoring pages with blocks is
-      // the primary day-to-day swatchbook interaction. Addon is peer-of-
-      // blocks; core is for build-time consumers; config is rarely read
-      // end-to-end so it goes last.
-      items: ['reference/blocks', 'reference/addon', 'reference/core', 'reference/config'],
+      items: ['reference/addon', 'reference/core', 'reference/config'],
     },
   ],
 };


### PR DESCRIPTION
## Summary

Blocks is the primary day-to-day swatchbook interaction after initial setup — but the docs site ordered it last in every list. Promote it:

- **sidebars.ts** → Reference reordered to \`blocks\` → \`addon\` → \`core\` → \`config\` (most-used leads, config last). Guides reordered to \`authoring-doc-stories\` → \`multi-axis-walkthrough\`.
- **intro.mdx** → "What the addon gives you" now leads with the doc-blocks bullet and links to the blocks reference + authoring guide. "How to read these docs" calls out the authoring guide explicitly.

Ordering + one-paragraph rewrite; no new content.

Milestone: Documentation
Closes: #307
Plan impact: none.