### PR TITLE
fix(storybook): wrap Dashboard blocks in <Unstyled>

### DIFF
--- a/apps/storybook/src/docs/Dashboard.mdx
+++ b/apps/storybook/src/docs/Dashboard.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta, Unstyled } from '@storybook/addon-docs/blocks';
 import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 
 <Meta title='Docs/Dashboard' />
@@ -9,14 +9,24 @@ The recommended composition that replaces the old in-manager Design
 Tokens panel. Flip themes from the toolbar — every block below
 re-renders against the active tuple.
 
+Each block is wrapped in `<Unstyled>` to opt out of the docs page's
+600px prose column so the tree and table use the full docs viewport
+width.
+
 ## Diagnostics
 
-<Diagnostics />
+<Unstyled>
+  <Diagnostics />
+</Unstyled>
 
 ## Token graph
 
-<TokenNavigator />
+<Unstyled>
+  <TokenNavigator />
+</Unstyled>
 
 ## All tokens (searchable)
 
-<TokenTable />
+<Unstyled>
+  <TokenTable />
+</Unstyled>


### PR DESCRIPTION
## Summary

Storybook 10's MDX docs wraps every child block in a 600px prose column by default. The Dashboard page added in PR #352 renders `<Diagnostics />`, `<TokenNavigator />`, `<TokenTable />` directly and inherits the cap — the tree + table were squished into a narrow center strip with ~500px of empty space on each side on a wide viewport.

Wrap each block in `<Unstyled>` from `@storybook/addon-docs/blocks` to opt out. `Meta`, the heading, and the prose paragraph keep the docs styling.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-storybook build:storybook` — clean.

Milestone: Maintenance
Closes: #354
Plan impact: none — Storybook docs layout fix.
