### PR TITLE
docs(docs): add token-dashboard authoring guide

### DIFF
--- a/apps/docs/docs/guides/token-dashboard.mdx
+++ b/apps/docs/docs/guides/token-dashboard.mdx
@@ -1,0 +1,75 @@
+---
+id: token-dashboard
+title: Authoring a token-dashboard page
+sidebar_position: 3
+---
+
+# Authoring a token-dashboard page
+
+A single MDX page composing [`<Diagnostics />`](../reference/blocks),
+[`<TokenNavigator />`](../reference/blocks), and
+[`<TokenTable />`](../reference/blocks) gives consumers a
+top-to-bottom view of the design-token set for the active theme:
+project-level health, a browsable tree of every token, and a searchable
+table for quick lookup.
+
+This is the recommended replacement for the in-manager Design Tokens
+panel the addon used to ship. Blocks live in docs, so the dashboard
+lives where it belongs — alongside every other surface you publish for
+designers and engineers consuming your tokens.
+
+## Template
+
+```mdx
+---
+title: Design Tokens
+---
+
+import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+
+# Design Tokens
+
+<Diagnostics />
+
+## Tree
+
+<TokenNavigator />
+
+## Table
+
+<TokenTable />
+```
+
+Drop that file under your Storybook MDX stories directory. The toolbar's
+theme switcher is live — every block re-renders against the active theme.
+Outside Storybook, wrap the tree in `SwatchbookProvider` with a hand-built
+or exported `ProjectSnapshot` (see the [blocks reference](../reference/blocks)).
+
+You can see this dashboard composition live against our
+[`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference)
+fixture in the [live Storybook](pathname:///storybook/).
+
+## Why a dashboard instead of the old panel?
+
+- **One surface.** The addon's old panel re-implemented the tree and
+  diagnostics in the manager bundle, where it couldn't reach MDX docs
+  pages and had to maintain a parallel virtual-module contract. Blocks
+  already render everywhere — story decorators, autodocs, MDX pages,
+  plain React apps via `SwatchbookProvider`.
+
+- **One dependency graph.** One place to add a new block type, one
+  place to track bugs, one place to theme the chrome.
+
+- **Docs is where designers look up tokens.** The panel's always-on
+  story-view placement made sense when stories were the primary target;
+  for a DTCG documentation tool the docs page is the right home.
+
+## Variations
+
+- **Per-subsystem.** Pass a `root` or `filter` prop to scope the tree
+  and table: `<TokenNavigator root="color.sys" />`,
+  `<TokenTable filter="space.*" />`.
+
+- **Diagnostics auto-collapses** unless errors or warnings are present,
+  so you can leave it at the top of every page without it adding noise
+  on clean loads.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -13,7 +13,7 @@ const sidebars: SidebarsConfig = {
       type: 'category',
       label: 'Blocks',
       collapsed: false,
-      items: ['reference/blocks', 'guides/authoring-doc-stories'],
+      items: ['reference/blocks', 'guides/authoring-doc-stories', 'guides/token-dashboard'],
     },
     {
       type: 'category',


### PR DESCRIPTION
## Summary

New guide page showing the recommended composition of \`<Diagnostics />\` + \`<TokenNavigator />\` + \`<TokenTable />\` into a single MDX page — the consumer-authored replacement for the addon's in-manager Design Tokens panel that #339 will retire.

Lives under **Blocks → Authoring a token-dashboard page** in the sidebar, alongside the existing authoring-doc-stories guide.

## Scope

- Copy-paste template MDX.
- Rationale for the pattern (one surface, docs is where designers look up tokens).
- Variations (per-subsystem scoping with \`root\` / \`filter\`).
- Link to the live Storybook for a working example — the docs site itself doesn't install blocks or mount \`SwatchbookProvider\`, so the guide shows the template rather than rendering blocks inline.

Depends on: PR #340 ships the \`<Diagnostics />\` block that the guide references.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs build\` — clean (only pre-existing \`/storybook/\` broken-link warnings).

Milestone: Panel → docblock migration
Closes: #338
Plan impact: none — doc content only.