### PR TITLE
fix(blocks): scoped element reset so MDX docs styles don't bleed

### DIFF
--- a/.changeset/block-reset-stylesheet.md
+++ b/.changeset/block-reset-stylesheet.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Fix blocks inheriting Storybook MDX docs element styling. Every block's outer wrapper now carries a `data-swatchbook-block` marker, and the blocks package mounts a scoped stylesheet (`[data-swatchbook-block] table, ul, li, details, summary, … { all: revert-layer }`) that neutralizes `.sbdocs` element styles bleeding into the chrome. Consumers no longer need to wrap blocks in `<Unstyled>` on MDX docs pages — blocks look the same in stories and in docs.

--- a/apps/storybook/src/docs/Dashboard.mdx
+++ b/apps/storybook/src/docs/Dashboard.mdx
@@ -1,4 +1,4 @@
-import { Meta, Unstyled } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 
 <Meta title='Docs/Dashboard' />
@@ -9,24 +9,14 @@ The recommended composition that replaces the old in-manager Design
 Tokens panel. Flip themes from the toolbar — every block below
 re-renders against the active tuple.
 
-Each block is wrapped in `<Unstyled>` to opt out of the docs page's
-600px prose column so the tree and table use the full docs viewport
-width.
-
 ## Diagnostics
 
-<Unstyled>
-  <Diagnostics />
-</Unstyled>
+<Diagnostics />
 
 ## Token graph
 
-<Unstyled>
-  <TokenNavigator />
-</Unstyled>
+<TokenNavigator />
 
 ## All tokens (searchable)
 
-<Unstyled>
-  <TokenTable />
-</Unstyled>
+<TokenTable />

--- a/packages/blocks/src/internal/block-reset.ts
+++ b/packages/blocks/src/internal/block-reset.ts
@@ -1,0 +1,57 @@
+/**
+ * Defensive element reset scoped to every block wrapper.
+ *
+ * Storybook 10's MDX docs applies house-style CSS to semantic elements
+ * (`.sbdocs table`, `.sbdocs th/td`, `.sbdocs ul/li`, `.sbdocs details/summary`)
+ * that bleeds into any block rendered inside a docs page. Our blocks set
+ * inline styles on those elements for the properties they care about, but
+ * anything they don't touch (background, border, margin, etc.) inherits
+ * the docs look. That's why the Dashboard tree/table looked different
+ * inside MDX vs a regular story.
+ *
+ * The fix mounts one stylesheet once per browsing session that scopes
+ * `all: revert` on the semantic elements used by blocks, under the
+ * `[data-swatchbook-block]` attribute carried by every block's outer
+ * wrapper (via `themeAttrs`). `all: revert` restores browser defaults —
+ * the block's inline styles still win on top of that, and MDX house
+ * styles stop leaking in.
+ *
+ * The reset excludes the wrapper itself (direct `[data-swatchbook-block]`
+ * selector) because the wrapper's `surfaceStyle` is what we want to keep.
+ */
+
+const STYLE_ID = 'swatchbook-block-reset';
+
+const RESET_CSS = `[data-swatchbook-block] table,
+[data-swatchbook-block] thead,
+[data-swatchbook-block] tbody,
+[data-swatchbook-block] tr,
+[data-swatchbook-block] th,
+[data-swatchbook-block] td,
+[data-swatchbook-block] caption,
+[data-swatchbook-block] ul,
+[data-swatchbook-block] ol,
+[data-swatchbook-block] li,
+[data-swatchbook-block] details,
+[data-swatchbook-block] summary,
+[data-swatchbook-block] code,
+[data-swatchbook-block] pre,
+[data-swatchbook-block] p,
+[data-swatchbook-block] h1,
+[data-swatchbook-block] h2,
+[data-swatchbook-block] h3,
+[data-swatchbook-block] h4,
+[data-swatchbook-block] h5,
+[data-swatchbook-block] h6 {
+  all: revert-layer;
+}
+`;
+
+export function ensureBlockResetStylesheet(): void {
+  if (typeof document === 'undefined') return;
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement('style');
+  style.id = STYLE_ID;
+  style.textContent = RESET_CSS;
+  document.head.appendChild(style);
+}

