### PR TITLE
feat(blocks): add <Diagnostics /> block

### DIFF
--- a/.changeset/diagnostics-block.md
+++ b/.changeset/diagnostics-block.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+Add `<Diagnostics />` block. Renders the project's load diagnostics — parser errors, resolver warnings, disabled-axes validation issues, etc. — as a collapsible severity-colored list. Auto-opens when the project carries errors or warnings; stays collapsed for clean loads. Consumers compose it on their own MDX pages alongside `<TokenNavigator />` / `<TokenTable />` to replace what the Design Tokens panel used to show at the top of its tree.

--- a/packages/blocks/src/Diagnostics.tsx
+++ b/packages/blocks/src/Diagnostics.tsx
@@ -1,0 +1,140 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
+import { surfaceStyle } from '#/internal/styles.ts';
+import { useProject } from '#/internal/use-project.ts';
+import type { VirtualDiagnostic } from '#/types.ts';
+
+export interface DiagnosticsProps {
+  /** Override the section caption. Defaults to a severity summary. */
+  caption?: string;
+}
+
+type DiagnosticSeverity = VirtualDiagnostic['severity'];
+
+const severityColor: Record<DiagnosticSeverity, string> = {
+  error: '#d64545',
+  warn: '#b08900',
+  info: 'inherit',
+};
+
+const severityLabel: Record<DiagnosticSeverity, string> = {
+  error: 'ERROR',
+  warn: 'WARN',
+  info: 'INFO',
+};
+
+const styles = {
+  wrapper: surfaceStyle,
+  summary: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: '4px 0',
+    fontSize: 13,
+    cursor: 'pointer',
+    listStyle: 'none',
+    fontWeight: 600,
+  } satisfies CSSProperties,
+  list: {
+    listStyle: 'none',
+    margin: '8px 0 0',
+    padding: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  } satisfies CSSProperties,
+  row: {
+    display: 'grid',
+    gridTemplateColumns: '60px 1fr',
+    gap: 12,
+    padding: '8px 4px',
+    borderTop: '1px solid var(--sb-color-sys-border-default, rgba(128,128,128,0.12))',
+    fontSize: 12,
+  } satisfies CSSProperties,
+  label: {
+    fontWeight: 600,
+    fontSize: 10,
+    letterSpacing: 0.5,
+  } satisfies CSSProperties,
+  meta: {
+    color: 'var(--sb-color-sys-text-muted, CanvasText)',
+    fontSize: 11,
+    marginTop: 4,
+    opacity: 0.7,
+  } satisfies CSSProperties,
+};
+
+function summaryText(diagnostics: readonly VirtualDiagnostic[]): string {
+  if (diagnostics.length === 0) return '✔ OK · no diagnostics';
+  const counts = { error: 0, warn: 0, info: 0 };
+  for (const d of diagnostics) counts[d.severity] += 1;
+  const parts: string[] = [];
+  if (counts.error > 0) parts.push(`✖ ${counts.error} error${counts.error === 1 ? '' : 's'}`);
+  if (counts.warn > 0) parts.push(`⚠ ${counts.warn} warning${counts.warn === 1 ? '' : 's'}`);
+  if (counts.info > 0) parts.push(`${counts.info} info`);
+  return parts.join(' · ');
+}
+
+function diagnosticKey(d: VirtualDiagnostic, i: number): string {
+  return `${d.severity}:${d.group}:${d.filename ?? ''}:${d.line ?? ''}:${d.message}:${i}`;
+}
+
+function summaryColor(diagnostics: readonly VirtualDiagnostic[]): string {
+  if (diagnostics.length === 0) return '#30a46c';
+  if (diagnostics.some((d) => d.severity === 'error')) return severityColor.error;
+  if (diagnostics.some((d) => d.severity === 'warn')) return severityColor.warn;
+  return 'inherit';
+}
+
+/**
+ * Render the project's load diagnostics — parser errors, resolver warnings,
+ * disabled-axes validation issues, etc. — as a collapsible list. Auto-opens
+ * when the project carries errors or warnings; stays collapsed for clean
+ * loads and info-only loads.
+ *
+ * Replaces the diagnostics section from the addon's (now-retired) Design
+ * Tokens panel. Consumers compose it alongside TokenNavigator / TokenTable
+ * on their own MDX pages.
+ */
+export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
+  const { activeTheme, cssVarPrefix, diagnostics } = useProject();
+
+  const hasErrorsOrWarnings = diagnostics.some(
+    (d) => d.severity === 'error' || d.severity === 'warn',
+  );
+  const headingText = caption ?? `Diagnostics · ${summaryText(diagnostics)}`;
+
+  return (
+    <div
+      {...themeAttrs(cssVarPrefix, activeTheme)}
+      style={{ ...chromeAliases(cssVarPrefix), ...styles.wrapper }}
+      data-testid='diagnostics'
+    >
+      <details open={hasErrorsOrWarnings}>
+        <summary style={{ ...styles.summary, color: summaryColor(diagnostics) }}>
+          {headingText}
+        </summary>
+        {diagnostics.length > 0 && (
+          <ul style={styles.list}>
+            {diagnostics.map((d, i) => (
+              <li key={diagnosticKey(d, i)} style={styles.row}>
+                <span style={{ ...styles.label, color: severityColor[d.severity] }}>
+                  {severityLabel[d.severity]}
+                </span>
+                <div>
+                  <div>{d.message}</div>
+                  {(d.group || d.filename) && (
+                    <div style={styles.meta}>
+                      {[d.group, d.filename, d.line ? `:${d.line}` : '']
+                        .filter(Boolean)
+                        .join(' · ')}
+                    </div>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </details>
+    </div>
+  );
+}

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -8,6 +8,7 @@ export {
 export { BorderPreview, type BorderPreviewProps } from '#/BorderPreview.tsx';
 export { BorderSample, type BorderSampleProps } from '#/border-preview/BorderSample.tsx';
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
+export { Diagnostics, type DiagnosticsProps } from '#/Diagnostics.tsx';
 export { DimensionScale, type DimensionKind, type DimensionScaleProps } from '#/DimensionScale.tsx';
 export { DimensionBar, type DimensionBarProps } from '#/dimension-scale/DimensionBar.tsx';
 export { FontFamilySample, type FontFamilySampleProps } from '#/FontFamilySample.tsx';

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -6,10 +6,17 @@ import {
   css as generatedCss,
   cssVarPrefix,
   defaultTheme,
+  diagnostics as virtualDiagnostics,
   themes,
   themesResolved,
 } from 'virtual:swatchbook/tokens';
-import type { ProjectSnapshot, VirtualAxis, VirtualTheme, VirtualToken } from '#/types.ts';
+import type {
+  ProjectSnapshot,
+  VirtualAxis,
+  VirtualDiagnostic,
+  VirtualTheme,
+  VirtualToken,
+} from '#/types.ts';
 
 type ResolvedTokens = Record<string, VirtualToken>;
 
@@ -20,6 +27,7 @@ export interface ProjectData {
   themes: readonly VirtualTheme[];
   resolved: ResolvedTokens;
   themesResolved: Record<string, ResolvedTokens>;
+  diagnostics: readonly VirtualDiagnostic[];
   cssVarPrefix: string;
 }
 
@@ -74,6 +82,7 @@ function snapshotToData(snapshot: ProjectSnapshot): ProjectData {
     themes: snapshot.themes,
     themesResolved: snapshot.themesResolved,
     resolved: snapshot.themesResolved[snapshot.activeTheme] ?? {},
+    diagnostics: snapshot.diagnostics,
     cssVarPrefix: snapshot.cssVarPrefix,
   };
 }
@@ -131,6 +140,7 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     themes,
     themesResolved,
     resolved: themesResolved[activeTheme] ?? {},
+    diagnostics: virtualDiagnostics,
     cssVarPrefix,
   };
 }

--- a/packages/blocks/test/diagnostics.test.tsx
+++ b/packages/blocks/test/diagnostics.test.tsx
@@ -1,0 +1,84 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Diagnostics, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
+
+function makeSnapshot(diagnostics: ProjectSnapshot['diagnostics'] = []): ProjectSnapshot {
+  return {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    disabledAxes: [],
+    presets: [],
+    themes: [{ name: 'Light', input: { theme: 'Light' }, sources: [] }],
+    themesResolved: { Light: {} },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics,
+    css: '',
+  };
+}
+
+describe('Diagnostics', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders an OK summary when the project carries no diagnostics', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <Diagnostics />
+      </SwatchbookProvider>,
+    );
+    expect(screen.getByText(/✔ OK · no diagnostics/)).toBeDefined();
+  });
+
+  it('auto-expands when there are errors and lists each row', () => {
+    render(
+      <SwatchbookProvider
+        value={makeSnapshot([
+          {
+            severity: 'error',
+            group: 'parser',
+            message: 'Missing $value on color.sys.bg',
+            filename: '/proj/tokens.json',
+            line: 4,
+          },
+          { severity: 'warn', group: 'swatchbook/resolver', message: 'modifier unusable' },
+        ])}
+      >
+        <Diagnostics />
+      </SwatchbookProvider>,
+    );
+
+    // Summary shows the aggregated count.
+    expect(screen.getByText(/✖ 1 error · ⚠ 1 warning/)).toBeDefined();
+
+    // <details> auto-opens when errors exist — rows visible.
+    const details = screen.getByText(/✖ 1 error · ⚠ 1 warning/).closest('details');
+    expect(details?.hasAttribute('open')).toBe(true);
+
+    expect(screen.getByText('Missing $value on color.sys.bg')).toBeDefined();
+    expect(screen.getByText('modifier unusable')).toBeDefined();
+    expect(screen.getByText(/parser · \/proj\/tokens.json · :4/)).toBeDefined();
+  });
+
+  it('stays collapsed when only info-level diagnostics are present', () => {
+    render(
+      <SwatchbookProvider
+        value={makeSnapshot([{ severity: 'info', group: 'parser', message: 'loaded 20 files' }])}
+      >
+        <Diagnostics />
+      </SwatchbookProvider>,
+    );
+    const details = screen.getByText(/1 info/).closest('details');
+    expect(details?.hasAttribute('open')).toBe(false);
+  });
+
+  it('honors the caption override', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <Diagnostics caption='Project health' />
+      </SwatchbookProvider>,
+    );
+    expect(screen.getByText('Project health')).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

First step in retiring the in-manager Design Tokens panel (milestone: Panel → docblock migration). The panel's diagnostics section was the one piece of its functionality not already reachable via existing blocks; this adds it as `<Diagnostics />`.

## Shape

```mdx
import { Diagnostics } from '@unpunnyfuns/swatchbook-blocks';

<Diagnostics />
```

Optional `caption` prop overrides the default summary heading. No `filter` knobs yet — renders every diagnostic on the active snapshot; we can add severity/group filters if real use calls for them.

- Severity-colored rows: red error, amber warn, muted info.
- Auto-expands when errors or warnings are present; collapsed on clean loads and info-only.
- Prefix-alias layer on the wrapper so chrome themes correctly regardless of `cssVarPrefix`.

## Plumbing

- `ProjectSnapshot.diagnostics` already existed; `useProject()`'s internal `ProjectData` now threads it through from both the provider path and the virtual-module fallback.

## Test plan

- [x] 4 component-render tests: OK state, auto-open on errors (+row rendering + meta line), collapsed on info-only, caption override.
- [x] `pnpm turbo run lint typecheck test` across blocks + addon + storybook — clean.

## Next in milestone

- #338 docs MDX template (Diagnostics + TokenNavigator + TokenTable).
- #339 remove the addon panel entirely (breaking, minor bump).

Milestone: Panel → docblock migration
Refs: #337
Changeset: minor across the fixed-group.