### PR TITLE
ci: cancel in-progress release runs to close the VP-race window

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,18 @@ on:
 
 # Prevent concurrent release runs — we don't want two Version Packages PRs
 # racing or a publish triggering while another is mid-flight.
+#
+# `cancel-in-progress: true`: when a newer push arrives (most importantly
+# the Version Packages PR's merge commit right after a sibling feature
+# merge), cancel any earlier in-flight run. The earlier run was only going
+# to regenerate the VP PR from a pre-consumption snapshot of `.changeset/`
+# and would spawn a ghost PR (see issue #361 post-0.3.0 for the symptom).
+# The workflow is idempotent — publishing a version that's already shipped
+# is a no-op on npm, and re-updating the VP PR is free — so cancellation
+# loses no work.
 concurrency:
   group: release
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   release:


### PR DESCRIPTION
## Summary

Root cause of the v0.3.0 ghost VP PR was a **cross-run race**, not the ignored-package issue from [changesets/action#527](https://github.com/changesets/action/issues/527):

| Run | Trigger | Started | Finished |
| - | - | - | - |
| 24637855162 | #360 merge (chore, no changeset) | 20:00:12Z | 20:00:45Z |
| 24637864816 | VP #345 merge (v0.3.0) | 20:00:36Z | 20:01:26Z |

They overlapped for 9s because `cancel-in-progress: false` lets runs queue but GitHub's concurrency enforcement isn't always tight. Run A (#360's push) had its own merge SHA checked out, where `.changeset/*.md` was still full (the VP merge hadn't happened from A's view), saw `hasChangesets: true`, and opened a fresh VP PR right as the real #345 was closing. Ghost PR landed at 20:00:40Z — inside A's window.

Flip to `cancel-in-progress: true`: the VP merge's run cancels any earlier in-flight run. The earlier run was only going to regenerate the VP PR anyway, and the workflow is idempotent (publish is a no-op on already-shipped versions, PR regeneration is free), so cancellation loses nothing.

PR #364's post-step stays in place as belt-and-suspenders for any residual empty-PR case.

## Test plan

- [ ] Next release cycle exercises the new config. Any in-flight non-VP run at VP-merge time should be cleanly cancelled rather than producing a ghost PR.

Milestone: Maintenance
Closes: #366
Plan impact: none — CI-only guardrail.