### PR TITLE
fix(blocks): route every value display through formatTokenValue

### DIFF
--- a/.changeset/format-token-value.md
+++ b/.changeset/format-token-value.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Fix value display across every block: TokenTable, TokenDetail, TokenNavigator, AxisVariance, CompositeBreakdown, DimensionScale, StrokeStyleSample now route one-line value strings through a single `formatTokenValue` helper that honors the active color-format dropdown for color tokens and known composites (border, shadow, gradient). Typography / transition / cubicBezier / dimension / fontFamily get dedicated stringifications instead of raw JSON dumps; only truly-foreign shapes fall through to truncated JSON now.

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -9,7 +9,8 @@ import {
   surfaceStyle,
 } from '#/internal/styles.ts';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
-import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export type { DimensionKind };
 
@@ -124,7 +125,7 @@ export function DimensionScale({
       collected.push({
         path,
         cssVar: makeCssVar(path, cssVarPrefix),
-        displayValue: formatValue(token.$value),
+        displayValue: formatTokenValue(token.$value, token.$type, 'raw'),
         pxValue,
         capped: Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX,
       });

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -8,7 +8,8 @@ import {
   surfaceStyle,
 } from '#/internal/styles.ts';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
-import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface StrokeStyleSampleProps {
   /**
@@ -107,7 +108,7 @@ export function StrokeStyleSample({
       .map(([path, token]) => ({
         path,
         cssVar: makeCssVar(path, cssVarPrefix),
-        displayValue: formatValue(token.$value),
+        displayValue: formatTokenValue(token.$value, token.$type, 'raw'),
         cssStyle: extractCssStyle(token.$value),
       }));
   }, [resolved, filter, cssVarPrefix]);

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
-import { formatValue } from '#/internal/use-project.ts';
+import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { AliasChain } from '#/token-detail/AliasChain.tsx';
 import { AliasedBy } from '#/token-detail/AliasedBy.tsx';
 import { AxisVariance } from '#/token-detail/AxisVariance.tsx';
@@ -39,9 +39,9 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
   }
 
   const isColor = token.$type === 'color';
-  const formatted = isColor ? formatColor(token.$value, colorFormat) : null;
-  const value = formatted ? formatted.value : formatValue(token.$value);
-  const outOfGamut = formatted?.outOfGamut ?? false;
+  const gamut = isColor ? formatColor(token.$value, colorFormat) : null;
+  const value = formatTokenValue(token.$value, token.$type, colorFormat);
+  const outOfGamut = gamut?.outOfGamut ?? false;
 
   return (
     <div

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -3,10 +3,10 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
-import { formatColor } from '#/format-color.ts';
 import { BORDER_DEFAULT, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
-import { formatValue, makeCssVar, useProject } from '#/internal/use-project.ts';
+import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { makeCssVar, useProject } from '#/internal/use-project.ts';
 import { MotionSample } from '#/motion-preview/MotionSample.tsx';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 import { TokenDetail } from '#/TokenDetail.tsx';
@@ -420,10 +420,9 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
 
   if (type === 'color') {
     const cssVar = makeCssVar(path, cssVarPrefix);
-    const formatted = formatColor(token.$value, colorFormat);
     return (
       <span style={styles.previewBox}>
-        <span style={styles.value}>{formatted?.value ?? formatValue(token.$value)}</span>
+        <span style={styles.value}>{formatTokenValue(token.$value, type, colorFormat)}</span>
         <span style={{ ...styles.colorSwatch, background: cssVar, marginLeft: 8 }} aria-hidden />
       </span>
     );
@@ -431,7 +430,7 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
   if (type === 'dimension') {
     return (
       <span style={styles.previewBox}>
-        <span style={styles.value}>{formatValue(token.$value)}</span>
+        <span style={styles.value}>{formatTokenValue(token.$value, type, colorFormat)}</span>
         <span style={{ marginLeft: 8, display: 'inline-block', minWidth: 40, maxWidth: 120 }}>
           <DimensionBar path={path} kind='length' />
         </span>
@@ -482,7 +481,7 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
 
   return (
     <span style={styles.previewBox}>
-      <span style={styles.value}>{formatValue(token.$value)}</span>
+      <span style={styles.value}>{formatTokenValue(token.$value, type, colorFormat)}</span>
     </span>
   );
 }

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -4,7 +4,8 @@ import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import { BORDER_FAINT, emptyStyle, MONO_STACK, surfaceStyle } from '#/internal/styles.ts';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
-import { formatValue, globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface TokenTableProps {
   /**
@@ -102,7 +103,7 @@ export function TokenTable({
       return {
         path,
         type: token.$type ?? '',
-        value: color ? color.value : formatValue(token.$value),
+        value: formatTokenValue(token.$value, token.$type, colorFormat),
         outOfGamut: color?.outOfGamut ?? false,
         description: token.$description ?? '',
         cssVar: makeCssVar(path, cssVarPrefix),

--- a/packages/blocks/src/internal/format-token-value.ts
+++ b/packages/blocks/src/internal/format-token-value.ts
@@ -1,0 +1,180 @@
+import { type ColorFormat, formatColor } from '#/format-color.ts';
+
+/**
+ * Produce a single-line display string for any DTCG token `$value`,
+ * respecting the active color format for color-typed tokens and the
+ * color sub-values of composite types (border, shadow, gradient).
+ *
+ * Replaces the old `formatValue` one-shot that hex-short-circuited
+ * colors and fell through to raw JSON for known composites.
+ *
+ * Shape by type:
+ * - `color`              → `formatColor(value, colorFormat)` — e.g. `#3b82f6`, `oklch(...)`, `raw` JSON.
+ * - `dimension|duration` → `value + unit` — e.g. `16px`, `200ms`.
+ * - `fontFamily`         → string or array joined with `, `.
+ * - `fontWeight`         → primitive.
+ * - `cubicBezier`        → `cubic-bezier(a, b, c, d)`.
+ * - `strokeStyle`        → primitive string, or `dashed · dashArray · lineCap` when it's the object shape.
+ * - `shadow`             → one or more `offsetX offsetY blur spread color` layers joined with `, `.
+ * - `border`             → `width style color`.
+ * - `transition`         → `duration easing [delay]`.
+ * - `typography`         → `family / size / line-height / weight`.
+ * - `gradient`           → `stops joined with →` — compact representation, not a CSS gradient string (those live in GradientPalette's preview).
+ *
+ * Unknown object shapes fall through to truncated JSON.
+ */
+export function formatTokenValue(
+  value: unknown,
+  $type: string | undefined,
+  colorFormat: ColorFormat,
+): string {
+  if (value == null) return '';
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
+  }
+
+  switch ($type) {
+    case 'color':
+      return formatColor(value, colorFormat).value;
+    case 'dimension':
+    case 'duration':
+      return formatDimension(value);
+    case 'fontFamily':
+      return formatFontFamily(value);
+    case 'fontWeight':
+    case 'lineHeight':
+    case 'letterSpacing':
+    case 'opacity':
+    case 'number':
+      return formatPrimitive(value);
+    case 'cubicBezier':
+      return formatCubicBezier(value);
+    case 'strokeStyle':
+      return formatStrokeStyle(value);
+    case 'shadow':
+      return formatShadow(value, colorFormat);
+    case 'border':
+      return formatBorder(value, colorFormat);
+    case 'transition':
+      return formatTransition(value);
+    case 'typography':
+      return formatTypography(value);
+    case 'gradient':
+      return formatGradient(value, colorFormat);
+    default:
+      return formatUnknown(value);
+  }
+}
+
+function formatDimension(v: unknown): string {
+  if (typeof v === 'string' || typeof v === 'number') return String(v);
+  if (v && typeof v === 'object') {
+    const d = v as { value?: unknown; unit?: unknown };
+    if (typeof d.value === 'number' && typeof d.unit === 'string') return `${d.value}${d.unit}`;
+  }
+  return formatUnknown(v);
+}
+
+function formatFontFamily(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return v.map(String).join(', ');
+  return formatUnknown(v);
+}
+
+function formatPrimitive(v: unknown): string {
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v);
+  return formatUnknown(v);
+}
+
+function formatCubicBezier(v: unknown): string {
+  if (Array.isArray(v) && v.length === 4) {
+    return `cubic-bezier(${v.map((n) => (typeof n === 'number' ? n : 0)).join(', ')})`;
+  }
+  return formatUnknown(v);
+}
+
+function formatStrokeStyle(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (v && typeof v === 'object') {
+    const s = v as { dashArray?: unknown; lineCap?: unknown };
+    const parts: string[] = ['dashed'];
+    if (Array.isArray(s.dashArray)) {
+      parts.push(s.dashArray.map((n) => formatDimension(n)).join(' '));
+    }
+    if (typeof s.lineCap === 'string') parts.push(s.lineCap);
+    return parts.join(' · ');
+  }
+  return formatUnknown(v);
+}
+
+function formatShadow(v: unknown, colorFormat: ColorFormat): string {
+  const layers = Array.isArray(v) ? v : [v];
+  const parts = layers.map((layer) => {
+    if (!layer || typeof layer !== 'object') return formatUnknown(layer);
+    const s = layer as Record<string, unknown>;
+    const pieces = [
+      formatDimension(s['offsetX']),
+      formatDimension(s['offsetY']),
+      formatDimension(s['blur']),
+      formatDimension(s['spread']),
+      formatColor(s['color'], colorFormat).value,
+    ].filter((p) => p !== '');
+    if (s['inset']) pieces.push('inset');
+    return pieces.join(' ');
+  });
+  return parts.join(', ');
+}
+
+function formatBorder(v: unknown, colorFormat: ColorFormat): string {
+  if (!v || typeof v !== 'object') return formatUnknown(v);
+  const b = v as Record<string, unknown>;
+  const width = formatDimension(b['width']);
+  const style = formatPrimitive(b['style']);
+  const color = formatColor(b['color'], colorFormat).value;
+  return [width, style, color].filter((p) => p !== '').join(' ');
+}
+
+function formatTransition(v: unknown): string {
+  if (!v || typeof v !== 'object') return formatUnknown(v);
+  const t = v as Record<string, unknown>;
+  const duration = formatDimension(t['duration']);
+  const easing = formatPrimitive(t['timingFunction']);
+  const delay = formatDimension(t['delay']);
+  const parts = [duration, easing];
+  // Only emit delay when non-zero. `0ms` / `0s` clutters the one-liner.
+  if (!/^0\D/.test(delay) && delay !== '') parts.push(delay);
+  return parts.filter((p) => p !== '').join(' ');
+}
+
+function formatTypography(v: unknown): string {
+  if (!v || typeof v !== 'object') return formatUnknown(v);
+  const t = v as Record<string, unknown>;
+  const family = formatFontFamily(t['fontFamily']);
+  const size = formatDimension(t['fontSize']);
+  const lineHeight = formatPrimitive(t['lineHeight']);
+  const weight = formatPrimitive(t['fontWeight']);
+  return [family, size, lineHeight, weight].filter((p) => p !== '').join(' / ');
+}
+
+function formatGradient(v: unknown, colorFormat: ColorFormat): string {
+  if (!Array.isArray(v) || v.length === 0) return formatUnknown(v);
+  const parts = v.map((stop) => {
+    if (!stop || typeof stop !== 'object') return formatUnknown(stop);
+    const s = stop as Record<string, unknown>;
+    const position =
+      typeof s['position'] === 'number' ? `${Math.round(s['position'] * 100)}%` : '?';
+    const color = formatColor(s['color'], colorFormat).value;
+    return `${color} ${position}`;
+  });
+  return parts.join(' → ');
+}
+
+function formatUnknown(v: unknown): string {
+  if (v == null) return '';
+  if (typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean') return String(v);
+  try {
+    return JSON.stringify(v).slice(0, 120);
+  } catch {
+    return String(v);
+  }
+}

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -175,15 +175,3 @@ export function globMatch(path: string, glob: string | undefined): boolean {
   if (glob.endsWith('**')) return path.startsWith(glob.slice(0, -2));
   return path === glob || path.startsWith(`${glob}.`);
 }
-
-export function formatValue(value: unknown): string {
-  if (value == null) return '';
-  if (typeof value === 'string' || typeof value === 'number') return String(value);
-  if (typeof value === 'object') {
-    const v = value as Record<string, unknown>;
-    if (typeof v['hex'] === 'string') return v['hex'] as string;
-    if ('value' in v && 'unit' in v) return `${String(v['value'])}${String(v['unit'])}`;
-    return JSON.stringify(value).slice(0, 120);
-  }
-  return String(value);
-}

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -1,9 +1,9 @@
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
-import { type ColorFormat, formatColor } from '#/format-color.ts';
+import type { ColorFormat } from '#/format-color.ts';
 import { dataAttr } from '#/internal/data-attr.ts';
-import { formatValue } from '#/internal/use-project.ts';
+import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { styles } from '#/token-detail/styles.ts';
 import {
   type DetailToken,
@@ -26,8 +26,9 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
   const { token, cssVar, axes, themes, themesResolved, activeAxes, cssVarPrefix } =
     useTokenDetailData(path);
   const colorFormat = useColorFormat();
-  const isColor = token?.$type === 'color';
-  const formatFn = (t: DetailToken | undefined): string => valueFor(t, isColor, colorFormat);
+  const tokenType = token?.$type;
+  const isColor = tokenType === 'color';
+  const formatFn = (t: DetailToken | undefined): string => valueFor(t, tokenType, colorFormat);
 
   const variance = useMemo(
     () => analyzeVariance(path, axes, themes, themesResolved),
@@ -167,19 +168,29 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
   );
 }
 
-function valueFor(token: DetailToken | undefined, isColor: boolean, format: ColorFormat): string {
+function valueFor(
+  token: DetailToken | undefined,
+  $type: string | undefined,
+  format: ColorFormat,
+): string {
   if (!token) return '—';
-  if (isColor) return formatColor(token.$value, format).value;
-  return formatValue(token.$value);
+  return formatTokenValue(token.$value, $type, format);
 }
 
-function themeValue(
+/**
+ * Stable key for variance detection — compares structural equality across
+ * themes, not a display string. We pin `raw` so color representation
+ * changes (the toolbar's format dropdown) don't artificially make axes
+ * look like they vary.
+ */
+function varianceKey(
   themesResolved: Record<string, Record<string, DetailToken>>,
   themeName: string,
   path: string,
 ): string {
   const t = themesResolved[themeName]?.[path];
-  return t ? formatValue(t.$value) : '—';
+  if (!t) return '';
+  return JSON.stringify(t.$value);
 }
 
 function tupleName(
@@ -210,7 +221,7 @@ function analyzeVariance(
         .join('|');
       const ctx = theme.input[axis.name] ?? '';
       const bucket = byOthers.get(others) ?? new Map<string, string>();
-      bucket.set(ctx, themeValue(themesResolved, theme.name, path));
+      bucket.set(ctx, varianceKey(themesResolved, theme.name, path));
       byOthers.set(others, bucket);
     }
     let varies = false;

--- a/packages/blocks/src/token-detail/CompositeBreakdown.tsx
+++ b/packages/blocks/src/token-detail/CompositeBreakdown.tsx
@@ -1,4 +1,6 @@
 import type { ReactElement } from 'react';
+import { useColorFormat } from '#/contexts.ts';
+import { type ColorFormat, formatColor } from '#/format-color.ts';
 import { styles } from '#/token-detail/styles.ts';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
 
@@ -9,16 +11,25 @@ export interface CompositeBreakdownProps {
 
 export function CompositeBreakdown({ path }: CompositeBreakdownProps): ReactElement | null {
   const { token } = useTokenDetailData(path);
+  const colorFormat = useColorFormat();
   if (!token) return null;
-  return <CompositeBreakdownContent type={token.$type} rawValue={token.$value} />;
+  return (
+    <CompositeBreakdownContent
+      type={token.$type}
+      rawValue={token.$value}
+      colorFormat={colorFormat}
+    />
+  );
 }
 
 export function CompositeBreakdownContent({
   type,
   rawValue,
+  colorFormat,
 }: {
   type: string | undefined;
   rawValue: unknown;
+  colorFormat: ColorFormat;
 }): ReactElement | null {
   if (!rawValue || typeof rawValue !== 'object') return null;
 
@@ -36,7 +47,7 @@ export function CompositeBreakdownContent({
   if (type === 'border') {
     const v = rawValue as Record<string, unknown>;
     return renderKeyValueList([
-      ['color', formatColorValue(v['color'])],
+      ['color', formatColorSubValue(v['color'], colorFormat)],
       ['width', formatDimensionValue(v['width'])],
       ['style', formatPrimitive(v['style'])],
     ]);
@@ -61,7 +72,7 @@ export function CompositeBreakdownContent({
           return (
             <div key={shadowLayerKey(v, i)} style={{ display: 'contents' }}>
               {multi && <div style={styles.breakdownLayerHeader}>Layer {i + 1}</div>}
-              <KeyValueRow label='color' value={formatColorValue(v['color'])} />
+              <KeyValueRow label='color' value={formatColorSubValue(v['color'], colorFormat)} />
               <KeyValueRow label='offsetX' value={formatDimensionValue(v['offsetX'])} />
               <KeyValueRow label='offsetY' value={formatDimensionValue(v['offsetY'])} />
               <KeyValueRow label='blur' value={formatDimensionValue(v['blur'])} />
@@ -86,7 +97,7 @@ export function CompositeBreakdownContent({
             <KeyValueRow
               key={gradientStopKey(v, i)}
               label={`${(position * 100).toFixed(0)}%`}
-              value={formatColorValue(v['color'])}
+              value={formatColorSubValue(v['color'], colorFormat)}
             />
           );
         })}
@@ -141,18 +152,15 @@ function formatDimensionValue(v: unknown): string | null {
   return JSON.stringify(v);
 }
 
-function formatColorValue(v: unknown): string | null {
+/**
+ * Route sub-value colors through `formatColor` so they honor the active
+ * color-format dropdown, just like the standalone `<ColorPalette />` and
+ * `<TokenDetail />` top-line do. Returns `null` for a missing field so
+ * the key/value row drops out entirely.
+ */
+function formatColorSubValue(v: unknown, format: ColorFormat): string | null {
   if (v == null) return null;
-  if (typeof v === 'string') return v;
-  if (typeof v === 'object') {
-    const c = v as { colorSpace?: unknown; components?: unknown; alpha?: unknown };
-    if (Array.isArray(c.components) && typeof c.colorSpace === 'string') {
-      const parts = c.components.map((n) => (typeof n === 'number' ? n.toFixed(3) : String(n)));
-      const alpha = typeof c.alpha === 'number' && c.alpha !== 1 ? ` / ${c.alpha}` : '';
-      return `${c.colorSpace}(${parts.join(' ')}${alpha})`;
-    }
-  }
-  return JSON.stringify(v);
+  return formatColor(v, format).value;
 }
 
 function shadowLayerKey(layer: Record<string, unknown>, fallback: number): string {

--- a/packages/blocks/test/format-token-value.test.ts
+++ b/packages/blocks/test/format-token-value.test.ts
@@ -1,0 +1,99 @@
+// Pragmatic exception: `formatTokenValue` is an internal helper, but it's
+// the one place we make the one-line value-display decisions for every
+// DTCG type. Testing it directly is materially cheaper than a dozen
+// component-render tests that each just assert the same display strings,
+// and it's pure so the refactor tax is low.
+import { describe, expect, it } from 'vitest';
+import { formatTokenValue } from '#/internal/format-token-value.ts';
+
+describe('formatTokenValue', () => {
+  it('returns empty string for null / undefined', () => {
+    expect(formatTokenValue(null, 'dimension', 'hex')).toBe('');
+    expect(formatTokenValue(undefined, 'color', 'hex')).toBe('');
+  });
+
+  it('respects the active color format for color tokens', () => {
+    const color = { colorSpace: 'srgb', components: [1, 0, 0], hex: '#ff0000' };
+    expect(formatTokenValue(color, 'color', 'hex')).toContain('#');
+    expect(formatTokenValue(color, 'color', 'rgb')).toContain('rgb');
+    expect(formatTokenValue(color, 'color', 'oklch')).toContain('oklch');
+  });
+
+  it('stringifies dimensions as value+unit', () => {
+    expect(formatTokenValue({ value: 16, unit: 'px' }, 'dimension', 'hex')).toBe('16px');
+    expect(formatTokenValue({ value: 1.5, unit: 'rem' }, 'dimension', 'hex')).toBe('1.5rem');
+    expect(formatTokenValue({ value: 200, unit: 'ms' }, 'duration', 'hex')).toBe('200ms');
+  });
+
+  it('joins fontFamily arrays with commas; passes strings through', () => {
+    expect(formatTokenValue('Inter', 'fontFamily', 'hex')).toBe('Inter');
+    expect(formatTokenValue(['Inter', 'system-ui'], 'fontFamily', 'hex')).toBe('Inter, system-ui');
+  });
+
+  it('formats cubicBezier as the CSS function', () => {
+    expect(formatTokenValue([0.2, 0, 0, 1], 'cubicBezier', 'hex')).toBe(
+      'cubic-bezier(0.2, 0, 0, 1)',
+    );
+  });
+
+  it('honors colorFormat in border sub-values', () => {
+    const border = {
+      width: { value: 1, unit: 'px' },
+      style: 'solid',
+      color: { colorSpace: 'srgb', components: [0, 0, 0], hex: '#000000' },
+    };
+    const out = formatTokenValue(border, 'border', 'hex');
+    expect(out).toContain('1px');
+    expect(out).toContain('solid');
+    expect(out).toContain('#');
+  });
+
+  it('honors colorFormat in shadow sub-values and joins layers', () => {
+    const shadow = [
+      {
+        offsetX: { value: 0, unit: 'px' },
+        offsetY: { value: 2, unit: 'px' },
+        blur: { value: 4, unit: 'px' },
+        spread: { value: 0, unit: 'px' },
+        color: { colorSpace: 'srgb', components: [0, 0, 0], alpha: 0.1, hex: '#0000001a' },
+      },
+    ];
+    const out = formatTokenValue(shadow, 'shadow', 'rgb');
+    expect(out).toContain('0px 2px 4px 0px');
+    expect(out).toMatch(/rgb/);
+  });
+
+  it('formats typography as family / size / lineHeight / weight', () => {
+    const typography = {
+      fontFamily: 'Inter',
+      fontSize: { value: 16, unit: 'px' },
+      lineHeight: 1.5,
+      fontWeight: 400,
+    };
+    expect(formatTokenValue(typography, 'typography', 'hex')).toBe('Inter / 16px / 1.5 / 400');
+  });
+
+  it('formats transitions without trailing zero delay', () => {
+    const transition = {
+      duration: { value: 200, unit: 'ms' },
+      timingFunction: 'ease-out',
+      delay: { value: 0, unit: 'ms' },
+    };
+    expect(formatTokenValue(transition, 'transition', 'hex')).toBe('200ms ease-out');
+  });
+
+  it('formats gradient stops with percent positions', () => {
+    const gradient = [
+      { position: 0, color: { colorSpace: 'srgb', components: [0, 0, 0], hex: '#000' } },
+      { position: 1, color: { colorSpace: 'srgb', components: [1, 1, 1], hex: '#fff' } },
+    ];
+    const out = formatTokenValue(gradient, 'gradient', 'hex');
+    expect(out).toContain('0%');
+    expect(out).toContain('100%');
+  });
+
+  it('falls through to JSON only for unknown object shapes', () => {
+    const out = formatTokenValue({ foo: 'bar' }, 'mystery', 'hex');
+    expect(out).toBe('{"foo":"bar"}');
+  });
+});


### PR DESCRIPTION
## Summary

Single source of truth for one-line value strings across every block that renders a token `$value`. Replaces:

- `formatValue` (hex-short-circuited colors regardless of the dropdown; raw-JSON fallback for every composite).
- `CompositeBreakdown.formatColorValue` (rendered `srgb(r g b)` ignoring the dropdown).

Both are deleted.

## New helper

`formatTokenValue(value, $type, colorFormat)` dispatches per DTCG `$type`:

| $type | Output |
| --- | --- |
| `color` | `formatColor(value, colorFormat)` |
| `dimension` / `duration` | `value + unit` |
| `fontFamily` | string or joined array |
| `cubicBezier` | `cubic-bezier(a, b, c, d)` |
| `strokeStyle` | primitive or `dashed · dashArray · lineCap` |
| `shadow` | layers joined with `, `, color via `formatColor` |
| `border` | `width style color`, color via `formatColor` |
| `transition` | `duration easing [delay]` (drops zero delays) |
| `typography` | `family / size / lineHeight / weight` |
| `gradient` | stops with percent positions, colors via `formatColor` |
| unknown object | truncated JSON (last resort) |

## Call-site replacements

- **TokenTable** — color cells re-render on format flip (was always `#hex`).
- **TokenDetail** — top-line value honors format for composite types too.
- **TokenNavigator** — leaf value pill respects format for any color-carrying type.
- **AxisVariance** — per-axis cells route through the same helper; variance-detection now uses `JSON.stringify` for stable structural keys so format flips don't fake-trigger "values differ" readings.
- **CompositeBreakdown** — sub-value colors (`border.color`, `shadow.color`, gradient stops) honor the dropdown.
- **DimensionScale** / **StrokeStyleSample** — non-color types but same entry point.

## Test plan

- [x] 11 new unit tests in `test/format-token-value.test.ts` — per-type shape + colorFormat flow-through for color-carrying composites.
- [x] `pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks` — clean.
- [x] Cross-package check against addon + storybook — clean.

Changeset: patch across the fixed-group.

Milestone: Block value display + chrome consistency
Closes: #342
Closes: #343
Plan impact: none — pure display-layer fix.