### PR TITLE
feat(blocks): type prop on TokenNavigator

### DIFF
--- a/.changeset/token-navigator-type.md
+++ b/.changeset/token-navigator-type.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+feat(blocks): `type` prop on `<TokenNavigator>`
+
+Scope the tree by DTCG `$type`. Pass a single string (`type="color"`) to restrict to one type, or an array (`type={['duration', 'cubicBezier', 'transition']}`) for a small-multiples view. Composes with `root` — both constraints must hold. Matches the `type` prop already available on `<TokenTable>`.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -17,13 +17,14 @@ Most blocks in this group take:
 
 ## Across types
 
-### `<TokenNavigator root? initiallyExpanded? onSelect? />`
+### `<TokenNavigator root? type? initiallyExpanded? onSelect? />`
 
 Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
 Props:
 
 - `root?: string` — mount at this subtree (e.g. `"color"`, `"typography"`). Omit to show everything.
+- `type?: string | readonly string[]` — restrict to one DTCG `$type` (`type="color"`) or a small-multiples set (`type={['duration', 'cubicBezier', 'transition']}`). Composes with `root` — both constraints must hold.
 - `initiallyExpanded?: number` — depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
 - `onSelect?(path: string): void` — receives a leaf's full dot-path on click; suppresses the built-in overlay.
 

--- a/apps/storybook/src/docs/Dashboard.mdx
+++ b/apps/storybook/src/docs/Dashboard.mdx
@@ -14,7 +14,7 @@ re-renders against the active tuple.
 
 ## Token graph
 
-<TokenNavigator />
+<TokenNavigator initiallyExpanded={0} />
 
 ## All tokens (searchable)
 

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -8,6 +8,7 @@ const meta = preview.meta({
   component: TokenNavigator,
   argTypes: {
     root: { control: 'text' },
+    type: { control: 'text' },
     initiallyExpanded: { control: { type: 'number', min: 0, max: 6 } },
   },
 });
@@ -21,6 +22,17 @@ export const ColorSubtree = meta.story({ args: { root: 'color' } });
 export const FullyCollapsed = meta.story({ args: { initiallyExpanded: 0 } });
 
 export const DeepExpanded = meta.story({ args: { initiallyExpanded: 3, root: 'color' } });
