### PR TITLE
refactor(addon): consolidate virtual-payload types into channel-types.ts

### DIFF
--- a/packages/addon/src/channel-types.ts
+++ b/packages/addon/src/channel-types.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared payload types for the INIT_EVENT channel broadcast — both the
+ * preview (emitter) and the manager-side consumers (`manager.tsx`,
+ * `panel.tsx`) pin their shapes here so the three don't drift.
+ *
+ * The types intentionally mirror what `@unpunnyfuns/swatchbook-core`
+ * produces, but are re-declared locally because the manager bundle runs
+ * in a Node-free environment and can't import from core at runtime (core
+ * pulls `node:fs/promises` via the loader).
+ */
+
+export type DiagnosticSeverity = 'error' | 'warn' | 'info';
+
+export interface VirtualToken {
+  $type?: string;
+  $value?: unknown;
+  $description?: string;
+}
+
+export interface VirtualTheme {
+  name: string;
+  input: Record<string, string>;
+  sources: string[];
+}
+
+export interface VirtualAxis {
+  name: string;
+  contexts: readonly string[];
+  default: string;
+  description?: string;
+  source: 'resolver' | 'layered' | 'synthetic';
+}
+
+export interface VirtualPreset {
+  name: string;
+  axes: Partial<Record<string, string>>;
+  description?: string;
+}
+
+export interface VirtualDiagnostic {
+  severity: DiagnosticSeverity;
+  group: string;
+  message: string;
+  filename?: string;
+  line?: number;
+  column?: number;
+}
+
+/**
+ * The full INIT_EVENT payload. Preview emits it whole via `broadcastInit`;
+ * consumers read the subset they need — manager's toolbar reads axes +
+ * presets + themes + defaultTheme, panel reads additionally disabledAxes +
+ * themesResolved + diagnostics + cssVarPrefix.
+ */
+export interface InitPayload {
+  axes: readonly VirtualAxis[];
+  disabledAxes: readonly string[];
+  presets: readonly VirtualPreset[];
+  themes: readonly VirtualTheme[];
+  defaultTheme: string | null;
+  themesResolved: Record<string, Record<string, VirtualToken>>;
+  diagnostics: readonly VirtualDiagnostic[];
+  cssVarPrefix: string;
+}

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -2,6 +2,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState, type ReactEle
 import { IconButton, WithTooltipPure } from 'storybook/internal/components';
 import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
 import {
+  type InitPayload,
+  type VirtualAxis as AxisEntry,
+  type VirtualPreset as PresetEntry,
+  type VirtualTheme as ThemeEntry,
+} from '#/channel-types.ts';
+import {
   ADDON_ID,
   AXES_GLOBAL_KEY,
   COLOR_FORMAT_GLOBAL_KEY,
@@ -24,36 +30,9 @@ import { DesignTokensPanel } from '#/panel.tsx';
  */
 const h = React.createElement;
 
-interface AxisEntry {
-  name: string;
-  contexts: readonly string[];
-  default: string;
-  description?: string;
-  source: 'resolver' | 'layered' | 'synthetic';
-}
-
-interface ThemeEntry {
-  name: string;
-  input: Record<string, string>;
-  sources: string[];
-}
-
-interface PresetEntry {
-  name: string;
-  axes: Partial<Record<string, string>>;
-  description?: string;
-}
-
-interface InitPayload {
-  axes: readonly AxisEntry[];
-  presets: readonly PresetEntry[];
-  themes: ThemeEntry[];
-  defaultTheme: string | null;
-}
-
 const EMPTY_AXES: readonly AxisEntry[] = [];
 const EMPTY_PRESETS: readonly PresetEntry[] = [];
-const EMPTY_THEMES: ThemeEntry[] = [];
+const EMPTY_THEMES: readonly ThemeEntry[] = [];
 
 /**
  * Root toolbar glyph — a split-circle ("yinyang") mark: a faint filled

--- a/packages/addon/src/panel.tsx
+++ b/packages/addon/src/panel.tsx
@@ -9,51 +9,16 @@ import React, {
 } from 'react';
 import { Placeholder, ScrollArea } from 'storybook/internal/components';
 import { addons, useGlobals } from 'storybook/manager-api';
+import type {
+  DiagnosticSeverity,
+  InitPayload,
+  VirtualDiagnostic,
+  VirtualToken,
+} from '#/channel-types.ts';
 import { AXES_GLOBAL_KEY, GLOBAL_KEY, INIT_EVENT } from '#/constants.ts';
 
 /** `React.createElement` alias so the manager bundle avoids `react/jsx-runtime`. */
 const h = React.createElement;
-
-interface VirtualToken {
-  $type?: string;
-  $value?: unknown;
-  $description?: string;
-}
-
-interface VirtualTheme {
-  name: string;
-  input: Record<string, string>;
-  sources: string[];
-}
-
-interface VirtualAxis {
-  name: string;
-  contexts: readonly string[];
-  default: string;
-  description?: string;
-  source: 'resolver' | 'layered' | 'synthetic';
-}
-
-type DiagnosticSeverity = 'error' | 'warn' | 'info';
-
-interface VirtualDiagnostic {
-  severity: DiagnosticSeverity;
-  group: string;
-  message: string;
-  filename?: string;
-  line?: number;
-  column?: number;
-}
-
-interface InitPayload {
-  axes: VirtualAxis[];
-  disabledAxes: readonly string[];
-  themes: VirtualTheme[];
-  defaultTheme: string | null;
-  themesResolved: Record<string, Record<string, VirtualToken>>;
-  diagnostics: VirtualDiagnostic[];
-  cssVarPrefix: string;
-}
 
 function usePayload(): InitPayload | null {
   const [payload, setPayload] = useState<InitPayload | null>(null);

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -2,46 +2,18 @@
  * Typed shape of the addon's `virtual:swatchbook/tokens` module. The runtime
  * payload is produced by this package's Vite plugin (`swatchbookTokensPlugin`)
  * and JSON-serialized, so this declaration describes the plain-data shape
- * consumers read back.
+ * consumers read back. Shapes are drawn from `#/channel-types.ts` so the
+ * virtual module, the INIT_EVENT payload, and the manager-side consumers
+ * can't drift from each other.
  */
 declare module 'virtual:swatchbook/tokens' {
-  interface VirtualAxis {
-    name: string;
-    contexts: readonly string[];
-    default: string;
-    description?: string;
-    source: 'resolver' | 'layered' | 'synthetic';
-  }
-
-  interface VirtualTheme {
-    name: string;
-    input: Record<string, string>;
-    sources: string[];
-  }
-
-  interface VirtualDiagnostic {
-    severity: 'error' | 'warn' | 'info';
-    group: string;
-    message: string;
-    filename?: string;
-    line?: number;
-    column?: number;
-  }
-
-  interface VirtualToken {
-    $type?: string;
-    $value?: unknown;
-    $description?: string;
-    aliasOf?: string;
-    aliasChain?: readonly string[];
-    aliasedBy?: readonly string[];
-  }
-
-  interface VirtualPreset {
-    name: string;
-    axes: Partial<Record<string, string>>;
-    description?: string;
-  }
+  import type {
+    VirtualAxis,
+    VirtualDiagnostic,
+    VirtualPreset,
+    VirtualTheme,
+    VirtualToken,
+  } from '#/channel-types.ts';
 
   export const axes: readonly VirtualAxis[];
   export const disabledAxes: readonly string[];


### PR DESCRIPTION
## Summary

Three files carried parallel copies of the INIT_EVENT channel payload shape — `manager.tsx`, `panel.tsx`, `virtual.d.ts` — each maintained by eye and prone to drift (which is how `'layered'` went missing from four copies of the `source` union before PR #320 fixed them). Extract one type-only `src/channel-types.ts` and import everywhere.

- `manager.tsx`: imports `VirtualAxis as AxisEntry`, `VirtualTheme as ThemeEntry`, `VirtualPreset as PresetEntry`, `InitPayload`. The local aliases keep call sites readable.
- `panel.tsx`: imports `DiagnosticSeverity`, `InitPayload`, `VirtualDiagnostic`, `VirtualToken`.
- `virtual.d.ts`: the ambient `declare module 'virtual:swatchbook/tokens'` references shared types via `import type` inside the declaration.

No public API change. No behavior change. No changeset (internal-only).

## Test plan

- [x] `pnpm turbo run lint typecheck --filter=@unpunnyfuns/swatchbook-addon --filter=@unpunnyfuns/swatchbook-storybook` — clean.
- [x] Diff stat: `4 files changed, 87 insertions(+), 107 deletions(-)` — net subtraction as expected.

Milestone: Maintenance
Closes: #316
Plan impact: none — pure refactor.