### PR TITLE
docs(storybook): promote Introduction to the top-level sidebar, outside the Docs section

### DIFF
--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -16,10 +16,10 @@ export default definePreview({
     options: {
       storySort: {
         order: [
+          'Introduction',
           'Docs',
           [
             'Dashboard',
-            'Introduction',
             'Colors',
             'Typography',
             'Fonts',

--- a/apps/storybook/src/docs/Introduction.mdx
+++ b/apps/storybook/src/docs/Introduction.mdx
@@ -1,6 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 
-<Meta title="Docs/Introduction" />
+<Meta title="Introduction" />
 
 # Swatchbook
 


### PR DESCRIPTION
## Summary

Live Storybook sidebar: Introduction was buried inside the \`Docs\` group (\`Docs/Introduction\`). This promotes it to the sidebar root so it shows up as the very first entry, above the \`Docs\` section.

- \`Introduction.mdx\` → \`<Meta title=\"Introduction\" />\`
- \`preview.tsx\` storySort → \`Introduction\` listed before \`Docs\`; removed from the inner Docs-group array

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck\` — clean.
- Visual check in live Storybook: Introduction appears at sidebar root; Docs group expands to show Dashboard / Colors / Typography / etc.

Milestone: Pre-1.0 positioning
Closes: none
Plan impact: none