### PR TITLE
feat(blocks): runtime search on TokenTable and TokenNavigator

### DIFF
--- a/.changeset/searchable-blocks.md
+++ b/.changeset/searchable-blocks.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+feat(blocks): runtime search on `<TokenTable>` and `<TokenNavigator>`
+
+Both blocks now render a search input at the top (default on) that narrows the visible tokens by case-insensitive substring. `<TokenTable>` filters rows by path, type, or value; `<TokenNavigator>` prunes the tree to matching leaves and auto-expands every group on the way to a match so hits are visible without clicking. Adds a `searchable?: boolean` prop to both; pass `false` to hide the input when you want authoring-time filtering (`filter` / `type` / `root`) only.
+
+Restores the runtime search UX the retired Design Tokens panel used to have, which the docs and Dashboard page have been (misleadingly) claiming ever since.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -17,20 +17,21 @@ Most blocks in this group take:
 
 ## Across types
 
-### `<TokenNavigator root? type? initiallyExpanded? onSelect? />`
+### `<TokenNavigator root? type? initiallyExpanded? searchable? onSelect? />`
 
-Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
+Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A search input at the top filters by path substring — matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
 Props:
 
 - `root?: string` — mount at this subtree (e.g. `"color"`, `"typography"`). Omit to show everything.
 - `type?: string | readonly string[]` — restrict to one DTCG `$type` (`type="color"`) or a small-multiples set (`type={['duration', 'cubicBezier', 'transition']}`). Composes with `root` — both constraints must hold.
 - `initiallyExpanded?: number` — depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
+- `searchable?: boolean` — render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
 - `onSelect?(path: string): void` — receives a leaf's full dot-path on click; suppresses the built-in overlay.
 
-### `<TokenTable filter? type? caption? sortBy? sortDir? onSelect? />`
+### `<TokenTable filter? type? caption? sortBy? sortDir? searchable? onSelect? />`
 
-Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
+Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). A search input at the top narrows rows by path, type, or value substring. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
 
 Props:
 
@@ -39,6 +40,7 @@ Props:
 - `caption?: string` — override the caption.
 - `sortBy?: 'path' | 'value' | 'none'` — default `'path'`.
 - `sortDir?: 'asc' | 'desc'` — default `'asc'`.
