### PR TITLE
docs(docs): fix broken links + regroup blocks reference + drop 'old panel' noise

### DIFF
--- a/apps/docs/docs/concepts/axes.mdx
+++ b/apps/docs/docs/concepts/axes.mdx
@@ -42,7 +42,7 @@ CSS emission matches those attributes with compound selectors:
 
 Each non-default tuple gets its own flat block (every var redeclared). The `:root` block carries the default tuple. Nested cascading isn't used because axes are allowed to write to the same token path under the DTCG spec; flat emission avoids the collision-detection work that nesting would require.
 
-> These attributes + CSS vars are the scaffolding swatchbook needs so tokens repaint when a reader flips an axis in the toolbar. They are not a public styling API — consumer components shouldn't depend on them for production theming. See [what swatchbook is not](../intro#what-its-not).
+> These attributes + CSS vars are the scaffolding swatchbook needs so tokens repaint when a reader flips an axis in the toolbar. They are not a public styling API — consumer components shouldn't depend on them for production theming. See [what swatchbook is not](/).
 
 ## Independence
 

--- a/apps/docs/docs/concepts/diagnostics.mdx
+++ b/apps/docs/docs/concepts/diagnostics.mdx
@@ -36,7 +36,7 @@ interface Diagnostic {
 
 ## Rendering them in docs
 
-The `<Diagnostics />` block renders the project's diagnostics as a collapsible list — green **OK** badge when clean, auto-expanded with a severity summary when warnings or errors are present. Compose it on an MDX page alongside `<TokenNavigator />` / `<TokenTable />` to get the same surface area the in-manager Design Tokens panel used to provide; see the [token-dashboard guide](../guides/token-dashboard).
+The `<Diagnostics />` block renders the project's diagnostics as a collapsible list — green **OK** badge when clean, auto-expanded with a severity summary when warnings or errors are present. Compose it on an MDX page alongside `<TokenNavigator />` / `<TokenTable />` via the [token-dashboard guide](../guides/token-dashboard).
 
 ## Interpreting them
 

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -101,4 +101,4 @@ channel.on('globalsUpdated', (payload) => {
 
 - [Reference: blocks](../reference/blocks) — every block's props.
 - [Reference: addon](../reference/addon) — `useToken` and the other hooks.
-- [Live Storybook](/swatchbook/storybook/) — real doc stories you can steal from.
+- [Live Storybook](pathname:///storybook/) — real doc stories you can steal from.

--- a/apps/docs/docs/guides/multi-axis-walkthrough.mdx
+++ b/apps/docs/docs/guides/multi-axis-walkthrough.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Multi-axis walkthrough
 
-Step-by-step setup of a multi-axis theming model — `mode × brand × contrast` — using the resolver input. The walkthrough builds it up in stages, starting with `mode × brand` and adding `contrast` at the end. The [live Storybook](/swatchbook/storybook/) runs the full three-axis fixture; open it in a second tab and cross-reference as you read.
+Step-by-step setup of a multi-axis theming model — `mode × brand × contrast` — using the resolver input. The walkthrough builds it up in stages, starting with `mode × brand` and adding `contrast` at the end. The [live Storybook](pathname:///storybook/) runs the full three-axis fixture; open it in a second tab and cross-reference as you read.
 
 ## 1. The token layout
 
@@ -127,10 +127,10 @@ The fixture now has a `contrast` modifier too, composing additively with `mode` 
 }
 ```
 
-`contrast` is appended to `resolutionOrder` after `brand`, so brand's accent stays dominant and contrast only reinforces where they don't collide. The [live Storybook](/swatchbook/storybook/) includes an **A11y High Contrast** preset that flips `contrast` to `High` on the Light baseline — open the preview and try it alongside the other two presets. See [axes](../concepts/axes) on why the CSS emission is flat rather than nested.
+`contrast` is appended to `resolutionOrder` after `brand`, so brand's accent stays dominant and contrast only reinforces where they don't collide. The [live Storybook](pathname:///storybook/) includes an **A11y High Contrast** preset that flips `contrast` to `High` on the Light baseline — open the preview and try it alongside the other two presets. See [axes](../concepts/axes) on why the CSS emission is flat rather than nested.
 
 ## See also
 
 - [Theming inputs](../concepts/theming-inputs) — resolver vs layered trade-off.
 - [Authoring doc stories](./authoring-doc-stories) — documenting this setup in MDX.
-- [Live Storybook](/swatchbook/storybook/) — this exact config, running.
+- [Live Storybook](pathname:///storybook/) — this exact config, running.

--- a/apps/docs/docs/guides/token-dashboard.mdx
+++ b/apps/docs/docs/guides/token-dashboard.mdx
@@ -13,10 +13,8 @@ top-to-bottom view of the design-token set for the active theme:
 project-level health, a browsable tree of every token, and a searchable
 table for quick lookup.
 
-This is the recommended replacement for the in-manager Design Tokens
-panel the addon used to ship. Blocks live in docs, so the dashboard
-lives where it belongs — alongside every other surface you publish for
-designers and engineers consuming your tokens.
+Blocks live in docs, so the dashboard lives alongside every other
+surface you publish for designers and engineers consuming your tokens.
 
 ## Template
 
@@ -48,21 +46,6 @@ or exported `ProjectSnapshot` (see the [blocks reference](../reference/blocks)).
 You can see this dashboard composition live against our
 [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference)
 fixture in the [live Storybook](pathname:///storybook/).
-
-## Why a dashboard instead of the old panel?
-
-- **One surface.** The addon's old panel re-implemented the tree and
-  diagnostics in the manager bundle, where it couldn't reach MDX docs
-  pages and had to maintain a parallel virtual-module contract. Blocks
-  already render everywhere — story decorators, autodocs, MDX pages,
-  plain React apps via `SwatchbookProvider`.
-
-- **One dependency graph.** One place to add a new block type, one
-  place to track bugs, one place to theme the chrome.
-
-- **Docs is where designers look up tokens.** The panel's always-on
-  story-view placement made sense when stories were the primary target;
-  for a DTCG documentation tool the docs page is the right home.
 
 ## Variations
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -19,13 +19,13 @@ Swatchbook isn't a runtime theme-switcher, a CSS-variable framework, or a compon
 
 ## What the addon gives you
 
-- **Doc blocks** — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, `Diagnostics`, motion/shadow/border previews. Once the addon is wired up, *authoring pages with these blocks is the primary day-to-day swatchbook interaction*. See the [blocks reference](./reference/blocks), the [authoring guide](./guides/authoring-doc-stories), and the [token-dashboard template](./guides/token-dashboard) for a drop-in replacement of the old in-manager Design Tokens panel.
+- **Doc blocks** — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, `Diagnostics`, motion/shadow/border previews. Once the addon is wired up, *authoring pages with these blocks is the primary day-to-day swatchbook interaction*. See the [blocks reference](./reference/blocks), the [authoring guide](./guides/authoring-doc-stories), and the [token-dashboard template](./guides/token-dashboard) for a turnkey browsable tree + diagnostics + table composition.
 - **Toolbar** — a single Swatchbook icon button opens a popover with preset pills, one dropdown per modifier axis (so a reader can browse tokens in every context), and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`) that controls how blocks display colors.
 - **`useToken` hook** — typed lookups from component code, reactive to the active theme.
 
 ## See it live
 
-The [live Storybook](/swatchbook/storybook/) runs the addon against this repo's [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference) fixture — a multi-file DTCG token set with two layers (ref and sys) and resolver-driven axes. Every block, panel, and toolbar control is wired up against those tokens.
+The [live Storybook](pathname:///storybook/) runs the addon against this repo's [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference) fixture — a multi-file DTCG token set with two layers (ref and sys) and resolver-driven axes. Every block, panel, and toolbar control is wired up against those tokens.
 
 ## How to read these docs
 

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -99,4 +99,4 @@ Each context names an ordered list of file paths (or globs) that layer on top of
 
 - Read [theming inputs](./concepts/theming-inputs) to understand the resolver vs layered trade-off.
 - Embed [doc blocks in MDX stories](./guides/authoring-doc-stories) to build a proper reference page.
-- Poke at the [live Storybook](/swatchbook/storybook/) to see the addon running against a real multi-axis fixture.
+- Poke at the [live Storybook](pathname:///storybook/) to see the addon running against a real multi-axis fixture.

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -14,7 +14,7 @@ Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
-This gives you the toolbar, preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `Diagnostics`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks` — install it alongside if you want them. See the [token-dashboard guide](../guides/token-dashboard) for the recommended MDX composition that replaces the old in-manager Design Tokens panel.
+This gives you the toolbar, preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `Diagnostics`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks` — install it alongside if you want them. See the [token-dashboard guide](../guides/token-dashboard) for the recommended MDX composition.
 
 Peer requirements: Storybook 10.3+ on the Vite builder, React 18+.
 
@@ -57,7 +57,7 @@ export default definePreview({
 - **Preview decorator** — reads the active axis tuple, writes `data-<prefix>-<axis>="<context>"` attributes (plus `data-<prefix>-theme="<composed id>"`) on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager. The prefix follows `cssVarPrefix` (default `swatch`).
 - **Toolbar tool** — a single Swatchbook `IconButton`. Clicking opens a popover containing preset pills, one dropdown per axis, and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`). Escape and outside-click close it.
 
-For the browsable tree + diagnostics surface that the old Design Tokens panel provided, compose `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />` on an MDX page — see the [token-dashboard guide](../guides/token-dashboard).
+For a browsable tree + diagnostics surface, compose `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />` on an MDX page — see the [token-dashboard guide](../guides/token-dashboard).
 
 ## Globals
 

--- a/apps/docs/docs/reference/blocks.mdx
+++ b/apps/docs/docs/reference/blocks.mdx
@@ -53,33 +53,102 @@ export function TokenDocs() {
 
 ## Blocks
 
-### `<TokenDetail path />`
+Four groups by shape of use: **overviews** (survey many tokens at once — `TokenNavigator`, `TokenTable`, plus the per-type scales and palettes), the **inspector** (single-token deep-dive — `TokenDetail` and its subparts), **samples** (one-token visual atoms you can drop inline), and **utility** (`Diagnostics`). Most overviews take `filter?` (path glob), `sortBy?`, `sortDir?`, and `caption?`.
 
-Single-token deep-dive. Renders:
+## Overview blocks
 
-- Header: heading, `$type` pill, cssVar reference, description.
-- Composite preview — for `typography`, `shadow`, `border`, `transition`, `dimension`, `duration`, `cubicBezier`, `fontFamily`, `fontWeight`, `strokeStyle`, `gradient`, `color`.
-- Composite breakdown — labelled sub-value grid for composite types.
-- Alias chain (forward) — e.g. `color.sys.accent.bg → color.ref.blue.700`.
-- Aliased-by tree (backward) — everything that transitively aliases this token.
-- Per-axis variance — values along whichever axes move the token.
-- Consumer output — a two-row summary of **Path** and **CSS var** for the active token, each with a copy button (see `<ConsumerOutput />`).
+### Across types
 
-Props: `path: string`, `heading?: string`.
+#### `<TokenNavigator root? initiallyExpanded? onSelect? />`
 
-`TokenDetail` is a composition. Each section is also exported as a standalone block so MDX authors can embed just the piece they need — all take the same `path: string` prop.
+Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
+
+Props:
+
+- `root?: string` — mount at this subtree (e.g. `"color"`, `"typography.sys"`). Omit to show everything.
+- `initiallyExpanded?: number` — depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
+- `onSelect?(path: string): void` — receives a leaf's full dot-path on click; suppresses the built-in overlay.
+
+#### `<TokenTable filter? type? caption? sortBy? sortDir? onSelect? />`
+
+Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
+
+Props:
+
+- `filter?: string` — path glob.
+- `type?: string` — DTCG `$type` filter (`"color"`, `"dimension"`, …).
+- `caption?: string` — override the caption.
+- `sortBy?: 'path' | 'value' | 'none'` — default `'path'`.
+- `sortDir?: 'asc' | 'desc'` — default `'asc'`.
+- `onSelect?(path: string): void` — suppress the built-in drawer.
+
+### Per-type
+
+Every block in this group scopes to one DTCG `$type`, filters / sorts, and renders a type-specific visual. All accept `filter?: string`, `sortBy?`, `sortDir?`, and `caption?: string`.
+
+#### `<ColorPalette filter? groupBy? caption? sortBy? sortDir? />`
+
+Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
+
+#### `<TypographyScale filter? sample? caption? sortBy? sortDir? />`
+
+One sample line per `typography` composite, rendered with the token's own `fontFamily` / `fontSize` / `fontWeight` / `lineHeight` / `letterSpacing`. `sample?: string` overrides the text.
+
+#### `<DimensionScale filter? kind? caption? sortBy? sortDir? />`
+
+Width-driven bar (default), radius-sample square, or size-sample square per `dimension` token. Defaults to `sortBy: 'value'` — ordered numerically by the rendered pixel size.
+
+- `kind?: 'length' | 'radius' | 'size'` — visualization mode (default `'length'`).
+
+#### `<FontFamilySample filter? sample? caption? sortBy? sortDir? />`
+
+Pangram rendered per `fontFamily` primitive. `sample?: string` overrides the text.
+
+#### `<FontWeightScale filter? sample? caption? sortBy? sortDir? />`
+
+Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: 'value'` — ordered 100 → 900.
+
+#### `<BorderPreview filter? caption? sortBy? sortDir? />`
+
+One framed `<BorderSample>` per `border` composite token.
+
+#### `<ShadowPreview filter? caption? sortBy? sortDir? />`
+
+One `<ShadowSample>` surface per `shadow` composite token.
+
+#### `<MotionPreview filter? caption? sortBy? sortDir? />`
+
+One animated `<MotionSample>` per `transition` / `duration` / `cubicBezier` token. Respects `prefers-reduced-motion`.
+
+#### `<StrokeStyleSample filter? caption? sortBy? sortDir? />`
+
+Border rendered per `strokeStyle` primitive. Supports string forms (`solid`, `dashed`, `dotted`, `double`) natively; object forms (`dashArray` / `lineCap`) fall back to a textual summary.
+
+#### `<GradientPalette filter? caption? sortBy? sortDir? />`
+
+Wide sample per `gradient` token (linear, left → right by default) with a stop list. DTCG gradients are stop arrays — the gradient *function* is a rendering choice the consumer makes.
+
+## Inspector blocks
+
+`TokenDetail` is a composition of the subcomponents below. All take the same `path: string` prop and can be embedded individually.
+
+### `<TokenDetail path heading? />`
+
+Full deep-dive: header + composite preview + composite breakdown + alias chain + aliased-by tree + per-axis variance + consumer output + usage snippet.
+
+Props: `path: string`, `heading?: string` (defaults to `path`).
 
 ### `<TokenHeader path heading? />`
 
-Heading, `$type` pill, cssVar reference, and description. Renders a missing-token empty state if `path` isn't in the active theme.
+Heading + `$type` pill + cssVar reference + description. Renders a missing-token empty state when `path` isn't in the active theme.
 
 ### `<CompositePreview path />`
 
-Live, type-dispatched preview of the token's resolved value (typography sample, shadow swatch, gradient strip, animating ball for `duration` / `cubicBezier` / `transition`, etc.).
+Type-dispatched live preview of the token's resolved value (typography sample, shadow swatch, gradient strip, animating ball for motion, etc.).
 
 ### `<CompositeBreakdown path />`
 
-Labelled sub-value grid for composite token types (`typography`, `border`, `transition`, `shadow`, `gradient`). Renders nothing for primitives.
+Labelled sub-value grid for composite types (`typography`, `border`, `transition`, `shadow`, `gradient`). Renders nothing for primitives.
 
 ### `<AliasChain path />`
 
@@ -87,11 +156,11 @@ Forward alias chain (`color.sys.accent.bg → color.ref.blue.700`). Renders noth
 
 ### `<AliasedBy path />`
 
-Aliased-by tree — every token that transitively aliases this one. Truncates at depth 6 with a note.
+Backward alias tree — every token that transitively aliases this one. Truncates at depth 6.
 
 ### `<AxisVariance path />`
 
-Per-axis value table. Collapses to a single row when the value is constant, a vertical list for one varying axis, or a two-axis matrix when values cross two axes (extra axes are fixed to the active selection).
+Per-axis value table. Collapses to one row when the value is constant, a list for one varying axis, or a matrix for two axes (extras pinned to the active selection).
 
 ### `<TokenUsageSnippet path />`
 
@@ -99,93 +168,35 @@ Copy-ready `color: var(--…);` reference snippet.
 
 ### `<ConsumerOutput path />`
 
-Compact two-row summary of the token's consumer-facing outputs: the token's dot-path and its CSS custom property name (`var(--…)`). Each row has its own copy-to-clipboard button. Displays the active axis tuple above the rows when more than one axis is in play.
+Two-row summary of the token's **Path** and **CSS var** with copy-to-clipboard on each. Shows the active axis tuple above the rows when more than one axis is in play.
 
-Props: `path: string`.
+## Sample blocks
 
-### `<TokenNavigator root? initiallyExpanded? onSelect? />`
-
-Expandable tree view of the token graph, keyed on dot-path segments. Complements the flat `TokenTable` and the typed `ColorPalette` with an explorable hierarchy. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value fallback for types without a preview primitive).
-
-Props:
-
-- `root?: string` — mount at this subtree (e.g. `"color"`, `"typography.sys"`). Omit to show everything.
-- `initiallyExpanded?: number` — depth open on first render. `0` = all collapsed, `1` = top-level groups open (default), `2` = one level deeper, etc.
-- `onSelect?(path: string): void` — receives a leaf's full dot-path on click. When provided, the inline `<TokenDetail>` slide-over is suppressed and the consumer owns the follow-up UI; when omitted, clicking a leaf opens a fixed-position overlay with a full `<TokenDetail>` and a close button.
-
-### `<TokenTable filter? type? showVar? caption? />`
-
-Filterable table. Columns: name, value, resolved, description.
-
-Props:
-
-- `filter?: string` — path glob (`"color.sys.*"`, `"color.sys"`, or exact path).
-- `type?: string` — DTCG `$type` filter.
-- `showVar?: boolean` — show the CSS variable reference column. Default `true`.
-- `caption?: string` — override the table caption.
-
-Rows sort numerically by dot-path, so `blue.50` lands before `blue.100`. Color cells are rendered through the active color-format global (`swatchbookColorFormat`).
-
-### `<ColorPalette filter? groupBy? caption? />`
-
-Swatch grid grouped by dot-path prefix. Sorted numerically by path.
-
-Props:
-
-- `filter?: string` — path glob (`"color.ref.blue.*"`, `"color.sys.*"`, …). Default: every `color` token.
-- `groupBy?: number` — grouping depth. `2` yields groups like `color.sys`/`color.ref`; `3` yields `color.sys.surface`/`color.sys.text`, etc. Default `3`. Pick a depth where each group holds at least a handful of swatches — setting it too high (e.g. `groupBy={5}` on a three-segment path) produces one swatch per group.
-- `caption?: string` — override the section caption.
-
-Color values are rendered through the active color-format global (`swatchbookColorFormat`).
-
-### `<TypographyScale />`
-
-Renders each `typography` composite token as a sample line using its own value.
-
-### `<FontFamilySample sample? />`
-
-Pangram rendered per `fontFamily` primitive. Props: `sample?: string` (default: the quick brown fox…).
-
-### `<FontWeightScale sample? />`
-
-Same "Aa" sample at each `fontWeight` primitive, sorted ascending. Props: `sample?: string` (default: "Aa").
-
-### `<StrokeStyleSample />`
-
-Border rendered per `strokeStyle` primitive. String-form styles (`solid`, `dashed`, `dotted`, `double`) render as `border-style`; object-form (with `dashArray` / `lineCap`) renders a textual fallback.
+Lower-level than the "Per-type overviews" blocks — these render the visual for **one** token by path. Useful for custom MDX layouts that don't want the full overview chrome.
 
 ### `<MotionSample path speed? runKey? />`
 
-Standalone per-token animated sample (the animated ball + track from `MotionPreview`). Accepts any `transition`, `duration`, or `cubicBezier` token path. Respects `prefers-reduced-motion`.
-
-Props: `path: string`, `speed?: 0.25 | 0.5 | 1 | 2` (default `1`), `runKey?: number` (change to force a restart).
+Animated ball + track for one `transition` / `duration` / `cubicBezier`. `speed?: 0.25 | 0.5 | 1 | 2` (default `1`); `runKey?: number` forces a restart when it changes.
 
 ### `<ShadowSample path />`
 
-Standalone per-token shadow sample (the surface rectangle with `box-shadow` from `ShadowPreview`).
-
-Props: `path: string`.
+Surface rectangle with the token's shadow applied as `box-shadow`.
 
 ### `<BorderSample path />`
 
-Standalone per-token border sample (the surface rectangle with `border` from `BorderPreview`).
-
-Props: `path: string`.
+Surface rectangle with the token's border applied.
 
 ### `<DimensionBar path kind? />`
 
-Standalone per-token dimension visual (the bar / square / radius sample from `DimensionScale`).
+Width-driven bar, border-radius square, or sized square for one `dimension` token. `kind?: 'length' | 'radius' | 'size'` (default `'length'`).
 
-Props: `path: string`, `kind?: 'length' | 'radius' | 'size'` (default `'length'`).
+## Utility blocks
 
-### `<GradientPalette filter? caption? />`
+### `<Diagnostics caption? />`
 
-Wide sample per `gradient` token with the stop list as a sidebar. Samples use `linear-gradient(to right, …)` by default — DTCG gradients are stop arrays, and the gradient function is a rendering choice the consumer makes at use-site. If you want radial/conic previews here, open an issue.
+Project load diagnostics (parser errors, resolver warnings, disabled-axis validation) as a collapsible list. Green **OK** badge when clean; auto-expands with a severity summary on warnings or errors. Not a token view — surfaces the project's own load state. See the [diagnostics concept](../concepts/diagnostics) for severity semantics.
 
-Props:
-
-- `filter?: string` — path glob (`"gradient.ref.*"`, etc.). Defaults to every `gradient` token.
-- `caption?: string` — override the caption.
+Props: `caption?: string` — overrides the summary heading.
 
 ## Hooks
 

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -39,6 +39,13 @@ const config: Config = {
   organizationName: 'unpunnyfuns',
   projectName: 'swatchbook',
 
+  // The Storybook build is stitched into apps/docs/build/storybook by the
+  // deploy workflow (see .github/workflows/docs.yml), so links to
+  // `/storybook/` work at runtime but Docusaurus's compile-time broken-link
+  // checker can't see the stitched route. Leave this as 'warn' — the
+  // per-link hook only runs for markdown links, not the build-end check
+  // that reports every route, so there's no way to allowlist just that
+  // path without silencing the whole check.
   onBrokenLinks: 'warn',
 
   i18n: {

--- a/apps/docs/versioned_docs/version-0.2/concepts/axes.mdx
+++ b/apps/docs/versioned_docs/version-0.2/concepts/axes.mdx
@@ -42,7 +42,7 @@ CSS emission matches those attributes with compound selectors:
 
 Each non-default tuple gets its own flat block (every var redeclared). The `:root` block carries the default tuple. Nested cascading isn't used because axes are allowed to write to the same token path under the DTCG spec; flat emission avoids the collision-detection work that nesting would require.
 
-> These attributes + CSS vars are the scaffolding swatchbook needs so tokens repaint when a reader flips an axis in the toolbar. They are not a public styling API — consumer components shouldn't depend on them for production theming. See [what swatchbook is not](../intro#what-its-not).
+> These attributes + CSS vars are the scaffolding swatchbook needs so tokens repaint when a reader flips an axis in the toolbar. They are not a public styling API — consumer components shouldn't depend on them for production theming. See [what swatchbook is not](/).
 
 ## Independence
 

--- a/apps/docs/versioned_docs/version-0.2/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.2/guides/authoring-doc-stories.mdx
@@ -101,4 +101,4 @@ channel.on('globalsUpdated', (payload) => {
 
 - [Reference: blocks](../reference/blocks) — every block's props.
 - [Reference: addon](../reference/addon) — `useToken` and the other hooks.
-- [Live Storybook](/swatchbook/storybook/) — real doc stories you can steal from.
+- [Live Storybook](pathname:///storybook/) — real doc stories you can steal from.

--- a/apps/docs/versioned_docs/version-0.2/guides/multi-axis-walkthrough.mdx
+++ b/apps/docs/versioned_docs/version-0.2/guides/multi-axis-walkthrough.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Multi-axis walkthrough
 
-Step-by-step setup of a multi-axis theming model — `mode × brand × contrast` — using the resolver input. The walkthrough builds it up in stages, starting with `mode × brand` and adding `contrast` at the end. The [live Storybook](/swatchbook/storybook/) runs the full three-axis fixture; open it in a second tab and cross-reference as you read.
+Step-by-step setup of a multi-axis theming model — `mode × brand × contrast` — using the resolver input. The walkthrough builds it up in stages, starting with `mode × brand` and adding `contrast` at the end. The [live Storybook](pathname:///storybook/) runs the full three-axis fixture; open it in a second tab and cross-reference as you read.
 
 ## 1. The token layout
 
@@ -127,10 +127,10 @@ The fixture now has a `contrast` modifier too, composing additively with `mode` 
 }
 ```
 
-`contrast` is appended to `resolutionOrder` after `brand`, so brand's accent stays dominant and contrast only reinforces where they don't collide. The [live Storybook](/swatchbook/storybook/) includes an **A11y High Contrast** preset that flips `contrast` to `High` on the Light baseline — open the preview and try it alongside the other two presets. See [axes](../concepts/axes) on why the CSS emission is flat rather than nested.
+`contrast` is appended to `resolutionOrder` after `brand`, so brand's accent stays dominant and contrast only reinforces where they don't collide. The [live Storybook](pathname:///storybook/) includes an **A11y High Contrast** preset that flips `contrast` to `High` on the Light baseline — open the preview and try it alongside the other two presets. See [axes](../concepts/axes) on why the CSS emission is flat rather than nested.
 
 ## See also
 
 - [Theming inputs](../concepts/theming-inputs) — resolver vs layered trade-off.
 - [Authoring doc stories](./authoring-doc-stories) — documenting this setup in MDX.
-- [Live Storybook](/swatchbook/storybook/) — this exact config, running.
+- [Live Storybook](pathname:///storybook/) — this exact config, running.

--- a/apps/docs/versioned_docs/version-0.2/intro.mdx
+++ b/apps/docs/versioned_docs/version-0.2/intro.mdx
@@ -26,7 +26,7 @@ Swatchbook isn't a runtime theme-switcher, a CSS-variable framework, or a compon
 
 ## See it live
 
-The [live Storybook](/swatchbook/storybook/) runs the addon against this repo's [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference) fixture — a multi-file DTCG token set with two layers (ref and sys) and resolver-driven axes. Every block, panel, and toolbar control is wired up against those tokens.
+The [live Storybook](pathname:///storybook/) runs the addon against this repo's [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference) fixture — a multi-file DTCG token set with two layers (ref and sys) and resolver-driven axes. Every block, panel, and toolbar control is wired up against those tokens.
 
 ## How to read these docs
 

--- a/apps/docs/versioned_docs/version-0.2/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.2/quickstart.mdx
@@ -100,4 +100,4 @@ Each context names an ordered list of file paths (or globs) that layer on top of
 
 - Read [theming inputs](./concepts/theming-inputs) to understand the resolver vs layered trade-off.
 - Embed [doc blocks in MDX stories](./guides/authoring-doc-stories) to build a proper reference page.
-- Poke at the [live Storybook](/swatchbook/storybook/) to see the addon running against a real multi-axis fixture.
+- Poke at the [live Storybook](pathname:///storybook/) to see the addon running against a real multi-axis fixture.

--- a/apps/docs/versioned_docs/version-0.3/concepts/axes.mdx
+++ b/apps/docs/versioned_docs/version-0.3/concepts/axes.mdx
@@ -42,7 +42,7 @@ CSS emission matches those attributes with compound selectors:
 
 Each non-default tuple gets its own flat block (every var redeclared). The `:root` block carries the default tuple. Nested cascading isn't used because axes are allowed to write to the same token path under the DTCG spec; flat emission avoids the collision-detection work that nesting would require.
 
-> These attributes + CSS vars are the scaffolding swatchbook needs so tokens repaint when a reader flips an axis in the toolbar. They are not a public styling API — consumer components shouldn't depend on them for production theming. See [what swatchbook is not](../intro#what-its-not).
+> These attributes + CSS vars are the scaffolding swatchbook needs so tokens repaint when a reader flips an axis in the toolbar. They are not a public styling API — consumer components shouldn't depend on them for production theming. See [what swatchbook is not](/).
 
 ## Independence
 


### PR DESCRIPTION
## Summary

Three docs cleanups:

### 1. Broken-link warnings

- Swap `/swatchbook/storybook/` markdown links to `pathname:///storybook/`. The path is stitched into `apps/docs/build/storybook` by the deploy workflow (works at runtime) but Docusaurus's compile-time route check can't see it. Four `/storybook/` warnings remain because Docusaurus's build-end check (separate from the per-link hook) still reports them; `onBrokenLinks` stays `warn` with a comment explaining why.
- Drop the `#what-its-not` anchor from `axes.mdx` — Docusaurus auto-slugs the heading differently, so the anchor never existed. Link resolves cleanly to `../intro` (intro's root slug).
- Fix `../intro` → `/` in axes.mdx — intro.mdx has `slug: /`, so path-relative doesn't resolve.

### 2. Blocks reference regroup

Was a flat list of 18 blocks; now four intent-based sections:

- **Overview blocks** — survey many tokens at once. Split into *Across types* (`TokenNavigator`, `TokenTable`) and *Per-type* (`ColorPalette`, `TypographyScale`, `DimensionScale`, `FontFamilySample`, `FontWeightScale`, `BorderPreview`, `ShadowPreview`, `MotionPreview`, `StrokeStyleSample`, `GradientPalette`).
- **Inspector blocks** — `TokenDetail` + the 8 subparts (`TokenHeader`, `CompositePreview`, `CompositeBreakdown`, `AliasChain`, `AliasedBy`, `AxisVariance`, `TokenUsageSnippet`, `ConsumerOutput`).
- **Sample blocks** — one-token visual atoms (`BorderSample`, `ShadowSample`, `MotionSample`, `DimensionBar`).
- **Utility blocks** — `Diagnostics`.

Prop listings updated for the post-0.3 surface: `showVar` removed from TokenTable; `sortBy`/`sortDir` added across the overviews; `onSelect` documented on TokenTable; Diagnostics entry added.

### 3. Drop "old panel" references

The Design Tokens panel never shipped to external consumers, so every "this replaces the old panel" cross-reference on intro / quickstart / addon / diagnostics / token-dashboard is noise for new readers. Reframed without the comparison.

Same broken-link fixes applied to `versioned_docs/version-0.2/` and `versioned_docs/version-0.3/` so the snapshot pages render clean too.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-docs build` — succeeds. Only the 4 unavoidable `/storybook/` warnings remain.

Milestone: Maintenance
Refs: #309
Plan impact: none — docs content / policy only.
