### PR TITLE
docs: split docs sidebar per section so left rail stops duplicating navbar

### DIFF
--- a/.changeset/sidebar-split.md
+++ b/.changeset/sidebar-split.md
@@ -1,0 +1,18 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+docs: split docs sidebar per section so left rail stops duplicating navbar
+
+The left sidebar listed every category (Blocks / Concepts / Guides /
+Reference) as a collapsible header, which mirrored the navbar entries
+added in the previous patch. Split the single `docs` sidebar into five
+section-scoped sidebars (`home`, `concepts`, `blocks`, `guides`,
+`reference`) and bind each navbar entry with `type: 'docSidebar'` +
+`sidebarId`. The left rail now lists only the pages in the current
+section.
+
+Versioned sidebar snapshots (0.4 / 0.5 / 0.6) were rewritten to the new
+shape — navbar `docSidebar` entries resolve per-version, so leaving
+older versions on the old `docs` sidebar would 500 every page under
+`/0.4/…` etc.

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -87,37 +87,17 @@ const config: Config = {
         src: 'img/logo.svg',
       },
       items: [
-        // Per-category top-level entries so readers can jump straight to
-        // the section they want rather than landing on Intro and fishing
-        // through the sidebar. Each entry points at the first page in its
-        // sidebar group; `activeBaseRegex` highlights the nav pill across
-        // the whole section. Reference excludes `/reference/blocks/*`
-        // because Blocks has its own top-level entry.
-        { to: '/quickstart', label: 'Quickstart', position: 'left' },
-        {
-          to: '/concepts/theming-inputs',
-          label: 'Concepts',
-          position: 'left',
-          activeBaseRegex: '^/(?:next/)?concepts(?:/|$)',
-        },
-        {
-          to: '/reference/blocks/',
-          label: 'Blocks',
-          position: 'left',
-          activeBaseRegex: '^/(?:next/)?reference/blocks(?:/|$)',
-        },
-        {
-          to: '/guides/multi-axis-walkthrough',
-          label: 'Guides',
-          position: 'left',
-          activeBaseRegex: '^/(?:next/)?guides(?:/|$)',
-        },
-        {
-          to: '/reference/addon',
-          label: 'Reference',
-          position: 'left',
-          activeBaseRegex: '^/(?:next/)?reference/(?!blocks)(?:$|.*)',
-        },
+        // Per-section top-level entries bound to a sidebar via
+        // `type: 'docSidebar'` + `sidebarId`. Docusaurus auto-links to
+        // the first doc in the bound sidebar and keeps the nav pill
+        // active across every doc in it — no `activeBaseRegex` needed,
+        // and the left rail shows only the current section's pages
+        // rather than duplicating the navbar's category list.
+        { type: 'docSidebar', sidebarId: 'home', position: 'left', label: 'Quickstart' },
+        { type: 'docSidebar', sidebarId: 'concepts', position: 'left', label: 'Concepts' },
+        { type: 'docSidebar', sidebarId: 'blocks', position: 'left', label: 'Blocks' },
+        { type: 'docSidebar', sidebarId: 'guides', position: 'left', label: 'Guides' },
+        { type: 'docSidebar', sidebarId: 'reference', position: 'left', label: 'Reference' },
         { href: 'pathname:///storybook/', label: 'Live Storybook', position: 'left' },
         ...(hasReleasedVersion
           ? [{ type: 'docsVersionDropdown' as const, position: 'right' as const }]

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -1,52 +1,36 @@
 import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
 
+/**
+ * One sidebar per top-nav section. The navbar uses `type: 'docSidebar'`
+ * entries bound by `sidebarId`, which auto-link to each sidebar's first
+ * doc and keep the nav pill active across all docs in that sidebar.
+ * Splitting the sidebar per section removes the category-header
+ * redundancy the old single `docs` sidebar had (the navbar already
+ * names the section).
+ *
+ * `home` covers the landing pages — Introduction and Quickstart — so
+ * visitors on `/` or `/quickstart` get a minimal two-item sidebar
+ * instead of the full flattened graph.
+ */
 const sidebars: SidebarsConfig = {
-  docs: [
-    'intro',
-    'quickstart',
-    // Blocks promoted to the top level. After initial setup, authoring
-    // pages with the doc blocks is the primary swatchbook interaction —
-    // the reference (what's available) and the authoring guide (how to
-    // compose them) land right below the quickstart rather than buried
-    // under Reference / Guides.
-    {
-      type: 'category',
-      label: 'Blocks',
-      collapsed: false,
-      items: [
-        'reference/blocks/blocks',
-        'reference/blocks/overview',
-        'reference/blocks/inspector',
-        'reference/blocks/samples',
-        'reference/blocks/utility',
-        'guides/authoring-doc-stories',
-        'guides/token-dashboard',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Concepts',
-      collapsed: false,
-      items: [
-        'concepts/theming-inputs',
-        'concepts/axes',
-        'concepts/presets',
-        'concepts/diagnostics',
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Guides',
-      collapsed: false,
-      items: ['guides/multi-axis-walkthrough'],
-    },
-    {
-      type: 'category',
-      label: 'Reference',
-      collapsed: false,
-      items: ['reference/addon', 'reference/core', 'reference/config'],
-    },
+  home: ['intro', 'quickstart'],
+  concepts: [
+    'concepts/theming-inputs',
+    'concepts/axes',
+    'concepts/presets',
+    'concepts/diagnostics',
   ],
+  blocks: [
+    'reference/blocks/blocks',
+    'reference/blocks/overview',
+    'reference/blocks/inspector',
+    'reference/blocks/samples',
+    'reference/blocks/utility',
+    'guides/authoring-doc-stories',
+    'guides/token-dashboard',
+  ],
+  guides: ['guides/multi-axis-walkthrough'],
+  reference: ['reference/addon', 'reference/core', 'reference/config'],
 };
 
 export default sidebars;

--- a/apps/docs/versioned_sidebars/version-0.4-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-0.4-sidebars.json
@@ -1,49 +1,20 @@
 {
-  "docs": [
-    "intro",
-    "quickstart",
-    {
-      "type": "category",
-      "label": "Blocks",
-      "collapsed": false,
-      "items": [
-        "reference/blocks/blocks",
-        "reference/blocks/overview",
-        "reference/blocks/inspector",
-        "reference/blocks/samples",
-        "reference/blocks/utility",
-        "guides/authoring-doc-stories",
-        "guides/token-dashboard"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Concepts",
-      "collapsed": false,
-      "items": [
-        "concepts/theming-inputs",
-        "concepts/axes",
-        "concepts/presets",
-        "concepts/diagnostics"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Guides",
-      "collapsed": false,
-      "items": [
-        "guides/multi-axis-walkthrough"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Reference",
-      "collapsed": false,
-      "items": [
-        "reference/addon",
-        "reference/core",
-        "reference/config"
-      ]
-    }
-  ]
+  "home": ["intro", "quickstart"],
+  "concepts": [
+    "concepts/theming-inputs",
+    "concepts/axes",
+    "concepts/presets",
+    "concepts/diagnostics"
+  ],
+  "blocks": [
+    "reference/blocks/blocks",
+    "reference/blocks/overview",
+    "reference/blocks/inspector",
+    "reference/blocks/samples",
+    "reference/blocks/utility",
+    "guides/authoring-doc-stories",
+    "guides/token-dashboard"
+  ],
+  "guides": ["guides/multi-axis-walkthrough"],
+  "reference": ["reference/addon", "reference/core", "reference/config"]
 }

--- a/apps/docs/versioned_sidebars/version-0.5-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-0.5-sidebars.json
@@ -1,49 +1,20 @@
 {
-  "docs": [
-    "intro",
-    "quickstart",
-    {
-      "type": "category",
-      "label": "Blocks",
-      "collapsed": false,
-      "items": [
-        "reference/blocks/blocks",
-        "reference/blocks/overview",
-        "reference/blocks/inspector",
-        "reference/blocks/samples",
-        "reference/blocks/utility",
-        "guides/authoring-doc-stories",
-        "guides/token-dashboard"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Concepts",
-      "collapsed": false,
-      "items": [
-        "concepts/theming-inputs",
-        "concepts/axes",
-        "concepts/presets",
-        "concepts/diagnostics"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Guides",
-      "collapsed": false,
-      "items": [
-        "guides/multi-axis-walkthrough"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Reference",
-      "collapsed": false,
-      "items": [
-        "reference/addon",
-        "reference/core",
-        "reference/config"
-      ]
-    }
-  ]
+  "home": ["intro", "quickstart"],
+  "concepts": [
+    "concepts/theming-inputs",
+    "concepts/axes",
+    "concepts/presets",
+    "concepts/diagnostics"
+  ],
+  "blocks": [
+    "reference/blocks/blocks",
+    "reference/blocks/overview",
+    "reference/blocks/inspector",
+    "reference/blocks/samples",
+    "reference/blocks/utility",
+    "guides/authoring-doc-stories",
+    "guides/token-dashboard"
+  ],
+  "guides": ["guides/multi-axis-walkthrough"],
+  "reference": ["reference/addon", "reference/core", "reference/config"]
 }

--- a/apps/docs/versioned_sidebars/version-0.6-sidebars.json
+++ b/apps/docs/versioned_sidebars/version-0.6-sidebars.json
@@ -1,49 +1,20 @@
 {
-  "docs": [
-    "intro",
-    "quickstart",
-    {
-      "type": "category",
-      "label": "Blocks",
-      "collapsed": false,
-      "items": [
-        "reference/blocks/blocks",
-        "reference/blocks/overview",
-        "reference/blocks/inspector",
-        "reference/blocks/samples",
-        "reference/blocks/utility",
-        "guides/authoring-doc-stories",
-        "guides/token-dashboard"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Concepts",
-      "collapsed": false,
-      "items": [
-        "concepts/theming-inputs",
-        "concepts/axes",
-        "concepts/presets",
-        "concepts/diagnostics"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Guides",
-      "collapsed": false,
-      "items": [
-        "guides/multi-axis-walkthrough"
-      ]
-    },
-    {
-      "type": "category",
-      "label": "Reference",
-      "collapsed": false,
-      "items": [
-        "reference/addon",
-        "reference/core",
-        "reference/config"
-      ]
-    }
-  ]
+  "home": ["intro", "quickstart"],
+  "concepts": [
+    "concepts/theming-inputs",
+    "concepts/axes",
+    "concepts/presets",
+    "concepts/diagnostics"
+  ],
+  "blocks": [
+    "reference/blocks/blocks",
+    "reference/blocks/overview",
+    "reference/blocks/inspector",
+    "reference/blocks/samples",
+    "reference/blocks/utility",
+    "guides/authoring-doc-stories",
+    "guides/token-dashboard"
+  ],
+  "guides": ["guides/multi-axis-walkthrough"],
+  "reference": ["reference/addon", "reference/core", "reference/config"]
 }


### PR DESCRIPTION
Follow-up to #450. The left sidebar still listed every category (Blocks / Concepts / Guides / Reference) as a collapsible header, mirroring the per-section navbar entries that PR added — the categorisation appeared twice on every page.

Splits the single `docs` sidebar into five section-scoped sidebars (`home`, `concepts`, `blocks`, `guides`, `reference`) and binds each navbar entry with `type: 'docSidebar'` + `sidebarId`. Docusaurus auto-links to the first doc in the bound sidebar and keeps the nav pill active across the section, so `activeBaseRegex` drops out too. The left rail now lists only the pages in the current section.

Versioned sidebar snapshots (0.4 / 0.5 / 0.6) rewritten to the same shape — navbar `docSidebar` entries resolve per-version, so older versions without the new sidebar ids would 500 every page under `/0.4/…`. Patch changeset included.

Milestone: Maintenance
Closes: #452
Plan impact: none