### PR TITLE
fix(blocks): alias --sb-* chrome vars to active cssVarPrefix

### DIFF
--- a/.changeset/blocks-chrome-prefix.md
+++ b/.changeset/blocks-chrome-prefix.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Fix block chrome rendering when `cssVarPrefix` is anything other than `sb`. Blocks were referencing their own chrome (surface, borders, text, accent) via literal `var(--sb-color-sys-*)`, which fell through to fallback values for every project on the post-0.2.0 default prefix (`swatch`) or any custom prefix. Each block wrapper now spreads a CSS custom-property alias layer redirecting the `--sb-*` names to the project's actual prefix; chrome renders correctly regardless of prefix.

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -8,7 +8,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface BorderPreviewProps {
@@ -132,14 +132,20 @@ export function BorderPreview({ filter = 'border', caption }: BorderPreviewProps
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No border tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -9,7 +9,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface ColorPaletteProps {
@@ -163,7 +163,10 @@ export function ColorPalette({
 
   if (totalCount === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No color tokens match this filter.</div>
       </div>
     );

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -8,7 +8,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export type { DimensionKind };
@@ -142,14 +142,20 @@ export function DimensionScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No dimension tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -7,7 +7,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface FontFamilySampleProps {
@@ -102,14 +102,20 @@ export function FontFamilySample({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No fontFamily tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -7,7 +7,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface FontWeightScaleProps {
@@ -111,14 +111,20 @@ export function FontWeightScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No fontWeight tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -8,7 +8,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface GradientPaletteProps {
@@ -146,14 +146,20 @@ export function GradientPalette({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No gradient tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties, ReactElement } from 'react';
 import { useMemo, useState } from 'react';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { BORDER_DEFAULT, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 import {
   MotionSample,
@@ -164,14 +164,20 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No motion tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       <div style={styles.controls}>
         <span style={styles.controlLabel}>Speed</span>

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -7,7 +7,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 
@@ -156,14 +156,20 @@ export function ShadowPreview({ filter = 'shadow', caption }: ShadowPreviewProps
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No shadow tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -7,7 +7,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface StrokeStyleSampleProps {
@@ -118,14 +118,20 @@ export function StrokeStyleSample({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No strokeStyle tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatValue } from '#/internal/use-project.ts';
 import { AliasChain } from '#/token-detail/AliasChain.tsx';
 import { AliasedBy } from '#/token-detail/AliasedBy.tsx';
@@ -27,7 +27,10 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
 
   if (!token) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.missing}>
           Token <code>{path}</code> not found in theme <strong>{activeTheme}</strong>.
         </div>
@@ -41,7 +44,10 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
   const outOfGamut = formatted?.outOfGamut ?? false;
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <TokenHeader path={path} {...(heading !== undefined && { heading })} />
 
       <div style={styles.sectionHeader}>Resolved value · {activeTheme}</div>

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -5,7 +5,7 @@ import { useColorFormat } from '#/contexts.ts';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
 import { formatColor } from '#/format-color.ts';
 import { BORDER_DEFAULT, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatValue, makeCssVar, useProject } from '#/internal/use-project.ts';
 import { MotionSample } from '#/motion-preview/MotionSample.tsx';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
@@ -283,7 +283,10 @@ export function TokenNavigator({
 
   if (tree.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>
           {root ? `No tokens under "${root}".` : 'No tokens in the active theme.'}
         </div>
@@ -292,7 +295,10 @@ export function TokenNavigator({
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>
         {root ? `Tokens under ${root}` : 'Token graph'} · {activeTheme}
       </div>

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import { BORDER_FAINT, emptyStyle, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface TokenTableProps {
@@ -117,14 +117,20 @@ export function TokenTable({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <table style={styles.table}>
         <caption style={styles.caption}>{captionText}</caption>
         <colgroup>

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -7,7 +7,7 @@ import {
   MONO_STACK,
   surfaceStyle,
 } from '#/internal/styles.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, useProject } from '#/internal/use-project.ts';
 
 export interface TypographyScaleProps {
@@ -126,14 +126,20 @@ export function TypographyScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+      <div
+        {...themeAttrs(cssVarPrefix, activeTheme)}
+        style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      >
         <div style={styles.empty}>No typography tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} style={styles.row}>

--- a/packages/blocks/src/border-preview/BorderSample.tsx
+++ b/packages/blocks/src/border-preview/BorderSample.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactElement } from 'react';
+import { chromeAliases } from '#/internal/data-attr.ts';
 import { makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface BorderSampleProps {
@@ -16,5 +17,7 @@ const sampleStyle: CSSProperties = {
 export function BorderSample({ path }: BorderSampleProps): ReactElement {
   const { cssVarPrefix } = useProject();
   const cssVar = makeCssVar(path, cssVarPrefix);
-  return <div style={{ ...sampleStyle, border: cssVar }} aria-hidden />;
+  return (
+    <div style={{ ...chromeAliases(cssVarPrefix), ...sampleStyle, border: cssVar }} aria-hidden />
+  );
 }

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactElement } from 'react';
+import { chromeAliases } from '#/internal/data-attr.ts';
 import { makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export type DimensionKind = 'length' | 'radius' | 'size';
@@ -67,18 +68,21 @@ export function DimensionBar({ path, kind = 'length' }: DimensionBarProps): Reac
   const capped = Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX;
   const cappedValue = capped ? `${MAX_RENDER_PX}px` : cssVar;
 
+  const aliases = chromeAliases(cssVarPrefix);
   switch (kind) {
     case 'radius':
-      return <div style={{ ...styles.radiusSample, borderRadius: cssVar }} aria-hidden />;
+      return (
+        <div style={{ ...aliases, ...styles.radiusSample, borderRadius: cssVar }} aria-hidden />
+      );
     case 'size':
       return (
         <div
-          style={{ ...styles.sizeSample, width: cappedValue, height: cappedValue }}
+          style={{ ...aliases, ...styles.sizeSample, width: cappedValue, height: cappedValue }}
           aria-hidden
         />
       );
     case 'length':
     default:
-      return <div style={{ ...styles.bar, width: cappedValue }} aria-hidden />;
+      return <div style={{ ...aliases, ...styles.bar, width: cappedValue }} aria-hidden />;
   }
 }

--- a/packages/blocks/src/internal/data-attr.ts
+++ b/packages/blocks/src/internal/data-attr.ts
@@ -1,3 +1,5 @@
+import type { CSSProperties } from 'react';
+
 /**
  * Produce a prefixed `data-*` attribute name when `prefix` is set, bare
  * `data-<key>` otherwise. Mirrors `dataAttr` in `@unpunnyfuns/swatchbook-core`
@@ -15,4 +17,44 @@ export function dataAttr(prefix: string, key: string): string {
  */
 export function themeAttrs(prefix: string, themeName: string): Record<string, string> {
   return { [dataAttr(prefix, 'theme')]: themeName };
+}
+
+/**
+ * Vars block chrome reads by literal `var(--sb-*)` regardless of what the
+ * project's actual `cssVarPrefix` is. Keeping the literal spelling means we
+ * only need to alias these few names on each block wrapper; the bulk of
+ * block styling stays untouched.
+ */
+const CHROME_VARS = [
+  'color-sys-border-default',
+  'color-sys-surface-default',
+  'color-sys-surface-muted',
+  'color-sys-surface-raised',
+  'color-sys-text-default',
+  'color-sys-text-muted',
+  'color-sys-accent-bg',
+  'color-sys-accent-fg',
+  'typography-sys-body-font-family',
+  'typography-sys-body-font-size',
+] as const;
+
+/**
+ * CSS custom-property aliases that redirect the block chrome's `var(--sb-*)`
+ * reads to the project's actual `cssVarPrefix`. Block components spread the
+ * return into their wrapper's inline `style`, so the aliases cascade down
+ * into every nested block / sample / token-detail piece without each one
+ * re-reading the prefix.
+ *
+ * When `prefix === 'sb'` the aliases are self-references — we skip emission
+ * to keep the inline style shorter. When `prefix === ''` (opt-out) the
+ * aliases point at the bare `var(--color-sys-…)` names core emitted.
+ */
+export function chromeAliases(prefix: string): CSSProperties {
+  if (prefix === 'sb') return {};
+  const out: Record<string, string> = {};
+  const head = prefix ? `${prefix}-` : '';
+  for (const name of CHROME_VARS) {
+    out[`--sb-${name}`] = `var(--${head}${name})`;
+  }
+  return out as CSSProperties;
 }

--- a/packages/blocks/src/motion-preview/MotionSample.tsx
+++ b/packages/blocks/src/motion-preview/MotionSample.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useEffect, useMemo, useState } from 'react';
+import { chromeAliases } from '#/internal/data-attr.ts';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { useProject } from '#/internal/use-project.ts';
 
@@ -135,7 +136,7 @@ export function resolveMotionSpec(
 }
 
 export function MotionSample({ path, speed = 1, runKey = 0 }: MotionSampleProps): ReactElement {
-  const { resolved } = useProject();
+  const { resolved, cssVarPrefix } = useProject();
   const reducedMotion = usePrefersReducedMotion();
 
   const spec = useMemo(() => resolveMotionSpec(resolved[path], resolved), [resolved, path]);
@@ -161,14 +162,14 @@ export function MotionSample({ path, speed = 1, runKey = 0 }: MotionSampleProps)
 
   if (reducedMotion) {
     return (
-      <div style={styles.reducedMotion}>
+      <div style={{ ...chromeAliases(cssVarPrefix), ...styles.reducedMotion }}>
         Animation suppressed by `prefers-reduced-motion: reduce`.
       </div>
     );
   }
 
   return (
-    <div style={styles.track}>
+    <div style={{ ...chromeAliases(cssVarPrefix), ...styles.track }}>
       <div
         style={{
           ...styles.ball,

--- a/packages/blocks/src/shadow-preview/ShadowSample.tsx
+++ b/packages/blocks/src/shadow-preview/ShadowSample.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactElement } from 'react';
+import { chromeAliases } from '#/internal/data-attr.ts';
 import { makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface ShadowSampleProps {
@@ -17,5 +18,10 @@ const sampleStyle: CSSProperties = {
 export function ShadowSample({ path }: ShadowSampleProps): ReactElement {
   const { cssVarPrefix } = useProject();
   const cssVar = makeCssVar(path, cssVarPrefix);
-  return <div style={{ ...sampleStyle, boxShadow: cssVar }} aria-hidden />;
+  return (
+    <div
+      style={{ ...chromeAliases(cssVarPrefix), ...sampleStyle, boxShadow: cssVar }}
+      aria-hidden
+    />
+  );
 }

--- a/packages/blocks/test/chrome-aliases.test.ts
+++ b/packages/blocks/test/chrome-aliases.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { chromeAliases } from '#/internal/data-attr.ts';
+
+describe('chromeAliases', () => {
+  it('returns {} for sb prefix (no-op)', () => {
+    expect(chromeAliases('sb')).toEqual({});
+  });
+
+  it('aliases to var(--<prefix>-*) for swatch', () => {
+    const result = chromeAliases('swatch') as Record<string, string>;
+    expect(result['--sb-color-sys-border-default']).toBe('var(--swatch-color-sys-border-default)');
+    expect(result['--sb-color-sys-accent-bg']).toBe('var(--swatch-color-sys-accent-bg)');
+    expect(result['--sb-typography-sys-body-font-size']).toBe(
+      'var(--swatch-typography-sys-body-font-size)',
+    );
+  });
+
+  it('aliases to bare var(--*) when prefix is empty', () => {
+    const result = chromeAliases('') as Record<string, string>;
+    expect(result['--sb-color-sys-border-default']).toBe('var(--color-sys-border-default)');
+  });
+});

--- a/packages/blocks/test/virtual-stub.ts
+++ b/packages/blocks/test/virtual-stub.ts
@@ -5,6 +5,7 @@
  * addon Vite plugin is in the pipeline.
  */
 export const axes = [] as const;
+export const disabledAxes = [] as const;
 export const presets = [] as const;
 export const themes = [] as const;
 export const defaultTheme = null;


### PR DESCRIPTION
## Summary

Blocks render their own chrome (surface, borders, text colors, accent background) through literal `var(--sb-color-sys-*, fallback)` references — ~60 occurrences across 17 files. That worked when the default prefix was `sb`, but post-0.2.0 the default is `swatch`, so **every consumer on the default prefix (or any prefix other than `sb`) got fallback values for all block chrome** — gray borders, `CanvasText`, hardcoded `#3b82f6` accent. Our own Storybook still uses `cssVarPrefix: 'sb'` in `apps/storybook/.storybook/main.ts:28`, which masked the regression.

## Fix

One helper, spread into each block wrapper's inline style:

```ts
// packages/blocks/src/internal/data-attr.ts
export function chromeAliases(prefix: string): CSSProperties {
  if (prefix === 'sb') return {};
  const out: Record<string, string> = {};
  const head = prefix ? `${prefix}-` : '';
  for (const name of CHROME_VARS) {
    out[`--sb-${name}`] = `var(--${head}${name})`;
  }
  return out as CSSProperties;
}
```

The ~60 literal `var(--sb-*)` references stay untouched and read the correct value via CSS custom-property inheritance. When `prefix === 'sb'` the helper returns `{}` so the inline style stays empty (no-op).

Applied to:
- 13 block wrappers (`TokenDetail`, `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `MotionPreview`, `ShadowPreview`, `BorderPreview`, `DimensionScale`, `GradientPalette`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`).
- 4 sample components (`BorderSample`, `ShadowSample`, `MotionSample`, `DimensionBar`) since they're used standalone outside any wrapper.

Bundled: `disabledAxes: []` added to `test/virtual-stub.ts` for stub completeness; 3-case vitest unit test for `chromeAliases`.

## Test plan

- [x] `pnpm turbo run lint typecheck test` — clean across core, addon, blocks, storybook.
- [x] `pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook` — 126/126 interaction tests pass (with our `sb`-prefixed fixture, `chromeAliases` is a no-op — confirms no regression).
- [x] `chromeAliases` unit test — three cases (`sb` → `{}`, `swatch` → aliases, `''` → bare-name aliases).

Changeset: patch bump across the three fixed-group packages.

Milestone: Maintenance
Closes: #321
Plan impact: none — pure fix.