### PR TITLE
docs(blocks): document globMatch supported pattern shape

### DIFF
--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -140,6 +140,24 @@ export function makeCssVar(path: string, prefix: string): string {
   return prefix ? `var(--${prefix}-${tail})` : `var(--${tail})`;
 }
 
+/**
+ * Match a dot-separated DTCG token path against a block `filter` prop.
+ *
+ * **Supported shapes** (the narrow subset we need — DTCG paths don't have
+ * directories, brace expansion, or regex, so we skip a full glob engine):
+ *
+ * | Pattern            | Matches                                             |
+ * | ------------------ | --------------------------------------------------- |
+ * | `undefined` / `''` | everything                                          |
+ * | `*` or `**`        | everything                                          |
+ * | `color`            | exact path `color`, or any descendant `color.*`     |
+ * | `color.sys.*`      | any path whose fixed prefix is `color.sys.`         |
+ * | `color**`          | any path starting with `color`                      |
+ *
+ * Not supported (all pass through as literal segment matchers): brace
+ * expansion (`{a,b}`), mid-path globs (`color.*.bg`), negation (`!foo`),
+ * character classes (`[sys]`). If you hit those, pre-filter by hand.
+ */
 export function globMatch(path: string, glob: string | undefined): boolean {
   if (!glob) return true;
   if (glob === '*' || glob === '**') return true;

--- a/packages/blocks/test/glob-match.test.ts
+++ b/packages/blocks/test/glob-match.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { globMatch } from '#/internal/use-project.ts';
+
+describe('globMatch', () => {
+  it('matches everything on empty / wildcard patterns', () => {
+    expect(globMatch('color.sys.bg', undefined)).toBe(true);
+    expect(globMatch('color.sys.bg', '')).toBe(true);
+    expect(globMatch('color.sys.bg', '*')).toBe(true);
+    expect(globMatch('color.sys.bg', '**')).toBe(true);
+  });
+
+  it('matches exact path and descendants for a bare prefix', () => {
+    expect(globMatch('color', 'color')).toBe(true);
+    expect(globMatch('color.sys.bg', 'color')).toBe(true);
+    expect(globMatch('colorscheme', 'color')).toBe(false);
+  });
+
+  it('matches `foo.*` by fixed prefix with trailing dot', () => {
+    expect(globMatch('color.sys.bg', 'color.sys.*')).toBe(true);
+    expect(globMatch('color.sys', 'color.sys.*')).toBe(false);
+    expect(globMatch('color.ref.bg', 'color.sys.*')).toBe(false);
+  });
+
+  it('matches `foo**` by literal prefix (no dot boundary)', () => {
+    expect(globMatch('colorscheme', 'color**')).toBe(true);
+    expect(globMatch('color.sys', 'color**')).toBe(true);
+  });
+
+  it('rejects unsupported mid-path globs as literal segments', () => {
+    // `color.*.bg` is treated as a literal path, which no real DTCG path matches.
+    expect(globMatch('color.sys.bg', 'color.*.bg')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

\`globMatch\` handles a narrow subset of glob semantics — we don't need a full engine for DTCG dot-paths. Expand its JSDoc with a pattern table so consumers know which \`filter\` prop shapes are supported on blocks and which aren't. Pins the behavior with a small vitest so the matcher can't silently change.

## Supported

| Pattern            | Matches                                             |
| ------------------ | --------------------------------------------------- |
| \`undefined\` / \`''\` | everything                                          |
| \`*\` or \`**\`        | everything                                          |
| \`color\`            | exact path \`color\`, or any descendant \`color.*\`     |
| \`color.sys.*\`      | any path whose fixed prefix is \`color.sys.\`         |
| \`color**\`          | any path starting with \`color\`                      |

## Not supported (pass through as literal)

Brace expansion (\`{a,b}\`), mid-path globs (\`color.*.bg\`), negation (\`!foo\`), character classes (\`[sys]\`).

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks\` — clean.
- [x] New \`test/glob-match.test.ts\` adds 5 tests covering the table + one unsupported case.

Docs-only; no changeset. \`globMatch\` isn't re-exported from the public API.

Milestone: Maintenance
Closes: #323
Plan impact: none.