### PR TITLE
docs(docs): promote Introduction to a top-level navbar link (outside the Docs sidebar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Swatchbook
 
-A Storybook addon and supporting packages for documenting [DTCG](https://www.designtokens.org/) design tokens — parsed via [Terrazzo](https://terrazzo.app/) — inside your Storybook.
+A Storybook addon and MDX blocks for documenting [DTCG](https://www.designtokens.org/) design tokens — parsed via [Terrazzo](https://terrazzo.app/) — with a toolbar that flips **light/dark, brand, contrast, density, or whatever independent dimensions your design system cares about**. Each dimension is a modifier on your DTCG resolver; swatchbook reads them directly, so you don't enumerate every combination as a flat theme ID. (See ["why axes, not themes"](https://unpunnyfuns.github.io/swatchbook/concepts/axes-vs-themes).)
+
+Alongside the switcher, swatchbook ships MDX doc blocks — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and more — that render your tokens as browsable reference pages without a bespoke docs site.
 
 **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) (live Storybook at [`/storybook`](https://unpunnyfuns.github.io/swatchbook/storybook/)).
 
@@ -9,7 +11,7 @@ A Storybook addon and supporting packages for documenting [DTCG](https://www.des
 | Package | Purpose |
 | --- | --- |
 | [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Emits CSS variables and TypeScript types. |
-| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Toolbar, Design Tokens panel, preview decorator, `useToken()` hook. |
+| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Toolbar, preview decorator, `useToken()` hook. |
 | [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks. Color swatches, dimension bars, typography samples, composite previews, per-token detail. |
 
 ## Install

--- a/apps/docs/docs/concepts/axes-vs-themes.mdx
+++ b/apps/docs/docs/concepts/axes-vs-themes.mdx
@@ -1,0 +1,83 @@
+---
+id: axes-vs-themes
+title: Why axes, not themes
+sidebar_position: 1
+---
+
+# Why axes, not themes
+
+Most Storybook theme switchers — [`@storybook/addon-themes`](https://storybook.js.org/addons/@storybook/addon-themes), the framework provider wrappers (MUI / Chakra / Mantine), the Tailwind `dark:` variant, the whole ecosystem — model theme as **one string ID**. You pick `"light"` or `"dark"`, or `"brand-a-dark"` if you've stretched the shape far enough to accommodate more than one dimension.
+
+Swatchbook models theme as a **tuple across independent axes**. It's a different shape, and understanding why is the quickest way to judge whether swatchbook fits your project.
+
+## The familiar starting point
+
+You have dark mode.
+
+Then marketing asks for a second brand.
+
+Then accessibility asks for a high-contrast option.
+
+Then the tablet team asks for a compact density.
+
+With a one-string-ID model, the combinations multiply:
+
+```text
+light / dark                        → 2 themes
+× default / brand-a                 → 4 themes
+× normal / high contrast            → 8 themes
+× comfortable / compact             → 16 themes
+```
+
+You're now maintaining sixteen theme definitions, each one a cartesian combination of four capabilities. The name `brand-a-dark-high-compact` tells you nothing about what differs from `brand-a-dark-high-comfortable` — is it just the density values? You have to open the files to find out. Adding a fifth dimension doubles everything again.
+
+## Axes are the natural shape
+
+A capability is one axis. Each axis has its own contexts.
+
+```text
+mode:     Light | Dark
+brand:    Default | Brand A
+contrast: Normal | High
+density:  Comfortable | Compact
+```
+
+The cartesian product is implicit. You never write out the sixteen combinations — you write four axes and let them compose.
+
+[DTCG 2025.10](https://design-tokens.org/tr/2025/drafts/resolver/) encodes this directly: modifiers on the resolver define the axes, and `resolver.apply({ mode: 'Dark', brand: 'Brand A', contrast: 'Normal', density: 'Compact' })` composes the combined token set.
+
+## What that looks like in swatchbook
+
+Declare axes in your DTCG resolver, one modifier per dimension:
+
+```json
+{
+  "$schema": "https://design-tokens.org/schemas/resolver-v1.json",
+  "modifiers": {
+    "mode":    { "default": "Light", "contexts": { "Light": {…}, "Dark": {…} } },
+    "brand":   { "default": "Default", "contexts": { "Default": {…}, "Brand A": {…} } },
+    "contrast":{ "default": "Normal", "contexts": { "Normal": {…}, "High": {…} } }
+  }
+}
+```
+
+Swatchbook reads the modifiers directly. Each one becomes a toolbar dropdown. A reader flips `contrast` without touching `mode` or `brand`, and the CSS repaints for the one axis they changed.
+
+## What you get for free
+
+- **Independent axis toggling.** A reader inspects `Brand A / Dark / High Contrast` in one click; flipping back to `Normal` contrast doesn't require remembering which flat-ID combination that would be.
+- **Tuple-scoped CSS emission.** Each cartesian combination gets its own `[data-<prefix>-mode][data-<prefix>-brand][data-<prefix>-contrast]` selector block — no duplication beyond what the tokens actually require.
+- **Presets as shortcuts.** Named tuples (`"Default Light"`, `"Brand A Dark"`, `"A11y High Contrast"`) render as quick-select pills in the toolbar — faster than three independent dropdowns when a reader wants a common combination. See [Presets](./presets).
+- **Disabled axes as pinned context.** Hide an axis from the toolbar without removing it from the resolver: set `disabledAxes: ['contrast']` in config and the axis collapses to its default, disappearing from selectors and UI while the rest of the system carries on.
+
+## When axes *don't* pay off
+
+If your design system has exactly one dimension — the `light / dark` pair and nothing else on the horizon — the multi-axis machinery is overhead you don't need. [`@storybook/addon-themes`](https://storybook.js.org/addons/@storybook/addon-themes)' single-string-ID model is simpler and probably a better fit.
+
+Swatchbook's value is the composition. If you have (or plan to have) two or more dimensions, the axis model saves you from the sixteen-flat-themes future.
+
+## See also
+
+- [Axes](./axes) — the runtime model: tuples, data attributes, compound selectors.
+- [Theming inputs](./theming-inputs) — picking resolver vs layered axes vs plain-parse.
+- [Presets](./presets) — named shortcuts over raw tuples in the toolbar.

--- a/apps/docs/docs/concepts/axes.mdx
+++ b/apps/docs/docs/concepts/axes.mdx
@@ -1,7 +1,7 @@
 ---
 id: axes
 title: Axes
-sidebar_position: 2
+sidebar_position: 3
 ---
 
 # Axes

--- a/apps/docs/docs/concepts/diagnostics.mdx
+++ b/apps/docs/docs/concepts/diagnostics.mdx
@@ -1,7 +1,7 @@
 ---
 id: diagnostics
 title: Diagnostics
-sidebar_position: 4
+sidebar_position: 6
 ---
 
 # Diagnostics

--- a/apps/docs/docs/concepts/presets.mdx
+++ b/apps/docs/docs/concepts/presets.mdx
@@ -1,7 +1,7 @@
 ---
 id: presets
 title: Presets
-sidebar_position: 3
+sidebar_position: 4
 ---
 
 # Presets

--- a/apps/docs/docs/concepts/theme-reactivity.mdx
+++ b/apps/docs/docs/concepts/theme-reactivity.mdx
@@ -1,0 +1,104 @@
+---
+id: theme-reactivity
+title: Theme reactivity in your stories
+sidebar_position: 5
+---
+
+# Theme reactivity in your stories
+
+Swatchbook's toolbar flips the active tuple. Your stories need to react. This page is the contract — how swatchbook exposes the active state and how your components consume it.
+
+## Two paths
+
+**Most stories can skip this entire page** and read CSS custom properties directly. That's the recommended path and it works everywhere.
+
+The second path — observing the DOM state from JavaScript — is for stories whose components style themselves through a JS theme object (styled-components / Emotion / MUI / Chakra / Mantine / …) where the theme isn't a CSS variable chain.
+
+### Path 1 — CSS variables (recommended)
+
+Swatchbook emits CSS custom properties keyed on the active tuple. A component that reads those variables updates automatically when the toolbar flips an axis:
+
+```css
+.my-button {
+  background: var(--<prefix>-color-sys-accent-bg);
+  color: var(--<prefix>-color-sys-accent-fg);
+  border: 1px solid var(--<prefix>-color-sys-border-default);
+}
+```
+
+No JavaScript, no subscriptions, no observers. The cascade does the work. If your stories already use CSS variables for theming, you're done.
+
+### Path 2 — DOM observation
+
+For JS-theme-object component libraries, the active tuple is also available on the DOM. Subscribe to it via `MutationObserver`:
+
+```ts
+function readAxes(): Record<string, string> {
+  const el = document.documentElement;
+  const out: Record<string, string> = {};
+  for (const name of el.getAttributeNames()) {
+    if (name.startsWith('data-<prefix>-')) {
+      out[name.slice('data-<prefix>-'.length)] = el.getAttribute(name) ?? '';
+    }
+  }
+  return out;
+}
+
+const observer = new MutationObserver(() => apply(readAxes()));
+observer.observe(document.documentElement, { attributes: true });
+apply(readAxes());
+```
+
+Wrap that in whatever idiom your framework uses. A React story wiring it into a `ThemeProvider`:
+
+```tsx
+function useSwatchbookAxes(): Record<string, string> {
+  const [axes, setAxes] = useState(readAxes);
+  useEffect(() => {
+    const observer = new MutationObserver(() => setAxes(readAxes()));
+    observer.observe(document.documentElement, { attributes: true });
+    return () => observer.disconnect();
+  }, []);
+  return axes;
+}
+
+function ThemeBridge({ children }: { children: ReactNode }) {
+  const axes = useSwatchbookAxes();
+  const theme = mapAxesToMyTheme(axes);
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+}
+```
+
+Same pattern for Vue (`onMounted` + `ref`), Angular (a service with RxJS or a signal), Svelte (`onMount` + a writable store), plain HTML (attach directly to state). The DOM contract is identical across frameworks.
+
+## The contract
+
+This is what swatchbook guarantees:
+
+1. **`data-<prefix>-<axisName>="<context>"` attributes on `<html>`** — one per active axis, plus `data-<prefix>-theme` holding the composed tuple string (`"Dark · Brand A · Normal"`). `<prefix>` follows your `cssVarPrefix` config (default `swatch`).
+2. **The same attributes on each story's wrapper element.** Redundant with `<html>` in most cases, but useful if your story iframe hosts multiple wrappers.
+3. **Per-tuple CSS** emitted under compound attribute selectors — `[data-<prefix>-mode="Dark"][data-<prefix>-brand="Brand A"] { … }`. One block per tuple, with the default tuple's values in `:root` as the fallback.
+4. **Attributes update on toolbar flip.** Synchronously, before the next paint — observers fire on the microtask queue.
+
+Any change to this shape would be a breaking change. The DOM is the API.
+
+## What swatchbook does not ship
+
+- **No framework-specific hooks.** No `useSwatchbookAxes()` from `@unpunnyfuns/swatchbook-addon`, no Vue composable, no Angular service. The core package is pure TypeScript with no React dependency; the addon's preview code is DOM-only. If you need a reusable hook inside your project, write the ten lines above — that's less code than importing a package and pinning its version.
+- **No recipes per component library.** MUI, Chakra, Mantine, styled-components, Emotion, Tailwind class-mode — each one has its own theming model, and we aren't in the business of tracking them. The bridge pattern above is the starting point; your component library's theming docs are the rest.
+
+## Troubleshooting
+
+**My component library's theme is a JS object — can I drive it from `<prefix>-*` CSS variables?**
+Only if the library consumes CSS variables natively (Tailwind does, Bootstrap 5 does). If the theme is a JS object read at render time (MUI, Chakra, Mantine), you need the DOM-observation path.
+
+**Tailwind's `dark:` variant isn't responding to swatchbook.**
+Tailwind looks for `.dark` on an ancestor, or `data-theme="dark"` in its attribute mode. Swatchbook writes `data-<prefix>-mode="Dark"` — the attribute shape and name don't match. Either configure Tailwind to key on swatchbook's attribute (`@custom-variant dark (&:where([data-<prefix>-mode=Dark], [data-<prefix>-mode=Dark] *));`), or have the preview decorator mirror a `.dark` class yourself via the DOM-observation path.
+
+**Storybook's own manager theme (light/dark chrome around the preview) doesn't flip.**
+That's `@storybook/theming`, which controls Storybook's UI chrome — a separate concern. See [Storybook's manager theming docs](https://storybook.js.org/docs/configure/user-interface/theming).
+
+## See also
+
+- [Axes](./axes) — the runtime model for tuples and attribute composition.
+- [Why axes, not themes](./axes-vs-themes) — the shape that makes this contract expressive across multiple dimensions.

--- a/apps/docs/docs/concepts/theming-inputs.mdx
+++ b/apps/docs/docs/concepts/theming-inputs.mdx
@@ -1,7 +1,7 @@
 ---
 id: theming-inputs
 title: Theming inputs
-sidebar_position: 1
+sidebar_position: 2
 ---
 
 # Theming inputs

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -7,15 +7,21 @@ sidebar_position: 1
 
 # Swatchbook
 
-A Storybook addon and MDX blocks for **documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/)**. It parses your token files through [Terrazzo](https://terrazzo.app/), composes them across a resolver's modifier axes (mode × brand × contrast × …), and renders a browsable reference inside your Storybook — searchable token panel, a toolbar that flips axes so readers can see every token in every context, tuple-aware `TokenDetail` blocks, `ColorPalette`, `TypographyScale`, and more.
+A Storybook addon and MDX blocks for **documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/)**.
+
+Flip **light/dark, brand, contrast, density** — or whatever independent dimensions your design system has — from one toolbar, without enumerating every combination as a flat theme ID. Swatchbook reads your resolver's modifiers directly through [Terrazzo](https://terrazzo.app/): each one becomes a toolbar dropdown, tokens repaint as readers flip axes, and CSS emission covers every combination under `[data-<prefix>-<axis>]` compound selectors. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape and what it gets you.
+
+Alongside the switcher, the addon ships MDX doc blocks — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and more — that render your tokens as browsable reference pages without a bespoke docs site. For day-to-day authoring, the blocks are the primary interaction.
 
 ## Who it's for
 
-Design-system authors who already have DTCG tokens (or are authoring them) and want a browsable, interactive reference without building a custom docs site.
+Design-system authors who already have DTCG tokens (or are authoring them) — especially systems with more than one independent dimension (brand × mode, contrast × mode, density, and so on) — and want a browsable, interactive reference without building a custom docs site.
+
+If your system has exactly one dimension and no plans for more, [`@storybook/addon-themes`](https://storybook.js.org/addons/@storybook/addon-themes)' single-string-ID model is simpler and probably a better fit.
 
 ## What it's not
 
-Swatchbook isn't a runtime theme-switcher, a CSS-variable framework, or a component styling system. It emits CSS vars and `data-<prefix>-*` attributes on `<html>` inside the Storybook preview so tokens repaint when an author toggles an axis in the toolbar — that's a documentation affordance, not a production theming API. For production theme switching, use your framework's theming tools (or call `@unpunnyfuns/swatchbook-core`'s `emitCss` at build time and wire it up yourself).
+Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable framework, or a component styling system. It emits CSS variables and `data-<prefix>-*` attributes on `<html>` inside the Storybook preview so tokens repaint when an author toggles an axis — that's a documentation affordance, not a production theming API. For production theme switching, use your framework's theming tools (or call `@unpunnyfuns/swatchbook-core`'s `emitCss` at build time and wire it up yourself). For how your stories react to toolbar flips, see [theme reactivity](./concepts/theme-reactivity).
 
 ## What the addon gives you
 
@@ -31,7 +37,7 @@ The [live Storybook](pathname:///storybook/) runs the addon against this repo's 
 
 - **[Quickstart](./quickstart)** — install, configure, run.
 - **Blocks** — the MDX doc blocks you'll spend most of your time with: the [reference](./reference/blocks) lists what's available and the [authoring guide](./guides/authoring-doc-stories) walks through composing them.
-- **Concepts** — the mental model: theming inputs, axes, presets, diagnostics.
+- **Concepts** — the mental model: [why axes, not themes](./concepts/axes-vs-themes), [theming inputs](./concepts/theming-inputs), [axes](./concepts/axes), [theme reactivity](./concepts/theme-reactivity), [presets](./concepts/presets), [diagnostics](./concepts/diagnostics).
 - **Guides** — the [multi-axis walkthrough](./guides/multi-axis-walkthrough) covers one-time setup.
 - **Reference** — API surface for the remaining packages (`addon`, `core`, `config`).
 

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -83,6 +83,7 @@ const config: Config = {
     navbar: {
       title: 'Swatchbook',
       items: [
+        { to: '/', label: 'Introduction', position: 'left', activeBaseRegex: '^/(next/)?$' },
         { type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs' },
         { href: 'pathname:///storybook/', label: 'Live Storybook', position: 'left' },
         ...(hasReleasedVersion

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -2,7 +2,10 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 
 const sidebars: SidebarsConfig = {
   docs: [
-    'intro',
+    // `intro` is intentionally not in this sidebar. It's exposed as a
+    // top-level navbar link ("Introduction") so the landing page lives
+    // outside the Docs tree — visitors hitting the site hero first, then
+    // entering Docs when they want to read the manual.
     'quickstart',
     // Blocks promoted to the top level. After initial setup, authoring
     // pages with the doc blocks is the primary swatchbook interaction —
@@ -28,9 +31,11 @@ const sidebars: SidebarsConfig = {
       label: 'Concepts',
       collapsed: false,
       items: [
+        'concepts/axes-vs-themes',
         'concepts/theming-inputs',
         'concepts/axes',
         'concepts/presets',
+        'concepts/theme-reactivity',
         'concepts/diagnostics',
       ],
     },


### PR DESCRIPTION
## Summary

Follow-up on PR #408. The Introduction page now lives outside the Docs tree:

- **Navbar**: new \`Introduction\` item to the left of \`Docs\` (with an \`activeBaseRegex\` so it highlights on \`/\` and \`/next/\` but not on any \`/docs/...\` path).
- **Sidebar**: dropped \`'intro'\` from the \`docs\` sidebar so clicking \`Docs\` enters the manual at \`Quickstart\`.
- Folds in the two concept pages from #408 that were missing from the sidebar: \`concepts/axes-vs-themes\` lands first in Concepts (the mental-model primer), \`concepts/theme-reactivity\` sits between presets and diagnostics.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs build\` — docs site builds green. Pre-existing broken links in archived 0.3 docs unchanged.
- [x] Introduction still reachable at \`/\` (the \`slug: /\` frontmatter on \`intro.mdx\` is unchanged).
- [x] \`Docs\` navbar item now targets the first sidebar entry (\`Quickstart\`).

Milestone: Pre-1.0 positioning
Closes: none (#402 / #403 / #407 already closed by #408)
Plan impact: none