### PR TITLE
docs: add logo + lowercase 'swatchbook' wordmark to Docusaurus navbar and Storybook manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-# Swatchbook
+# swatchbook
 
-A Storybook addon and MDX blocks for documenting [DTCG](https://www.designtokens.org/) design tokens — parsed via [Terrazzo](https://terrazzo.app/) — with a toolbar that flips **light/dark, brand, contrast, density, or whatever independent dimensions your design system cares about**. Each dimension is a modifier on your DTCG resolver; swatchbook reads them directly, so you don't enumerate every combination as a flat theme ID. (See ["why axes, not themes"](https://unpunnyfuns.github.io/swatchbook/concepts/axes-vs-themes).)
+A Storybook addon and MDX blocks for documenting [DTCG](https://www.designtokens.org/) design tokens.
 
-Alongside the switcher, swatchbook ships MDX doc blocks — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and more — that render your tokens as browsable reference pages without a bespoke docs site.
+Two things in one:
 
-**Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) (live Storybook at [`/storybook`](https://unpunnyfuns.github.io/swatchbook/storybook/)).
+- **Doc blocks** — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and more. Drop them into MDX pages and your token reference writes itself.
+- **A multi-axis theme switcher** — flip dark mode, brand, contrast, density, whatever dimensions your design system has, from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown inside a single popover. (See [*why axes, not themes*](https://unpunnyfuns.github.io/swatchbook/concepts/axes-vs-themes).)
+
+**Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) · **Live Storybook:** [/storybook](https://unpunnyfuns.github.io/swatchbook/storybook/)
 
 ## Packages
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -5,13 +5,14 @@ title: Introduction
 sidebar_position: 1
 ---
 
-# Swatchbook
+# swatchbook
 
 A Storybook addon and MDX blocks for **documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/)**.
 
-Flip **light/dark, brand, contrast, density** — or whatever independent dimensions your design system has — from one toolbar, without enumerating every combination as a flat theme ID. Swatchbook reads your resolver's modifiers directly through [Terrazzo](https://terrazzo.app/): each one becomes a toolbar dropdown, tokens repaint as readers flip axes, and CSS emission covers every combination under `[data-<prefix>-<axis>]` compound selectors. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape and what it gets you.
+Two things in one:
 
-Alongside the switcher, the addon ships MDX doc blocks — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and more — that render your tokens as browsable reference pages without a bespoke docs site. For day-to-day authoring, the blocks are the primary interaction.
+- **Doc blocks.** `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and a handful of type-specific previews. Drop them into MDX pages and your token reference writes itself.
+- **A multi-axis theme switcher.** Flip dark mode, brand, contrast, density — whatever dimensions your design system has — from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown in a single popover. Tokens repaint live as readers flip axes. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape.
 
 ## Who it's for
 

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -19,9 +19,9 @@ const hasReleasedVersion =
   existsSync(versionsPath) && JSON.parse(readFileSync(versionsPath, 'utf8')).length > 0;
 
 const config: Config = {
-  title: 'Swatchbook',
+  title: 'swatchbook',
   tagline: 'Storybook addon for DTCG design tokens',
-  favicon: 'img/favicon.ico',
+  favicon: 'img/logo.svg',
 
   future: {
     v4: {
@@ -81,7 +81,11 @@ const config: Config = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: 'Swatchbook',
+      title: 'swatchbook',
+      logo: {
+        alt: 'swatchbook logo',
+        src: 'img/logo.svg',
+      },
       items: [
         { type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs' },
         { href: 'pathname:///storybook/', label: 'Live Storybook', position: 'left' },

--- a/apps/storybook/.storybook/assets/logo.svg
+++ b/apps/storybook/.storybook/assets/logo.svg
@@ -1,0 +1,9 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="-2.4 -2.4 28.80 28.80" fill="none" xmlns="http://www.w3.org/2000/svg" transform="matrix(1, 0, 0, 1, 0, 0)rotate(0)" stroke="#444" stroke-width="0.00024000000000000003">
+<g id="SVGRepo_bgCarrier" stroke-width="0" transform="translate(0,0), scale(1)">
+<path transform="translate(-2.4, -2.4), scale(1.7999999999999998)" fill="#ddd" d="M9.166.33a2.25 2.25 0 00-2.332 0l-5.25 3.182A2.25 2.25 0 00.5 5.436v5.128a2.25 2.25 0 001.084 1.924l5.25 3.182a2.25 2.25 0 002.332 0l5.25-3.182a2.25 2.25 0 001.084-1.924V5.436a2.25 2.25 0 00-1.084-1.924L9.166.33z" strokewidth="0"/>
+</g>
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round" stroke="#CCCCCC" stroke-width="0.048"/>
+<g id="SVGRepo_iconCarrier"> <path d="M14 16C14 17.1046 13.1046 18 12 18C10.8954 18 10 17.1046 10 16C10 14.8954 10.8954 14 12 14C13.1046 14 14 14.8954 14 16Z" fill="#444"/> <path fill-rule="evenodd" clip-rule="evenodd" d="M22 12C22 17.5228 17.5228 22 12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12ZM12 12C9.79086 12 8 10.2091 8 8C8 5.79086 9.79086 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20C14.2091 20 16 18.2091 16 16C16 13.7909 14.2091 12 12 12ZM14 8C14 9.10457 13.1046 10 12 10C10.8954 10 10 9.10457 10 8C10 6.89543 10.8954 6 12 6C13.1046 6 14 6.89543 14 8Z" fill="#444"/> </g>
+</svg>

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -9,6 +9,7 @@ function pkg(name: string): string {
 
 export default defineMain({
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(ts|tsx)'],
+  staticDirs: ['./assets'],
   addons: [
     pkg('@chromatic-com/storybook'),
     pkg('@storybook/addon-vitest'),

--- a/apps/storybook/.storybook/manager.ts
+++ b/apps/storybook/.storybook/manager.ts
@@ -1,0 +1,22 @@
+import { addons } from 'storybook/manager-api';
+import { create, themes } from 'storybook/theming';
+
+/**
+ * Manager-side theming for the Storybook UI chrome (sidebar, toolbar,
+ * panel tabs) — separate from the preview-side swatchbook addon that
+ * themes stories. This just brands the manager with the swatchbook logo
+ * + lowercase wordmark so readers know where they are.
+ *
+ * Light theme only for now; the stock light chrome reads cleanly under
+ * both preview color-schemes.
+ */
+addons.setConfig({
+  theme: create({
+    ...themes.light,
+    base: 'light',
+    brandTitle: 'swatchbook',
+    brandUrl: 'https://unpunnyfuns.github.io/swatchbook/',
+    brandImage: './logo.svg',
+    brandTarget: '_self',
+  }),
+});


### PR DESCRIPTION
## Summary

Two brand surfaces, one identity.

### Docusaurus navbar

- Adds \`navbar.logo\` pointing at \`img/logo.svg\` (already in the static tree).
- Site \`title\` and \`navbar.title\` drop to lowercase **swatchbook**, matching the package-name stylization (\`@unpunnyfuns/swatchbook-core\`, etc.).
- \`favicon\` switches from \`img/favicon.ico\` (which was a 404 — no such file existed) to the SVG logo.

### Storybook manager

- New \`apps/storybook/.storybook/manager.ts\` calls \`addons.setConfig\` with a theme composed via \`storybook/theming\`'s \`create()\` — brand title \`swatchbook\`, brand image \`./logo.svg\`, brand URL the docs site. No behavioral change beyond branding.
- Logo copied to \`apps/storybook/.storybook/assets/logo.svg\` and served via \`staticDirs: ['./assets']\` added to \`main.ts\`.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs build\` — green, logo + favicon resolve.
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-storybook typecheck\` — green.
- Visual: live Storybook sidebar now shows the logo + **swatchbook** wordmark; docs site navbar shows the same.

Milestone: Maintenance
Plan impact: none