### PR TITLE
fix(blocks): let TokenNavigator leaf values use flex-granted width

### DIFF
--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -118,9 +118,11 @@ const styles = {
     fontSize: SIZE_LABEL,
     color: TEXT_MUTED,
     marginLeft: 'auto',
-    wordBreak: 'break-all',
-    maxWidth: '40%',
+    minWidth: 0,
     textAlign: 'right',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   } satisfies CSSProperties,
   count: {
     marginLeft: 'auto',


### PR DESCRIPTION
## Summary

`TokenNavigator` leaf rows capped the value pill at `maxWidth: 40%` + `wordBreak: 'break-all'`. In narrow containers (e.g. the Dashboard MDX page in Storybook docs, reported rendering at ~40px wide) that produced aggressive character-break truncation long before the row actually ran out of horizontal space.

## Fix

Drop the hard `maxWidth` cap — let the row's flex layout allocate width — and switch to `overflow: hidden` + `textOverflow: ellipsis` + `whiteSpace: nowrap` so long stacks truncate cleanly on a single line. `minWidth: 0` unblocks shrinking inside the preview-box flex context.

## Test plan

- [x] `pnpm turbo run lint typecheck --filter=@unpunnyfuns/swatchbook-blocks` — clean.

No changeset — purely visual / CSS tweak.

Milestone: Maintenance
Plan impact: none — layout tuning.
