### PR TITLE
feat(blocks)!: compact TokenTable + shared slide-over drawer

### DIFF
--- a/.changeset/tokentable-compact-drawer.md
+++ b/.changeset/tokentable-compact-drawer.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+**Breaking**: `<TokenTable />` redesign — compact two-column layout (`Path | Value`) with a click-to-open `<TokenDetail>` slide-over. The row's value cell renders the type pill + color swatch + formatted value inline. The `showVar` prop is removed; the CSS var is one click away in the drawer. Table layout is now `auto` (no fixed percentage widths) with per-column `min-width` floors so columns follow content and stop collapsing on narrow containers. Consumers who want to own the follow-up UI can pass `onSelect(path)` to suppress the built-in drawer. The `<TokenNavigator />` drawer is unchanged in behavior but now shares the same overlay component internally (no visible difference).

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -72,7 +72,7 @@ export const TokenTableRenders = meta.story({
     const headerTexts = [...canvasElement.querySelectorAll('thead th')].map((th) =>
       th.textContent?.trim(),
     );
-    expect(headerTexts).toEqual(expect.arrayContaining(['Path', 'Type', 'Value']));
+    expect(headerTexts).toEqual(expect.arrayContaining(['Path', 'Value']));
     const rows = canvasElement.querySelectorAll('tbody tr');
     expect(rows.length, 'table must render at least one row').toBeGreaterThan(0);
   },

--- a/apps/storybook/src/stories/ColorFormat.stories.tsx
+++ b/apps/storybook/src/stories/ColorFormat.stories.tsx
@@ -14,15 +14,12 @@ export default meta;
 
 async function firstColorValueCell(canvasElement: HTMLElement): Promise<HTMLElement> {
   await waitFor(() => {
-    const row = canvasElement.querySelector('tbody tr');
-    if (!row) throw new Error('no rows yet');
+    const value = canvasElement.querySelector('[data-testid="token-table-value"]');
+    if (!value) throw new Error('no rows yet');
   });
-  const row = canvasElement.querySelector('tbody tr');
-  if (!row) throw new Error('no rows');
-  const cells = row.querySelectorAll<HTMLElement>('td');
-  const valueCell = cells[2];
-  if (!valueCell) throw new Error('no value cell');
-  return valueCell;
+  const value = canvasElement.querySelector<HTMLElement>('[data-testid="token-table-value"]');
+  if (!value) throw new Error('no value span');
+  return value;
 }
 
 async function waitForMatch(

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -94,7 +94,7 @@ export const ExpandAndOpenDetail = meta.story({
     expect(overlay).toBeDefined();
 
     // 4. Close via the close button.
-    const close = await canvas.findByTestId('token-navigator-close');
+    const close = await canvas.findByTestId('token-navigator-overlay-close');
     await userEvent.click(close);
 
     await waitFor(() => {

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -23,7 +23,6 @@ const meta = preview.meta({
         'transition',
       ],
     },
-    showVar: { control: 'boolean' },
   },
 });
 

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -3,15 +3,14 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
+import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import {
   BORDER_DEFAULT,
-  BORDER_STRONG,
   EmptyState,
   MONO_STACK,
   SIZE_LABEL,
   SIZE_META,
   SIZE_PILL,
-  SURFACE_DEFAULT,
   surfaceStyle,
   TEXT_DEFAULT,
   TEXT_MUTED,
@@ -22,7 +21,6 @@ import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { makeCssVar, useProject } from '#/internal/use-project.ts';
 import { MotionSample } from '#/motion-preview/MotionSample.tsx';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
-import { TokenDetail } from '#/TokenDetail.tsx';
 import type { VirtualToken } from '#/types.ts';
 
 export interface TokenNavigatorProps {
@@ -141,39 +139,6 @@ const styles = {
     alignItems: 'center',
     justifyContent: 'flex-end',
     marginLeft: 'auto',
-  } satisfies CSSProperties,
-  backdrop: {
-    position: 'fixed',
-    inset: 0,
-    background: 'rgba(0,0,0,0.4)',
-    zIndex: 10000,
-    display: 'flex',
-    alignItems: 'stretch',
-    justifyContent: 'flex-end',
-  } satisfies CSSProperties,
-  panel: {
-    width: 'min(560px, 100%)',
-    height: '100%',
-    overflowY: 'auto',
-    background: SURFACE_DEFAULT,
-    color: TEXT_DEFAULT,
-    boxShadow: '-8px 0 24px rgba(0,0,0,0.2)',
-    padding: 16,
-    position: 'relative',
-  } satisfies CSSProperties,
-  closeButton: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
-    width: 32,
-    height: 32,
-    borderRadius: 4,
-    border: BORDER_STRONG,
-    background: 'transparent',
-    color: 'inherit',
-    cursor: 'pointer',
-    fontSize: 16,
-    lineHeight: 1,
   } satisfies CSSProperties,
 };
 
@@ -323,7 +288,11 @@ export function TokenNavigator({
       </ul>
 
       {selectedPath !== null && (
-        <DetailOverlay path={selectedPath} onClose={() => setSelectedPath(null)} />
+        <DetailOverlay
+          path={selectedPath}
+          onClose={() => setSelectedPath(null)}
+          testId='token-navigator-overlay'
+        />
       )}
     </div>
   );
@@ -491,48 +460,5 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
     <span style={styles.previewBox}>
       <span style={styles.value}>{formatTokenValue(token.$value, type, colorFormat)}</span>
     </span>
-  );
-}
-
-interface DetailOverlayProps {
-  path: string;
-  onClose(): void;
-}
-
-function DetailOverlay({ path, onClose }: DetailOverlayProps): ReactElement {
-  useEffect(() => {
-    const onKey = (e: globalThis.KeyboardEvent): void => {
-      if (e.key === 'Escape') onClose();
-    };
-    window.addEventListener('keydown', onKey);
-    return () => window.removeEventListener('keydown', onKey);
-  }, [onClose]);
-
-  return (
-    <div
-      style={styles.backdrop}
-      onClick={onClose}
-      role='presentation'
-      data-testid='token-navigator-overlay'
-    >
-      <div
-        style={styles.panel}
-        onClick={(e) => e.stopPropagation()}
-        role='dialog'
-        aria-modal='true'
-        aria-label={`Token detail for ${path}`}
-      >
-        <button
-          type='button'
-          style={styles.closeButton}
-          onClick={onClose}
-          aria-label='Close'
-          data-testid='token-navigator-close'
-        >
-          ×
-        </button>
-        <TokenDetail path={path} />
-      </div>
-    </div>
   );
 }

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,17 +1,21 @@
-import type { ReactElement } from 'react';
-import { useMemo } from 'react';
+import type { CSSProperties, ReactElement } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import {
-  BORDER_DEFAULT,
   BORDER_FAINT,
   BORDER_STRONG,
   MONO_STACK,
+  SIZE_LABEL,
+  SIZE_META,
+  SIZE_PILL,
   SURFACE_MUTED,
+  TEXT_MUTED,
   emptyStyle,
   surfaceStyle,
 } from '#/internal/styles.tsx';
 import { chromeAliases, themeAttrs } from '#/internal/data-attr.ts';
+import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -24,8 +28,6 @@ export interface TokenTableProps {
   filter?: string;
   /** Restrict to one DTCG `$type`. */
   type?: string;
-  /** Show the CSS variable reference column. Defaults to `true`. */
-  showVar?: boolean;
   /** Override the table caption. */
   caption?: string;
   /**
@@ -40,6 +42,12 @@ export interface TokenTableProps {
   sortBy?: SortBy;
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
+  /**
+   * Called with the clicked row's dot-path. When set, the built-in
+   * `<TokenDetail>` slide-over is suppressed — the consumer owns the
+   * follow-up UI (inline panel, drill-down route, …).
+   */
+  onSelect?(path: string): void;
 }
 
 const styles = {
@@ -49,68 +57,90 @@ const styles = {
     captionSide: 'top',
     textAlign: 'left',
     padding: '8px 0',
-    opacity: 0.7,
-    fontSize: 12,
-  } satisfies React.CSSProperties,
+    color: TEXT_MUTED,
+    fontSize: SIZE_META,
+  } satisfies CSSProperties,
   table: {
+    // `tableLayout: auto` lets column widths follow content; the per-cell
+    // `minWidth` values below keep the important columns from collapsing
+    // on narrow containers.
     width: '100%',
     borderCollapse: 'collapse',
-    tableLayout: 'fixed',
-  } satisfies React.CSSProperties,
+  } satisfies CSSProperties,
   th: {
     textAlign: 'left',
     padding: '8px 12px',
-    fontSize: 11,
+    fontSize: SIZE_LABEL,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
-    opacity: 0.6,
+    color: TEXT_MUTED,
     borderBottom: BORDER_STRONG,
-  } satisfies React.CSSProperties,
+  } satisfies CSSProperties,
+  thPath: {
+    minWidth: 180,
+  } satisfies CSSProperties,
+  thValue: {
+    minWidth: 160,
+  } satisfies CSSProperties,
+  row: {
+    cursor: 'pointer',
+  } satisfies CSSProperties,
   td: {
     padding: '8px 12px',
     borderBottom: BORDER_FAINT,
     verticalAlign: 'top',
-  } satisfies React.CSSProperties,
+  } satisfies CSSProperties,
   path: {
     fontFamily: MONO_STACK,
-    fontSize: 12,
-  } satisfies React.CSSProperties,
+    fontSize: SIZE_META,
+  } satisfies CSSProperties,
+  valueCell: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    minWidth: 0,
+    fontFamily: MONO_STACK,
+    fontSize: SIZE_META,
+  } satisfies CSSProperties,
   typePill: {
     display: 'inline-block',
-    padding: '2px 6px',
+    padding: '1px 6px',
     borderRadius: 4,
-    fontSize: 10,
+    fontSize: SIZE_PILL,
     letterSpacing: 0.5,
     textTransform: 'uppercase',
     background: SURFACE_MUTED,
-  } satisfies React.CSSProperties,
-  value: {
+    color: TEXT_MUTED,
     fontFamily: MONO_STACK,
-    fontSize: 12,
-    opacity: 0.85,
-    wordBreak: 'break-all',
-  } satisfies React.CSSProperties,
+    flexShrink: 0,
+  } satisfies CSSProperties,
   swatch: {
     display: 'inline-block',
-    width: 14,
-    height: 14,
-    verticalAlign: 'middle',
-    marginRight: 6,
+    width: 16,
+    height: 16,
     borderRadius: 3,
-    border: BORDER_DEFAULT,
-  } satisfies React.CSSProperties,
+    border: BORDER_STRONG,
+    flexShrink: 0,
+  } satisfies CSSProperties,
+  valueText: {
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  } satisfies CSSProperties,
 };
 
 export function TokenTable({
   filter,
   type,
-  showVar = true,
   caption,
   sortBy = 'path',
   sortDir = 'asc',
+  onSelect,
 }: TokenTableProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
   const colorFormat = useColorFormat();
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
 
   const rows = useMemo(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -127,16 +157,25 @@ export function TokenTable({
         type: token.$type ?? '',
         value: formatTokenValue(token.$value, token.$type, colorFormat),
         outOfGamut: color?.outOfGamut ?? false,
-        description: token.$description ?? '',
         cssVar: makeCssVar(path, cssVarPrefix),
         isColor,
       };
     });
   }, [resolved, filter, type, cssVarPrefix, colorFormat, sortBy, sortDir]);
 
