### PR TITLE
refactor(addon): tighten HMR watch-path matching + picomatch glob scan

### DIFF
--- a/.changeset/addon-watch-paths.md
+++ b/.changeset/addon-watch-paths.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Tighten the addon's HMR watch-path matching. File-path matches now require a path-separator boundary (`/project/resolver.json` no longer also matches `/project/resolver.json.backup`), and `picomatch.scan` replaces the hand-rolled glob-to-dir regex — brace-expansion patterns (`tokens/{base,overlays}/**/*.json`) and nested globstars now derive the correct watch root.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -77,7 +77,8 @@
   "dependencies": {
     "@unpunnyfuns/swatchbook-blocks": "workspace:*",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
-    "jiti": "^2.4.0"
+    "jiti": "^2.4.0",
+    "picomatch": "^4.0.4"
   },
   "peerDependencies": {
     "react": ">=18",
@@ -87,6 +88,7 @@
   "devDependencies": {
     "@storybook/react-vite": "^10.3.5",
     "@types/node": "^25.6.0",
+    "@types/picomatch": "^4.0.3",
     "@types/react": "^19.2.14",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,6 +1,7 @@
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
-import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
+import { dirname, isAbsolute, resolve as resolvePath, sep } from 'node:path';
+import picomatch from 'picomatch';
 import type { Plugin } from 'vite';
 import { RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from '#/constants.ts';
 
@@ -66,16 +67,17 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
         server.ws.send({ type: 'full-reload' });
       };
 
+      const matches = (changed: string): boolean =>
+        watchPaths.some((p) => changed === p || changed.startsWith(`${p}${sep}`));
+
       server.watcher.on('change', (changed) => {
-        if (watchPaths.some((p) => changed === p || changed.startsWith(p))) {
-          void invalidate();
-        }
+        if (matches(changed)) void invalidate();
       });
       server.watcher.on('add', (changed) => {
-        if (watchPaths.some((p) => changed.startsWith(p))) void invalidate();
+        if (matches(changed)) void invalidate();
       });
       server.watcher.on('unlink', (changed) => {
-        if (watchPaths.some((p) => changed.startsWith(p))) void invalidate();
+        if (matches(changed)) void invalidate();
       });
     },
   };
@@ -93,8 +95,11 @@ function collectWatchPaths(config: Config, project: Project | undefined, cwd: st
   const paths: string[] = [];
   if (config.tokens && config.tokens.length > 0) {
     for (const glob of config.tokens) {
-      const base = glob.replace(/\/\*.*$/, '').replace(/\/[^/]*\*.*$/, '');
-      paths.push(resolveFromCwd(base, cwd));
+      // `picomatch.scan` yields the longest literal prefix before any glob
+      // metachar, so it handles brace expansion, nested globstars, and the
+      // other shapes the hand-rolled regex missed.
+      const { base } = picomatch.scan(glob);
+      paths.push(resolveFromCwd(base || '.', cwd));
     }
   } else if (project?.sourceFiles) {
     for (const file of project.sourceFiles) paths.push(dirname(file));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       jiti:
         specifier: ^2.4.0
         version: 2.6.1
+      picomatch:
+        specifier: ^4.0.4
+        version: 4.0.4
     devDependencies:
       '@storybook/react-vite':
         specifier: ^10.3.5
@@ -164,6 +167,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@types/picomatch':
+        specifier: ^4.0.3
+        version: 4.0.3
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
@@ -3193,6 +3199,9 @@ packages:
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
+
+  '@types/picomatch@4.0.3':
+    resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
 
   '@types/prismjs@1.26.6':
     resolution: {integrity: sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==}
@@ -11177,6 +11186,8 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
+
+  '@types/picomatch@4.0.3': {}
 
   '@types/prismjs@1.26.6': {}
 


### PR DESCRIPTION
## Summary

Two defensive fixes in the addon's virtual-module plugin (`src/virtual/plugin.ts`):

- **File-path watch boundary.** `watchPaths.some(p => changed.startsWith(p))` matched `/proj/resolver.json.backup` when watching `/proj/resolver.json`. Now requires a path-separator boundary — only descendants fire.
- **Picomatch for glob-to-dir.** `collectWatchPaths` stripped patterns to their literal prefix via a home-rolled regex that broke on brace expansion (`tokens/{base,overlays}/**/*.json` resolved to a useless root) and other common shapes. `picomatch.scan(pattern).base` yields the correct longest literal prefix for any picomatch-compatible pattern.

## Dependency

Picomatch promoted from transitive to direct at `^4.0.4`; `@types/picomatch` added as devDep.

## Test plan

- [x] `pnpm turbo run lint typecheck --filter=@unpunnyfuns/swatchbook-addon --filter=@unpunnyfuns/swatchbook-storybook` — clean.

Milestone: Maintenance
Closes: #317
Plan impact: none.