### PR TITLE
docs: simplify block reference headers

### DIFF
--- a/.changeset/block-reference-headers.md
+++ b/.changeset/block-reference-headers.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+docs: simplify block reference headers and add inline usage snippets

--- a/.changeset/contributing-md.md
+++ b/.changeset/contributing-md.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+docs: add CONTRIBUTING.md
+
+First-class contributor guide covering dev setup (Node 24, pnpm 10.33.0, `pnpm install`, `pnpm dev`), the full pre-commit check chain (`pnpm -r format && pnpm turbo run lint typecheck test`), code conventions (ESM only, explicit extensions, `#/*` subpath imports, no CSS-in-JS, oxlint + oxfmt), test structure rules (flat, no nested describe, prose names), PR title + body conventions (Conventional Commits, lowercase scope, Milestone / Closes / Plan impact), and the changeset policy (patch for docs, minor for features and breakings pre-1.0).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,137 @@
+# Contributing
+
+Thanks for considering a contribution. Swatchbook is a Storybook addon for DTCG design tokens; everything user-facing lives under `packages/core`, `packages/addon`, `packages/blocks`, with a dogfood Storybook in `apps/storybook` and the docs site in `apps/docs`.
+
+By participating, you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Before you start
+
+- Read the [quickstart](https://unpunnyfuns.github.io/swatchbook/quickstart) and poke the [live Storybook](https://unpunnyfuns.github.io/swatchbook/storybook/) so you know the shape of the project.
+- **File an issue first** for anything non-trivial — a bug report, a feature sketch, a docs gap. Merging the eventual PR auto-closes it. Issues land under the **Maintenance** milestone by default; feature work goes to whatever scope milestone is active, if any.
+- Question-shaped contributions (“how do I…”, “is X intentional?”) are better as [Discussions](https://github.com/unpunnyfuns/swatchbook/discussions) than issues.
+
+## Dev setup
+
+Requirements:
+
+- **Node 24+** (latest LTS). We pin `engines.node` and test only against the current LTS.
+- **pnpm 10.33.0+**. This is a pnpm-workspaces monorepo; npm / yarn won't work for development.
+
+```sh
+git clone https://github.com/unpunnyfuns/swatchbook
+cd swatchbook
+pnpm install
+pnpm dev                     # = turbo run storybook — serves apps/storybook on :6006
+```
+
+The dogfood Storybook at `http://localhost:6006` runs the addon against `packages/tokens-reference` — a multi-axis DTCG fixture. Every block you're changing renders there against real data.
+
+## Running the checks
+
+Before opening a PR, run:
+
+```sh
+pnpm -r format                            # oxfmt across every package
+pnpm turbo run lint typecheck test        # oxlint + tsc --noEmit + vitest
+```
+
+Scope with `--filter=<pkg>` when something is slow:
+
+```sh
+pnpm turbo run test --filter=@unpunnyfuns/swatchbook-core
+```
+
+Storybook interaction tests run through `@storybook/addon-vitest`:
+
+```sh
+pnpm turbo run test:storybook
+```
+
+CI enforces all four. Don't skip locally — format regressions land as noisy follow-up commits, and CI fails on lint / typecheck / test regressions.
+
+## Code style
+
+- **Functional**. Avoid classes and singletons.
+- **ESM only**. Every package is `"type": "module"`; no CJS builds, no dual-format outputs.
+- **Explicit import extensions.** Relative and subpath imports both carry the on-disk extension: `.ts`, `.tsx`, `.css`, `.json`, whatever. The rule is *what you see is what's imported*.
+- **Internal imports use `#/*`** (maps to `./src/*` per package). `import { emitCss } from '#/css.ts'` — not `../css` or `#/css`.
+- **No CSS-in-JS.** Blocks use colocated `.css` files with `sb-<block>__<part>--<modifier>` BEM-ish class names; `clsx` at JSX sites when a class needs composition.
+- **No inline end-of-line comments.** Comments sit on their own line above the code they describe.
+- **oxlint + oxfmt** are the linter and formatter. Don't install Biome.
+
+## Tests
+
+[Vitest](https://vitest.dev/) everywhere. Tests live alongside or under `test/` directories.
+
+Structure convention per [Avoid Nesting When You're Testing](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing):
+
+- **Flat.** Each `it` reads top-to-bottom without scrolling up.
+- **No nested `describe`.** One `describe` per file at most, as a file-level grouping. If you feel the urge to nest, split files instead.
+- **No `beforeEach`** for cosmetic shared setup. Write an inline `setup()` helper and have each test call it. `beforeAll` is a performance escape hatch, not a grouping tool.
+- **Prose test names over jargon.** `it('resolves alias chains (role → primitive)')` beats `it('resolves')` inside nested describes.
+
+Storybook interaction tests (in `apps/storybook/src/stories/*.stories.tsx`) use the `play` function; keep them short and deterministic.
+
+## Commits and PRs
+
+### PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+Format: `<type>(<scope>): <description>`.
+
+**Types:** `feat` / `fix` / `chore` / `docs` / `test` / `ci` / `refactor` / `perf` / `build` / `revert`.
+
+**Scopes:** one of `core`, `addon`, `blocks`, `tokens-reference`, `tokens-starter`, `storybook`, `docs`, `ci` — or omitted when a change spans multiple packages.
+
+**Subject:** imperative verb first, lowercase even for proper nouns. `feat(addon): rebind keyboard shortcut` — not `Feat(Addon): Rebinding the keyboard shortcut`.
+
+Breaking changes: drop the `!` suffix. Breaking-ness is tracked in the changeset body, not the conventional-commits marker — we're pre-1.0 so breaking changes bump `minor`, not `major`.
+
+### PR body
+
+The template (`.github/pull_request_template.md`) requires three lines:
+
+- **Milestone:** which milestone this belongs to.
+- **Closes:** the linked issue, one per line (`Closes #42` — not a comma-separated list; GitHub only auto-closes the first item).
+- **Plan impact:** `none` for most PRs; describe if the change reshapes a tracked plan.
+
+Milestone goes in the body, never the title — squash-merge lands the title on `main` and you don't want the milestone tag in `git log`.
+
+### Squash-merge
+
+All PRs are squash-merged. One PR → one commit on `main`.
+
+## Changesets
+
+Any PR with a user-visible change to `@unpunnyfuns/swatchbook-core`, `@unpunnyfuns/swatchbook-addon`, or `@unpunnyfuns/swatchbook-blocks` carries a changeset:
+
+```sh
+pnpm changeset
+```
+
+Pick a bump level and write a short description. The three published packages are a **fixed group** (always the same version), so the bump level you pick applies to all of them.
+
+**Bump levels, pre-1.0:**
+
+- **`patch`** — bug fixes, docs-only PRs (the snapshot script rebuilds the current minor's docs on every release, so docs fixes need a release cycle to reach `/`).
+- **`minor`** — new features *and* breaking changes. Pre-1.0, semver `0.x` treats minor as the "major-ish" position, so we bump minor rather than major for breakings until we cut 1.0.
+- **`major`** — reserved for the 1.0 cut itself.
+
+**Skip the changeset** for purely internal refactors (code style, test-only changes, CI, repo hygiene).
+
+Publishing is automatic: Changesets opens a "Version Packages" PR that bumps versions + regenerates `CHANGELOG.md` and the docs snapshot. Merging that PR builds and publishes to npm via trusted publishing (OIDC; no token secrets).
+
+## Issues and labels
+
+- **`future`** — iceboxed / not scheduled. Revisit when a trigger in the issue body fires.
+- **`bug`**, **`enhancement`**, **`documentation`** — GitHub defaults, used sparingly.
+- Issues under the **Future Considerations** milestone plus the `future` label = "we've thought about it, intentionally deferring."
+
+Don't file duplicates — search closed issues first. If you find a stale one that's come back around, reopen with a comment rather than filing a new one.
+
+## Licensing
+
+Swatchbook is MIT. By contributing, you agree your contribution is licensed the same way. No CLA.
+
+## Thanks
+
+If you got this far, you're already doing more work than most. Ping @unpunnyfuns on the PR if something in this doc didn't match reality — it's a living file.

--- a/apps/docs/docs/reference/blocks/inspector.mdx
+++ b/apps/docs/docs/reference/blocks/inspector.mdx
@@ -8,40 +8,76 @@ sidebar_position: 3
 
 Single-token deep-dive. `<TokenDetail>` is the composition; each subcomponent below is also exported and takes the same `path: string` prop, so MDX authors can embed just the piece they need.
 
-## `<TokenDetail path heading? />`
+## TokenDetail
+
+```tsx
+<TokenDetail path="color.accent.bg" />
+```
 
 Full deep-dive: header + composite preview + composite breakdown + alias chain + aliased-by tree + per-axis variance + consumer output + usage snippet.
 
 Props: `path: string`, `heading?: string` (defaults to `path`).
 
-## `<TokenHeader path heading? />`
+## TokenHeader
+
+```tsx
+<TokenHeader path="color.accent.bg" />
+```
 
 Heading + `$type` pill + cssVar reference + description. Renders a missing-token empty state when `path` isn't in the active theme.
 
-## `<CompositePreview path />`
+## CompositePreview
+
+```tsx
+<CompositePreview path="typography.body" />
+```
 
 Type-dispatched live preview of the token's resolved value (typography sample, shadow swatch, gradient strip, animating ball for motion, etc.).
 
-## `<CompositeBreakdown path />`
+## CompositeBreakdown
+
+```tsx
+<CompositeBreakdown path="typography.body" />
+```
 
 Labelled sub-value grid for composite types (`typography`, `border`, `transition`, `shadow`, `gradient`). Renders nothing for primitives.
 
-## `<AliasChain path />`
+## AliasChain
+
+```tsx
+<AliasChain path="color.accent.bg" />
+```
 
 Forward alias chain (`color.accent.bg → color.palette.blue.700`). Renders nothing for non-aliases.
 
-## `<AliasedBy path />`
+## AliasedBy
+
+```tsx
+<AliasedBy path="color.palette.blue.500" />
+```
 
 Backward alias tree — every token that transitively aliases this one. Truncates at depth 6.
 
-## `<AxisVariance path />`
+## AxisVariance
+
+```tsx
+<AxisVariance path="color.accent.bg" />
+```
 
 Per-axis value table. Collapses to one row when the value is constant, a list for one varying axis, or a matrix for two axes (extras pinned to the active selection).
 
-## `<TokenUsageSnippet path />`
+## TokenUsageSnippet
+
+```tsx
+<TokenUsageSnippet path="color.accent.bg" />
+```
 
 Copy-ready `color: var(--…);` reference snippet.
 
-## `<ConsumerOutput path />`
+## ConsumerOutput
+
+```tsx
+<ConsumerOutput path="color.accent.bg" />
+```
 
 Two-row summary of the token's **Path** and **CSS var** with copy-to-clipboard on each. Shows the active axis tuple above the rows when more than one axis is in play.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -17,7 +17,11 @@ Most blocks in this group take:
 
 ## Across types
 
-### `<TokenNavigator root? type? initiallyExpanded? searchable? onSelect? />`
+### TokenNavigator
+
+```tsx
+<TokenNavigator root="color" />
+```
 
 Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A search input at the top filters by path substring — matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
@@ -29,7 +33,11 @@ Props:
 - `searchable?: boolean` — render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
 - `onSelect?(path: string): void` — receives a leaf's full dot-path on click; suppresses the built-in overlay.
 
-### `<TokenTable filter? type? caption? sortBy? sortDir? searchable? onSelect? />`
+### TokenTable
+
+```tsx
+<TokenTable type="color" />
+```
 
 Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). A search input at the top narrows rows by path, type, or value substring. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
 
@@ -47,44 +55,84 @@ Props:
 
 Every block in this group scopes to one DTCG `$type`, filters / sorts, and renders a type-specific visual. All accept `filter?: string`, `sortBy?`, `sortDir?`, and `caption?: string`.
 
-### `<ColorPalette filter? groupBy? caption? sortBy? sortDir? />`
+### ColorPalette
+
+```tsx
+<ColorPalette filter="color.palette.*" />
+```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
 
-### `<TypographyScale filter? sample? caption? sortBy? sortDir? />`
+### TypographyScale
+
+```tsx
+<TypographyScale />
+```
 
 One sample line per `typography` composite, rendered with the token's own `fontFamily` / `fontSize` / `fontWeight` / `lineHeight` / `letterSpacing`. `sample?: string` overrides the text.
 
-### `<DimensionScale filter? kind? caption? sortBy? sortDir? />`
+### DimensionScale
+
+```tsx
+<DimensionScale kind="length" />
+```
 
 Width-driven bar (default), radius-sample square, or size-sample square per `dimension` token. Defaults to `sortBy: 'value'` — ordered numerically by the rendered pixel size.
 
 - `kind?: 'length' | 'radius' | 'size'` — visualization mode (default `'length'`).
 
-### `<FontFamilySample filter? sample? caption? sortBy? sortDir? />`
+### FontFamilySample
+
+```tsx
+<FontFamilySample />
+```
 
 Pangram rendered per `fontFamily` primitive. `sample?: string` overrides the text.
 
-### `<FontWeightScale filter? sample? caption? sortBy? sortDir? />`
+### FontWeightScale
+
+```tsx
+<FontWeightScale />
+```
 
 Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: 'value'` — ordered 100 → 900.
 
-### `<BorderPreview filter? caption? sortBy? sortDir? />`
+### BorderPreview
+
+```tsx
+<BorderPreview />
+```
 
 One framed `<BorderSample>` per `border` composite token.
 
-### `<ShadowPreview filter? caption? sortBy? sortDir? />`
+### ShadowPreview
+
+```tsx
+<ShadowPreview />
+```
 
 One `<ShadowSample>` surface per `shadow` composite token.
 
-### `<MotionPreview filter? caption? sortBy? sortDir? />`
+### MotionPreview
+
+```tsx
+<MotionPreview />
+```
 
 One animated `<MotionSample>` per `transition` / `duration` / `cubicBezier` token. Respects `prefers-reduced-motion`.
 
-### `<StrokeStyleSample filter? caption? sortBy? sortDir? />`
+### StrokeStyleSample
+
+```tsx
+<StrokeStyleSample />
+```
 
 Border rendered per `strokeStyle` primitive. Supports string forms (`solid`, `dashed`, `dotted`, `double`) natively; object forms (`dashArray` / `lineCap`) fall back to a textual summary.
 
-### `<GradientPalette filter? caption? sortBy? sortDir? />`
+### GradientPalette
+
+```tsx
+<GradientPalette />
+```
 
 Wide sample per `gradient` token (linear, left → right by default) with a stop list. DTCG gradients are stop arrays — the gradient *function* is a rendering choice the consumer makes.

--- a/apps/docs/docs/reference/blocks/samples.mdx
+++ b/apps/docs/docs/reference/blocks/samples.mdx
@@ -8,18 +8,34 @@ sidebar_position: 4
 
 Lower-level than the per-type overview blocks — these render the visual for **one** token by path. Useful for custom MDX layouts that don't want the full overview chrome, and for embedding a single sample next to prose.
 
-## `<MotionSample path speed? runKey? />`
+## MotionSample
+
+```tsx
+<MotionSample path="transition.enter" />
+```
 
 Animated ball + track for one `transition` / `duration` / `cubicBezier`. `speed?: 0.25 | 0.5 | 1 | 2` (default `1`); `runKey?: number` forces a restart when it changes.
 
-## `<ShadowSample path />`
+## ShadowSample
+
+```tsx
+<ShadowSample path="shadow.md" />
+```
 
 Surface rectangle with the token's shadow applied as `box-shadow`.
 
-## `<BorderSample path />`
+## BorderSample
+
+```tsx
+<BorderSample path="border.default" />
+```
 
 Surface rectangle with the token's border applied.
 
-## `<DimensionBar path kind? />`
+## DimensionBar
+
+```tsx
+<DimensionBar path="size.md" kind="length" />
+```
 
 Width-driven bar, border-radius square, or sized square for one `dimension` token. `kind?: 'length' | 'radius' | 'size'` (default `'length'`).

--- a/apps/docs/docs/reference/blocks/utility.mdx
+++ b/apps/docs/docs/reference/blocks/utility.mdx
@@ -8,7 +8,11 @@ sidebar_position: 5
 
 Blocks that surface project-level state rather than tokens themselves.
 
-## `<Diagnostics caption? />`
+## Diagnostics
+
+```tsx
+<Diagnostics />
+```
 
 Project load diagnostics (parser errors, resolver warnings, disabled-axis validation) as a collapsible list. Green **OK** badge when clean; auto-expands with a severity summary on warnings or errors. See the [diagnostics concept](../../concepts/diagnostics) for severity semantics.
 


### PR DESCRIPTION
Block reference pages had the full JSX surface embedded in each `###` heading — good for see-it-all-at-once, bad for the Docusaurus right-rail TOC and anchor links. Headers are now just the block name; a one-line usage example renders in a `tsx` code block directly beneath, with the existing prop list unchanged.

Covers `overview.mdx`, `inspector.mdx`, `samples.mdx`, `utility.mdx`.

Milestone: Maintenance
Closes: #438
Plan impact: none