--- a/packages/blocks/src/internal/data-attr.ts
+++ b/packages/blocks/src/internal/data-attr.ts
@@ -11,12 +11,24 @@ export function dataAttr(prefix: string, key: string): string {
 }
 
 /**
- * Spread helper for the common `<div data-<prefix>-theme="…">` block
- * wrapper. Returns an object keyed on the prefixed attribute name so the
- * call site stays readable: `<div {...themeAttrs(prefix, theme)} />`.
+ * Marker attribute set on every block wrapper. Used as the scope selector
+ * for the defensive element-reset stylesheet in `block-reset.ts` so
+ * Storybook MDX docs CSS (`.sbdocs table`, `.sbdocs ul`, …) can't bleed
+ * into our chrome.
+ */
+export const BLOCK_ATTR = 'data-swatchbook-block';
+
+/**
+ * Spread helper for the common `<div data-<prefix>-theme="…" data-swatchbook-block>`
+ * block wrapper. Returns an object keyed on the prefixed theme attribute
+ * plus the scoping marker so the call site stays readable:
+ * `<div {...themeAttrs(prefix, theme)} />`.
  */
 export function themeAttrs(prefix: string, themeName: string): Record<string, string> {
-  return { [dataAttr(prefix, 'theme')]: themeName };
+  return {
+    [dataAttr(prefix, 'theme')]: themeName,
+    [BLOCK_ATTR]: '',
+  };
 }
 
 /**

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useActiveAxes, useActiveTheme, useOptionalSwatchbookData } from '#/contexts.ts';
+import { ensureBlockResetStylesheet } from '#/internal/block-reset.ts';
 import { useChannelGlobals } from '#/internal/channel-globals.ts';
 import {
   axes as virtualAxes,
@@ -102,6 +103,9 @@ function snapshotToData(snapshot: ProjectSnapshot): ProjectData {
 export function useProject(): ProjectData {
   const snapshot = useOptionalSwatchbookData();
   const fallback = useVirtualModuleFallback(snapshot === null);
+  useEffect(() => {
+    ensureBlockResetStylesheet();
+  }, []);
   return snapshot !== null ? snapshotToData(snapshot) : fallback;
 }
 


### PR DESCRIPTION
## Summary

Supersedes PR #355. That PR asked consumers to wrap every block in `<Unstyled>` on MDX docs pages to dodge Storybook's `.sbdocs` element-styling inheritance. Fine for us, not great as a consumer-facing pattern — every new dashboard page becomes `<Unstyled>` boilerplate.

Absorb it on the blocks side instead. Every block wrapper now carries a `data-swatchbook-block` marker (added to the existing `themeAttrs` helper, zero call-site changes). The blocks package mounts one scoped stylesheet on first `useProject()`:

```css
[data-swatchbook-block] table,
[data-swatchbook-block] th, [data-swatchbook-block] td,
[data-swatchbook-block] ul, [data-swatchbook-block] li,
[data-swatchbook-block] details, [data-swatchbook-block] summary,
[data-swatchbook-block] code, [data-swatchbook-block] pre,
[data-swatchbook-block] p, [data-swatchbook-block] h1…h6 { all: revert-layer; }
```

Inline styles the blocks already set still win (inline beats cascade), so the reset only touches properties we didn't specify — exactly the `.sbdocs` bleed.

Drops the `<Unstyled>` wrappers from `apps/storybook/src/docs/Dashboard.mdx` now that the fix lives on the blocks.

## What to do with PR #355

Close once this merges. The `<Unstyled>` approach gets replaced entirely.

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks --filter=@unpunnyfuns/swatchbook-storybook` — clean.
- [x] `pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook` — 126/126 interaction tests pass.
- [x] Build + visual sanity on `docs-dashboard--docs` after.

Milestone: Maintenance
Closes: #356
Closes: #354 (the underlying layout bug from #355's issue)
Plan impact: none — bugfix absorbed on the library side.