+- `searchable?: boolean` — render a runtime search input above the table. Defaults to `true`.
 - `onSelect?(path: string): void` — suppress the built-in drawer.
 
 ## Per-type

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -1,3 +1,25 @@
+.sb-token-navigator__search {
+  padding: 0 0 8px;
+}
+
+.sb-token-navigator__search-input {
+  width: 100%;
+  max-width: 360px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  background: var(--swatchbook-surface-default, Canvas);
+  color: var(--swatchbook-text-default, CanvasText);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.sb-token-navigator__search-input:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: 1px;
+}
+
 .sb-token-navigator__caption {
   padding: 4px 0 12px;
   color: var(--swatchbook-text-muted, CanvasText);

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -31,6 +31,14 @@ export interface TokenNavigatorProps {
    */
   initiallyExpanded?: number;
   /**
+   * Render a runtime search input above the tree. Matches are
+   * case-insensitive substrings against a leaf's token path; groups
+   * that contain no matching leaves collapse out, and every group on
+   * the path to a match auto-expands so hits are visible without
+   * clicking. Defaults to `true`.
+   */
+  searchable?: boolean;
+  /**
    * Called with a leaf's full dot-path when it is clicked. When set, the
    * inline `<TokenDetail>` slide-over is suppressed — the consumer owns
    * the follow-up UI.
@@ -132,10 +140,33 @@ function countLeaves(node: TreeNode): number {
   return n;
 }
 
+/**
+ * Return a pruned copy of the tree containing only leaves whose path
+ * matches `needle` (case-insensitive substring) plus the groups on the
+ * way to them. Every surviving group's path is added to `expandOut` so
+ * callers can force those groups open.
+ */
+function pruneTreeForSearch(nodes: TreeNode[], needle: string, expandOut: Set<string>): TreeNode[] {
+  const out: TreeNode[] = [];
+  for (const node of nodes) {
+    if (node.kind === 'leaf') {
+      if (node.path.toLowerCase().includes(needle)) out.push(node);
+    } else {
+      const children = pruneTreeForSearch(node.children, needle, expandOut);
+      if (children.length > 0) {
+        expandOut.add(node.path);
+        out.push({ ...node, children });
+      }
+    }
+  }
+  return out;
+}
+
 export function TokenNavigator({
   root,
   type,
   initiallyExpanded = 1,
+  searchable = true,
   onSelect,
 }: TokenNavigatorProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
@@ -159,6 +190,24 @@ export function TokenNavigator({
   }, [initialExpanded]);
 
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+
+  const { visibleTree, searchExpanded } = useMemo(() => {
+    if (!searchable || query.trim() === '') {
+      return { visibleTree: tree, searchExpanded: null as Set<string> | null };
+    }
+    const needle = query.trim().toLowerCase();
+    const expandOut = new Set<string>();
+    const pruned = pruneTreeForSearch(tree, needle, expandOut);
+    return { visibleTree: pruned, searchExpanded: expandOut };
+  }, [tree, query, searchable]);
+
+  const effectiveExpanded = useMemo(() => {
+    if (!searchExpanded) return expanded;
+    const merged = new Set(expanded);
+    for (const p of searchExpanded) merged.add(p);
+    return merged;
+  }, [expanded, searchExpanded]);
 
   const toggle = useCallback((path: string): void => {
     setExpanded((prev) => {
@@ -193,23 +242,49 @@ export function TokenNavigator({
     );
   }
 
+  const trimmedQuery = query.trim();
+  const matchCount = useMemo(() => {
+    if (!searchExpanded) return 0;
+    let n = 0;
+    for (const node of visibleTree) n += countLeaves(node);
+    return n;
+  }, [visibleTree, searchExpanded]);
+
   return (
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      {searchable && (
+        <div className="sb-token-navigator__search">
+          <input
+            type="search"
+            className="sb-token-navigator__search-input"
+            placeholder="Search tokens…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Search tokens by path"
+            data-testid="token-navigator-search"
+          />
+        </div>
+      )}
       <div className="sb-token-navigator__caption">
         {root ? `Tokens under ${root}` : 'Token graph'}
-        {typeLabel} · {activeTheme}
+        {typeLabel}
+        {trimmedQuery !== '' ? ` · ${matchCount} matching "${trimmedQuery}"` : ''} · {activeTheme}
       </div>
-      <ul className="sb-token-navigator__tree" role="tree">
-        {tree.map((node) => (
-          <TreeNodeRow
-            key={node.path || node.segment}
-            node={node}
-            expanded={expanded}
-            onToggle={toggle}
-            onLeafClick={handleLeafClick}
-          />
-        ))}
-      </ul>
+      {visibleTree.length === 0 ? (
+        <div className="sb-block__empty">No tokens match "{trimmedQuery}".</div>
+      ) : (
+        <ul className="sb-token-navigator__tree" role="tree">
+          {visibleTree.map((node) => (
+            <TreeNodeRow
+              key={node.path || node.segment}
+              node={node}
+              expanded={effectiveExpanded}
+              onToggle={toggle}
+              onLeafClick={handleLeafClick}
+            />
+          ))}
+        </ul>
+      )}
 
       {selectedPath !== null && (
         <DetailOverlay

--- a/packages/blocks/src/TokenTable.css
+++ b/packages/blocks/src/TokenTable.css
@@ -3,6 +3,35 @@
   border-collapse: collapse;
 }
 
+.sb-token-table__search {
+  padding: 0 0 8px;
+}
+
+.sb-token-table__search-input {
+  width: 100%;
+  max-width: 360px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  background: var(--swatchbook-surface-default, Canvas);
+  color: var(--swatchbook-text-default, CanvasText);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.sb-token-table__search-input:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: 1px;
+}
+
+.sb-token-table__empty-row {
+  color: var(--swatchbook-text-muted, CanvasText);
+  font-style: italic;
+  text-align: center;
+  padding: 16px 12px;
+}
+
 .sb-token-table__caption {
   caption-side: top;
   text-align: left;

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -33,6 +33,14 @@ export interface TokenTableProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
   /**
+   * Render a runtime search input above the table that narrows rows by
+   * case-insensitive substring against the token path, type, or value.
+   * Defaults to `true` because browsing a multi-hundred-token reference
+   * without search is painful. Pass `false` to hide the input (the
+   * `filter` / `type` props still apply at authoring time).
+   */
+  searchable?: boolean;
+  /**
    * Called with the clicked row's dot-path. When set, the built-in
    * `<TokenDetail>` slide-over is suppressed — the consumer owns the
    * follow-up UI (inline panel, drill-down route, …).
@@ -46,11 +54,13 @@ export function TokenTable({
   caption,
   sortBy = 'path',
   sortDir = 'asc',
+  searchable = true,
   onSelect,
 }: TokenTableProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
   const colorFormat = useColorFormat();
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
 
   const rows = useMemo(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -73,6 +83,17 @@ export function TokenTable({
     });
   }, [resolved, filter, type, cssVarPrefix, colorFormat, sortBy, sortDir]);
 
+  const visibleRows = useMemo(() => {
+    if (!searchable || query.trim() === '') return rows;
+    const needle = query.trim().toLowerCase();
+    return rows.filter(
+      (row) =>
+        row.path.toLowerCase().includes(needle) ||
+        row.type.toLowerCase().includes(needle) ||
+        row.value.toLowerCase().includes(needle),
+    );
+  }, [rows, query, searchable]);
+
   const handleRowClick = useCallback(
     (path: string) => {
       if (onSelect) onSelect(path);
@@ -81,11 +102,13 @@ export function TokenTable({
     [onSelect],
   );
 
+  const matchSuffix =
+    searchable && query.trim() !== '' ? ` · ${visibleRows.length} matching "${query.trim()}"` : '';
   const captionText =
     caption ??
     `${rows.length} token${rows.length === 1 ? '' : 's'}${
       filter ? ` matching \`${filter}\`` : ''
-    }${type ? ` · $type=${type}` : ''} · ${activeTheme}`;
+    }${type ? ` · $type=${type}` : ''}${matchSuffix} · ${activeTheme}`;
 
   if (rows.length === 0) {
     return (
@@ -97,6 +120,19 @@ export function TokenTable({
 
   return (
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      {searchable && (
+        <div className="sb-token-table__search">
+          <input
+            type="search"
+            className="sb-token-table__search-input"
+            placeholder="Search tokens…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Search tokens by path, type, or value"
+            data-testid="token-table-search"
+          />
+        </div>
+      )}
       <table className="sb-token-table__table">
         <caption className="sb-token-table__caption">{captionText}</caption>
         <thead>
@@ -106,7 +142,14 @@ export function TokenTable({
           </tr>
         </thead>
         <tbody>
-          {rows.map((row) => (
+          {visibleRows.length === 0 && (
+            <tr>
+              <td colSpan={2} className="sb-token-table__td sb-token-table__empty-row">
+                No tokens match "{query.trim()}".
+              </td>
+            </tr>
+          )}
+          {visibleRows.map((row) => (
             <tr
               key={row.path}
               className="sb-token-table__row"

--- a/packages/blocks/test/token-navigator.test.tsx
+++ b/packages/blocks/test/token-navigator.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { type ProjectSnapshot, SwatchbookProvider, TokenNavigator } from '#/index.ts';
 
@@ -110,5 +110,68 @@ describe('TokenNavigator', () => {
       </SwatchbookProvider>,
     );
     expect(screen.getByText(/No tokens matching \$type=fontWeight/)).toBeDefined();
+  });
+
+  it('renders a search input by default that prunes the tree to matching leaves', () => {
+    const { container } = render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator />
+      </SwatchbookProvider>,
+    );
+
+    const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
+    expect(input).toBeDefined();
+
+    fireEvent.change(input, { target: { value: 'bg' } });
+
+    // `color.bg` is the single leaf matching 'bg'; `radius` and `color.fg` /
+    // `color.palette.blue.500` prune out.
+    const leafPaths = within(screen.getByRole('tree'))
+      .getAllByTestId('token-navigator-leaf')
+      .map((el) => el.getAttribute('data-path'));
+    expect(leafPaths).toEqual(['color.bg']);
+    expect(container.textContent).toContain('matching "bg"');
+  });
+
+  it('auto-expands groups on the path to a matching leaf', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator initiallyExpanded={0} />
+      </SwatchbookProvider>,
+    );
+
+    const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'blue' } });
+
+    // `color.palette.blue.500` is nested under `color > palette > blue`.
+    // Even though `initiallyExpanded={0}` leaves everything collapsed, the
+    // search should reveal the matching leaf.
+    const leafPaths = within(screen.getByRole('tree'))
+      .getAllByTestId('token-navigator-leaf')
+      .map((el) => el.getAttribute('data-path'));
+    expect(leafPaths).toContain('color.palette.blue.500');
+  });
+
+  it('shows an empty message when the search matches nothing', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator />
+      </SwatchbookProvider>,
+    );
+
+    const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'xyz-no-match' } });
+
+    expect(screen.getByText(/No tokens match "xyz-no-match"/)).toBeDefined();
+    expect(screen.queryByRole('tree')).toBeNull();
+  });
+
+  it('hides the search input when searchable={false}', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenNavigator searchable={false} />
+      </SwatchbookProvider>,
+    );
+    expect(screen.queryByTestId('token-navigator-search')).toBeNull();
   });
 });

--- a/packages/blocks/test/token-table.test.tsx
+++ b/packages/blocks/test/token-table.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { type ProjectSnapshot, SwatchbookProvider, TokenTable } from '#/index.ts';
 
@@ -113,6 +113,58 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     expect(rows.length).toBe(3);
 
     expect(within(table).queryByText('space.md')).toBeNull();
+  });
+
+  it('renders a search input by default that filters rows by substring', () => {
+    const snapshot = makeSnapshot();
+    const { container } = render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable />
+      </SwatchbookProvider>,
+    );
+
+    const input = screen.getByTestId('token-table-search') as HTMLInputElement;
+    expect(input).toBeDefined();
+
+    const before = within(screen.getByRole('table')).getAllByRole('row').length;
+    expect(before).toBeGreaterThan(2);
+
+    // Typing narrows rows to those whose path contains the needle.
+    fireEvent.change(input, { target: { value: 'surface' } });
+
+    const after = within(screen.getByRole('table')).getAllByRole('row');
+    // Header row + at least one matching row; no non-matching rows.
+    const bodyRows = after.filter((r) => r.getAttribute('data-path'));
+    expect(bodyRows.length).toBeGreaterThan(0);
+    for (const row of bodyRows) {
+      expect(row.getAttribute('data-path')).toContain('surface');
+    }
+    expect(container.textContent).toContain('matching "surface"');
+  });
+
+  it('shows a "no matches" row when the search query matches nothing', () => {
+    const snapshot = makeSnapshot();
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable />
+      </SwatchbookProvider>,
+    );
+
+    const input = screen.getByTestId('token-table-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'xyz-no-match' } });
+
+    expect(screen.getByText(/No tokens match "xyz-no-match"/)).toBeDefined();
+  });
+
+  it('hides the search input when searchable={false}', () => {
+    const snapshot = makeSnapshot();
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenTable searchable={false} />
+      </SwatchbookProvider>,
+    );
+
+    expect(screen.queryByTestId('token-table-search')).toBeNull();
   });
 
   it('renders the empty state when the filter matches nothing', () => {


### PR DESCRIPTION
## Summary

Both blocks grow a runtime search input at the top. \`searchable?: boolean\` (default \`true\`) on each; pass \`false\` to hide it.

### \`<TokenTable>\`

- Input above the table narrows rows by case-insensitive substring against path, type, or value.
- Caption grows a \`· N matching "query"\` suffix during search.
- Fallback row renders \`No tokens match "query"\` when the filter empties the table.

### \`<TokenNavigator>\`

- Input above the tree prunes nodes — only leaves whose path matches survive, groups with no matches collapse out.
- Groups on the way to a match **auto-expand** so hits are visible without clicking. Manual expand/collapse state is preserved underneath: merges the search-expanded set with the user-toggled set; clearing the query restores the user's state.
- Block-level empty message replaces the tree when the query matches nothing.

### Why

The retired Design Tokens panel (pre-v0.3.0) had a search input. When we moved to doc blocks, nothing replaced it, but four doc pages have been calling the blocks "searchable" since. This delivers what the docs already promise.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run lint typecheck test\` — clean.
- [x] New block-level tests for both blocks: substring narrows rows / prunes tree, no-match empty states, \`searchable={false}\` hides the input, search auto-expands a collapsed tree to reveal a nested match.
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-blocks build\` — bundle builds; dist includes the new styles.
- Live verification: dogfood Storybook Dashboard page now has a real text input that filters the full token set.

Milestone: Maintenance
Plan impact: none

Closes #426
