### PR TITLE
fix(blocks): carry chromeAliases on ColorPalette success wrapper

### DIFF
--- a/.changeset/color-palette-chrome-alias.md
+++ b/.changeset/color-palette-chrome-alias.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Fix `ColorPalette` success-state wrapper missing the `chromeAliases` spread that PR #324 added elsewhere. The empty-state wrapper got the alias layer; the main grid wrapper didn't, so consumers on any `cssVarPrefix` other than `sb` saw fallback colors for border / text chrome on the populated ColorPalette block. One-line fix — all other blocks were already correct.

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -173,7 +173,10 @@ export function ColorPalette({
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} style={styles.wrapper}>
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+    >
       <div style={styles.caption}>{captionText}</div>
       {groups.map(([group, swatches]) => (
         <section key={group} style={styles.group}>


### PR DESCRIPTION
## Summary

PR #324 added the \`chromeAliases\` spread to every block wrapper via a batch edit, but a mid-refactor manual \`Edit\` on \`ColorPalette\` only caught the empty-state wrapper and left the main grid wrapper with plain \`styles.wrapper\`. Same symptom as the bug #324 fixed — consumers on any non-\`sb\` \`cssVarPrefix\` saw fallback border / text colors on a populated ColorPalette.

One-line fix: spread \`chromeAliases(cssVarPrefix)\` into the success wrapper's inline style, matching every other block and the empty-state wrapper right above it.

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks\` — clean.

Changeset: patch across the fixed-group (mirrors PR #324's).

Milestone: Maintenance
Plan impact: none — bugfix.