+
+/**
+ * `type` scopes the tree by DTCG `$type`. Passing a single string restricts
+ * to one type; passing an array narrows to a small-multiples view. Composes
+ * with `root` — both constraints must hold.
+ */
+export const ColorTypeFilter = meta.story({ args: { type: 'color' } });
+
+export const MotionTypes = meta.story({
+  args: { type: ['duration', 'cubicBezier', 'transition'], initiallyExpanded: 2 },
+});
 
 function RecordingNavigator() {
   const [last, setLast] = useState<string | null>(null);

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -17,6 +17,14 @@ export interface TokenNavigatorProps {
   /** If provided, mount at this dot-path subtree and hide everything outside it. */
   root?: string;
   /**
+   * Restrict the tree to tokens with the given DTCG `$type`(s). Pass a single
+   * string to scope to one type (`type="color"`), or an array for a narrow
+   * small-multiples view (`type={['duration', 'cubicBezier', 'transition']}`).
+   * Composes with `root` — both constraints must hold. Group nodes that end
+   * up with no surviving leaves collapse out.
+   */
+  type?: string | readonly string[];
+  /**
    * Depth (from the mounted root) that is expanded on first render.
    * `0` = everything collapsed, `1` = top-level groups open (default),
    * `2` = one level deeper, etc.
@@ -46,13 +54,18 @@ interface GroupNode {
 
 type TreeNode = LeafNode | GroupNode;
 
-function buildTree(resolved: Record<string, VirtualToken>, root: string | undefined): TreeNode[] {
+function buildTree(
+  resolved: Record<string, VirtualToken>,
+  root: string | undefined,
+  typeFilter: ReadonlySet<string> | undefined,
+): TreeNode[] {
   const rootPrefix = root && root.length > 0 ? `${root}.` : '';
   const rootSegments = root ? root.split('.') : [];
 
-  const entries = Object.entries(resolved).filter(([path]) => {
-    if (!root) return true;
-    return path === root || path.startsWith(rootPrefix);
+  const entries = Object.entries(resolved).filter(([path, token]) => {
+    if (root && !(path === root || path.startsWith(rootPrefix))) return false;
+    if (typeFilter && !(token.$type && typeFilter.has(token.$type))) return false;
+    return true;
   });
 
   const rootNode: GroupNode = { kind: 'group', segment: '', path: '', children: [] };
@@ -121,12 +134,18 @@ function countLeaves(node: TreeNode): number {
 
 export function TokenNavigator({
   root,
+  type,
   initiallyExpanded = 1,
   onSelect,
 }: TokenNavigatorProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
 
-  const tree = useMemo(() => buildTree(resolved, root), [resolved, root]);
+  const typeFilter = useMemo<ReadonlySet<string> | undefined>(() => {
+    if (type === undefined) return undefined;
+    return new Set(Array.isArray(type) ? type : [type]);
+  }, [type]);
+
+  const tree = useMemo(() => buildTree(resolved, root, typeFilter), [resolved, root, typeFilter]);
 
   const initialExpanded = useMemo(() => {
     const out = new Set<string>();
@@ -158,11 +177,17 @@ export function TokenNavigator({
     [onSelect],
   );
 
+  const typeLabel = typeFilter ? ` · ${[...typeFilter].map((t) => `$type=${t}`).join(', ')}` : '';
+
   if (tree.length === 0) {
     return (
       <div {...themeAttrs(cssVarPrefix, activeTheme)}>
         <EmptyState>
-          {root ? `No tokens under "${root}".` : 'No tokens in the active theme.'}
+          {root
+            ? `No tokens under "${root}"${typeFilter ? ` matching ${typeLabel.slice(3)}` : ''}.`
+            : typeFilter
+              ? `No tokens matching ${typeLabel.slice(3)} in the active theme.`
+              : 'No tokens in the active theme.'}
         </EmptyState>
       </div>
     );
@@ -171,7 +196,8 @@ export function TokenNavigator({
   return (
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
       <div className="sb-token-navigator__caption">
-        {root ? `Tokens under ${root}` : 'Token graph'} · {activeTheme}
+        {root ? `Tokens under ${root}` : 'Token graph'}
+        {typeLabel} · {activeTheme}
       </div>
       <ul className="sb-token-navigator__tree" role="tree">
         {tree.map((node) => (

--- a/packages/blocks/test/token-navigator.test.tsx
+++ b/packages/blocks/test/token-navigator.test.tsx
@@ -64,4 +64,51 @@ describe('TokenNavigator', () => {
     );
     expect(screen.getByText(/No tokens under "does-not-exist"/)).toBeDefined();
   });
+
+  it('filters by DTCG $type with a single string', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator type="dimension" />
+      </SwatchbookProvider>,
+    );
+    const tree = screen.getByRole('tree');
+    const topGroups = within(tree)
+      .getAllByTestId('token-navigator-group')
+      .filter((el) => el.getAttribute('data-path')?.split('.').length === 1);
+    const names = topGroups.map((el) => el.getAttribute('data-path'));
+    expect(names).toEqual(['radius']);
+    expect(screen.queryByText('bg')).toBeNull();
+  });
+
+  it('filters by DTCG $type with an array of types', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator type={['color', 'dimension']} />
+      </SwatchbookProvider>,
+    );
+    const tree = screen.getByRole('tree');
+    const topGroups = within(tree)
+      .getAllByTestId('token-navigator-group')
+      .filter((el) => el.getAttribute('data-path')?.split('.').length === 1);
+    const names = topGroups.map((el) => el.getAttribute('data-path')).toSorted();
+    expect(names).toEqual(['color', 'radius']);
+  });
+
+  it('composes `type` with `root` — both constraints must hold', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator root="color" type="dimension" />
+      </SwatchbookProvider>,
+    );
+    expect(screen.getByText(/No tokens under "color"/)).toBeDefined();
+  });
+
+  it('shows a type-aware empty-state when no tokens match', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator type="fontWeight" />
+      </SwatchbookProvider>,
+    );
+    expect(screen.getByText(/No tokens matching \$type=fontWeight/)).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

Adds a \`type\` prop to \`<TokenNavigator>\` for DTCG \`\$type\` filtering, matching the one \`<TokenTable>\` already ships.

- \`type=\"color\"\` — restrict to one type.
- \`type={['duration', 'cubicBezier', 'transition']}\` — small-multiples / union view.
- Composes with \`root\` — both constraints must hold.
- Group nodes that end up with no surviving leaves collapse out of the tree.

## Test plan

- [x] New unit tests in \`packages/blocks/test/token-navigator.test.tsx\`: single string, array form, \`type\` + \`root\` composition, type-aware empty-state message.
- [x] \`pnpm turbo run lint typecheck test\` — clean.
- Stories added: \`Blocks/TokenNavigator\` → \`ColorTypeFilter\`, \`MotionTypes\`.
- Docs: \`reference/blocks/overview\` signature + prop list updated.

Milestone: Maintenance
Closes: none (direct user request after v0.5.0)
Plan impact: none