### PR TITLE
docs: split navbar Docs link into per-category entries

### DIFF
--- a/.changeset/navbar-categories.md
+++ b/.changeset/navbar-categories.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+docs: split Docs nav into per-category top-level entries
+
+The Docusaurus navbar now exposes Quickstart, Concepts, Blocks, Guides,
+and Reference as discrete top-level items instead of a single collapsed
+"Docs" link. `activeBaseRegex` on each entry highlights the pill for the
+whole section — Reference excludes `/reference/blocks/*` so the Blocks
+entry keeps the active style while browsing block pages.

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -87,7 +87,37 @@ const config: Config = {
         src: 'img/logo.svg',
       },
       items: [
-        { type: 'docSidebar', sidebarId: 'docs', position: 'left', label: 'Docs' },
+        // Per-category top-level entries so readers can jump straight to
+        // the section they want rather than landing on Intro and fishing
+        // through the sidebar. Each entry points at the first page in its
+        // sidebar group; `activeBaseRegex` highlights the nav pill across
+        // the whole section. Reference excludes `/reference/blocks/*`
+        // because Blocks has its own top-level entry.
+        { to: '/quickstart', label: 'Quickstart', position: 'left' },
+        {
+          to: '/concepts/theming-inputs',
+          label: 'Concepts',
+          position: 'left',
+          activeBaseRegex: '^/(?:next/)?concepts(?:/|$)',
+        },
+        {
+          to: '/reference/blocks/',
+          label: 'Blocks',
+          position: 'left',
+          activeBaseRegex: '^/(?:next/)?reference/blocks(?:/|$)',
+        },
+        {
+          to: '/guides/multi-axis-walkthrough',
+          label: 'Guides',
+          position: 'left',
+          activeBaseRegex: '^/(?:next/)?guides(?:/|$)',
+        },
+        {
+          to: '/reference/addon',
+          label: 'Reference',
+          position: 'left',
+          activeBaseRegex: '^/(?:next/)?reference/(?!blocks)(?:$|.*)',
+        },
         { href: 'pathname:///storybook/', label: 'Live Storybook', position: 'left' },
         ...(hasReleasedVersion
           ? [{ type: 'docsVersionDropdown' as const, position: 'right' as const }]


### PR DESCRIPTION
Docusaurus navbar used to collapse every docs section behind a single "Docs" link, so readers always landed on Intro. This replaces it with five discrete top-level entries — **Quickstart / Concepts / Blocks / Guides / Reference** — each with `activeBaseRegex` so the pill stays highlighted for the whole section. Reference's regex excludes `/reference/blocks/*` so the Blocks entry keeps the active style while browsing block pages (both live under `/reference/` on disk).

Live Storybook, versions dropdown, and GitHub right-side items unchanged.

Milestone: Maintenance
Closes: #449
Plan impact: none