+  const handleRowClick = useCallback(
+    (path: string) => {
+      if (onSelect) onSelect(path);
+      else setSelectedPath(path);
+    },
+    [onSelect],
+  );
+
   const captionText =
     caption ??
-    `${rows.length} token${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''}${type ? ` · $type=${type}` : ''} · ${activeTheme}`;
+    `${rows.length} token${rows.length === 1 ? '' : 's'}${
+      filter ? ` matching \`${filter}\`` : ''
+    }${type ? ` · $type=${type}` : ''} · ${activeTheme}`;
 
   if (rows.length === 0) {
     return (
@@ -156,50 +195,62 @@ export function TokenTable({
     >
       <table style={styles.table}>
         <caption style={styles.caption}>{captionText}</caption>
-        <colgroup>
-          <col style={{ width: '30%' }} />
-          <col style={{ width: '8%' }} />
-          <col style={{ width: showVar ? '28%' : '40%' }} />
-          {showVar && <col style={{ width: '24%' }} />}
-          <col />
-        </colgroup>
         <thead>
           <tr>
-            <th style={styles.th}>Path</th>
-            <th style={styles.th}>Type</th>
-            <th style={styles.th}>Value</th>
-            {showVar && <th style={styles.th}>CSS var</th>}
-            <th style={styles.th}>Description</th>
+            <th style={{ ...styles.th, ...styles.thPath }}>Path</th>
+            <th style={{ ...styles.th, ...styles.thValue }}>Value</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
-            <tr key={row.path}>
+            <tr
+              key={row.path}
+              style={styles.row}
+              onClick={() => handleRowClick(row.path)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleRowClick(row.path);
+                }
+              }}
+              tabIndex={0}
+              aria-label={`Inspect ${row.path}`}
+              data-testid='token-table-row'
+              data-path={row.path}
+            >
               <td style={{ ...styles.td, ...styles.path }}>{row.path}</td>
               <td style={styles.td}>
-                {row.type && <span style={styles.typePill}>{row.type}</span>}
-              </td>
-              <td style={{ ...styles.td, ...styles.value }}>
-                {row.isColor && (
-                  <span style={{ ...styles.swatch, background: row.cssVar }} aria-hidden />
-                )}
-                <span>{row.value}</span>
-                {row.outOfGamut && (
-                  <span
-                    title='Out of sRGB gamut for this format'
-                    aria-label='out of gamut'
-                    style={{ marginLeft: 6 }}
-                  >
-                    ⚠
+                <span style={styles.valueCell}>
+                  {row.type && <span style={styles.typePill}>{row.type}</span>}
+                  {row.isColor && (
+                    <span style={{ ...styles.swatch, background: row.cssVar }} aria-hidden />
+                  )}
+                  <span style={styles.valueText} title={row.value} data-testid='token-table-value'>
+                    {row.value}
                   </span>
-                )}
+                  {row.outOfGamut && (
+                    <span
+                      title='Out of sRGB gamut for this format'
+                      aria-label='out of gamut'
+                      style={{ flexShrink: 0 }}
+                    >
+                      ⚠
+                    </span>
+                  )}
+                </span>
               </td>
-              {showVar && <td style={{ ...styles.td, ...styles.value }}>{row.cssVar}</td>}
-              <td style={styles.td}>{row.description}</td>
             </tr>
           ))}
         </tbody>
       </table>
+
+      {selectedPath !== null && (
+        <DetailOverlay
+          path={selectedPath}
+          onClose={() => setSelectedPath(null)}
+          testId='token-table-overlay'
+        />
+      )}
     </div>
   );
 }

--- a/packages/blocks/src/internal/DetailOverlay.tsx
+++ b/packages/blocks/src/internal/DetailOverlay.tsx
@@ -1,0 +1,92 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { useEffect } from 'react';
+import { BORDER_STRONG, SURFACE_DEFAULT, TEXT_DEFAULT } from '#/internal/styles.tsx';
+import { TokenDetail } from '#/TokenDetail.tsx';
+
+/**
+ * Slide-over that wraps `<TokenDetail>`. Shared between `<TokenNavigator />`
+ * and `<TokenTable />` so both land on the same opener and the same styling.
+ *
+ * Dismisses on backdrop click, Escape, and the close button. `role="dialog"`
+ * + `aria-modal="true"` hints to AT that focus is trapped here; actual focus
+ * management is tracked in the open-issue #253.
+ */
+
+const styles = {
+  backdrop: {
+    position: 'fixed',
+    inset: 0,
+    background: 'rgba(0,0,0,0.4)',
+    zIndex: 10000,
+    display: 'flex',
+    alignItems: 'stretch',
+    justifyContent: 'flex-end',
+  } satisfies CSSProperties,
+  panel: {
+    width: 'min(560px, 100%)',
+    height: '100%',
+    overflowY: 'auto',
+    background: SURFACE_DEFAULT,
+    color: TEXT_DEFAULT,
+    boxShadow: '-8px 0 24px rgba(0,0,0,0.2)',
+    padding: 16,
+    position: 'relative',
+  } satisfies CSSProperties,
+  closeButton: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    width: 32,
+    height: 32,
+    borderRadius: 4,
+    border: BORDER_STRONG,
+    background: 'transparent',
+    color: 'inherit',
+    cursor: 'pointer',
+    fontSize: 16,
+    lineHeight: 1,
+  } satisfies CSSProperties,
+} as const;
+
+export interface DetailOverlayProps {
+  path: string;
+  onClose(): void;
+  testId?: string;
+}
+
+export function DetailOverlay({
+  path,
+  onClose,
+  testId = 'swatchbook-overlay',
+}: DetailOverlayProps): ReactElement {
+  useEffect(() => {
+    const onKey = (e: globalThis.KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div style={styles.backdrop} onClick={onClose} role='presentation' data-testid={testId}>
+      <div
+        style={styles.panel}
+        onClick={(e) => e.stopPropagation()}
+        role='dialog'
+        aria-modal='true'
+        aria-label={`Token detail for ${path}`}
+      >
+        <button
+          type='button'
+          style={styles.closeButton}
+          onClick={onClose}
+          aria-label='Close'
+          data-testid={`${testId}-close`}
+        >
+          ×
+        </button>
+        <TokenDetail path={path} />
+      </div>
+    </div>
+  );
+}

--- a/packages/blocks/test/token-table.test.tsx
+++ b/packages/blocks/test/token-table.test.tsx
@@ -66,8 +66,37 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     expect(within(table).getByText('color.sys.text')).toBeDefined();
     expect(within(table).getByText('color.sys.surface')).toBeDefined();
     expect(within(table).getByText('space.sys.md')).toBeDefined();
+  });
 
-    expect(within(table).getByText('var(--sb-color-sys-text)')).toBeDefined();
+  it('clicking a row opens the TokenDetail overlay by default', async () => {
+    const snapshot = makeSnapshot();
+    const { findByTestId } = render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable />
+      </SwatchbookProvider>,
+    );
+
+    const rows = screen.getAllByTestId('token-table-row');
+    const target = rows.find((r) => r.getAttribute('data-path') === 'color.sys.text');
+    if (!target) throw new Error('row not found');
+    target.click();
+
+    const overlay = await findByTestId('token-table-overlay');
+    expect(overlay).toBeDefined();
+  });
+
+  it('onSelect suppresses the overlay and hands the path to the consumer', () => {
+    const snapshot = makeSnapshot();
+    const picks: string[] = [];
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable onSelect={(p) => picks.push(p)} />
+      </SwatchbookProvider>,
+    );
+    const rows = screen.getAllByTestId('token-table-row');
+    rows[0]?.click();
+    expect(picks.length).toBe(1);
+    expect(screen.queryByTestId('token-table-overlay')).toBeNull();
   });
 
   it('honors the filter prop to narrow to a path subtree', () => {


### PR DESCRIPTION
## Summary

TokenTable's old 5-column Path | Type | Value | CSS var | Description layout was too dense for any constrained container (Storybook docs pages, dashboards, narrow sidebars). Redesign:

- **Two columns**: `Path | Value`.
- **Value cell inlines** the type pill + color swatch (when applicable) + formatted value text + out-of-gamut marker. Single-line ellipsis on overflow.
- **Click any row** → opens `<TokenDetail>` slide-over. Same drawer TokenNavigator already ships, so consumers get the same affordance in both blocks.
- **`onSelect?(path)` prop** suppresses the built-in drawer for consumers who want to own the follow-up (inline panel, route, etc.).
- **`showVar` prop removed** — CSS var is one click away in the drawer.
- **Table layout: `auto`** (no `tableLayout: fixed` + percentage colgroup). Per-column `min-width` floors (Path 180, Value 160) so columns follow content and stop collapsing on narrow containers — matches the ask to "let the table deal with widths, set min-widths instead."

## Shared drawer

Extracted `DetailOverlay` from `TokenNavigator` → `internal/DetailOverlay.tsx`. Both blocks use it through `<DetailOverlay path={p} onClose={...} testId="..." />`. Close-button testid format is now `${testId}-close` (was the hardcoded `token-navigator-close`); the one story asserting against the old name got updated.

## Test plan

- [x] `pnpm -F @unpunnyfuns/swatchbook-blocks exec vitest run` — all pass; token-table adds 2 new tests (row click opens overlay, `onSelect` suppresses it).
- [x] `pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook` — 126/126 Chromium interaction tests pass. Updated ColorFormat story to read `[data-testid="token-table-value"]` directly instead of indexing `td[2]` (which no longer exists).
- [x] `pnpm turbo run lint typecheck` across blocks + addon + storybook — clean.

## Breaking change

Minor bump. `showVar` prop removed; any consumer setting it will see a TypeScript error on props, no runtime break. Everyone else renders the new compact shape automatically.

Milestone: Maintenance
Closes: #358
Plan impact: none — block redesign.
