### PR TITLE
fix(blocks): align detail-overlay close button with panel padding

### DIFF
--- a/.changeset/overlay-close-inset.md
+++ b/.changeset/overlay-close-inset.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix(blocks): align detail-overlay close button with panel padding
+
+The slide-over close button was pinned at `top: 8px; right: 8px` — half
+the 16px panel padding — so it sat tucked against the corner instead of
+aligning with the content. Bumped both to `16px` so the button sits
+inside the visual inset, flush with the heading.

--- a/packages/blocks/src/internal/DetailOverlay.css
+++ b/packages/blocks/src/internal/DetailOverlay.css
@@ -21,8 +21,8 @@
 
 .sb-detail-overlay__close {
   position: absolute;
-  top: 8px;
-  right: 8px;
+  top: 16px;
+  right: 16px;
   width: 32px;
   height: 32px;
   border-radius: 4px;


### PR DESCRIPTION
Close button on the `<DetailOverlay>` slide-over moved from `top/right: 8px` to `16px`, matching the 16px panel padding. Now the × sits inside the visual inset and aligns with the heading instead of hugging the corner.

Milestone: Maintenance
Closes: #442
Plan impact: none