### PR TITLE
refactor(blocks): navigator + table cluster to colocated CSS

### DIFF
--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -1,0 +1,116 @@
+.sb-token-navigator__caption {
+  padding: 4px 0 12px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  font-size: 12px;
+}
+
+.sb-token-navigator__tree {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sb-token-navigator__nested {
+  list-style: none;
+  margin: 0;
+  padding-left: 18px;
+  border-left: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+}
+
+.sb-token-navigator__group-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  user-select: none;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sb-token-navigator__leaf-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sb-token-navigator__caret {
+  display: inline-block;
+  width: 12px;
+  text-align: center;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-token-navigator__tail {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sb-token-navigator__type-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+}
+
+.sb-token-navigator__value {
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  margin-left: auto;
+  min-width: 0;
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-token-navigator__count {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--swatchbook-text-default, CanvasText);
+}
+
+.sb-token-navigator__color-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  margin-left: 8px;
+}
+
+.sb-token-navigator__preview-box {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
+.sb-token-navigator__preview-dimension {
+  margin-left: 8px;
+  display: inline-block;
+  min-width: 40px;
+  max-width: 120px;
+}
+
+.sb-token-navigator__preview-scaled {
+  margin-left: 8px;
+  display: inline-block;
+  transform: scale(0.5);
+  transform-origin: right center;
+}
+
+.sb-token-navigator__preview-motion {
+  margin-left: 8px;
+  display: inline-block;
+  width: 80px;
+}

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -1,22 +1,13 @@
-import type { CSSProperties, KeyboardEvent, ReactElement } from 'react';
+import type { KeyboardEvent, ReactElement } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import './TokenNavigator.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
-import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
-import {
-  BORDER_DEFAULT,
-  EmptyState,
-  MONO_STACK,
-  SIZE_LABEL,
-  SIZE_META,
-  SIZE_PILL,
-  TEXT_DEFAULT,
-  TEXT_MUTED,
-  typePillStyle,
-} from '#/internal/styles.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
+import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { EmptyState } from '#/internal/styles.tsx';
 import { makeCssVar, useProject } from '#/internal/use-project.ts';
 import { MotionSample } from '#/motion-preview/MotionSample.tsx';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
@@ -54,91 +45,6 @@ interface GroupNode {
 }
 
 type TreeNode = LeafNode | GroupNode;
-
-const styles = {
-  caption: {
-    padding: '4px 0 12px',
-    color: TEXT_MUTED,
-    fontSize: SIZE_META,
-  } satisfies CSSProperties,
-  tree: {
-    listStyle: 'none',
-    margin: 0,
-    padding: 0,
-  } satisfies CSSProperties,
-  nested: {
-    listStyle: 'none',
-    margin: 0,
-    paddingLeft: 18,
-    borderLeft: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  groupRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 6,
-    padding: '4px 6px',
-    borderRadius: 4,
-    cursor: 'pointer',
-    userSelect: 'none',
-    fontFamily: MONO_STACK,
-    fontSize: SIZE_META,
-  } satisfies CSSProperties,
-  leafRow: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-    padding: '4px 6px',
-    borderRadius: 4,
-    cursor: 'pointer',
-    fontFamily: MONO_STACK,
-    fontSize: SIZE_META,
-  } satisfies CSSProperties,
-  caret: {
-    display: 'inline-block',
-    width: 12,
-    textAlign: 'center',
-    color: TEXT_MUTED,
-  } satisfies CSSProperties,
-  tail: {
-    fontFamily: MONO_STACK,
-    fontSize: SIZE_META,
-  } satisfies CSSProperties,
-  typePill: {
-    ...typePillStyle,
-    // Tree leaves use a smaller pill (1px vs 2px padding) so the row
-    // height stays compact against inline swatch/preview visuals.
-    padding: '1px 6px',
-    fontSize: SIZE_PILL,
-  } satisfies CSSProperties,
-  value: {
-    fontSize: SIZE_LABEL,
-    color: TEXT_MUTED,
-    marginLeft: 'auto',
-    minWidth: 0,
-    textAlign: 'right',
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-  count: {
-    marginLeft: 'auto',
-    fontSize: SIZE_LABEL,
-    color: TEXT_DEFAULT,
-  } satisfies CSSProperties,
-  colorSwatch: {
-    display: 'inline-block',
-    width: 14,
-    height: 14,
-    borderRadius: 3,
-    border: BORDER_DEFAULT,
-  } satisfies CSSProperties,
-  previewBox: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'flex-end',
-    marginLeft: 'auto',
-  } satisfies CSSProperties,
-};
 
 function buildTree(resolved: Record<string, VirtualToken>, root: string | undefined): TreeNode[] {
   const rootPrefix = root && root.length > 0 ? `${root}.` : '';
@@ -264,10 +170,10 @@ export function TokenNavigator({
 
   return (
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
-      <div style={styles.caption}>
+      <div className="sb-token-navigator__caption">
         {root ? `Tokens under ${root}` : 'Token graph'} · {activeTheme}
       </div>
-      <ul style={styles.tree} role="tree">
+      <ul className="sb-token-navigator__tree" role="tree">
         {tree.map((node) => (
           <TreeNodeRow
             key={node.path || node.segment}
@@ -313,20 +219,20 @@ function TreeNodeRow({ node, expanded, onToggle, onLeafClick }: TreeNodeRowProps
       <div
         role="button"
         tabIndex={0}
-        style={styles.groupRow}
+        className="sb-token-navigator__group-row"
         onClick={() => onToggle(node.path)}
         onKeyDown={onKey}
         data-path={node.path}
         data-testid="token-navigator-group"
       >
-        <span style={styles.caret} aria-hidden>
+        <span className="sb-token-navigator__caret" aria-hidden>
           {isOpen ? '▾' : '▸'}
         </span>
         <span>{node.segment}</span>
-        <span style={styles.count}>{countLeaves(node)}</span>
+        <span className="sb-token-navigator__count">{countLeaves(node)}</span>
       </div>
       {isOpen && (
-        <ul style={styles.nested} role="group">
+        <ul className="sb-token-navigator__nested" role="group">
           {node.children.map((c) => (
             <TreeNodeRow
               key={c.path || c.segment}
@@ -360,17 +266,17 @@ function LeafRow({ node, onLeafClick }: LeafRowProps): ReactElement {
       <div
         role="button"
         tabIndex={0}
-        style={styles.leafRow}
+        className="sb-token-navigator__leaf-row"
         onClick={() => onLeafClick(node.path)}
         onKeyDown={onKey}
         data-path={node.path}
         data-testid="token-navigator-leaf"
       >
-        <span style={styles.caret} aria-hidden>
+        <span className="sb-token-navigator__caret" aria-hidden>
           •
         </span>
-        <span style={styles.tail}>{node.segment}</span>
-        {type && <span style={styles.typePill}>{type}</span>}
+        <span className="sb-token-navigator__tail">{node.segment}</span>
+        {type && <span className="sb-token-navigator__type-pill">{type}</span>}
         <LeafPreview path={node.path} token={node.token} />
       </div>
     </li>
@@ -390,17 +296,25 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
   if (type === 'color') {
     const cssVar = makeCssVar(path, cssVarPrefix);
     return (
-      <span style={styles.previewBox}>
-        <span style={styles.value}>{formatTokenValue(token.$value, type, colorFormat)}</span>
-        <span style={{ ...styles.colorSwatch, background: cssVar, marginLeft: 8 }} aria-hidden />
+      <span className="sb-token-navigator__preview-box">
+        <span className="sb-token-navigator__value">
+          {formatTokenValue(token.$value, type, colorFormat)}
+        </span>
+        <span
+          className="sb-token-navigator__color-swatch"
+          style={{ background: cssVar }}
+          aria-hidden
+        />
       </span>
     );
   }
   if (type === 'dimension') {
     return (
-      <span style={styles.previewBox}>
-        <span style={styles.value}>{formatTokenValue(token.$value, type, colorFormat)}</span>
-        <span style={{ marginLeft: 8, display: 'inline-block', minWidth: 40, maxWidth: 120 }}>
+      <span className="sb-token-navigator__preview-box">
+        <span className="sb-token-navigator__value">
+          {formatTokenValue(token.$value, type, colorFormat)}
+        </span>
+        <span className="sb-token-navigator__preview-dimension">
           <DimensionBar path={path} kind="length" />
         </span>
       </span>
@@ -408,15 +322,8 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
   }
   if (type === 'shadow') {
     return (
-      <span style={styles.previewBox}>
-        <span
-          style={{
-            marginLeft: 8,
-            display: 'inline-block',
-            transform: 'scale(0.5)',
-            transformOrigin: 'right center',
-          }}
-        >
+      <span className="sb-token-navigator__preview-box">
+        <span className="sb-token-navigator__preview-scaled">
           <ShadowSample path={path} />
         </span>
       </span>
@@ -424,15 +331,8 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
   }
   if (type === 'border') {
     return (
-      <span style={styles.previewBox}>
-        <span
-          style={{
-            marginLeft: 8,
-            display: 'inline-block',
-            transform: 'scale(0.5)',
-            transformOrigin: 'right center',
-          }}
-        >
+      <span className="sb-token-navigator__preview-box">
+        <span className="sb-token-navigator__preview-scaled">
           <BorderSample path={path} />
         </span>
       </span>
@@ -440,8 +340,8 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
   }
   if (type === 'transition' || type === 'duration' || type === 'cubicBezier') {
     return (
-      <span style={styles.previewBox}>
-        <span style={{ marginLeft: 8, display: 'inline-block', width: 80 }}>
+      <span className="sb-token-navigator__preview-box">
+        <span className="sb-token-navigator__preview-motion">
           <MotionSample path={path} />
         </span>
       </span>
@@ -449,8 +349,10 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
   }
 
   return (
-    <span style={styles.previewBox}>
-      <span style={styles.value}>{formatTokenValue(token.$value, type, colorFormat)}</span>
+    <span className="sb-token-navigator__preview-box">
+      <span className="sb-token-navigator__value">
+        {formatTokenValue(token.$value, type, colorFormat)}
+      </span>
     </span>
   );
 }

--- a/packages/blocks/src/TokenTable.css
+++ b/packages/blocks/src/TokenTable.css
@@ -1,0 +1,87 @@
+.sb-token-table__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.sb-token-table__caption {
+  caption-side: top;
+  text-align: left;
+  padding: 8px 0;
+  color: var(--swatchbook-text-muted, CanvasText);
+  font-size: 12px;
+}
+
+.sb-token-table__th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+}
+
+.sb-token-table__th--path {
+  min-width: 180px;
+}
+
+.sb-token-table__th--value {
+  min-width: 160px;
+}
+
+.sb-token-table__row {
+  cursor: pointer;
+}
+
+.sb-token-table__td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  vertical-align: top;
+}
+
+.sb-token-table__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sb-token-table__value-cell {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+}
+
+.sb-token-table__type-pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  color: var(--swatchbook-text-muted, CanvasText);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  flex-shrink: 0;
+}
+
+.sb-token-table__swatch {
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+  border-radius: 3px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  flex-shrink: 0;
+}
+
+.sb-token-table__value-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sb-token-table__gamut-warn {
+  flex-shrink: 0;
+}

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,17 +1,9 @@
-import type { CSSProperties, ReactElement } from 'react';
+import cx from 'clsx';
+import type { ReactElement } from 'react';
 import { useCallback, useMemo, useState } from 'react';
+import './TokenTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
-import {
-  BORDER_FAINT,
-  BORDER_STRONG,
-  MONO_STACK,
-  SIZE_LABEL,
-  SIZE_META,
-  SIZE_PILL,
-  SURFACE_MUTED,
-  TEXT_MUTED,
-} from '#/internal/styles.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
@@ -47,84 +39,6 @@ export interface TokenTableProps {
    */
   onSelect?(path: string): void;
 }
-
-const styles = {
-  caption: {
-    captionSide: 'top',
-    textAlign: 'left',
-    padding: '8px 0',
-    color: TEXT_MUTED,
-    fontSize: SIZE_META,
-  } satisfies CSSProperties,
-  table: {
-    // `tableLayout: auto` lets column widths follow content; the per-cell
-    // `minWidth` values below keep the important columns from collapsing
-    // on narrow containers.
-    width: '100%',
-    borderCollapse: 'collapse',
-  } satisfies CSSProperties,
-  th: {
-    textAlign: 'left',
-    padding: '8px 12px',
-    fontSize: SIZE_LABEL,
-    textTransform: 'uppercase',
-    letterSpacing: 0.5,
-    color: TEXT_MUTED,
-    borderBottom: BORDER_STRONG,
-  } satisfies CSSProperties,
-  thPath: {
-    minWidth: 180,
-  } satisfies CSSProperties,
-  thValue: {
-    minWidth: 160,
-  } satisfies CSSProperties,
-  row: {
-    cursor: 'pointer',
-  } satisfies CSSProperties,
-  td: {
-    padding: '8px 12px',
-    borderBottom: BORDER_FAINT,
-    verticalAlign: 'top',
-  } satisfies CSSProperties,
-  path: {
-    fontFamily: MONO_STACK,
-    fontSize: SIZE_META,
-  } satisfies CSSProperties,
-  valueCell: {
-    display: 'flex',
-    alignItems: 'center',
-    gap: 8,
-    minWidth: 0,
-    fontFamily: MONO_STACK,
-    fontSize: SIZE_META,
-  } satisfies CSSProperties,
-  typePill: {
-    display: 'inline-block',
-    padding: '1px 6px',
-    borderRadius: 4,
-    fontSize: SIZE_PILL,
-    letterSpacing: 0.5,
-    textTransform: 'uppercase',
-    background: SURFACE_MUTED,
-    color: TEXT_MUTED,
-    fontFamily: MONO_STACK,
-    flexShrink: 0,
-  } satisfies CSSProperties,
-  swatch: {
-    display: 'inline-block',
-    width: 16,
-    height: 16,
-    borderRadius: 3,
-    border: BORDER_STRONG,
-    flexShrink: 0,
-  } satisfies CSSProperties,
-  valueText: {
-    minWidth: 0,
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-  } satisfies CSSProperties,
-};
 
 export function TokenTable({
   filter,
@@ -183,19 +97,19 @@ export function TokenTable({
 
   return (
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
-      <table style={styles.table}>
-        <caption style={styles.caption}>{captionText}</caption>
+      <table className="sb-token-table__table">
+        <caption className="sb-token-table__caption">{captionText}</caption>
         <thead>
           <tr>
-            <th style={{ ...styles.th, ...styles.thPath }}>Path</th>
-            <th style={{ ...styles.th, ...styles.thValue }}>Value</th>
+            <th className={cx('sb-token-table__th', 'sb-token-table__th--path')}>Path</th>
+            <th className={cx('sb-token-table__th', 'sb-token-table__th--value')}>Value</th>
           </tr>
         </thead>
         <tbody>
           {rows.map((row) => (
             <tr
               key={row.path}
-              style={styles.row}
+              className="sb-token-table__row"
               onClick={() => handleRowClick(row.path)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
@@ -208,21 +122,29 @@ export function TokenTable({
               data-testid="token-table-row"
               data-path={row.path}
             >
-              <td style={{ ...styles.td, ...styles.path }}>{row.path}</td>
-              <td style={styles.td}>
-                <span style={styles.valueCell}>
-                  {row.type && <span style={styles.typePill}>{row.type}</span>}
+              <td className={cx('sb-token-table__td', 'sb-token-table__path')}>{row.path}</td>
+              <td className="sb-token-table__td">
+                <span className="sb-token-table__value-cell">
+                  {row.type && <span className="sb-token-table__type-pill">{row.type}</span>}
                   {row.isColor && (
-                    <span style={{ ...styles.swatch, background: row.cssVar }} aria-hidden />
+                    <span
+                      className="sb-token-table__swatch"
+                      style={{ background: row.cssVar }}
+                      aria-hidden
+                    />
                   )}
-                  <span style={styles.valueText} title={row.value} data-testid="token-table-value">
+                  <span
+                    className="sb-token-table__value-text"
+                    title={row.value}
+                    data-testid="token-table-value"
+                  >
                     {row.value}
                   </span>
                   {row.outOfGamut && (
                     <span
                       title="Out of sRGB gamut for this format"
                       aria-label="out of gamut"
-                      style={{ flexShrink: 0 }}
+                      className="sb-token-table__gamut-warn"
                     >
                       ⚠
                     </span>

--- a/packages/blocks/src/internal/DetailOverlay.css
+++ b/packages/blocks/src/internal/DetailOverlay.css
@@ -1,0 +1,35 @@
+.sb-detail-overlay__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 10000;
+  display: flex;
+  align-items: stretch;
+  justify-content: flex-end;
+}
+
+.sb-detail-overlay__panel {
+  width: min(560px, 100%);
+  height: 100%;
+  overflow-y: auto;
+  background: var(--swatchbook-surface-default, Canvas);
+  color: var(--swatchbook-text-default, CanvasText);
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.2);
+  padding: 16px;
+  position: relative;
+}
+
+.sb-detail-overlay__close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 32px;
+  height: 32px;
+  border-radius: 4px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+}

--- a/packages/blocks/src/internal/DetailOverlay.tsx
+++ b/packages/blocks/src/internal/DetailOverlay.tsx
@@ -1,6 +1,6 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useEffect } from 'react';
-import { BORDER_STRONG, SURFACE_DEFAULT, TEXT_DEFAULT } from '#/internal/styles.tsx';
+import './DetailOverlay.css';
 import { TokenDetail } from '#/TokenDetail.tsx';
 
 /**
@@ -11,42 +11,6 @@ import { TokenDetail } from '#/TokenDetail.tsx';
  * + `aria-modal="true"` hints to AT that focus is trapped here; actual focus
  * management is tracked in the open-issue #253.
  */
-
-const styles = {
-  backdrop: {
-    position: 'fixed',
-    inset: 0,
-    background: 'rgba(0,0,0,0.4)',
-    zIndex: 10000,
-    display: 'flex',
-    alignItems: 'stretch',
-    justifyContent: 'flex-end',
-  } satisfies CSSProperties,
-  panel: {
-    width: 'min(560px, 100%)',
-    height: '100%',
-    overflowY: 'auto',
-    background: SURFACE_DEFAULT,
-    color: TEXT_DEFAULT,
-    boxShadow: '-8px 0 24px rgba(0,0,0,0.2)',
-    padding: 16,
-    position: 'relative',
-  } satisfies CSSProperties,
-  closeButton: {
-    position: 'absolute',
-    top: 8,
-    right: 8,
-    width: 32,
-    height: 32,
-    borderRadius: 4,
-    border: BORDER_STRONG,
-    background: 'transparent',
-    color: 'inherit',
-    cursor: 'pointer',
-    fontSize: 16,
-    lineHeight: 1,
-  } satisfies CSSProperties,
-} as const;
 
 export interface DetailOverlayProps {
   path: string;
@@ -68,9 +32,14 @@ export function DetailOverlay({
   }, [onClose]);
 
   return (
-    <div style={styles.backdrop} onClick={onClose} role="presentation" data-testid={testId}>
+    <div
+      className="sb-detail-overlay__backdrop"
+      onClick={onClose}
+      role="presentation"
+      data-testid={testId}
+    >
       <div
-        style={styles.panel}
+        className="sb-detail-overlay__panel"
         onClick={(e) => e.stopPropagation()}
         role="dialog"
         aria-modal="true"
@@ -78,7 +47,7 @@ export function DetailOverlay({
       >
         <button
           type="button"
-          style={styles.closeButton}
+          className="sb-detail-overlay__close"
           onClick={onClose}
           aria-label="Close"
           data-testid={`${testId}-close`}


### PR DESCRIPTION
## Summary

Cluster 4 of the blocks styling migration (#375).

- \`TokenNavigator.tsx\` → \`TokenNavigator.css\`
- \`TokenTable.tsx\` → \`TokenTable.css\`
- \`internal/DetailOverlay.tsx\` → \`internal/DetailOverlay.css\` (shared slide-over, migrated alongside its two call sites)

Dynamic inline styles kept only where the value is per-row (\`background: row.cssVar\` for color swatches). Scaled preview wrappers in TokenNavigator move from inline \`transform: scale(0.5)\` composed into every leaf to dedicated \`sb-token-navigator__preview-scaled\` / \`__preview-dimension\` / \`__preview-motion\` classes.

Strict visual parity.

## Test plan

- [x] \`pnpm turbo run lint typecheck test\` — clean across core, addon, blocks, storybook.
- [x] All 13 Storybook interaction tests for TokenNavigator, TokenTable, and the assertion stories pass, zero a11y violations.

Milestone: Blocks styling migration
Closes: #396
Plan impact: part of #375 cluster breakdown