### PR TITLE
ci: surface vitest + storybook test summaries in the job Step Summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,17 +67,22 @@ jobs:
 
       - name: Lint / format / typecheck / test / build
         id: checks
+        # Container image's default shell is `sh` (dash), which has no
+        # `set -o pipefail`. Force bash so the pipe exit code propagates.
+        shell: bash
         run: |
           set -o pipefail
           pnpm turbo run lint format:check typecheck test build 2>&1 | tee .ci-checks.log
 
       - name: Storybook interaction tests
+        shell: bash
         run: |
           set -o pipefail
           pnpm turbo run test:storybook 2>&1 | tee .ci-storybook.log
 
       - name: Test results summary
         if: always()
+        shell: bash
         run: |
           {
             echo "## Test results"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,19 +84,22 @@ jobs:
         if: always()
         shell: bash
         run: |
+          # Vitest colorizes its summary; strip ANSI so the markdown code
+          # block reads as plain text instead of `\x1b[2m Test Files …`.
+          strip_ansi='sed -E s/\x1B\[[0-9;]*[A-Za-z]//g'
           {
             echo "## Test results"
             echo ""
             echo "### Unit tests (vitest)"
             echo ""
             echo '```'
-            grep -E " (Test Files|Tests) +" .ci-checks.log 2>/dev/null || echo "(no summary lines parsed — see job log)"
+            grep -E " (Test Files|Tests) +" .ci-checks.log 2>/dev/null | $strip_ansi || echo "(no summary lines parsed — see job log)"
             echo '```'
             echo ""
             echo "### Storybook interaction tests"
             echo ""
             echo '```'
-            grep -E " (Test Files|Tests) +" .ci-storybook.log 2>/dev/null || echo "(no summary lines parsed — see job log)"
+            grep -E " (Test Files|Tests) +" .ci-storybook.log 2>/dev/null | $strip_ansi || echo "(no summary lines parsed — see job log)"
             echo '```'
             echo ""
             echo "Failure annotations (if any) appear inline on the **Files changed** tab via Vitest's auto-wired \`github-actions\` reporter."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,37 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      - run: pnpm turbo run lint format:check typecheck test build
+      - name: Lint / format / typecheck / test / build
+        id: checks
+        run: |
+          set -o pipefail
+          pnpm turbo run lint format:check typecheck test build 2>&1 | tee .ci-checks.log
 
       - name: Storybook interaction tests
-        run: pnpm turbo run test:storybook
+        run: |
+          set -o pipefail
+          pnpm turbo run test:storybook 2>&1 | tee .ci-storybook.log
+
+      - name: Test results summary
+        if: always()
+        run: |
+          {
+            echo "## Test results"
+            echo ""
+            echo "### Unit tests (vitest)"
+            echo ""
+            echo '```'
+            grep -E " (Test Files|Tests) +" .ci-checks.log 2>/dev/null || echo "(no summary lines parsed — see job log)"
+            echo '```'
+            echo ""
+            echo "### Storybook interaction tests"
+            echo ""
+            echo '```'
+            grep -E " (Test Files|Tests) +" .ci-storybook.log 2>/dev/null || echo "(no summary lines parsed — see job log)"
+            echo '```'
+            echo ""
+            echo "Failure annotations (if any) appear inline on the **Files changed** tab via Vitest's auto-wired \`github-actions\` reporter."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build Storybook
         run: pnpm turbo run build:storybook


### PR DESCRIPTION
Vitest 4.x auto-wires the `github-actions` reporter when `GITHUB_ACTIONS=true`, so failure annotations already land inline on the PR's **Files changed** tab for free. This adds the complementary at-a-glance bit: a Step Summary block with Vitest's `Test Files` / `Tests` lines from both the unit-test turbo run and the Storybook interaction-test run.

- Renamed the combined turbo step to "Lint / format / typecheck / test / build" and tee'd its output to `.ci-checks.log`.
- Likewise tee'd the Storybook interaction-test run to `.ci-storybook.log`.
- New "Test results summary" step with `if: always()` greps the Vitest summary lines from both logs and writes them to `$GITHUB_STEP_SUMMARY`, with a footnote pointing at the auto-wired annotations.

Milestone: Maintenance
Closes: #447
Plan impact: none