### PR TITLE
fix(addon): rebind keyboard shortcut + cycle presets; surface chrome config in quickstart

### DIFF
--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -72,6 +72,36 @@ pnpm storybook
 
 For a browsable tree of every token in the active theme plus a diagnostics summary, compose `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />` into an MDX docs page — see the [token-dashboard guide](./guides/token-dashboard). Switching themes from the toolbar re-renders those blocks live.
 
+## Theme the block chrome against your tokens
+
+The MDX doc blocks read their surfaces, text, and accent colours from a fixed `--swatchbook-*` CSS-variable namespace. Out of the box those variables fall back to light/dark literals that flip with the active `color-scheme`, which means the blocks render legibly before you wire anything up. To have them reflect your own tokens, supply a `chrome` map — one entry per role, each pointing at a token path in your project:
+
+```ts title=".storybook/main.ts"
+{
+  name: '@unpunnyfuns/swatchbook-addon',
+  options: {
+    config: {
+      resolver: 'tokens/resolver.json',
+      cssVarPrefix: 'ds',
+      chrome: {
+        surfaceDefault: 'color.sys.surface.default',
+        surfaceMuted:   'color.sys.surface.muted',
+        surfaceRaised:  'color.sys.surface.raised',
+        textDefault:    'color.sys.text.default',
+        textMuted:      'color.sys.text.muted',
+        borderDefault:  'color.sys.border.default',
+        accentBg:       'color.sys.accent.bg',
+        accentFg:       'color.sys.accent.fg',
+        bodyFontFamily: 'typography.sys.body.font-family',
+        bodyFontSize:   'typography.sys.body.font-size',
+      },
+    },
+  },
+},
+```
+
+With a `chrome` map in place the blocks track every toolbar flip — switch brand or contrast and the block chrome repaints alongside your stories. The closed set of roles (and what each maps to internally) is in the [`chrome` config reference](./reference/config#chrome-recordstring-string).
+
 ## No resolver yet?
 
 If you haven't written a DTCG 2025.10 resolver, you can use the **layered** config form instead:

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -467,29 +467,34 @@ function AxesToolbar(): ReactElement {
   );
 
   useEffect(() => {
-    if (axes.length === 0) return;
+    if (presets.length === 0) return;
     /**
-     * alt+T cycles the primary (first) axis's contexts, keeping the rest
-     * of the tuple pinned. With multi-axis projects this makes the shortcut
-     * predictable — you always know which wheel you're spinning. For
-     * single-axis projects the behavior is identical to the pre-N-dropdown
-     * toolbar (cycle through every theme).
+     * `alt+shift+C` cycles through the project's presets, applying the
+     * next one each press. When no preset has been applied yet, starts
+     * from the first. Stays out of Storybook's core shortcut surface —
+     * the earlier default (`alt+T`) collided with the built-in "toggle
+     * addon panel" binding on some platforms. Users can still rebind it
+     * through Storybook's own keyboard-shortcuts panel.
+     *
+     * Only registers when the project actually defines presets. For
+     * projects without presets the cycle would have nothing to cycle
+     * through, so the shortcut disappears entirely rather than sitting
+     * dead in the menu.
      */
-    const primary = axes[0];
-    if (!primary) return;
     api.setAddonShortcut(ADDON_ID, {
-      label: `Cycle swatchbook ${displayLabelFor(primary)}`,
-      defaultShortcut: ['alt', 'T'],
-      actionName: 'cycleAxis',
+      label: `Cycle swatchbook presets (${presets.length})`,
+      defaultShortcut: ['alt', 'shift', 'C'],
+      actionName: 'cyclePreset',
       showInMenu: true,
       action: () => {
-        const current = activeTuple[primary.name] ?? primary.default;
-        const idx = primary.contexts.indexOf(current);
-        const next = primary.contexts[(idx + 1) % primary.contexts.length];
-        if (next !== undefined) setAxis(primary.name, next);
+        const currentIdx = lastApplied
+          ? presets.findIndex((preset) => preset.name === lastApplied)
+          : -1;
+        const next = presets[(currentIdx + 1) % presets.length];
+        if (next) applyPreset(next);
       },
     });
-  }, [api, axes, activeTuple, setAxis]);
+  }, [api, presets, lastApplied, applyPreset]);
 
   const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>): void => {
     if (event.key === 'Escape') {


### PR DESCRIPTION
## Summary

Two fixes pulled out of the Pre-1.0 positioning pass.

### 1. Addon keyboard shortcut

**Rebind** \`alt+T\` → \`alt+shift+C\`. The old default collided with Storybook's built-in 'toggle addon panel' binding on some platforms (the user's macOS Storybook showed Alt+T as 'Cycle Swatchbook mode' sitting on top of Storybook's own panel-toggle chord). Three-key chord stays out of the core-Storybook shortcut surface; users can still rebind via Storybook's own keyboard-shortcuts panel.

**Re-point the action**: was 'cycle the primary axis's contexts', now 'cycle through the project's presets'. Presets are deliberately-authored named tuples (\`Default Light\`, \`Brand A Dark\`, \`A11y High Contrast\`) — cycling those is more useful than flipping one wheel while everything else stays pinned. The shortcut now only registers when the project defines presets; for preset-less projects it doesn't sit dead in the menu.

Menu label: \`Cycle swatchbook presets (N)\` so the action is legible in the application menu.

### 2. Quickstart: chrome config

The \`chrome\` config was only mentioned in the reference docs, which means consumers who want block chrome to follow their own tokens needed to discover it by accident. Quickstart now has a 'Theme the block chrome against your tokens' section between 'What you should see' and 'No resolver yet?' with a full 10-role example and a link through to the config reference.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — clean.
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs build\` — docs site builds green (pre-existing 0.3 archived-version broken links unchanged).
- Manual verification: in live Storybook, the application menu now shows \`⌥⇧C Cycle swatchbook presets (3)\` (or whatever your preset count is) for the reference fixture.

Milestone: Maintenance
Closes: none (filed directly from user feedback)
Plan impact: none