### PR TITLE
docs: hotfix 0.5 snapshot with the lighter two-bullet intro

### DIFF
--- a/apps/docs/versioned_docs/version-0.5/intro.mdx
+++ b/apps/docs/versioned_docs/version-0.5/intro.mdx
@@ -5,13 +5,14 @@ title: Introduction
 sidebar_position: 1
 ---
 
-# Swatchbook
+# swatchbook
 
 A Storybook addon and MDX blocks for **documenting [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/)**.
 
-Flip **light/dark, brand, contrast, density** — or whatever independent dimensions your design system has — from one toolbar, without enumerating every combination as a flat theme ID. Swatchbook reads your resolver's modifiers directly through [Terrazzo](https://terrazzo.app/): each one becomes a toolbar dropdown, tokens repaint as readers flip axes, and CSS emission covers every combination under `[data-<prefix>-<axis>]` compound selectors. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape and what it gets you.
+Two things in one:
 
-Alongside the switcher, the addon ships MDX doc blocks — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and more — that render your tokens as browsable reference pages without a bespoke docs site. For day-to-day authoring, the blocks are the primary interaction.
+- **Doc blocks.** `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and a handful of type-specific previews. Drop them into MDX pages and your token reference writes itself.
+- **A multi-axis theme switcher.** Flip dark mode, brand, contrast, density — whatever dimensions your design system has — from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown in a single popover. Tokens repaint live as readers flip axes. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape.
 
 ## Who it's for
 


### PR DESCRIPTION
## Summary

The 0.5 release snapshotted \`intro.mdx\` a few commits before PR #424's lighter two-bullet rewrite merged. Net effect: \`/\` (which serves the latest released version) still shows the dense single-paragraph intro, while \`/next/\` has the new copy.

Sync \`apps/docs/versioned_docs/version-0.5/intro.mdx\` with the current \`apps/docs/docs/intro.mdx\` so the front door matches what \`/next/\` has been saying for the last few hours.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs build\` — green.
- [x] \`diff apps/docs/docs/intro.mdx apps/docs/versioned_docs/version-0.5/intro.mdx\` — empty.

Milestone: Maintenance
Plan impact: none