### PR TITLE
fix(blocks): show sub-value alias chains in CompositeBreakdown

### DIFF
--- a/.changeset/block-reference-headers.md
+++ b/.changeset/block-reference-headers.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+docs: simplify block reference headers and add inline usage snippets

--- a/.changeset/composite-sub-value-aliases.md
+++ b/.changeset/composite-sub-value-aliases.md
@@ -1,0 +1,17 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix(blocks): surface sub-value alias chains in `<CompositeBreakdown>`
+
+When a composite token (`border`, `shadow`, `transition`, `typography`,
+`gradient`) references another token by alias on one of its sub-values,
+the `<TokenDetail>` drawer now shows the full alias chain next to that
+row — the same way top-level token aliases are surfaced by
+`<AliasChain>`. Previously a border whose `color` aliased another color
+token rendered only the resolved hex, with no indication that the value
+had been authored as an alias.
+
+Chains walk transitively via Terrazzo's `partialAliasOf` + the target
+token's own `aliasChain`, so authors see the full `borderColorAlias →
+colorRole → colorPrimitive` path.

--- a/.changeset/contributing-md.md
+++ b/.changeset/contributing-md.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+docs: add CONTRIBUTING.md
+
+First-class contributor guide covering dev setup (Node 24, pnpm 10.33.0, `pnpm install`, `pnpm dev`), the full pre-commit check chain (`pnpm -r format && pnpm turbo run lint typecheck test`), code conventions (ESM only, explicit extensions, `#/*` subpath imports, no CSS-in-JS, oxlint + oxfmt), test structure rules (flat, no nested describe, prose names), PR title + body conventions (Conventional Commits, lowercase scope, Milestone / Closes / Plan impact), and the changeset policy (patch for docs, minor for features and breakings pre-1.0).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,137 @@
+# Contributing
+
+Thanks for considering a contribution. Swatchbook is a Storybook addon for DTCG design tokens; everything user-facing lives under `packages/core`, `packages/addon`, `packages/blocks`, with a dogfood Storybook in `apps/storybook` and the docs site in `apps/docs`.
+
+By participating, you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Before you start
+
+- Read the [quickstart](https://unpunnyfuns.github.io/swatchbook/quickstart) and poke the [live Storybook](https://unpunnyfuns.github.io/swatchbook/storybook/) so you know the shape of the project.
+- **File an issue first** for anything non-trivial — a bug report, a feature sketch, a docs gap. Merging the eventual PR auto-closes it. Issues land under the **Maintenance** milestone by default; feature work goes to whatever scope milestone is active, if any.
+- Question-shaped contributions (“how do I…”, “is X intentional?”) are better as [Discussions](https://github.com/unpunnyfuns/swatchbook/discussions) than issues.
+
+## Dev setup
+
+Requirements:
+
+- **Node 24+** (latest LTS). We pin `engines.node` and test only against the current LTS.
+- **pnpm 10.33.0+**. This is a pnpm-workspaces monorepo; npm / yarn won't work for development.
+
+```sh
+git clone https://github.com/unpunnyfuns/swatchbook
+cd swatchbook
+pnpm install
+pnpm dev                     # = turbo run storybook — serves apps/storybook on :6006
+```
+
+The dogfood Storybook at `http://localhost:6006` runs the addon against `packages/tokens-reference` — a multi-axis DTCG fixture. Every block you're changing renders there against real data.
+
+## Running the checks
+
+Before opening a PR, run:
+
+```sh
+pnpm -r format                            # oxfmt across every package
+pnpm turbo run lint typecheck test        # oxlint + tsc --noEmit + vitest
+```
+
+Scope with `--filter=<pkg>` when something is slow:
+
+```sh
+pnpm turbo run test --filter=@unpunnyfuns/swatchbook-core
+```
+
+Storybook interaction tests run through `@storybook/addon-vitest`:
+
+```sh
+pnpm turbo run test:storybook
+```
+
+CI enforces all four. Don't skip locally — format regressions land as noisy follow-up commits, and CI fails on lint / typecheck / test regressions.
+
+## Code style
+
+- **Functional**. Avoid classes and singletons.
+- **ESM only**. Every package is `"type": "module"`; no CJS builds, no dual-format outputs.
+- **Explicit import extensions.** Relative and subpath imports both carry the on-disk extension: `.ts`, `.tsx`, `.css`, `.json`, whatever. The rule is *what you see is what's imported*.
+- **Internal imports use `#/*`** (maps to `./src/*` per package). `import { emitCss } from '#/css.ts'` — not `../css` or `#/css`.
+- **No CSS-in-JS.** Blocks use colocated `.css` files with `sb-<block>__<part>--<modifier>` BEM-ish class names; `clsx` at JSX sites when a class needs composition.
+- **No inline end-of-line comments.** Comments sit on their own line above the code they describe.
+- **oxlint + oxfmt** are the linter and formatter. Don't install Biome.
+
+## Tests
+
+[Vitest](https://vitest.dev/) everywhere. Tests live alongside or under `test/` directories.
+
+Structure convention per [Avoid Nesting When You're Testing](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing):
+
+- **Flat.** Each `it` reads top-to-bottom without scrolling up.
+- **No nested `describe`.** One `describe` per file at most, as a file-level grouping. If you feel the urge to nest, split files instead.
+- **No `beforeEach`** for cosmetic shared setup. Write an inline `setup()` helper and have each test call it. `beforeAll` is a performance escape hatch, not a grouping tool.
+- **Prose test names over jargon.** `it('resolves alias chains (role → primitive)')` beats `it('resolves')` inside nested describes.
+
+Storybook interaction tests (in `apps/storybook/src/stories/*.stories.tsx`) use the `play` function; keep them short and deterministic.
+
+## Commits and PRs
+
+### PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)
+
+Format: `<type>(<scope>): <description>`.
+
+**Types:** `feat` / `fix` / `chore` / `docs` / `test` / `ci` / `refactor` / `perf` / `build` / `revert`.
+
+**Scopes:** one of `core`, `addon`, `blocks`, `tokens-reference`, `tokens-starter`, `storybook`, `docs`, `ci` — or omitted when a change spans multiple packages.
+
+**Subject:** imperative verb first, lowercase even for proper nouns. `feat(addon): rebind keyboard shortcut` — not `Feat(Addon): Rebinding the keyboard shortcut`.
+
+Breaking changes: drop the `!` suffix. Breaking-ness is tracked in the changeset body, not the conventional-commits marker — we're pre-1.0 so breaking changes bump `minor`, not `major`.
+
+### PR body
+
+The template (`.github/pull_request_template.md`) requires three lines:
+
+- **Milestone:** which milestone this belongs to.
+- **Closes:** the linked issue, one per line (`Closes #42` — not a comma-separated list; GitHub only auto-closes the first item).
+- **Plan impact:** `none` for most PRs; describe if the change reshapes a tracked plan.
+
+Milestone goes in the body, never the title — squash-merge lands the title on `main` and you don't want the milestone tag in `git log`.
+
+### Squash-merge
+
+All PRs are squash-merged. One PR → one commit on `main`.
+
+## Changesets
+
+Any PR with a user-visible change to `@unpunnyfuns/swatchbook-core`, `@unpunnyfuns/swatchbook-addon`, or `@unpunnyfuns/swatchbook-blocks` carries a changeset:
+
+```sh
+pnpm changeset
+```
+
+Pick a bump level and write a short description. The three published packages are a **fixed group** (always the same version), so the bump level you pick applies to all of them.
+
+**Bump levels, pre-1.0:**
+
+- **`patch`** — bug fixes, docs-only PRs (the snapshot script rebuilds the current minor's docs on every release, so docs fixes need a release cycle to reach `/`).
+- **`minor`** — new features *and* breaking changes. Pre-1.0, semver `0.x` treats minor as the "major-ish" position, so we bump minor rather than major for breakings until we cut 1.0.
+- **`major`** — reserved for the 1.0 cut itself.
+
+**Skip the changeset** for purely internal refactors (code style, test-only changes, CI, repo hygiene).
+
+Publishing is automatic: Changesets opens a "Version Packages" PR that bumps versions + regenerates `CHANGELOG.md` and the docs snapshot. Merging that PR builds and publishes to npm via trusted publishing (OIDC; no token secrets).
+
+## Issues and labels
+
+- **`future`** — iceboxed / not scheduled. Revisit when a trigger in the issue body fires.
+- **`bug`**, **`enhancement`**, **`documentation`** — GitHub defaults, used sparingly.
+- Issues under the **Future Considerations** milestone plus the `future` label = "we've thought about it, intentionally deferring."
+
+Don't file duplicates — search closed issues first. If you find a stale one that's come back around, reopen with a comment rather than filing a new one.
+
+## Licensing
+
+Swatchbook is MIT. By contributing, you agree your contribution is licensed the same way. No CLA.
+
+## Thanks
+
+If you got this far, you're already doing more work than most. Ping @unpunnyfuns on the PR if something in this doc didn't match reality — it's a living file.

--- a/apps/docs/docs/reference/blocks/inspector.mdx
+++ b/apps/docs/docs/reference/blocks/inspector.mdx
@@ -8,40 +8,76 @@ sidebar_position: 3
 
 Single-token deep-dive. `<TokenDetail>` is the composition; each subcomponent below is also exported and takes the same `path: string` prop, so MDX authors can embed just the piece they need.
 
-## `<TokenDetail path heading? />`
+## TokenDetail
+
+```tsx
+<TokenDetail path="color.accent.bg" />
+```
 
 Full deep-dive: header + composite preview + composite breakdown + alias chain + aliased-by tree + per-axis variance + consumer output + usage snippet.
 
 Props: `path: string`, `heading?: string` (defaults to `path`).
 
-## `<TokenHeader path heading? />`
+## TokenHeader
+
+```tsx
+<TokenHeader path="color.accent.bg" />
+```
 
 Heading + `$type` pill + cssVar reference + description. Renders a missing-token empty state when `path` isn't in the active theme.
 
-## `<CompositePreview path />`
+## CompositePreview
+
+```tsx
+<CompositePreview path="typography.body" />
+```
 
 Type-dispatched live preview of the token's resolved value (typography sample, shadow swatch, gradient strip, animating ball for motion, etc.).
 
-## `<CompositeBreakdown path />`
+## CompositeBreakdown
+
+```tsx
+<CompositeBreakdown path="typography.body" />
+```
 
 Labelled sub-value grid for composite types (`typography`, `border`, `transition`, `shadow`, `gradient`). Renders nothing for primitives.
 
-## `<AliasChain path />`
+## AliasChain
+
+```tsx
+<AliasChain path="color.accent.bg" />
+```
 
 Forward alias chain (`color.accent.bg → color.palette.blue.700`). Renders nothing for non-aliases.
 
-## `<AliasedBy path />`
+## AliasedBy
+
+```tsx
+<AliasedBy path="color.palette.blue.500" />
+```
 
 Backward alias tree — every token that transitively aliases this one. Truncates at depth 6.
 
-## `<AxisVariance path />`
+## AxisVariance
+
+```tsx
+<AxisVariance path="color.accent.bg" />
+```
 
 Per-axis value table. Collapses to one row when the value is constant, a list for one varying axis, or a matrix for two axes (extras pinned to the active selection).
 
-## `<TokenUsageSnippet path />`
+## TokenUsageSnippet
+
+```tsx
+<TokenUsageSnippet path="color.accent.bg" />
+```
 
 Copy-ready `color: var(--…);` reference snippet.
 
-## `<ConsumerOutput path />`
+## ConsumerOutput
+
+```tsx
+<ConsumerOutput path="color.accent.bg" />
+```
 
 Two-row summary of the token's **Path** and **CSS var** with copy-to-clipboard on each. Shows the active axis tuple above the rows when more than one axis is in play.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -17,7 +17,11 @@ Most blocks in this group take:
 
 ## Across types
 
-### `<TokenNavigator root? type? initiallyExpanded? searchable? onSelect? />`
+### TokenNavigator
+
+```tsx
+<TokenNavigator root="color" />
+```
 
 Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A search input at the top filters by path substring — matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
@@ -29,7 +33,11 @@ Props:
 - `searchable?: boolean` — render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
 - `onSelect?(path: string): void` — receives a leaf's full dot-path on click; suppresses the built-in overlay.
 
-### `<TokenTable filter? type? caption? sortBy? sortDir? searchable? onSelect? />`
+### TokenTable
+
+```tsx
+<TokenTable type="color" />
+```
 
 Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). A search input at the top narrows rows by path, type, or value substring. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
 
@@ -47,44 +55,84 @@ Props:
 
 Every block in this group scopes to one DTCG `$type`, filters / sorts, and renders a type-specific visual. All accept `filter?: string`, `sortBy?`, `sortDir?`, and `caption?: string`.
 
-### `<ColorPalette filter? groupBy? caption? sortBy? sortDir? />`
+### ColorPalette
+
+```tsx
+<ColorPalette filter="color.palette.*" />
+```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
 
-### `<TypographyScale filter? sample? caption? sortBy? sortDir? />`
+### TypographyScale
+
+```tsx
+<TypographyScale />
+```
 
 One sample line per `typography` composite, rendered with the token's own `fontFamily` / `fontSize` / `fontWeight` / `lineHeight` / `letterSpacing`. `sample?: string` overrides the text.
 
-### `<DimensionScale filter? kind? caption? sortBy? sortDir? />`
+### DimensionScale
+
+```tsx
+<DimensionScale kind="length" />
+```
 
 Width-driven bar (default), radius-sample square, or size-sample square per `dimension` token. Defaults to `sortBy: 'value'` — ordered numerically by the rendered pixel size.
 
 - `kind?: 'length' | 'radius' | 'size'` — visualization mode (default `'length'`).
 
-### `<FontFamilySample filter? sample? caption? sortBy? sortDir? />`
+### FontFamilySample
+
+```tsx
+<FontFamilySample />
+```
 
 Pangram rendered per `fontFamily` primitive. `sample?: string` overrides the text.
 
-### `<FontWeightScale filter? sample? caption? sortBy? sortDir? />`
+### FontWeightScale
+
+```tsx
+<FontWeightScale />
+```
 
 Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: 'value'` — ordered 100 → 900.
 
-### `<BorderPreview filter? caption? sortBy? sortDir? />`
+### BorderPreview
+
+```tsx
+<BorderPreview />
+```
 
 One framed `<BorderSample>` per `border` composite token.
 
-### `<ShadowPreview filter? caption? sortBy? sortDir? />`
+### ShadowPreview
+
+```tsx
+<ShadowPreview />
+```
 
 One `<ShadowSample>` surface per `shadow` composite token.
 
-### `<MotionPreview filter? caption? sortBy? sortDir? />`
+### MotionPreview
+
+```tsx
+<MotionPreview />
+```
 
 One animated `<MotionSample>` per `transition` / `duration` / `cubicBezier` token. Respects `prefers-reduced-motion`.
 
-### `<StrokeStyleSample filter? caption? sortBy? sortDir? />`
+### StrokeStyleSample
+
+```tsx
+<StrokeStyleSample />
+```
 
 Border rendered per `strokeStyle` primitive. Supports string forms (`solid`, `dashed`, `dotted`, `double`) natively; object forms (`dashArray` / `lineCap`) fall back to a textual summary.
 
-### `<GradientPalette filter? caption? sortBy? sortDir? />`
+### GradientPalette
+
+```tsx
+<GradientPalette />
+```
 
 Wide sample per `gradient` token (linear, left → right by default) with a stop list. DTCG gradients are stop arrays — the gradient *function* is a rendering choice the consumer makes.

--- a/apps/docs/docs/reference/blocks/samples.mdx
+++ b/apps/docs/docs/reference/blocks/samples.mdx
@@ -8,18 +8,34 @@ sidebar_position: 4
 
 Lower-level than the per-type overview blocks — these render the visual for **one** token by path. Useful for custom MDX layouts that don't want the full overview chrome, and for embedding a single sample next to prose.
 
-## `<MotionSample path speed? runKey? />`
+## MotionSample
+
+```tsx
+<MotionSample path="transition.enter" />
+```
 
 Animated ball + track for one `transition` / `duration` / `cubicBezier`. `speed?: 0.25 | 0.5 | 1 | 2` (default `1`); `runKey?: number` forces a restart when it changes.
 
-## `<ShadowSample path />`
+## ShadowSample
+
+```tsx
+<ShadowSample path="shadow.md" />
+```
 
 Surface rectangle with the token's shadow applied as `box-shadow`.
 
-## `<BorderSample path />`
+## BorderSample
+
+```tsx
+<BorderSample path="border.default" />
+```
 
 Surface rectangle with the token's border applied.
 
-## `<DimensionBar path kind? />`
+## DimensionBar
+
+```tsx
+<DimensionBar path="size.md" kind="length" />
+```
 
 Width-driven bar, border-radius square, or sized square for one `dimension` token. `kind?: 'length' | 'radius' | 'size'` (default `'length'`).

--- a/apps/docs/docs/reference/blocks/utility.mdx
+++ b/apps/docs/docs/reference/blocks/utility.mdx
@@ -8,7 +8,11 @@ sidebar_position: 5
 
 Blocks that surface project-level state rather than tokens themselves.
 
-## `<Diagnostics caption? />`
+## Diagnostics
+
+```tsx
+<Diagnostics />
+```
 
 Project load diagnostics (parser errors, resolver warnings, disabled-axis validation) as a collapsible list. Green **OK** badge when clean; auto-expands with a severity summary on warnings or errors. See the [diagnostics concept](../../concepts/diagnostics) for severity semantics.
 

--- a/packages/blocks/src/token-detail/CompositeBreakdown.tsx
+++ b/packages/blocks/src/token-detail/CompositeBreakdown.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { type ColorFormat, formatColor } from '#/format-color.ts';
-import { useTokenDetailData } from '#/token-detail/internal.ts';
+import { type DetailToken, useTokenDetailData } from '#/token-detail/internal.ts';
 
 export interface CompositeBreakdownProps {
   /** Full dot-path of the token. */
@@ -9,13 +9,15 @@ export interface CompositeBreakdownProps {
 }
 
 export function CompositeBreakdown({ path }: CompositeBreakdownProps): ReactElement | null {
-  const { token } = useTokenDetailData(path);
+  const { token, resolved } = useTokenDetailData(path);
   const colorFormat = useColorFormat();
   if (!token) return null;
   return (
     <CompositeBreakdownContent
       type={token.$type}
       rawValue={token.$value}
+      partialAliasOf={token.partialAliasOf}
+      resolved={resolved}
       colorFormat={colorFormat}
     />
   );
@@ -24,46 +26,57 @@ export function CompositeBreakdown({ path }: CompositeBreakdownProps): ReactElem
 export function CompositeBreakdownContent({
   type,
   rawValue,
+  partialAliasOf,
+  resolved,
   colorFormat,
 }: {
   type: string | undefined;
   rawValue: unknown;
+  partialAliasOf?: unknown;
+  resolved?: Record<string, DetailToken>;
   colorFormat: ColorFormat;
 }): ReactElement | null {
   if (!rawValue || typeof rawValue !== 'object') return null;
 
+  const objectAliases = pickObjectAliases(partialAliasOf);
+  const arrayAliases = pickArrayAliases(partialAliasOf);
+  const aliasFor = (key: string): readonly string[] | undefined =>
+    subValueChain(objectAliases?.[key], resolved);
+
   if (type === 'typography') {
     const v = rawValue as Record<string, unknown>;
     return renderKeyValueList([
-      ['fontFamily', formatFontFamily(v['fontFamily'])],
-      ['fontSize', formatDimensionValue(v['fontSize'])],
-      ['fontWeight', formatPrimitive(v['fontWeight'])],
-      ['lineHeight', formatPrimitive(v['lineHeight'])],
-      ['letterSpacing', formatDimensionValue(v['letterSpacing'])],
+      ['fontFamily', formatFontFamily(v['fontFamily']), aliasFor('fontFamily')],
+      ['fontSize', formatDimensionValue(v['fontSize']), aliasFor('fontSize')],
+      ['fontWeight', formatPrimitive(v['fontWeight']), aliasFor('fontWeight')],
+      ['lineHeight', formatPrimitive(v['lineHeight']), aliasFor('lineHeight')],
+      ['letterSpacing', formatDimensionValue(v['letterSpacing']), aliasFor('letterSpacing')],
     ]);
   }
 
   if (type === 'border') {
     const v = rawValue as Record<string, unknown>;
     return renderKeyValueList([
-      ['color', formatColorSubValue(v['color'], colorFormat)],
-      ['width', formatDimensionValue(v['width'])],
-      ['style', formatPrimitive(v['style'])],
+      ['color', formatColorSubValue(v['color'], colorFormat), aliasFor('color')],
+      ['width', formatDimensionValue(v['width']), aliasFor('width')],
+      ['style', formatPrimitive(v['style']), aliasFor('style')],
     ]);
   }
 
   if (type === 'transition') {
     const v = rawValue as Record<string, unknown>;
     return renderKeyValueList([
-      ['duration', formatDimensionValue(v['duration'])],
-      ['timingFunction', formatPrimitive(v['timingFunction'])],
-      ['delay', formatDimensionValue(v['delay'])],
+      ['duration', formatDimensionValue(v['duration']), aliasFor('duration')],
+      ['timingFunction', formatPrimitive(v['timingFunction']), aliasFor('timingFunction')],
+      ['delay', formatDimensionValue(v['delay']), aliasFor('delay')],
     ]);
   }
 
   if (type === 'shadow') {
     const layers = Array.isArray(rawValue) ? rawValue : [rawValue];
     const multi = layers.length > 1;
+    const layerAliasFor = (i: number, key: string): readonly string[] | undefined =>
+      subValueChain(arrayAliases?.[i]?.[key], resolved);
     return (
       <div className="sb-token-detail__breakdown-section">
         {layers.map((layer, i) => {
@@ -73,12 +86,38 @@ export function CompositeBreakdownContent({
               {multi && (
                 <div className="sb-token-detail__breakdown-layer-header">Layer {i + 1}</div>
               )}
-              <KeyValueRow label="color" value={formatColorSubValue(v['color'], colorFormat)} />
-              <KeyValueRow label="offsetX" value={formatDimensionValue(v['offsetX'])} />
-              <KeyValueRow label="offsetY" value={formatDimensionValue(v['offsetY'])} />
-              <KeyValueRow label="blur" value={formatDimensionValue(v['blur'])} />
-              <KeyValueRow label="spread" value={formatDimensionValue(v['spread'])} />
-              {'inset' in v && <KeyValueRow label="inset" value={formatPrimitive(v['inset'])} />}
+              <KeyValueRow
+                label="color"
+                value={formatColorSubValue(v['color'], colorFormat)}
+                alias={layerAliasFor(i, 'color')}
+              />
+              <KeyValueRow
+                label="offsetX"
+                value={formatDimensionValue(v['offsetX'])}
+                alias={layerAliasFor(i, 'offsetX')}
+              />
+              <KeyValueRow
+                label="offsetY"
+                value={formatDimensionValue(v['offsetY'])}
+                alias={layerAliasFor(i, 'offsetY')}
+              />
+              <KeyValueRow
+                label="blur"
+                value={formatDimensionValue(v['blur'])}
+                alias={layerAliasFor(i, 'blur')}
+              />
+              <KeyValueRow
+                label="spread"
+                value={formatDimensionValue(v['spread'])}
+                alias={layerAliasFor(i, 'spread')}
+              />
+              {'inset' in v && (
+                <KeyValueRow
+                  label="inset"
+                  value={formatPrimitive(v['inset'])}
+                  alias={undefined}
+                />
+              )}
             </div>
           );
         })}
@@ -89,6 +128,8 @@ export function CompositeBreakdownContent({
   if (type === 'gradient') {
     const stops = Array.isArray(rawValue) ? rawValue : [];
     if (stops.length === 0) return null;
+    const stopAliasFor = (i: number): readonly string[] | undefined =>
+      subValueChain(arrayAliases?.[i]?.['color'], resolved);
     return (
       <div className="sb-token-detail__breakdown-section">
         {stops.map((stop, i) => {
@@ -99,6 +140,7 @@ export function CompositeBreakdownContent({
               key={gradientStopKey(v, i)}
               label={`${(position * 100).toFixed(0)}%`}
               value={formatColorSubValue(v['color'], colorFormat)}
+              alias={stopAliasFor(i)}
             />
           );
         })}
@@ -109,23 +151,46 @@ export function CompositeBreakdownContent({
   return null;
 }
 
-function renderKeyValueList(rows: Array<[string, string | null]>): ReactElement {
+function renderKeyValueList(
+  rows: Array<[string, string | null, readonly string[] | undefined]>,
+): ReactElement {
   return (
     <div className="sb-token-detail__breakdown-section">
       {rows
-        .filter(([, v]) => v !== null)
-        .map(([k, v]) => (
-          <KeyValueRow key={k} label={k} value={v ?? ''} />
+        .filter(([, v, alias]) => v !== null || (alias && alias.length > 0))
+        .map(([k, v, alias]) => (
+          <KeyValueRow key={k} label={k} value={v ?? ''} alias={alias} />
         ))}
     </div>
   );
 }
 
-function KeyValueRow({ label, value }: { label: string; value: string | null }): ReactElement {
+function KeyValueRow({
+  label,
+  value,
+  alias,
+}: {
+  label: string;
+  value: string | null;
+  alias: readonly string[] | undefined;
+}): ReactElement {
+  const hasAlias = alias && alias.length > 0;
   return (
     <>
       <span className="sb-token-detail__breakdown-key">{label}</span>
-      <span>{value ?? '—'}</span>
+      <span className="sb-token-detail__breakdown-value">
+        <span>{value ?? '—'}</span>
+        {hasAlias && (
+          <span className="sb-token-detail__breakdown-alias" data-testid="breakdown-alias">
+            {alias.map((p, i) => (
+              <span key={p} className="sb-token-detail__breakdown-alias-step">
+                {i > 0 && <span className="sb-token-detail__arrow">→</span>}
+                <span className="sb-token-detail__chain-node">{p}</span>
+              </span>
+            ))}
+          </span>
+        )}
+      </span>
     </>
   );
 }
@@ -162,6 +227,31 @@ function formatDimensionValue(v: unknown): string | null {
 function formatColorSubValue(v: unknown, format: ColorFormat): string | null {
   if (v == null) return null;
   return formatColor(v, format).value;
+}
+
+function pickObjectAliases(v: unknown): Record<string, string | undefined> | undefined {
+  if (!v || typeof v !== 'object' || Array.isArray(v)) return undefined;
+  return v as Record<string, string | undefined>;
+}
+
+function pickArrayAliases(v: unknown): Array<Record<string, string | undefined>> | undefined {
+  if (!Array.isArray(v)) return undefined;
+  return v as Array<Record<string, string | undefined>>;
+}
+
+/**
+ * Walk the alias chain starting from an immediate sub-value alias target.
+ * `aliasTarget` is the path the sub-value directly references; the target
+ * token's own `aliasChain` continues the walk to the primitive.
+ */
+function subValueChain(
+  aliasTarget: string | undefined,
+  resolved: Record<string, DetailToken> | undefined,
+): readonly string[] | undefined {
+  if (!aliasTarget) return undefined;
+  const tok = resolved?.[aliasTarget];
+  const tail = tok?.aliasChain;
+  return tail && tail.length > 0 ? [aliasTarget, ...tail] : [aliasTarget];
 }
 
 function shadowLayerKey(layer: Record<string, unknown>, fallback: number): string {

--- a/packages/blocks/src/token-detail/CompositeBreakdown.tsx
+++ b/packages/blocks/src/token-detail/CompositeBreakdown.tsx
@@ -112,11 +112,7 @@ export function CompositeBreakdownContent({
                 alias={layerAliasFor(i, 'spread')}
               />
               {'inset' in v && (
-                <KeyValueRow
-                  label="inset"
-                  value={formatPrimitive(v['inset'])}
-                  alias={undefined}
-                />
+                <KeyValueRow label="inset" value={formatPrimitive(v['inset'])} alias={undefined} />
               )}
             </div>
           );

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -7,6 +7,15 @@ export interface DetailToken {
   aliasOf?: string;
   aliasChain?: readonly string[];
   aliasedBy?: readonly string[];
+  /**
+   * Terrazzo-populated sub-value alias map for composite tokens. Shape
+   * varies by $type: object-valued composites (`border`, `typography`,
+   * `transition`) use `Record<string, string | undefined>` keyed by
+   * sub-key; array-valued composites (`shadow`, `gradient`) use an array
+   * of such records indexed per layer / stop. Carried through `unknown`
+   * here so each consumer narrows at use-site.
+   */
+  partialAliasOf?: unknown;
 }
 
 export interface VirtualAxisLike {

--- a/packages/blocks/src/token-detail/styles.css
+++ b/packages/blocks/src/token-detail/styles.css
@@ -182,6 +182,29 @@
   color: var(--swatchbook-text-muted, CanvasText);
 }
 
+.sb-token-detail__breakdown-value {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
+  min-width: 0;
+}
+
+.sb-token-detail__breakdown-alias {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  opacity: 0.8;
+}
+
+.sb-token-detail__breakdown-alias-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
 .sb-token-detail__breakdown-layer-header {
   grid-column: 1 / -1;
   font-size: 10px;

--- a/packages/blocks/test/composite-breakdown.test.tsx
+++ b/packages/blocks/test/composite-breakdown.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CompositeBreakdown, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
+
+function makeSnapshot(): ProjectSnapshot {
+  const themesResolved = {
+    Light: {
+      'color.palette.blue.500': { $type: 'color', $value: { hex: '#3b82f6' } },
+      'color.border.default': {
+        $type: 'color',
+        $value: { hex: '#3b82f6' },
+        aliasOf: 'color.palette.blue.500',
+        aliasChain: ['color.palette.blue.500'],
+      },
+      'border.default': {
+        $type: 'border',
+        $value: {
+          color: { hex: '#3b82f6' },
+          width: { value: 1, unit: 'px' },
+          style: 'solid',
+        },
+        partialAliasOf: {
+          color: 'color.border.default',
+          width: undefined,
+          style: undefined,
+        },
+      },
+    },
+  };
+  return {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    disabledAxes: [],
+    presets: [],
+    themes: [{ name: 'Light', input: { theme: 'Light' }, sources: [] }],
+    themesResolved,
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+}
+
+describe('CompositeBreakdown', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('surfaces the full alias chain for each aliased sub-value on a composite token', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <CompositeBreakdown path="border.default" />
+      </SwatchbookProvider>,
+    );
+
+    const aliasAnnotations = screen.getAllByTestId('breakdown-alias');
+    expect(aliasAnnotations.length).toBe(1);
+
+    const chain = aliasAnnotations[0];
+    expect(chain).toBeDefined();
+    expect(within(chain as HTMLElement).getByText('color.border.default')).toBeDefined();
+    expect(within(chain as HTMLElement).getByText('color.palette.blue.500')).toBeDefined();
+  });
+
+  it('omits the alias annotation on sub-values that are literal (not aliases)', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <CompositeBreakdown path="border.default" />
+      </SwatchbookProvider>,
+    );
+
+    // border.default has partialAliasOf only on `color`; `width` and `style`
+    // are literals and should render without the alias chain span.
+    const annotations = screen.queryAllByTestId('breakdown-alias');
+    expect(annotations.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Composite token sub-values (e.g. a border's `color`) that alias another token now render the full alias chain next to the resolved value in the `<TokenDetail>` drawer — the same chain-node + arrow visual that `<AliasChain>` already uses for top-level aliases.

Terrazzo exposes the immediate alias target per sub-key in `partialAliasOf`; we walk the target's own `aliasChain` to render the full transitive path. Covers all five composite types: `border`, `transition`, `typography` (object-shaped) and `shadow`, `gradient` (array-shaped).

Added `packages/blocks/test/composite-breakdown.test.tsx` covering the border → color-role → color-primitive case.

Milestone: Maintenance
Closes: #440
Plan impact: none