### PR TITLE
fix(blocks): honor color-format selector in Shadow/Border/Gradient previews

### DIFF
--- a/.changeset/color-format-composite-previews.md
+++ b/.changeset/color-format-composite-previews.md
@@ -1,0 +1,16 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix(blocks): honor the color-format selector in Shadow/Border/Gradient previews
+
+`<ShadowPreview>`, `<BorderPreview>`, and `<GradientPalette>` each shipped
+a local `formatColor` helper that ignored the toolbar's color-format
+selector — their sub-value text stayed in `colorSpace(components…)` or
+`rgb(%)` regardless of what the user picked. Now they route through the
+shared `formatColor` from `@unpunnyfuns/swatchbook-blocks`, subscribing
+to `useColorFormat()` the same way `<ColorPalette>` and
+`<CompositeBreakdown>` do.
+
+Flipping the toolbar between hex / rgb / hsl / oklch / raw now updates
+the breakdown labels in all three blocks.

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -2,6 +2,8 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './BorderPreview.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
+import { useColorFormat } from '#/contexts.ts';
+import { type ColorFormat, formatColor } from '#/format-color.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -49,18 +51,9 @@ function formatDimension(raw: unknown): string {
   return JSON.stringify(raw);
 }
 
-function formatColor(raw: unknown): string {
+function formatSubColor(raw: unknown, format: ColorFormat): string {
   if (raw == null) return '—';
-  if (typeof raw === 'string') return raw;
-  if (typeof raw === 'object') {
-    const v = raw as { components?: unknown; alpha?: unknown; colorSpace?: unknown };
-    if (Array.isArray(v.components) && typeof v.colorSpace === 'string') {
-      const parts = v.components.map((c) => (typeof c === 'number' ? c.toFixed(3) : String(c)));
-      const alpha = typeof v.alpha === 'number' && v.alpha !== 1 ? `, ${v.alpha}` : '';
-      return `${v.colorSpace}(${parts.join(' ')}${alpha})`;
-    }
-  }
-  return JSON.stringify(raw);
+  return formatColor(raw, format).value;
 }
 
 export function BorderPreview({
@@ -70,6 +63,7 @@ export function BorderPreview({
   sortDir = 'asc',
 }: BorderPreviewProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
+  const colorFormat = useColorFormat();
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -113,7 +107,7 @@ export function BorderPreview({
             <span className="sb-border-preview__breakdown-key">style</span>
             <span>{row.value.style != null ? String(row.value.style) : '—'}</span>
             <span className="sb-border-preview__breakdown-key">color</span>
-            <span>{formatColor(row.value.color)}</span>
+            <span>{formatSubColor(row.value.color, colorFormat)}</span>
           </div>
         </div>
       ))}

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -1,6 +1,8 @@
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './GradientPalette.css';
+import { useColorFormat } from '#/contexts.ts';
+import { formatColor } from '#/format-color.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -69,6 +71,7 @@ export function GradientPalette({
   sortDir = 'asc',
 }: GradientPaletteProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
+  const colorFormat = useColorFormat();
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -116,7 +119,7 @@ export function GradientPalette({
                   style={{ background: stopCssColor(stop) }}
                   aria-hidden
                 />
-                <span>{stopCssColor(stop)}</span>
+                <span>{formatColor(stop.color, colorFormat).value}</span>
                 <span className="sb-gradient-palette__stop-position">
                   @ {((stop.position ?? 0) * 100).toFixed(0)}%
                 </span>

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -2,6 +2,8 @@ import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './ShadowPreview.css';
+import { useColorFormat } from '#/contexts.ts';
+import { type ColorFormat, formatColor } from '#/format-color.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
@@ -53,18 +55,9 @@ function formatDimension(raw: unknown): string {
   return JSON.stringify(raw);
 }
 
-function formatColor(raw: unknown): string {
+function formatSubColor(raw: unknown, format: ColorFormat): string {
   if (raw == null) return '—';
-  if (typeof raw === 'string') return raw;
-  if (typeof raw === 'object') {
-    const v = raw as { components?: unknown; alpha?: unknown; colorSpace?: unknown };
-    if (Array.isArray(v.components) && typeof v.colorSpace === 'string') {
-      const parts = v.components.map((c) => (typeof c === 'number' ? c.toFixed(3) : String(c)));
-      const alpha = typeof v.alpha === 'number' && v.alpha !== 1 ? `, ${v.alpha}` : '';
-      return `${v.colorSpace}(${parts.join(' ')}${alpha})`;
-    }
-  }
-  return JSON.stringify(raw);
+  return formatColor(raw, format).value;
 }
 
 function asLayers(raw: unknown): ShadowLayer[] {
@@ -87,6 +80,7 @@ export function ShadowPreview({
   sortDir = 'asc',
 }: ShadowPreviewProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
+  const colorFormat = useColorFormat();
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -126,13 +120,14 @@ export function ShadowPreview({
           </div>
           <div className="sb-shadow-preview__breakdown">
             {row.layers.length === 1
-              ? renderLayer(row.layers[0])
+              ? renderLayer(row.layers[0], colorFormat)
               : row.layers.map((layer, i) => (
                   <Layer
                     key={layerKey(row.path, layer, i)}
                     layer={layer}
                     index={i}
                     total={row.layers.length}
+                    colorFormat={colorFormat}
                   />
                 ))}
           </div>
@@ -142,13 +137,13 @@ export function ShadowPreview({
   );
 }
 
-function renderLayer(layer: ShadowLayer | undefined): ReactElement[] {
+function renderLayer(layer: ShadowLayer | undefined, format: ColorFormat): ReactElement[] {
   if (!layer) return [];
   const entries: [string, string][] = [
     ['offset', `${formatDimension(layer.offsetX)} ${formatDimension(layer.offsetY)}`],
     ['blur', formatDimension(layer.blur)],
     ['spread', formatDimension(layer.spread)],
-    ['color', formatColor(layer.color)],
+    ['color', formatSubColor(layer.color, format)],
   ];
   if (layer.inset) entries.push(['inset', String(layer.inset)]);
   return entries.flatMap(([k, v]) => [
@@ -163,10 +158,12 @@ function Layer({
   layer,
   index,
   total,
+  colorFormat,
 }: {
   layer: ShadowLayer;
   index: number;
   total: number;
+  colorFormat: ColorFormat;
 }): ReactElement {
   return (
     <div className="sb-shadow-preview__layer">
@@ -174,7 +171,7 @@ function Layer({
         layer {index + 1} of {total}
       </div>
       <div className={cx('sb-shadow-preview__breakdown', 'sb-shadow-preview__layer-breakdown')}>
-        {renderLayer(layer)}
+        {renderLayer(layer, colorFormat)}
       </div>
     </div>
   );


### PR DESCRIPTION
Three composite-preview blocks shipped local `formatColor` helpers that stringified Terrazzo's normalized color shape with a fixed format (`colorSpace(components…)` for shadow/border; `rgb(%)` for gradient stops). None subscribed to `useColorFormat()`, so the toolbar's hex / rgb / hsl / oklch / raw selector had no effect on their sub-value labels — unlike `<ColorPalette>` and `<CompositeBreakdown>`, which already worked.

Routed all three through the shared `formatColor` + `useColorFormat()`. Flipping the format now updates their labels live; gradient swatch backgrounds still paint with the `rgb()` form since those are CSS values, not display strings.

Milestone: Maintenance
Closes: #444
Plan impact: none