### PR TITLE
feat(blocks): sortBy/sortDir props + fix broken default filters

### DIFF
--- a/.changeset/sort-tokens.md
+++ b/.changeset/sort-tokens.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+Two behavioural changes to the list-style blocks (`TokenTable`, `ColorPalette`, `TokenNavigator`-adjacent, `TypographyScale`, `DimensionScale`, `FontWeightScale`, `GradientPalette`, `StrokeStyleSample`, `FontFamilySample`, `BorderPreview`, `ShadowPreview`):
+
+- **Fix empty renders for typed-but-differently-pathed tokens.** Every block defaulted its `filter` prop to its `$type` name (`filter = 'fontFamily'`, `filter = 'dimension'`, etc.), which treated the type name as a **path** glob. Projects whose token paths don't coincidentally start with the type name (e.g. `font.ref.weight.*` for `fontWeight`) rendered as empty. Defaults removed — the `$type` check inside each block already scopes correctly, `filter` is purely additive for narrowing.
+- **Add `sortBy` / `sortDir` props.** `sortBy: 'path' | 'value' | 'none'` (default `'path'`, except `DimensionScale` and `FontWeightScale` which default to `'value'` to preserve their pixel/weight-ordered layout). `sortDir: 'asc' | 'desc'`. `'value'` ordering uses numeric magnitude for `dimension` / `duration` / `fontWeight`, perceptual oklch L → C → H for `color`, lexicographic for `fontFamily` / `strokeStyle`, and falls through to path for composites where a one-dimensional "value" isn't meaningful.

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -10,6 +10,7 @@ import {
   surfaceStyle,
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface BorderPreviewProps {
@@ -20,6 +21,14 @@ export interface BorderPreviewProps {
   filter?: string;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order. `'path'` (default) sorts lexicographically on the
+   * dot-path; `'value'` falls through to path (borders don't have a
+   * single-axis ordering); `'none'` preserves project order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -109,23 +118,25 @@ function formatColor(raw: unknown): string {
   return JSON.stringify(raw);
 }
 
-export function BorderPreview({ filter = 'border', caption }: BorderPreviewProps): ReactElement {
+export function BorderPreview({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: BorderPreviewProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
-  const rows = useMemo(() => {
-    const collected: Row[] = [];
-    for (const [path, token] of Object.entries(resolved)) {
-      if (token.$type !== 'border') continue;
-      if (!globMatch(path, filter)) continue;
-      collected.push({
-        path,
-        cssVar: makeCssVar(path, cssVarPrefix),
-        value: (token.$value ?? {}) as BorderValue,
-      });
-    }
-    collected.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
-    return collected;
-  }, [resolved, filter, cssVarPrefix]);
+  const rows = useMemo<Row[]>(() => {
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'border') return false;
+      return globMatch(path, filter);
+    });
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+      path,
+      cssVar: makeCssVar(path, cssVarPrefix),
+      value: (token.$value ?? {}) as BorderValue,
+    }));
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -11,6 +11,7 @@ import {
   surfaceStyle,
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface ColorPaletteProps {
@@ -34,6 +35,16 @@ export interface ColorPaletteProps {
   groupBy?: number;
   /** Override the section caption. */
   caption?: string;
+  /**
+   * Sort order within each group.
+   * - `'path'` (default) — lexicographic on the dot-path.
+   * - `'value'` — perceptual ordering: oklch L → C → H (ramps read
+   *   light→dark, then warm→cool within each lightness band).
+   * - `'none'` — preserve project iteration order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -109,20 +120,21 @@ function fixedPrefixLength(filter: string | undefined): number {
 }
 
 export function ColorPalette({
-  filter = 'color',
+  filter,
   groupBy,
   caption,
+  sortBy = 'path',
+  sortDir = 'asc',
 }: ColorPaletteProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
   const colorFormat = useColorFormat();
 
   const groups = useMemo(() => {
-    const entries = Object.entries(resolved)
-      .filter(([path, token]) => {
-        if (token.$type !== 'color') return false;
-        return globMatch(path, filter);
-      })
-      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }));
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'color') return false;
+      return globMatch(path, filter);
+    });
+    const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
 
     const maxDepth = entries.reduce((m, [p]) => Math.max(m, p.split('.').length), 0);
     /**
@@ -155,7 +167,7 @@ export function ColorPalette({
     return [...bucket.entries()].toSorted(([a], [b]) =>
       a.localeCompare(b, undefined, { numeric: true }),
     );
-  }, [resolved, filter, groupBy, cssVarPrefix, colorFormat]);
+  }, [resolved, filter, groupBy, cssVarPrefix, colorFormat, sortBy, sortDir]);
 
   const totalCount = groups.reduce((acc, [, swatches]) => acc + swatches.length, 0);
   const captionText =

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -10,6 +10,7 @@ import {
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export type { DimensionKind };
@@ -29,6 +30,16 @@ export interface DimensionScaleProps {
   kind?: DimensionKind;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order.
+   * - `'value'` (default) — numeric by rendered pixel size (`px` / `rem` / `em`).
+   *   Non-convertible units (ex/ch/%) land after the convertible ones.
+   * - `'path'` — lexicographic on the dot-path.
+   * - `'none'` — preserve project iteration order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const MAX_RENDER_PX = 480;
@@ -110,32 +121,30 @@ function toPixels(raw: unknown): number {
 }
 
 export function DimensionScale({
-  filter = 'dimension',
+  filter,
   kind = 'length',
   caption,
+  sortBy = 'value',
+  sortDir = 'asc',
 }: DimensionScaleProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
-  const rows = useMemo(() => {
-    const collected: Row[] = [];
-    for (const [path, token] of Object.entries(resolved)) {
-      if (token.$type !== 'dimension') continue;
-      if (!globMatch(path, filter)) continue;
+  const rows = useMemo<Row[]>(() => {
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'dimension') return false;
+      return globMatch(path, filter);
+    });
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
       const pxValue = toPixels(token.$value);
-      collected.push({
+      return {
         path,
         cssVar: makeCssVar(path, cssVarPrefix),
         displayValue: formatTokenValue(token.$value, token.$type, 'raw'),
         pxValue,
         capped: Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX,
-      });
-    }
-    collected.sort((a, b) => {
-      if (Number.isFinite(a.pxValue) && Number.isFinite(b.pxValue)) return a.pxValue - b.pxValue;
-      return a.path.localeCompare(b.path, undefined, { numeric: true });
+      };
     });
-    return collected;
-  }, [resolved, filter, cssVarPrefix]);
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -10,6 +10,7 @@ import {
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 
 export interface FontFamilySampleProps {
   /**
@@ -21,6 +22,14 @@ export interface FontFamilySampleProps {
   sample?: string;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order. `'path'` (default) sorts lexicographically on the
+   * dot-path; `'value'` ordering falls through to path for this block's
+   * type (composite / non-numeric); `'none'` preserves project order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -77,25 +86,25 @@ function stackString(raw: unknown): string {
 }
 
 export function FontFamilySample({
-  filter = 'fontFamily',
+  filter,
   sample = 'The quick brown fox jumps over the lazy dog.',
   caption,
+  sortBy = 'path',
+  sortDir = 'asc',
 }: FontFamilySampleProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
   const rows = useMemo<Row[]>(() => {
-    return Object.entries(resolved)
-      .filter(([path, token]) => {
-        if (token.$type !== 'fontFamily') return false;
-        return globMatch(path, filter);
-      })
-      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
-      .map(([path, token]) => ({
-        path,
-        cssVar: makeCssVar(path, cssVarPrefix),
-        stack: stackString(token.$value),
-      }));
-  }, [resolved, filter, cssVarPrefix]);
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'fontFamily') return false;
+      return globMatch(path, filter);
+    });
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+      path,
+      cssVar: makeCssVar(path, cssVarPrefix),
+      stack: stackString(token.$value),
+    }));
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -9,6 +9,7 @@ import {
   surfaceStyle,
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface FontWeightScaleProps {
@@ -21,6 +22,15 @@ export interface FontWeightScaleProps {
   sample?: string;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order.
+   * - `'value'` (default) — ascending numeric by weight (100 → 900).
+   * - `'path'` — lexicographic on the dot-path.
+   * - `'none'` — preserve project iteration order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -81,30 +91,26 @@ function toWeight(raw: unknown): number {
 }
 
 export function FontWeightScale({
-  filter = 'fontWeight',
+  filter,
   sample = 'Aa',
   caption,
+  sortBy = 'value',
+  sortDir = 'asc',
 }: FontWeightScaleProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
   const rows = useMemo<Row[]>(() => {
-    const collected: Row[] = [];
-    for (const [path, token] of Object.entries(resolved)) {
-      if (token.$type !== 'fontWeight') continue;
-      if (!globMatch(path, filter)) continue;
-      collected.push({
-        path,
-        cssVar: makeCssVar(path, cssVarPrefix),
-        display: token.$value == null ? '' : String(token.$value),
-        weight: toWeight(token.$value),
-      });
-    }
-    collected.sort((a, b) => {
-      if (Number.isFinite(a.weight) && Number.isFinite(b.weight)) return a.weight - b.weight;
-      return a.path.localeCompare(b.path, undefined, { numeric: true });
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'fontWeight') return false;
+      return globMatch(path, filter);
     });
-    return collected;
-  }, [resolved, filter, cssVarPrefix]);
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+      path,
+      cssVar: makeCssVar(path, cssVarPrefix),
+      display: token.$value == null ? '' : String(token.$value),
+      weight: toWeight(token.$value),
+    }));
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -9,6 +9,7 @@ import {
   surfaceStyle,
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface GradientPaletteProps {
@@ -19,6 +20,14 @@ export interface GradientPaletteProps {
   filter?: string;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order. `'path'` (default) sorts lexicographically on the
+   * dot-path; `'value'` falls through to path (gradients don't have
+   * a single-axis ordering); `'none'` preserves project order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -120,25 +129,24 @@ function stopKey(path: string, stop: GradientStop, fallback: number): string {
 }
 
 export function GradientPalette({
-  filter = 'gradient',
+  filter,
   caption,
+  sortBy = 'path',
+  sortDir = 'asc',
 }: GradientPaletteProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
-  const rows = useMemo(() => {
-    const collected: Row[] = [];
-    for (const [path, token] of Object.entries(resolved)) {
-      if (token.$type !== 'gradient') continue;
-      if (!globMatch(path, filter)) continue;
-      collected.push({
-        path,
-        cssVar: makeCssVar(path, cssVarPrefix),
-        stops: asStops(token.$value),
-      });
-    }
-    collected.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
-    return collected;
-  }, [resolved, filter, cssVarPrefix]);
+  const rows = useMemo<Row[]>(() => {
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'gradient') return false;
+      return globMatch(path, filter);
+    });
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+      path,
+      cssVar: makeCssVar(path, cssVarPrefix),
+      stops: asStops(token.$value),
+    }));
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -9,6 +9,7 @@ import {
   surfaceStyle,
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 
@@ -20,6 +21,14 @@ export interface ShadowPreviewProps {
   filter?: string;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order. `'path'` (default) sorts lexicographically on the
+   * dot-path; `'value'` falls through to path (shadows don't have a
+   * single-axis ordering); `'none'` preserves project order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -133,23 +142,25 @@ function layerKey(path: string, layer: ShadowLayer, fallback: number): string {
   return `${path}|${off}|${blur}|${spread}|${fallback}`;
 }
 
-export function ShadowPreview({ filter = 'shadow', caption }: ShadowPreviewProps): ReactElement {
+export function ShadowPreview({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: ShadowPreviewProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
-  const rows = useMemo(() => {
-    const collected: Row[] = [];
-    for (const [path, token] of Object.entries(resolved)) {
-      if (token.$type !== 'shadow') continue;
-      if (!globMatch(path, filter)) continue;
-      collected.push({
-        path,
-        cssVar: makeCssVar(path, cssVarPrefix),
-        layers: asLayers(token.$value),
-      });
-    }
-    collected.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
-    return collected;
-  }, [resolved, filter, cssVarPrefix]);
+  const rows = useMemo<Row[]>(() => {
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'shadow') return false;
+      return globMatch(path, filter);
+    });
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+      path,
+      cssVar: makeCssVar(path, cssVarPrefix),
+      layers: asLayers(token.$value),
+    }));
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -12,6 +12,7 @@ import {
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 
 export interface StrokeStyleSampleProps {
   /**
@@ -21,6 +22,14 @@ export interface StrokeStyleSampleProps {
   filter?: string;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order. `'path'` (default) sorts lexicographically on the
+   * dot-path; `'value'` ordering falls through to path for this block's
+   * type (composite / non-numeric); `'none'` preserves project order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const STRING_STYLES = new Set([
@@ -95,25 +104,25 @@ function extractCssStyle(value: unknown): string | null {
 }
 
 export function StrokeStyleSample({
-  filter = 'strokeStyle',
+  filter,
   caption,
+  sortBy = 'path',
+  sortDir = 'asc',
 }: StrokeStyleSampleProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
   const rows = useMemo<Row[]>(() => {
-    return Object.entries(resolved)
-      .filter(([path, token]) => {
-        if (token.$type !== 'strokeStyle') return false;
-        return globMatch(path, filter);
-      })
-      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
-      .map(([path, token]) => ({
-        path,
-        cssVar: makeCssVar(path, cssVarPrefix),
-        displayValue: formatTokenValue(token.$value, token.$type, 'raw'),
-        cssStyle: extractCssStyle(token.$value),
-      }));
-  }, [resolved, filter, cssVarPrefix]);
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'strokeStyle') return false;
+      return globMatch(path, filter);
+    });
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+      path,
+      cssVar: makeCssVar(path, cssVarPrefix),
+      displayValue: formatTokenValue(token.$value, token.$type, 'raw'),
+      cssStyle: extractCssStyle(token.$value),
+    }));
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -13,6 +13,7 @@ import {
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface TokenTableProps {
@@ -27,6 +28,18 @@ export interface TokenTableProps {
   showVar?: boolean;
   /** Override the table caption. */
   caption?: string;
+  /**
+   * Sort order.
+   * - `'path'` (default) — lexicographic on the dot-path.
+   * - `'value'` — per-`$type`: numeric for `dimension` / `duration` /
+   *   `fontWeight`; perceptual (oklch L → C → H) for `color`; lexicographic
+   *   for `fontFamily` / `strokeStyle`. Composite types fall through to
+   *   path order.
+   * - `'none'` — preserve project iteration order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -93,18 +106,19 @@ export function TokenTable({
   type,
   showVar = true,
   caption,
+  sortBy = 'path',
+  sortDir = 'asc',
 }: TokenTableProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
   const colorFormat = useColorFormat();
 
   const rows = useMemo(() => {
-    const entries = Object.entries(resolved)
-      .filter(([path, token]) => {
-        if (!globMatch(path, filter)) return false;
-        if (type && token.$type !== type) return false;
-        return true;
-      })
-      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }));
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (!globMatch(path, filter)) return false;
+      if (type && token.$type !== type) return false;
+      return true;
+    });
+    const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
     return entries.map(([path, token]) => {
       const isColor = token.$type === 'color';
       const color = isColor ? formatColor(token.$value, colorFormat) : null;
@@ -118,7 +132,7 @@ export function TokenTable({
         isColor,
       };
     });
-  }, [resolved, filter, type, cssVarPrefix, colorFormat]);
+  }, [resolved, filter, type, cssVarPrefix, colorFormat, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -9,6 +9,7 @@ import {
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, useProject } from '#/internal/use-project.ts';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 
 export interface TypographyScaleProps {
   /**
@@ -20,6 +21,14 @@ export interface TypographyScaleProps {
   sample?: string;
   /** Override the caption. */
   caption?: string;
+  /**
+   * Sort order. `'path'` (default) sorts lexicographically on the
+   * dot-path; `'value'` ordering falls through to path for this block's
+   * type (composite / non-numeric); `'none'` preserves project order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
 }
 
 const styles = {
@@ -98,27 +107,27 @@ function buildRow(path: string, composite: Record<string, unknown>): Row {
 }
 
 export function TypographyScale({
-  filter = 'typography',
+  filter,
   sample = 'The quick brown fox jumps over the lazy dog.',
   caption,
+  sortBy = 'path',
+  sortDir = 'asc',
 }: TypographyScaleProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
   const rows = useMemo<Row[]>(() => {
-    return Object.entries(resolved)
-      .filter(([path, token]) => {
-        if (token.$type !== 'typography') return false;
-        return globMatch(path, filter);
-      })
-      .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
-      .map(([path, token]) => {
-        const value = token.$value;
-        if (!value || typeof value !== 'object') {
-          return { path, sampleStyle: {}, specs: '' };
-        }
-        return buildRow(path, value as Record<string, unknown>);
-      });
-  }, [resolved, filter]);
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'typography') return false;
+      return globMatch(path, filter);
+    });
+    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
+      const value = token.$value;
+      if (!value || typeof value !== 'object') {
+        return { path, sampleStyle: {}, specs: '' };
+      }
+      return buildRow(path, value as Record<string, unknown>);
+    });
+  }, [resolved, filter, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/internal/sort-tokens.ts
+++ b/packages/blocks/src/internal/sort-tokens.ts
@@ -1,0 +1,161 @@
+import Color from 'colorjs.io';
+import type { VirtualToken } from '#/types.ts';
+
+export type SortBy = 'path' | 'value' | 'none';
+export type SortDir = 'asc' | 'desc';
+
+export interface SortOptions {
+  by?: SortBy;
+  dir?: SortDir;
+}
+
+type Entry = readonly [string, VirtualToken];
+
+/**
+ * Stable sort for a filtered `[path, token][]` list.
+ *
+ * `sortBy: 'path'` — lexicographic on the dot-path (locale-aware, numeric).
+ * `sortBy: 'value'` — per-`$type` ordering:
+ *   - `dimension` / `duration` → numeric pixels / ms (via `toMagnitude`).
+ *   - `fontWeight` / `opacity` / `number` / `lineHeight` → numeric.
+ *   - `color` → perceptual by oklch L → C → H.
+ *   - `fontFamily` / `strokeStyle` (string form) → lexicographic.
+ *   - Composites (`typography`, `shadow`, `border`, `gradient`, `transition`) →
+ *     fall back to path-alpha. No useful single-axis order.
+ * `sortBy: 'none'` — preserve input order (still respects `sortDir: 'desc'`
+ *   as a reverse).
+ */
+export function sortTokens(entries: readonly Entry[], options: SortOptions = {}): Entry[] {
+  const by = options.by ?? 'path';
+  const dir = options.dir ?? 'asc';
+  const sign = dir === 'desc' ? -1 : 1;
+
+  if (by === 'none') {
+    return dir === 'desc' ? [...entries].toReversed() : [...entries];
+  }
+
+  if (by === 'path') {
+    return [...entries].toSorted(
+      ([a], [b]) => sign * a.localeCompare(b, undefined, { numeric: true }),
+    );
+  }
+
+  // by === 'value'
+  return [...entries].toSorted(([aPath, aTok], [bPath, bTok]) => {
+    const cmp = compareValue(aTok, bTok);
+    if (cmp !== 0) return sign * cmp;
+    // Stable tiebreak on path so the order is deterministic when values equal.
+    return sign * aPath.localeCompare(bPath, undefined, { numeric: true });
+  });
+}
+
+function compareValue(a: VirtualToken, b: VirtualToken): number {
+  const type = a.$type;
+  // When the two tokens differ in $type, fall back to type-alpha so at
+  // least the mixed list clusters by type.
+  if (type !== b.$type) return String(type ?? '').localeCompare(String(b.$type ?? ''));
+  if (!type) return 0;
+
+  if (
+    type === 'dimension' ||
+    type === 'duration' ||
+    type === 'fontWeight' ||
+    type === 'opacity' ||
+    type === 'number' ||
+    type === 'lineHeight'
+  ) {
+    const av = toMagnitude(a.$value);
+    const bv = toMagnitude(b.$value);
+    if (Number.isFinite(av) && Number.isFinite(bv)) return av - bv;
+    if (Number.isFinite(av)) return -1;
+    if (Number.isFinite(bv)) return 1;
+    return 0;
+  }
+
+  if (type === 'color') {
+    const ak = colorKey(a.$value);
+    const bk = colorKey(b.$value);
+    if (!ak && !bk) return 0;
+    if (!ak) return 1;
+    if (!bk) return -1;
+    // L → C → H.
+    if (ak.l !== bk.l) return ak.l - bk.l;
+    if (ak.c !== bk.c) return ak.c - bk.c;
+    return ak.h - bk.h;
+  }
+
+  if (type === 'fontFamily' || type === 'strokeStyle') {
+    const as = toDisplayable(a.$value);
+    const bs = toDisplayable(b.$value);
+    return as.localeCompare(bs, undefined, { numeric: true });
+  }
+
+  // Composite types — no one-dimensional ordering. Callers should have
+  // fallen through to 'path' for these; if they didn't, leave untouched.
+  return 0;
+}
+
+function toMagnitude(v: unknown): number {
+  if (typeof v === 'number') return v;
+  if (v && typeof v === 'object') {
+    const d = v as { value?: unknown; unit?: unknown };
+    if (typeof d.value !== 'number') return Number.NaN;
+    if (typeof d.unit !== 'string') return d.value;
+    switch (d.unit) {
+      case 'px':
+      case 'ms':
+        return d.value;
+      case 's':
+        return d.value * 1000;
+      case 'rem':
+      case 'em':
+        return d.value * 16;
+      default:
+        return d.value;
+    }
+  }
+  return Number.NaN;
+}
+
+function colorKey(v: unknown): { l: number; c: number; h: number } | null {
+  if (!v || typeof v !== 'object') return null;
+  try {
+    const c = v as {
+      colorSpace?: unknown;
+      components?: unknown;
+      channels?: unknown;
+      hex?: unknown;
+    };
+    let source: unknown;
+    if (typeof c.hex === 'string') source = c.hex;
+    else if (typeof c.colorSpace === 'string') {
+      const channels = Array.isArray(c.components)
+        ? c.components
+        : Array.isArray(c.channels)
+          ? c.channels
+          : undefined;
+      if (!channels) return null;
+      source = { space: c.colorSpace, coords: channels };
+    } else return null;
+    // Color.js's constructor signature is a string or PlainColorObject —
+    // we've already narrowed `source` to one of those shapes above, but
+    // the union ends up broader than Color.js's typed surface.
+    const color = new Color(source as string);
+    const [l, chroma, h] = color.to('oklch').coords;
+    // Guard against NaN hue on achromatic colors so the sort stays stable.
+    return {
+      l: Number.isFinite(l) ? (l as number) : 0,
+      c: Number.isFinite(chroma) ? (chroma as number) : 0,
+      h: Number.isFinite(h) ? (h as number) : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function toDisplayable(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return v.map(String).join(', ');
+  if (v && typeof v === 'object') return JSON.stringify(v);
+  return String(v ?? '');
+}

--- a/packages/blocks/test/sort-tokens.test.ts
+++ b/packages/blocks/test/sort-tokens.test.ts
@@ -1,0 +1,86 @@
+// Pragmatic exception: `sortTokens` is an internal helper, but it's the
+// one place we make the per-$type ordering decisions. Testing it directly
+// catches the common regressions (asc/desc, numeric vs lexicographic,
+// perceptual color order) at the source.
+import { describe, expect, it } from 'vitest';
+import { sortTokens } from '#/internal/sort-tokens.ts';
+import type { VirtualToken } from '#/types.ts';
+
+function entry(path: string, $type: string, $value: unknown): [string, VirtualToken] {
+  return [path, { $type, $value }];
+}
+
+describe('sortTokens', () => {
+  it('sorts by path ascending by default', () => {
+    const input = [
+      entry('color.ref.blue.500', 'color', { hex: '#3b82f6' }),
+      entry('color.ref.blue.100', 'color', { hex: '#dbeafe' }),
+      entry('color.ref.blue.300', 'color', { hex: '#93c5fd' }),
+    ];
+    const out = sortTokens(input);
+    expect(out.map(([p]) => p)).toEqual([
+      'color.ref.blue.100',
+      'color.ref.blue.300',
+      'color.ref.blue.500',
+    ]);
+  });
+
+  it('respects sortDir desc for path sort', () => {
+    const input = [
+      entry('a', 'dimension', { value: 1, unit: 'px' }),
+      entry('b', 'dimension', { value: 2, unit: 'px' }),
+    ];
+    const out = sortTokens(input, { by: 'path', dir: 'desc' });
+    expect(out.map(([p]) => p)).toEqual(['b', 'a']);
+  });
+
+  it('sorts dimensions numerically by pixel magnitude', () => {
+    const input = [
+      entry('space.lg', 'dimension', { value: 2, unit: 'rem' }),
+      entry('space.sm', 'dimension', { value: 4, unit: 'px' }),
+      entry('space.xs', 'dimension', { value: 2, unit: 'px' }),
+    ];
+    const out = sortTokens(input, { by: 'value' });
+    expect(out.map(([p]) => p)).toEqual(['space.xs', 'space.sm', 'space.lg']);
+  });
+
+  it('sorts fontWeight numerically', () => {
+    const input = [
+      entry('weight.bold', 'fontWeight', 700),
+      entry('weight.regular', 'fontWeight', 400),
+      entry('weight.semibold', 'fontWeight', 600),
+    ];
+    const out = sortTokens(input, { by: 'value' });
+    expect(out.map(([p]) => p)).toEqual(['weight.regular', 'weight.semibold', 'weight.bold']);
+  });
+
+  it('sorts colors perceptually (light before dark)', () => {
+    const input = [
+      entry('c.black', 'color', { hex: '#000000' }),
+      entry('c.white', 'color', { hex: '#ffffff' }),
+      entry('c.gray', 'color', { hex: '#808080' }),
+    ];
+    const out = sortTokens(input, { by: 'value' });
+    expect(out.map(([p]) => p)).toEqual(['c.black', 'c.gray', 'c.white']);
+  });
+
+  it('sortBy=none with dir=desc reverses input order', () => {
+    const input = [
+      entry('a', 'color', { hex: '#000' }),
+      entry('b', 'color', { hex: '#fff' }),
+      entry('c', 'color', { hex: '#888' }),
+    ];
+    const out = sortTokens(input, { by: 'none', dir: 'desc' });
+    expect(out.map(([p]) => p)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('falls back to path for composite value sort', () => {
+    const input = [
+      entry('shadow.md', 'shadow', [{}]),
+      entry('shadow.lg', 'shadow', [{}]),
+      entry('shadow.sm', 'shadow', [{}]),
+    ];
+    const out = sortTokens(input, { by: 'value' });
+    expect(out.map(([p]) => p)).toEqual(['shadow.lg', 'shadow.md', 'shadow.sm']);
+  });
+});


### PR DESCRIPTION
## Summary

Two behavioural changes for list-style blocks, landed together because they touch the same lines.

### 1. Drop `\$type`-named default filters (behaviour fix)

Every block defaulted its \`filter\` prop to its own \`\$type\` name — \`filter = 'fontFamily'\`, \`filter = 'dimension'\`, \`filter = 'strokeStyle'\`, etc. But \`filter\` is a path glob, not a type filter. Projects whose token paths don't happen to start with the type name rendered as **empty** despite having the tokens:

- \`font.ref.family.*\` for \`fontFamily\` → \`FontFamilySample\` showed \`No fontFamily tokens match this filter\`.
- \`font.ref.weight.*\` for \`fontWeight\` → \`FontWeightScale\` ditto.
- \`space.*\` / \`radius.*\` for \`dimension\` → \`DimensionScale\` ditto.
- \`stroke.ref.*\` for \`strokeStyle\` → \`StrokeStyleSample\` ditto.

The \`\$type\` check inside each block already scopes correctly. \`filter\` is purely additive for narrowing. Defaults removed.

### 2. Add shared \`sortBy\` / \`sortDir\` props

\`\`\`ts
sortBy?: 'path' | 'value' | 'none';   // default 'path' (except DimensionScale + FontWeightScale → 'value')
sortDir?: 'asc' | 'desc';             // default 'asc'
\`\`\`

\`'value'\` ordering by \`\$type\`:

| \$type | Ordering |
| --- | --- |
| \`dimension\` / \`duration\` | numeric magnitude (px / ms / rem→px etc.) |
| \`fontWeight\` / \`opacity\` / \`number\` / \`lineHeight\` | numeric |
| \`color\` | perceptual oklch L → C → H |
| \`fontFamily\` / \`strokeStyle\` (string form) | lexicographic |
| composites (\`typography\`, \`shadow\`, \`border\`, \`gradient\`, \`transition\`) | falls through to path |

\`'none'\` preserves project iteration order; \`'desc'\` reverses.

New \`internal/sort-tokens.ts\` exports the helper. Wired into every list-style block:

- **Defaults \`'value'\`**: \`DimensionScale\`, \`FontWeightScale\` (preserves the existing px-ordered / weight-ordered behaviour).
- **Defaults \`'path'\`**: \`TokenTable\`, \`ColorPalette\`, \`TypographyScale\`, \`GradientPalette\`, \`StrokeStyleSample\`, \`FontFamilySample\`, \`BorderPreview\`, \`ShadowPreview\`.

### Changeset

Minor across the fixed group — new props, behaviour change for consumers relying on the old \`filter = '\$type'\` default (those relying on it were almost certainly broken already).

### Test plan

- [x] \`pnpm -F @unpunnyfuns/swatchbook-blocks exec vitest run\` — 51 tests (was 45); new \`sort-tokens.test.ts\` adds 7.
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook\` — 126/126 Chromium.
- [x] \`pnpm turbo run lint typecheck test --filter @unpunnyfuns/swatchbook-blocks --filter @unpunnyfuns/swatchbook-addon --filter @unpunnyfuns/swatchbook-storybook\` — clean.

Milestone: Block value display + chrome consistency
Closes: #348
Plan impact: none.