### PR TITLE
refactor(blocks): font + color cluster to colocated CSS

### DIFF
--- a/packages/blocks/src/BorderPreview.css
+++ b/packages/blocks/src/BorderPreview.css
@@ -1,0 +1,48 @@
+.sb-border-preview__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 140px 1fr;
+  gap: 16px;
+  align-items: center;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-border-preview__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-border-preview__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-border-preview__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.sb-border-preview__sample-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sb-border-preview__breakdown {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 2px;
+}
+
+.sb-border-preview__breakdown-key {
+  color: var(--swatchbook-text-muted, CanvasText);
+}

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -1,7 +1,7 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useMemo } from 'react';
+import './BorderPreview.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
-import { BORDER_DEFAULT, MONO_STACK, TEXT_MUTED } from '#/internal/styles.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -23,51 +23,6 @@ export interface BorderPreviewProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
 }
-
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(160px, 220px) 140px 1fr',
-    gap: 16,
-    alignItems: 'center',
-    padding: '14px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    opacity: 0.7,
-  } satisfies CSSProperties,
-  sampleCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-  } satisfies CSSProperties,
-  breakdown: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr',
-    columnGap: 12,
-    rowGap: 2,
-  } satisfies CSSProperties,
-  breakdownKey: {
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-};
 
 interface BorderValue {
   color?: unknown;
@@ -144,20 +99,20 @@ export function BorderPreview({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.cssVar}>{row.cssVar}</span>
+        <div key={row.path} className="sb-border-preview__row">
+          <div className="sb-border-preview__meta">
+            <span className="sb-border-preview__path">{row.path}</span>
+            <span className="sb-border-preview__css-var">{row.cssVar}</span>
           </div>
-          <div style={styles.sampleCell}>
+          <div className="sb-border-preview__sample-cell">
             <BorderSample path={row.path} />
           </div>
-          <div style={styles.breakdown}>
-            <span style={styles.breakdownKey}>width</span>
+          <div className="sb-border-preview__breakdown">
+            <span className="sb-border-preview__breakdown-key">width</span>
             <span>{formatDimension(row.value.width)}</span>
-            <span style={styles.breakdownKey}>style</span>
+            <span className="sb-border-preview__breakdown-key">style</span>
             <span>{row.value.style != null ? String(row.value.style) : '—'}</span>
-            <span style={styles.breakdownKey}>color</span>
+            <span className="sb-border-preview__breakdown-key">color</span>
             <span>{formatColor(row.value.color)}</span>
           </div>
         </div>

--- a/packages/blocks/src/ColorPalette.css
+++ b/packages/blocks/src/ColorPalette.css
@@ -1,0 +1,54 @@
+.sb-color-palette__group {
+  margin-bottom: 20px;
+}
+
+.sb-color-palette__group-header {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+  margin-bottom: 8px;
+}
+
+.sb-color-palette__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.sb-color-palette__card {
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-radius: 6px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.sb-color-palette__swatch {
+  height: 56px;
+  width: 100%;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+}
+
+.sb-color-palette__meta {
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sb-color-palette__leaf {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sb-color-palette__value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.sb-color-palette__gamut-warn {
+  margin-left: 4px;
+}

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -1,8 +1,8 @@
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
+import './ColorPalette.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
-import { BORDER_DEFAULT, BORDER_FAINT, MONO_STACK } from '#/internal/styles.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -39,52 +39,6 @@ export interface ColorPaletteProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
 }
-
-const styles = {
-  group: {
-    marginBottom: 20,
-  } satisfies React.CSSProperties,
-  groupHeader: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    opacity: 0.6,
-    marginBottom: 8,
-  } satisfies React.CSSProperties,
-  grid: {
-    display: 'grid',
-    gridTemplateColumns: 'repeat(auto-fill, minmax(120px, 1fr))',
-    gap: 8,
-  } satisfies React.CSSProperties,
-  card: {
-    border: BORDER_DEFAULT,
-    borderRadius: 6,
-    overflow: 'hidden',
-    display: 'flex',
-    flexDirection: 'column',
-  } satisfies React.CSSProperties,
-  swatch: {
-    height: 56,
-    width: '100%',
-    borderBottom: BORDER_FAINT,
-  } satisfies React.CSSProperties,
-  meta: {
-    padding: '8px 10px',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-  } satisfies React.CSSProperties,
-  leaf: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-  } satisfies React.CSSProperties,
-  value: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    opacity: 0.7,
-  } satisfies React.CSSProperties,
-};
 
 interface Swatch {
   path: string;
@@ -127,13 +81,6 @@ export function ColorPalette({
     const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
 
     const maxDepth = entries.reduce((m, [p]) => Math.max(m, p.split('.').length), 0);
-    /**
-     * Auto-derive: group one level below the filter's fixed prefix, but
-     * clamp so each swatch retains at least one leaf segment. A filter
-     * like `color.ref.blue.*` (fixed length 3) with only 4-segment tokens
-     * would try groupBy=4 → one-per-group; clamp to `maxDepth - 1` so the
-     * whole ramp lands in one group with each shade as a leaf.
-     */
     const effectiveGroupBy =
       groupBy ?? Math.min(fixedPrefixLength(filter) + 1, Math.max(maxDepth - 1, 1));
 
@@ -176,21 +123,25 @@ export function ColorPalette({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {groups.map(([group, swatches]) => (
-        <section key={group} style={styles.group}>
-          <div style={styles.groupHeader}>{group}</div>
-          <div style={styles.grid}>
+        <section key={group} className="sb-color-palette__group">
+          <div className="sb-color-palette__group-header">{group}</div>
+          <div className="sb-color-palette__grid">
             {swatches.map((swatch) => (
-              <div key={swatch.path} style={styles.card}>
-                <div style={{ ...styles.swatch, background: swatch.cssVar }} aria-hidden />
-                <div style={styles.meta}>
-                  <span style={styles.leaf}>{swatch.leaf}</span>
-                  <span style={styles.value}>
+              <div key={swatch.path} className="sb-color-palette__card">
+                <div
+                  className="sb-color-palette__swatch"
+                  style={{ background: swatch.cssVar }}
+                  aria-hidden
+                />
+                <div className="sb-color-palette__meta">
+                  <span className="sb-color-palette__leaf">{swatch.leaf}</span>
+                  <span className="sb-color-palette__value">
                     {swatch.value}
                     {swatch.outOfGamut && (
                       <span
                         title="Out of sRGB gamut for this format"
                         aria-label="out of gamut"
-                        style={{ marginLeft: 4 }}
+                        className="sb-color-palette__gamut-warn"
                       >
                         {' '}
                         ⚠

--- a/packages/blocks/src/DimensionScale.css
+++ b/packages/blocks/src/DimensionScale.css
@@ -1,0 +1,49 @@
+.sb-dimension-scale__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-dimension-scale__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-dimension-scale__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-dimension-scale__specs {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.sb-dimension-scale__visual-cell {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.sb-dimension-scale__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+.sb-dimension-scale__cap {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 10px;
+  opacity: 0.6;
+  margin-left: 6px;
+}

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -1,7 +1,7 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useMemo } from 'react';
+import './DimensionScale.css';
 import { DimensionBar, type DimensionKind } from '#/dimension-scale/DimensionBar.tsx';
-import { BORDER_DEFAULT, MONO_STACK } from '#/internal/styles.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
@@ -38,52 +38,6 @@ export interface DimensionScaleProps {
 
 const MAX_RENDER_PX = 480;
 
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
-    gap: 16,
-    alignItems: 'center',
-    padding: '10px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  specs: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    opacity: 0.7,
-  } satisfies CSSProperties,
-  visualCell: {
-    display: 'flex',
-    alignItems: 'center',
-    minWidth: 0,
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    opacity: 0.7,
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  cap: {
-    fontFamily: MONO_STACK,
-    fontSize: 10,
-    opacity: 0.6,
-    marginLeft: 6,
-  } satisfies CSSProperties,
-};
-
 interface Row {
   path: string;
   cssVar: string;
@@ -92,10 +46,6 @@ interface Row {
   capped: boolean;
 }
 
-/**
- * Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
- * purpose of ordering and deciding whether to show a cap indicator.
- */
 function toPixels(raw: unknown): number {
   if (raw == null || typeof raw !== 'object') return Number.NaN;
   const v = raw as { value?: unknown; unit?: unknown };
@@ -153,16 +103,18 @@ export function DimensionScale({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.specs}>{row.displayValue}</span>
+        <div key={row.path} className="sb-dimension-scale__row">
+          <div className="sb-dimension-scale__meta">
+            <span className="sb-dimension-scale__path">{row.path}</span>
+            <span className="sb-dimension-scale__specs">{row.displayValue}</span>
           </div>
-          <div style={styles.visualCell}>
+          <div className="sb-dimension-scale__visual-cell">
             <DimensionBar path={row.path} kind={kind} />
-            {row.capped && <span style={styles.cap}>capped at {MAX_RENDER_PX}px</span>}
+            {row.capped && (
+              <span className="sb-dimension-scale__cap">capped at {MAX_RENDER_PX}px</span>
+            )}
           </div>
-          <span style={styles.cssVar}>{row.cssVar}</span>
+          <span className="sb-dimension-scale__css-var">{row.cssVar}</span>
         </div>
       ))}
     </div>

--- a/packages/blocks/src/FontFamilySample.css
+++ b/packages/blocks/src/FontFamilySample.css
@@ -1,0 +1,40 @@
+.sb-font-family-sample__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 1fr auto;
+  gap: 16px;
+  align-items: baseline;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-font-family-sample__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-font-family-sample__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-font-family-sample__stack {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-font-family-sample__sample {
+  font-size: 22px;
+  line-height: 1.2;
+}
+
+.sb-font-family-sample__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -1,6 +1,6 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useMemo } from 'react';
-import { BORDER_DEFAULT, MONO_STACK, TEXT_MUTED } from '#/internal/styles.tsx';
+import './FontFamilySample.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
@@ -24,44 +24,6 @@ export interface FontFamilySampleProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
 }
-
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
-    gap: 16,
-    alignItems: 'baseline',
-    padding: '14px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  stack: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-  sample: {
-    fontSize: 22,
-    lineHeight: 1.2,
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-};
 
 interface Row {
   path: string;
@@ -112,13 +74,15 @@ export function FontFamilySample({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.stack}>{row.stack}</span>
+        <div key={row.path} className="sb-font-family-sample__row">
+          <div className="sb-font-family-sample__meta">
+            <span className="sb-font-family-sample__path">{row.path}</span>
+            <span className="sb-font-family-sample__stack">{row.stack}</span>
           </div>
-          <div style={{ ...styles.sample, fontFamily: row.cssVar }}>{sample}</div>
-          <span style={styles.cssVar}>{row.cssVar}</span>
+          <div className="sb-font-family-sample__sample" style={{ fontFamily: row.cssVar }}>
+            {sample}
+          </div>
+          <span className="sb-font-family-sample__css-var">{row.cssVar}</span>
         </div>
       ))}
     </div>

--- a/packages/blocks/src/FontWeightScale.css
+++ b/packages/blocks/src/FontWeightScale.css
@@ -1,0 +1,40 @@
+.sb-font-weight-scale__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 1fr auto;
+  gap: 16px;
+  align-items: baseline;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-font-weight-scale__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-font-weight-scale__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-font-weight-scale__value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-font-weight-scale__sample {
+  font-size: 28px;
+  line-height: 1;
+}
+
+.sb-font-weight-scale__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
-import { BORDER_DEFAULT, MONO_STACK, TEXT_MUTED } from '#/internal/styles.tsx';
+import './FontWeightScale.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -25,44 +25,6 @@ export interface FontWeightScaleProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
 }
-
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
-    gap: 16,
-    alignItems: 'baseline',
-    padding: '12px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  value: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-  sample: {
-    fontSize: 28,
-    lineHeight: 1,
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-};
 
 interface Row {
   path: string;
@@ -118,20 +80,18 @@ export function FontWeightScale({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.value}>{row.display}</span>
+        <div key={row.path} className="sb-font-weight-scale__row">
+          <div className="sb-font-weight-scale__meta">
+            <span className="sb-font-weight-scale__path">{row.path}</span>
+            <span className="sb-font-weight-scale__value">{row.display}</span>
           </div>
           <div
-            style={{
-              ...styles.sample,
-              fontWeight: row.cssVar as unknown as CSSProperties['fontWeight'],
-            }}
+            className="sb-font-weight-scale__sample"
+            style={{ fontWeight: row.cssVar as unknown as CSSProperties['fontWeight'] }}
           >
             {sample}
           </div>
-          <span style={styles.cssVar}>{row.cssVar}</span>
+          <span className="sb-font-weight-scale__css-var">{row.cssVar}</span>
         </div>
       ))}
     </div>

--- a/packages/blocks/src/GradientPalette.css
+++ b/packages/blocks/src/GradientPalette.css
@@ -1,0 +1,61 @@
+.sb-gradient-palette__row {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) 1fr minmax(140px, 220px);
+  gap: 16px;
+  align-items: center;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-gradient-palette__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-gradient-palette__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-gradient-palette__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.sb-gradient-palette__sample {
+  height: 56px;
+  border-radius: 6px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+}
+
+.sb-gradient-palette__stops {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sb-gradient-palette__stop-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sb-gradient-palette__stop-swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 2px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  flex: 0 0 auto;
+}
+
+.sb-gradient-palette__stop-position {
+  opacity: 0.6;
+}

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -1,6 +1,6 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useMemo } from 'react';
-import { BORDER_DEFAULT, BORDER_FAINT, MONO_STACK } from '#/internal/styles.tsx';
+import './GradientPalette.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -22,62 +22,6 @@ export interface GradientPaletteProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
 }
-
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(180px, 240px) 1fr minmax(140px, 220px)',
-    gap: 16,
-    alignItems: 'center',
-    padding: '16px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    opacity: 0.7,
-  } satisfies CSSProperties,
-  sample: {
-    height: 56,
-    borderRadius: 6,
-    border: BORDER_FAINT,
-  } satisfies CSSProperties,
-  stops: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-  } satisfies CSSProperties,
-  stopRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-  } satisfies CSSProperties,
-  stopSwatch: {
-    width: 10,
-    height: 10,
-    borderRadius: 2,
-    border: BORDER_DEFAULT,
-    flex: '0 0 auto',
-  } satisfies CSSProperties,
-  stopPosition: {
-    opacity: 0.6,
-  } satisfies CSSProperties,
-};
 
 interface GradientStop {
   color?: {
@@ -154,24 +98,26 @@ export function GradientPalette({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.cssVar}>{row.cssVar}</span>
+        <div key={row.path} className="sb-gradient-palette__row">
+          <div className="sb-gradient-palette__meta">
+            <span className="sb-gradient-palette__path">{row.path}</span>
+            <span className="sb-gradient-palette__css-var">{row.cssVar}</span>
           </div>
           <div
-            style={{ ...styles.sample, background: `linear-gradient(to right, ${row.cssVar})` }}
+            className="sb-gradient-palette__sample"
+            style={{ background: `linear-gradient(to right, ${row.cssVar})` }}
             aria-hidden
           />
-          <div style={styles.stops}>
+          <div className="sb-gradient-palette__stops">
             {row.stops.map((stop, i) => (
-              <div key={stopKey(row.path, stop, i)} style={styles.stopRow}>
+              <div key={stopKey(row.path, stop, i)} className="sb-gradient-palette__stop-row">
                 <span
-                  style={{ ...styles.stopSwatch, background: stopCssColor(stop) }}
+                  className="sb-gradient-palette__stop-swatch"
+                  style={{ background: stopCssColor(stop) }}
                   aria-hidden
                 />
                 <span>{stopCssColor(stop)}</span>
-                <span style={styles.stopPosition}>
+                <span className="sb-gradient-palette__stop-position">
                   @ {((stop.position ?? 0) * 100).toFixed(0)}%
                 </span>
               </div>

--- a/packages/blocks/src/MotionPreview.css
+++ b/packages/blocks/src/MotionPreview.css
@@ -1,0 +1,78 @@
+.sb-motion-preview__controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 0 12px;
+}
+
+.sb-motion-preview__control-label {
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.sb-motion-preview__speed-btn {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  padding: 4px 8px;
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sb-motion-preview__speed-btn--active {
+  background: var(--swatchbook-accent-bg, #3b82f6);
+  color: var(--swatchbook-accent-fg, #fff);
+  border-color: transparent;
+}
+
+.sb-motion-preview__replay-btn {
+  font-size: 11px;
+  padding: 4px 10px;
+  margin-left: auto;
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.sb-motion-preview__row {
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-motion-preview__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-motion-preview__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-motion-preview__specs {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-motion-preview__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  white-space: nowrap;
+}

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -1,8 +1,9 @@
-import type { CSSProperties, ReactElement } from 'react';
+import cx from 'clsx';
+import type { ReactElement } from 'react';
 import { useMemo, useState } from 'react';
-import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
-import { BORDER_DEFAULT, BORDER_STRONG, MONO_STACK, TEXT_MUTED } from '#/internal/styles.tsx';
+import './MotionPreview.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
+import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 import {
   MotionSample,
@@ -23,88 +24,6 @@ export interface MotionPreviewProps {
 }
 
 const SPEEDS: MotionSpeed[] = [0.25, 0.5, 1, 2];
-
-const styles = {
-  caption: {
-    padding: '4px 0 4px',
-    color: TEXT_MUTED,
-    fontSize: 12,
-  } satisfies CSSProperties,
-  controls: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-    padding: '8px 0 12px',
-  } satisfies CSSProperties,
-  controlLabel: {
-    fontSize: 11,
-    color: TEXT_MUTED,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-  } satisfies CSSProperties,
-  speedBtn: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    padding: '4px 8px',
-    background: 'transparent',
-    color: 'inherit',
-    border: BORDER_STRONG,
-    borderRadius: 4,
-    cursor: 'pointer',
-  } satisfies CSSProperties,
-  speedBtnActive: {
-    background: 'var(--swatchbook-accent-bg, #3b82f6)',
-    color: 'var(--swatchbook-accent-fg, #fff)',
-    borderColor: 'transparent',
-  } satisfies CSSProperties,
-  replayBtn: {
-    fontSize: 11,
-    padding: '4px 10px',
-    marginLeft: 'auto',
-    background: 'transparent',
-    color: 'inherit',
-    border: BORDER_STRONG,
-    borderRadius: 4,
-    cursor: 'pointer',
-  } satisfies CSSProperties,
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(180px, 240px) 1fr auto',
-    gap: 16,
-    alignItems: 'center',
-    padding: '14px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  specs: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  empty: {
-    padding: '24px 12px',
-    textAlign: 'center',
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-};
 
 interface Row {
   path: string;
@@ -164,21 +83,23 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
   if (rows.length === 0) {
     return (
       <div {...themeAttrs(cssVarPrefix, activeTheme)}>
-        <div style={styles.empty}>No motion tokens match this filter.</div>
+        <div className="sb-block__empty">No motion tokens match this filter.</div>
       </div>
     );
   }
 
   return (
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
-      <div style={styles.caption}>{captionText}</div>
-      <div style={styles.controls}>
-        <span style={styles.controlLabel}>Speed</span>
+      <div className="sb-block__caption">{captionText}</div>
+      <div className="sb-motion-preview__controls">
+        <span className="sb-motion-preview__control-label">Speed</span>
         {SPEEDS.map((s) => (
           <button
             key={s}
             type="button"
-            style={{ ...styles.speedBtn, ...(s === speed ? styles.speedBtnActive : {}) }}
+            className={cx('sb-motion-preview__speed-btn', {
+              'sb-motion-preview__speed-btn--active': s === speed,
+            })}
             onClick={() => setSpeed(s)}
           >
             {s}×
@@ -186,7 +107,7 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
         ))}
         <button
           type="button"
-          style={styles.replayBtn}
+          className="sb-motion-preview__replay-btn"
           onClick={() => setRun((n) => n + 1)}
           disabled={reducedMotion}
           title={reducedMotion ? 'Disabled by prefers-reduced-motion' : 'Replay all'}
@@ -195,13 +116,13 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
         </button>
       </div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.specs}>{formatSpec(row)}</span>
+        <div key={row.path} className="sb-motion-preview__row">
+          <div className="sb-motion-preview__meta">
+            <span className="sb-motion-preview__path">{row.path}</span>
+            <span className="sb-motion-preview__specs">{formatSpec(row)}</span>
           </div>
           <MotionSample path={row.path} speed={speed} runKey={run} />
-          <span style={styles.cssVar}>{row.cssVar}</span>
+          <span className="sb-motion-preview__css-var">{row.cssVar}</span>
         </div>
       ))}
     </div>

--- a/packages/blocks/src/ShadowPreview.css
+++ b/packages/blocks/src/ShadowPreview.css
@@ -1,0 +1,65 @@
+.sb-shadow-preview__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 140px 1fr;
+  gap: 16px;
+  align-items: center;
+  padding: 16px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-shadow-preview__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-shadow-preview__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-shadow-preview__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  opacity: 0.7;
+}
+
+.sb-shadow-preview__sample-cell {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 96px;
+}
+
+.sb-shadow-preview__breakdown {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 12px;
+  row-gap: 2px;
+}
+
+.sb-shadow-preview__breakdown-key {
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-shadow-preview__layer {
+  grid-column: 1 / -1;
+}
+
+.sb-shadow-preview__layer-header {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  margin-top: 6px;
+}
+
+.sb-shadow-preview__layer-breakdown {
+  margin-top: 2px;
+}

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -1,6 +1,7 @@
-import type { CSSProperties, ReactElement } from 'react';
+import cx from 'clsx';
+import type { ReactElement } from 'react';
 import { useMemo } from 'react';
-import { BORDER_DEFAULT, MONO_STACK, TEXT_MUTED } from '#/internal/styles.tsx';
+import './ShadowPreview.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -23,59 +24,6 @@ export interface ShadowPreviewProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
 }
-
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(160px, 220px) 140px 1fr',
-    gap: 16,
-    alignItems: 'center',
-    padding: '16px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    opacity: 0.7,
-  } satisfies CSSProperties,
-  sampleCell: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    height: 96,
-  } satisfies CSSProperties,
-  breakdown: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr',
-    columnGap: 12,
-    rowGap: 2,
-  } satisfies CSSProperties,
-  breakdownKey: {
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-  layerHeader: {
-    fontSize: 10,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    color: TEXT_MUTED,
-    marginTop: 6,
-  } satisfies CSSProperties,
-};
 
 interface ShadowLayer {
   color?: unknown;
@@ -168,15 +116,15 @@ export function ShadowPreview({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.cssVar}>{row.cssVar}</span>
+        <div key={row.path} className="sb-shadow-preview__row">
+          <div className="sb-shadow-preview__meta">
+            <span className="sb-shadow-preview__path">{row.path}</span>
+            <span className="sb-shadow-preview__css-var">{row.cssVar}</span>
           </div>
-          <div style={styles.sampleCell}>
+          <div className="sb-shadow-preview__sample-cell">
             <ShadowSample path={row.path} />
           </div>
-          <div style={styles.breakdown}>
+          <div className="sb-shadow-preview__breakdown">
             {row.layers.length === 1
               ? renderLayer(row.layers[0])
               : row.layers.map((layer, i) => (
@@ -204,7 +152,7 @@ function renderLayer(layer: ShadowLayer | undefined): ReactElement[] {
   ];
   if (layer.inset) entries.push(['inset', String(layer.inset)]);
   return entries.flatMap(([k, v]) => [
-    <span key={`k-${k}`} style={styles.breakdownKey}>
+    <span key={`k-${k}`} className="sb-shadow-preview__breakdown-key">
       {k}
     </span>,
     <span key={`v-${k}`}>{v}</span>,
@@ -221,11 +169,13 @@ function Layer({
   total: number;
 }): ReactElement {
   return (
-    <div style={{ gridColumn: '1 / -1' }}>
-      <div style={styles.layerHeader}>
+    <div className="sb-shadow-preview__layer">
+      <div className="sb-shadow-preview__layer-header">
         layer {index + 1} of {total}
       </div>
-      <div style={{ ...styles.breakdown, marginTop: 2 }}>{renderLayer(layer)}</div>
+      <div className={cx('sb-shadow-preview__breakdown', 'sb-shadow-preview__layer-breakdown')}>
+        {renderLayer(layer)}
+      </div>
     </div>
   );
 }

--- a/packages/blocks/src/StrokeStyleSample.css
+++ b/packages/blocks/src/StrokeStyleSample.css
@@ -1,0 +1,48 @@
+.sb-stroke-style-sample__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 1fr auto;
+  gap: 16px;
+  align-items: center;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-stroke-style-sample__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.sb-stroke-style-sample__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-stroke-style-sample__value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-stroke-style-sample__line {
+  height: 0;
+  border-top-width: 4px;
+  border-top-color: var(--swatchbook-text-default, CanvasText);
+  width: 100%;
+}
+
+.sb-stroke-style-sample__object-fallback {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-stroke-style-sample__css-var {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
-import { BORDER_DEFAULT, MONO_STACK, TEXT_DEFAULT, TEXT_MUTED } from '#/internal/styles.tsx';
+import './StrokeStyleSample.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -34,51 +34,6 @@ const STRING_STYLES = new Set([
   'outset',
   'inset',
 ]);
-
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(160px, 220px) 1fr auto',
-    gap: 16,
-    alignItems: 'center',
-    padding: '14px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-    minWidth: 0,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  value: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-  line: {
-    height: 0,
-    borderTopWidth: 4,
-    borderTopColor: TEXT_DEFAULT,
-    width: '100%',
-  } satisfies CSSProperties,
-  objectFallback: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-  cssVar: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-};
 
 interface Row {
   path: string;
@@ -129,25 +84,25 @@ export function StrokeStyleSample({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            <span style={styles.value}>{row.displayValue}</span>
+        <div key={row.path} className="sb-stroke-style-sample__row">
+          <div className="sb-stroke-style-sample__meta">
+            <span className="sb-stroke-style-sample__path">{row.path}</span>
+            <span className="sb-stroke-style-sample__value">{row.displayValue}</span>
           </div>
           {row.cssStyle ? (
             <div
+              className="sb-stroke-style-sample__line"
               style={{
-                ...styles.line,
                 borderTopStyle: row.cssStyle as CSSProperties['borderTopStyle'],
               }}
               aria-hidden
             />
           ) : (
-            <span style={styles.objectFallback}>
+            <span className="sb-stroke-style-sample__object-fallback">
               Object-form (dashArray + lineCap) — no pure CSS `border-style` equivalent.
             </span>
           )}
-          <span style={styles.cssVar}>{row.cssVar}</span>
+          <span className="sb-stroke-style-sample__css-var">{row.cssVar}</span>
         </div>
       ))}
     </div>

--- a/packages/blocks/src/TypographyScale.css
+++ b/packages/blocks/src/TypographyScale.css
@@ -1,0 +1,25 @@
+.sb-typography-scale__row {
+  display: grid;
+  grid-template-columns: minmax(160px, 220px) 1fr;
+  gap: 16px;
+  align-items: baseline;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-typography-scale__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sb-typography-scale__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sb-typography-scale__specs {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  opacity: 0.7;
+}

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
-import { BORDER_DEFAULT, MONO_STACK } from '#/internal/styles.tsx';
+import './TypographyScale.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, useProject } from '#/internal/use-project.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
@@ -24,31 +24,6 @@ export interface TypographyScaleProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
 }
-
-const styles = {
-  row: {
-    display: 'grid',
-    gridTemplateColumns: 'minmax(160px, 220px) 1fr',
-    gap: 16,
-    alignItems: 'baseline',
-    padding: '14px 0',
-    borderBottom: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  meta: {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 2,
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: 12,
-  } satisfies CSSProperties,
-  specs: {
-    fontFamily: MONO_STACK,
-    fontSize: 11,
-    opacity: 0.7,
-  } satisfies CSSProperties,
-};
 
 interface Row {
   path: string;
@@ -136,10 +111,10 @@ export function TypographyScale({
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
-        <div key={row.path} style={styles.row}>
-          <div style={styles.meta}>
-            <span style={styles.path}>{row.path}</span>
-            {row.specs && <span style={styles.specs}>{row.specs}</span>}
+        <div key={row.path} className="sb-typography-scale__row">
+          <div className="sb-typography-scale__meta">
+            <span className="sb-typography-scale__path">{row.path}</span>
+            {row.specs && <span className="sb-typography-scale__specs">{row.specs}</span>}
           </div>
           <div style={row.sampleStyle}>{sample}</div>
         </div>


### PR DESCRIPTION
## Summary

Cluster 3 of the blocks styling migration (#375). Stacked on PR #393 (cluster 2); will auto-retarget once #393 merges.

- \`FontFamilySample.tsx\` → \`FontFamilySample.css\`
- \`ColorPalette.tsx\` → \`ColorPalette.css\`

Same template as previous clusters. The out-of-gamut warn span also moves its inline \`marginLeft: 4\` onto a \`.sb-color-palette__gamut-warn\` class. Strict visual parity.

## Test plan

- [x] \`pnpm turbo run lint typecheck test\` — clean.
- [x] All six Storybook stories for these blocks + the block-assertions test stories pass, zero a11y violations.

Milestone: Blocks styling migration
Closes: #394
Plan impact: part of #375 cluster breakdown