### PR TITLE
fix(docs): resolve versions.json relative to config file, not cwd

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -1,4 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { themes as prismThemes } from 'prism-react-renderer';
 import type { Config } from '@docusaurus/types';
 import type * as Preset from '@docusaurus/preset-classic';
@@ -7,7 +9,12 @@ import type * as Preset from '@docusaurus/preset-classic';
 // unreleased banner, and the newest snapshot under versioned_docs/ serves as
 // the default at /. Before the first snapshot exists, skip the versions map
 // entirely so current keeps serving at /.
-const versionsPath = './versions.json';
+//
+// Resolve relative to the config file itself — `./versions.json` vs
+// `process.cwd()` is brittle in CI (Turbo / docusaurus CLI can shift cwd),
+// and an empty `hasReleasedVersion` silently collapses the version routing.
+const here = dirname(fileURLToPath(import.meta.url));
+const versionsPath = resolve(here, 'versions.json');
 const hasReleasedVersion =
   existsSync(versionsPath) && JSON.parse(readFileSync(versionsPath, 'utf8')).length > 0;
 


### PR DESCRIPTION
## Summary

The v0.2.1 release's docs-versioning snapshot landed in the repo correctly (`apps/docs/versioned_docs/version-0.2/` + `apps/docs/versions.json`), but the deployed site didn't show the version dropdown or `/next/` route. Root cause: `docusaurus.config.ts` gated the version UI on `existsSync('./versions.json')`, which resolved relative to `process.cwd()`. Local builds happen to have cwd == `apps/docs`, so the check passed; the CI deploy invokes the build from a different cwd, so `existsSync` returned false and the `versions` map + navbar dropdown silently collapsed.

Fix: resolve `versions.json` relative to the config file itself via `fileURLToPath(import.meta.url)` + `path.resolve`. Works under any cwd.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-docs build` — produces `build/next/` and built `index.html` contains `docsVersionDropdown`, `Next 🚧`, links to `/swatchbook/next/`, and references to `version-0.2`.
- [x] After this merges, the Docs workflow rebuilds main; the deployed site should then expose the version dropdown.

Milestone: Maintenance
Refs: #309
Plan impact: none — tooling-only fix on top of the versioning pipeline landed in PR #310.