### PR TITLE
feat(tokens-reference): contrast=High overlay shifts typography to Comic family

### DIFF
--- a/packages/tokens-reference/tokens/font.json
+++ b/packages/tokens-reference/tokens/font.json
@@ -4,7 +4,8 @@
       "$type": "fontFamily",
       "sans": { "$value": ["Inter", "system-ui", "-apple-system", "sans-serif"] },
       "serif":{ "$value": ["Source Serif 4", "Georgia", "serif"] },
-      "mono": { "$value": ["JetBrains Mono", "Menlo", "monospace"] }
+      "mono": { "$value": ["JetBrains Mono", "Menlo", "monospace"] },
+      "comic":{ "$value": ["Comic Sans MS", "Comic Neue", "Chalkboard SE", "Marker Felt", "cursive"] }
     },
     "weight": {
       "$type": "fontWeight",

--- a/packages/tokens-reference/tokens/themes/contrast-high.json
+++ b/packages/tokens-reference/tokens/themes/contrast-high.json
@@ -1,7 +1,7 @@
 {
   "color": {
     "$type": "color",
-    "$description": "High-contrast overlay — strengthens borders and focus rings. Surfaces and accents stay in mode/brand's lane.",
+    "$description": "High-contrast overlay — strengthens borders and focus rings. Typography shifts to a Comic-family stack; irregular letterforms are easier to parse for some dyslexic readers. Surfaces and accents stay in mode/brand's lane.",
     "border": {
       "default": { "$value": "{color.palette.neutral.700}" },
       "strong":  { "$value": "{color.palette.neutral.900}" },
@@ -10,6 +10,37 @@
     "text": {
       "muted":  { "$value": "{color.palette.neutral.700}" },
       "subtle": { "$value": "{color.palette.neutral.600}" }
+    }
+  },
+  "typography": {
+    "$type": "typography",
+    "$description": "High-contrast typography — body and heading composites shift to the Comic family with slightly looser line-height; code stays monospace.",
+    "body": {
+      "$value": {
+        "fontFamily": "{font.family.comic}",
+        "fontSize":   "{size.rem-400}",
+        "fontWeight": "{font.weight.regular}",
+        "lineHeight": 1.6,
+        "letterSpacing": { "value": 0, "unit": "px" }
+      }
+    },
+    "body-strong": {
+      "$value": {
+        "fontFamily": "{font.family.comic}",
+        "fontSize":   "{size.rem-400}",
+        "fontWeight": "{font.weight.bold}",
+        "lineHeight": 1.6,
+        "letterSpacing": { "value": 0, "unit": "px" }
+      }
+    },
+    "heading": {
+      "$value": {
+        "fontFamily": "{font.family.comic}",
+        "fontSize":   "{size.rem-700}",
+        "fontWeight": "{font.weight.bold}",
+        "lineHeight": 1.3,
+        "letterSpacing": { "value": 0, "unit": "px" }
+      }
     }
   },
   "border": {


### PR DESCRIPTION
## Summary

The reference fixture's \`contrast=High\` overlay previously only touched borders, focus rings, and muted text. Extending it to demonstrate that modifier overlays can redirect **typography composites** too, not just color tokens.

- **New primitive**: \`font.family.comic\` — \`Comic Sans MS → Comic Neue → Chalkboard SE → Marker Felt → cursive\`.
- **Overlay shifts**: \`typography.body\`, \`typography.body-strong\`, \`typography.heading\` alias to \`{font.family.comic}\` with slightly looser line-height (1.6 body, 1.3 heading) and drop the heading's negative letter-spacing.
- **Deliberately unchanged**: \`typography.code\` stays on \`font.family.mono\`. Code should render monospace regardless of contrast.

### Why Comic

Irregular letterforms (Comic Sans, Comic Neue, etc.) are often cited as more readable for dyslexic readers. Also the single most-recognizable possible demo: flipping High contrast and seeing the page repaint in Comic Sans makes the "modifier overlays can touch any token type, not just color" story vivid in a way a font-size tweak wouldn't.

## Test plan

- [x] \`pnpm turbo run lint typecheck test\` — clean.
- [x] Live Storybook: \`blocks-typographyscale--all\` passes with \`contrast=High\` active; font repaints to Comic Sans MS on the fallback chain.
- [x] Presets (\`A11y High Contrast\`) pick up the typography shift alongside the border bumps.

Milestone: Maintenance
Plan impact: none

Closes #427
