### PR TITLE
feat(switcher): extract theme-switcher popover into a new package

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,8 @@
     [
       "@unpunnyfuns/swatchbook-core",
       "@unpunnyfuns/swatchbook-addon",
-      "@unpunnyfuns/swatchbook-blocks"
+      "@unpunnyfuns/swatchbook-blocks",
+      "@unpunnyfuns/swatchbook-switcher"
     ]
   ],
   "linked": [],

--- a/.changeset/extract-switcher.md
+++ b/.changeset/extract-switcher.md
@@ -1,0 +1,21 @@
+---
+'@unpunnyfuns/swatchbook-switcher': minor
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+feat(switcher): extract theme-switcher popover into a standalone package
+
+Introduce `@unpunnyfuns/swatchbook-switcher`, a framework-agnostic
+React component that renders the axis / preset / color-format popover
+swatchbook's Storybook toolbar used to own inline. Consumers pass in
+`axes`, `presets`, `activeTuple`, and change callbacks; the component
+owns the pill UI + keyboard-accessible menu. Compiled with classic JSX
+(`React.createElement`) so it embeds cleanly in Storybook's manager
+bundle (which does not expose `react/jsx-runtime`).
+
+The addon's `AxesToolbar` now composes `<ThemeSwitcher>` inside its
+existing `WithTooltipPure` popover — no user-visible change; the same
+icon button, shortcuts, and behavior stay in place.
+
+Ships the switcher in the fixed-version group alongside core / addon /
+blocks so the four release together.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -79,6 +79,7 @@
   "dependencies": {
     "@unpunnyfuns/swatchbook-blocks": "workspace:*",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
+    "@unpunnyfuns/swatchbook-switcher": "workspace:*",
     "jiti": "^2.4.0",
     "picomatch": "^4.0.4"
   },

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -1,3 +1,4 @@
+import { ThemeSwitcher, type SwitcherColorFormat } from '@unpunnyfuns/swatchbook-switcher';
 import React, { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { IconButton, WithTooltipPure } from 'storybook/internal/components';
 import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
@@ -25,6 +26,10 @@ import {
  * always part of that exposure, which breaks JSX with
  * "Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')".
  * Mirrors the pattern `@storybook/addon-a11y` uses in its manager.
+ *
+ * The imported `<ThemeSwitcher>` from `@unpunnyfuns/swatchbook-switcher`
+ * compiles with classic JSX (`React.createElement`) specifically so it
+ * survives embedding in the manager bundle the same way.
  */
 const h = React.createElement;
 
@@ -74,20 +79,9 @@ function defaultTupleFor(axes: readonly AxisEntry[]): Record<string, string> {
 }
 
 /**
- * Treat the `{ name: 'theme', source: 'synthetic' }` axis — the one core
- * fabricates for single-theme projects with no resolver — as a special case
- * that uses the label "Theme" instead of the axis name. Authored single-axis
- * resolvers keep their real axis name (e.g. `mode`).
- */
-function displayLabelFor(axis: AxisEntry): string {
-  if (axis.source === 'synthetic' && axis.name === 'theme') return 'Theme';
-  return axis.name;
-}
-
-/**
  * Compose a preset's sanitized partial tuple with the axis defaults, so
  * applying a preset that only names some axes leaves the omitted ones at
- * their defaults (not blank). Matches the preview decorator's own fallback
+ * their defaults (not blank). Mirrors the preview decorator's own fallback
  * logic so what the toolbar sends out is what the decorator honors.
  */
 function presetTuple(
@@ -103,302 +97,6 @@ function presetTuple(
     }
   }
   return out;
-}
-
-function tuplesEqual(
-  a: Readonly<Record<string, string>>,
-  b: Readonly<Record<string, string>>,
-  axes: readonly AxisEntry[],
-): boolean {
-  for (const axis of axes) {
-    if (a[axis.name] !== b[axis.name]) return false;
-  }
-  return true;
-}
-
-const SECTION_LABEL_STYLE: React.CSSProperties = {
-  padding: '8px 12px 4px',
-  fontSize: 11,
-  textTransform: 'uppercase',
-  letterSpacing: 0.5,
-  opacity: 0.6,
-};
-
-const SECTION_BODY_STYLE: React.CSSProperties = {
-  padding: '0 12px 10px',
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: 4,
-};
-
-const AXIS_ROW_STYLE: React.CSSProperties = {
-  padding: '0 12px 10px',
-  display: 'grid',
-  gridTemplateColumns: 'max-content 1fr',
-  columnGap: 12,
-  rowGap: 4,
-  alignItems: 'center',
-};
-
-const AXIS_LABEL_STYLE: React.CSSProperties = {
-  fontSize: 12,
-  fontWeight: 600,
-  opacity: 0.85,
-};
-
-const AXIS_PILLS_STYLE: React.CSSProperties = {
-  display: 'flex',
-  flexWrap: 'wrap',
-  gap: 4,
-};
-
-const OPTION_PILL_BASE: React.CSSProperties = {
-  padding: '3px 8px',
-  borderRadius: 4,
-  fontSize: 12,
-  lineHeight: '18px',
-  // Longhand border properties (not the `border` shorthand) so
-  // active → inactive only updates `borderColor`'s value instead of
-  // *removing* the key from inline style. Removing it lets Storybook's
-  // theme paint a stray border-color on the previously-selected pill.
-  borderWidth: 1,
-  borderStyle: 'solid',
-  borderColor: 'transparent',
-  background: 'transparent',
-  cursor: 'pointer',
-  color: 'inherit',
-  outline: 'none',
-  boxShadow: 'none',
-};
-
-const OPTION_PILL_ACTIVE: React.CSSProperties = {
-  ...OPTION_PILL_BASE,
-  fontWeight: 600,
-  background: 'rgba(0, 122, 255, 0.12)',
-  borderColor: 'rgba(0, 122, 255, 0.45)',
-};
-
-const PRESET_PILL_MODIFIED: React.CSSProperties = {
-  display: 'inline-block',
-  width: 6,
-  height: 6,
-  marginLeft: 6,
-  borderRadius: '50%',
-  background: 'currentColor',
-  opacity: 0.6,
-  verticalAlign: 'middle',
-};
-
-const DIVIDER_STYLE: React.CSSProperties = {
-  height: 1,
-  background: 'currentColor',
-  opacity: 0.1,
-  margin: '2px 8px',
-};
-
-interface OptionPillProps {
-  label: string;
-  active: boolean;
-  title?: string;
-  onClick: () => void;
-  trailing?: ReactElement | null;
-}
-
-function OptionPill({ label, active, title, onClick, trailing }: OptionPillProps): ReactElement {
-  return h(
-    'button',
-    {
-      type: 'button',
-      title,
-      onClick,
-      // Skip focus on mouse click so Storybook's `:focus` border-color
-      // theming doesn't stick on the previously-clicked pill. Keyboard
-      // tabbing still lands focus normally — preventDefault on mousedown
-      // only blocks the implicit focus-on-click behavior.
-      onMouseDown: (event) => event.preventDefault(),
-      style: active ? OPTION_PILL_ACTIVE : OPTION_PILL_BASE,
-    },
-    label,
-    trailing ?? null,
-  );
-}
-
-interface PresetsSectionProps {
-  presets: readonly PresetEntry[];
-  axes: readonly AxisEntry[];
-  defaults: Readonly<Record<string, string>>;
-  activeTuple: Readonly<Record<string, string>>;
-  lastApplied: string | null;
-  onApply: (preset: PresetEntry) => void;
-}
-
-function PresetsSection({
-  presets,
-  axes,
-  defaults,
-  activeTuple,
-  lastApplied,
-  onApply,
-}: PresetsSectionProps): ReactElement {
-  return h(
-    'div',
-    null,
-    h('div', { style: SECTION_LABEL_STYLE }, 'Presets'),
-    h(
-      'div',
-      { style: SECTION_BODY_STYLE },
-      ...presets.map((preset) => {
-        const tuple = presetTuple(preset, axes, defaults);
-        const matches = tuplesEqual(tuple, activeTuple, axes);
-        const modified = !matches && preset.name === lastApplied;
-        const title = preset.description ? `${preset.name} — ${preset.description}` : preset.name;
-        return h(OptionPill, {
-          key: `${TOOL_ID}/preset/${preset.name}`,
-          label: preset.name,
-          active: matches,
-          title,
-          onClick: () => onApply(preset),
-          trailing: modified
-            ? h('span', { 'aria-hidden': true, style: PRESET_PILL_MODIFIED })
-            : null,
-        });
-      }),
-    ),
-  );
-}
-
-interface AxisSectionProps {
-  axis: AxisEntry;
-  active: string;
-  onSelect: (next: string) => void;
-}
-
-function AxisSection({ axis, active, onSelect }: AxisSectionProps): ReactElement {
-  const label = displayLabelFor(axis);
-  return h(
-    'div',
-    { style: AXIS_ROW_STYLE },
-    h('div', { style: AXIS_LABEL_STYLE, title: axis.description }, label),
-    h(
-      'div',
-      { style: AXIS_PILLS_STYLE },
-      ...axis.contexts.map((ctx) =>
-        h(OptionPill, {
-          key: `${TOOL_ID}/${axis.name}/${ctx}`,
-          label: ctx,
-          active: ctx === active,
-          onClick: () => onSelect(ctx),
-        }),
-      ),
-    ),
-  );
-}
-
-const COLOR_FORMAT_OPTIONS: readonly { id: string; label: string }[] = [
-  { id: 'hex', label: 'Hex' },
-  { id: 'rgb', label: 'RGB' },
-  { id: 'hsl', label: 'HSL' },
-  { id: 'oklch', label: 'OKLCH' },
-  { id: 'raw', label: 'Raw (JSON)' },
-];
-
-interface ColorFormatSectionProps {
-  active: string;
-  onSelect: (next: string) => void;
-}
-
-function ColorFormatSection({ active, onSelect }: ColorFormatSectionProps): ReactElement {
-  return h(
-    'div',
-    null,
-    h('div', { style: SECTION_LABEL_STYLE }, 'Color format'),
-    h(
-      'div',
-      { style: SECTION_BODY_STYLE },
-      ...COLOR_FORMAT_OPTIONS.map((opt) =>
-        h(OptionPill, {
-          key: `${TOOL_ID}/color-format/${opt.id}`,
-          label: opt.label,
-          active: opt.id === active,
-          onClick: () => onSelect(opt.id),
-        }),
-      ),
-    ),
-  );
-}
-
-interface PopoverBodyProps {
-  axes: readonly AxisEntry[];
-  presets: readonly PresetEntry[];
-  defaults: Readonly<Record<string, string>>;
-  activeTuple: Readonly<Record<string, string>>;
-  activeColorFormat: string;
-  lastApplied: string | null;
-  onApplyPreset: (preset: PresetEntry) => void;
-  onSelectAxis: (axisName: string, next: string) => void;
-  onSelectColorFormat: (next: string) => void;
-  onKeyDown: (event: React.KeyboardEvent<HTMLDivElement>) => void;
-}
-
-function PopoverBody(props: PopoverBodyProps): ReactElement {
-  const {
-    axes,
-    presets,
-    defaults,
-    activeTuple,
-    activeColorFormat,
-    lastApplied,
-    onApplyPreset,
-    onSelectAxis,
-    onSelectColorFormat,
-    onKeyDown,
-  } = props;
-  const sections: ReactElement[] = [];
-  if (presets.length > 0) {
-    sections.push(
-      h(PresetsSection, {
-        key: 'presets',
-        presets,
-        axes,
-        defaults,
-        activeTuple,
-        lastApplied,
-        onApply: onApplyPreset,
-      }),
-      h('div', { key: 'presets-divider', style: DIVIDER_STYLE }),
-    );
-  }
-  axes.forEach((axis, idx) => {
-    sections.push(
-      h(AxisSection, {
-        key: `axis-${axis.name}`,
-        axis,
-        active: activeTuple[axis.name] ?? axis.default,
-        onSelect: (next) => onSelectAxis(axis.name, next),
-      }),
-    );
-    if (idx === axes.length - 1) {
-      sections.push(h('div', { key: 'axes-divider', style: DIVIDER_STYLE }));
-    }
-  });
-  sections.push(
-    h(ColorFormatSection, {
-      key: 'color-format',
-      active: activeColorFormat,
-      onSelect: onSelectColorFormat,
-    }),
-  );
-  return h(
-    'div',
-    {
-      role: 'menu',
-      tabIndex: -1,
-      onKeyDown,
-      style: { minWidth: 260, padding: '4px 0', outline: 'none' },
-      'data-testid': 'swatchbook-toolbar-popover',
-    },
-    ...sections,
-  );
 }
 
 function AxesToolbar(): ReactElement {
@@ -430,7 +128,8 @@ function AxesToolbar(): ReactElement {
   const defaults = useMemo(() => defaultTupleFor(axes), [axes]);
   const [lastApplied, setLastApplied] = useState<string | null>(null);
   const globalTuple = globals[AXES_GLOBAL_KEY] as Record<string, string> | undefined;
-  const activeColorFormat = (globals[COLOR_FORMAT_GLOBAL_KEY] as string | undefined) ?? 'hex';
+  const activeColorFormat = ((globals[COLOR_FORMAT_GLOBAL_KEY] as string | undefined) ??
+    'hex') as SwitcherColorFormat;
 
   const activeTuple = useMemo<Record<string, string>>(() => {
     const out: Record<string, string> = { ...defaults };
@@ -529,7 +228,7 @@ function AxesToolbar(): ReactElement {
       const target = e.target;
       if (!(target instanceof Element)) return;
       if (bodyRef.current?.contains(target)) return;
-      if (target.closest('[data-testid="swatchbook-toolbar-popover"]')) return;
+      if (target.closest('[data-testid="swatchbook-switcher"]')) return;
       setOpen(false);
     };
     /**
@@ -570,16 +269,17 @@ function AxesToolbar(): ReactElement {
     h(SwatchbookIcon),
   );
 
-  const tooltipBody = h(PopoverBody, {
+  const tooltipBody = h(ThemeSwitcher, {
     axes,
     presets,
-    defaults,
+    themes,
     activeTuple,
+    defaults,
     activeColorFormat,
     lastApplied,
-    onApplyPreset: applyPreset,
-    onSelectAxis: setAxis,
-    onSelectColorFormat: (next: string) => updateGlobals({ [COLOR_FORMAT_GLOBAL_KEY]: next }),
+    onAxisChange: setAxis,
+    onPresetApply: applyPreset,
+    onColorFormatChange: (next) => updateGlobals({ [COLOR_FORMAT_GLOBAL_KEY]: next }),
     onKeyDown: handleKeyDown,
   });
 

--- a/packages/switcher/package.json
+++ b/packages/switcher/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@unpunnyfuns/swatchbook-switcher",
+  "version": "0.6.2",
+  "description": "Framework-agnostic theme-switcher UI for swatchbook — axis pills, preset pills, color-format selector. Consumed by the Storybook addon toolbar and any React host that knows how to set data-attributes on the document.",
+  "license": "MIT",
+  "author": "unpunnyfuns <unpunnyfuns@gmail.com>",
+  "homepage": "https://unpunnyfuns.github.io/swatchbook/",
+  "bugs": "https://github.com/unpunnyfuns/swatchbook/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/unpunnyfuns/swatchbook.git",
+    "directory": "packages/switcher"
+  },
+  "keywords": [
+    "swatchbook",
+    "design-tokens",
+    "dtcg",
+    "theme-switcher",
+    "react"
+  ],
+  "type": "module",
+  "engines": {
+    "node": ">=24.14.0"
+  },
+  "main": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.mts",
+      "import": "./dist/index.mjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "imports": {
+    "#/*": "./src/*"
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": [
+    "**/*.css"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsdown",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
+    "format": "oxfmt -c ../../.oxfmtrc.json src test",
+    "format:check": "oxfmt --check -c ../../.oxfmtrc.json src test"
+  },
+  "peerDependencies": {
+    "react": ">=18"
+  },
+  "devDependencies": {
+    "@testing-library/react": "^16.3.2",
+    "@tsdown/css": "^0.21.9",
+    "@types/react": "^19.2.14",
+    "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "tsdown": "^0.21.9",
+    "typescript": "^6.0.0",
+    "vitest": "^4.1.4"
+  },
+  "dependencies": {
+    "clsx": "^2.1.1"
+  }
+}

--- a/packages/switcher/src/ThemeSwitcher.css
+++ b/packages/switcher/src/ThemeSwitcher.css
@@ -1,0 +1,84 @@
+.sb-switcher {
+  min-width: 260px;
+  padding: 4px 0;
+  outline: none;
+}
+
+.sb-switcher__section-label {
+  padding: 8px 12px 4px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.6;
+}
+
+.sb-switcher__section-body {
+  padding: 0 12px 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.sb-switcher__axis-row {
+  padding: 0 12px 10px;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 12px;
+  row-gap: 4px;
+  align-items: center;
+}
+
+.sb-switcher__axis-label {
+  font-size: 12px;
+  font-weight: 600;
+  opacity: 0.85;
+}
+
+.sb-switcher__axis-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.sb-switcher__pill {
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 18px;
+  /* Longhand border properties (not the `border` shorthand) so active →
+     inactive only updates `border-color`'s value instead of *removing* the
+     key from inline style — an inherited theme border-color would otherwise
+     paint through on the previously-selected pill. */
+  border-width: 1px;
+  border-style: solid;
+  border-color: transparent;
+  background: transparent;
+  cursor: pointer;
+  color: inherit;
+  outline: none;
+  box-shadow: none;
+}
+
+.sb-switcher__pill--active {
+  font-weight: 600;
+  background: rgba(0, 122, 255, 0.12);
+  border-color: rgba(0, 122, 255, 0.45);
+}
+
+.sb-switcher__pill-modified {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-left: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0.6;
+  vertical-align: middle;
+}
+
+.sb-switcher__divider {
+  height: 1px;
+  background: currentColor;
+  opacity: 0.1;
+  margin: 2px 8px;
+}

--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -1,0 +1,261 @@
+import cx from 'clsx';
+import React, { type KeyboardEvent, type ReactElement } from 'react';
+import './ThemeSwitcher.css';
+import type { SwitcherAxis, SwitcherColorFormat, SwitcherPreset, SwitcherTheme } from '#/types.ts';
+
+const COLOR_FORMAT_OPTIONS: readonly { id: SwitcherColorFormat; label: string }[] = [
+  { id: 'hex', label: 'Hex' },
+  { id: 'rgb', label: 'RGB' },
+  { id: 'hsl', label: 'HSL' },
+  { id: 'oklch', label: 'OKLCH' },
+  { id: 'raw', label: 'Raw (JSON)' },
+];
+
+export interface ThemeSwitcherProps {
+  /** Project axes the UI renders one section per. */
+  axes: readonly SwitcherAxis[];
+  /** Saved preset snapshots rendered above the axes, if any. */
+  presets?: readonly SwitcherPreset[];
+  /** Full theme list — only consulted for the "modified since preset applied" dot. */
+  themes?: readonly SwitcherTheme[];
+  /** Active axis tuple, keyed by axis name. */
+  activeTuple: Readonly<Record<string, string>>;
+  /** Default tuple used to fill in omitted preset axes. */
+  defaults: Readonly<Record<string, string>>;
+  /** Active display format for color sub-values. */
+  activeColorFormat: SwitcherColorFormat;
+  /** Name of the most recently applied preset, or null. Drives the "modified" dot. */
+  lastApplied: string | null;
+  /** Receives an axis name + new context. */
+  onAxisChange(axisName: string, next: string): void;
+  /** Called with the full preset object when the user clicks a preset pill. */
+  onPresetApply(preset: SwitcherPreset): void;
+  /** Called with the new color format when the user picks one. */
+  onColorFormatChange(next: SwitcherColorFormat): void;
+  /** Optional key handler, usually used by consumers to close a popover on Escape. */
+  onKeyDown?(event: KeyboardEvent<HTMLDivElement>): void;
+}
+
+/**
+ * Popover body for the swatchbook theme switcher. Renders preset pills
+ * (when the project ships any), one row per axis, and a color-format
+ * picker. Consumers own the trigger + positioning — the switcher just
+ * draws the menu. Uses classic JSX so it survives embedding in
+ * Storybook's manager bundle (which doesn't expose `react/jsx-runtime`).
+ */
+export function ThemeSwitcher({
+  axes,
+  presets = [],
+  themes = [],
+  activeTuple,
+  defaults,
+  activeColorFormat,
+  lastApplied,
+  onAxisChange,
+  onPresetApply,
+  onColorFormatChange,
+  onKeyDown,
+}: ThemeSwitcherProps): ReactElement {
+  return (
+    <div
+      role="menu"
+      tabIndex={-1}
+      className="sb-switcher"
+      onKeyDown={onKeyDown}
+      data-testid="swatchbook-switcher"
+    >
+      {presets.length > 0 && (
+        <>
+          <PresetsSection
+            presets={presets}
+            axes={axes}
+            themes={themes}
+            defaults={defaults}
+            activeTuple={activeTuple}
+            lastApplied={lastApplied}
+            onApply={onPresetApply}
+          />
+          <div className="sb-switcher__divider" />
+        </>
+      )}
+
+      {axes.map((axis) => (
+        <AxisSection
+          key={`axis-${axis.name}`}
+          axis={axis}
+          active={activeTuple[axis.name] ?? axis.default}
+          onSelect={(next) => onAxisChange(axis.name, next)}
+        />
+      ))}
+
+      {axes.length > 0 && <div className="sb-switcher__divider" />}
+
+      <ColorFormatSection active={activeColorFormat} onSelect={onColorFormatChange} />
+    </div>
+  );
+}
+
+interface OptionPillProps {
+  label: string;
+  active: boolean;
+  title?: string;
+  onClick(): void;
+  trailing?: ReactElement | null;
+}
+
+function OptionPill({ label, active, title, onClick, trailing }: OptionPillProps): ReactElement {
+  return (
+    <button
+      type="button"
+      title={title}
+      onClick={onClick}
+      // Skip focus on mouse click so host themes that paint a :focus
+      // border-color don't stick it on the previously-clicked pill.
+      // Keyboard tabbing still lands focus normally; only preventDefault
+      // on mousedown blocks the implicit focus-on-click behavior.
+      onMouseDown={(event) => event.preventDefault()}
+      className={cx('sb-switcher__pill', active && 'sb-switcher__pill--active')}
+    >
+      {label}
+      {trailing ?? null}
+    </button>
+  );
+}
+
+interface PresetsSectionProps {
+  presets: readonly SwitcherPreset[];
+  axes: readonly SwitcherAxis[];
+  themes: readonly SwitcherTheme[];
+  defaults: Readonly<Record<string, string>>;
+  activeTuple: Readonly<Record<string, string>>;
+  lastApplied: string | null;
+  onApply(preset: SwitcherPreset): void;
+}
+
+function PresetsSection({
+  presets,
+  axes,
+  defaults,
+  activeTuple,
+  lastApplied,
+  onApply,
+}: PresetsSectionProps): ReactElement {
+  return (
+    <div>
+      <div className="sb-switcher__section-label">Presets</div>
+      <div className="sb-switcher__section-body">
+        {presets.map((preset) => {
+          const tuple = presetTuple(preset, axes, defaults);
+          const matches = tuplesEqual(tuple, activeTuple, axes);
+          const modified = !matches && preset.name === lastApplied;
+          const title = preset.description ? `${preset.name} — ${preset.description}` : preset.name;
+          return (
+            <OptionPill
+              key={`preset/${preset.name}`}
+              label={preset.name}
+              active={matches}
+              title={title}
+              onClick={() => onApply(preset)}
+              trailing={
+                modified ? <span aria-hidden className="sb-switcher__pill-modified" /> : null
+              }
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface AxisSectionProps {
+  axis: SwitcherAxis;
+  active: string;
+  onSelect(next: string): void;
+}
+
+function AxisSection({ axis, active, onSelect }: AxisSectionProps): ReactElement {
+  return (
+    <div className="sb-switcher__axis-row">
+      <div className="sb-switcher__axis-label" title={axis.description}>
+        {displayLabelFor(axis)}
+      </div>
+      <div className="sb-switcher__axis-pills">
+        {axis.contexts.map((ctx) => (
+          <OptionPill
+            key={`${axis.name}/${ctx}`}
+            label={ctx}
+            active={ctx === active}
+            onClick={() => onSelect(ctx)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ColorFormatSectionProps {
+  active: SwitcherColorFormat;
+  onSelect(next: SwitcherColorFormat): void;
+}
+
+function ColorFormatSection({ active, onSelect }: ColorFormatSectionProps): ReactElement {
+  return (
+    <div>
+      <div className="sb-switcher__section-label">Color format</div>
+      <div className="sb-switcher__section-body">
+        {COLOR_FORMAT_OPTIONS.map((opt) => (
+          <OptionPill
+            key={`color-format/${opt.id}`}
+            label={opt.label}
+            active={opt.id === active}
+            onClick={() => onSelect(opt.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Treat the `{ name: 'theme', source: 'synthetic' }` axis — the one core
+ * fabricates for single-theme projects with no resolver — as a special case
+ * that reads as "Theme". Authored single-axis resolvers keep their real
+ * name (e.g. `mode`, `brand`).
+ */
+function displayLabelFor(axis: SwitcherAxis): string {
+  if (axis.source === 'synthetic' && axis.name === 'theme') return 'Theme';
+  return axis.name;
+}
+
+/**
+ * Compose a preset's sanitized partial tuple with the axis defaults, so
+ * applying a preset that only names some axes leaves the omitted ones at
+ * their defaults (not blank). Mirrors the addon preview decorator's own
+ * fallback logic so what the switcher sends out matches what the host
+ * honors.
+ */
+function presetTuple(
+  preset: SwitcherPreset,
+  axes: readonly SwitcherAxis[],
+  defaults: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const out: Record<string, string> = { ...defaults };
+  for (const axis of axes) {
+    const candidate = preset.axes[axis.name];
+    if (candidate !== undefined && axis.contexts.includes(candidate)) {
+      out[axis.name] = candidate;
+    }
+  }
+  return out;
+}
+
+function tuplesEqual(
+  a: Readonly<Record<string, string>>,
+  b: Readonly<Record<string, string>>,
+  axes: readonly SwitcherAxis[],
+): boolean {
+  for (const axis of axes) {
+    if (a[axis.name] !== b[axis.name]) return false;
+  }
+  return true;
+}

--- a/packages/switcher/src/css.d.ts
+++ b/packages/switcher/src/css.d.ts
@@ -1,0 +1,1 @@
+declare module '*.css';

--- a/packages/switcher/src/index.ts
+++ b/packages/switcher/src/index.ts
@@ -1,0 +1,2 @@
+export { ThemeSwitcher, type ThemeSwitcherProps } from '#/ThemeSwitcher.tsx';
+export type { SwitcherAxis, SwitcherColorFormat, SwitcherPreset, SwitcherTheme } from '#/types.ts';

--- a/packages/switcher/src/types.ts
+++ b/packages/switcher/src/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Structural types the switcher consumes. Mirror the shapes produced by
+ * `@unpunnyfuns/swatchbook-core` and by the addon's preview INIT payload —
+ * re-declared here so the switcher stays framework-agnostic and doesn't pull
+ * core / addon as runtime deps.
+ */
+
+export interface SwitcherAxis {
+  name: string;
+  contexts: readonly string[];
+  default: string;
+  description?: string;
+  source?: 'resolver' | 'layered' | 'synthetic';
+}
+
+export interface SwitcherPreset {
+  name: string;
+  axes: Partial<Record<string, string>>;
+  description?: string;
+}
+
+export interface SwitcherTheme {
+  name: string;
+  input: Record<string, string>;
+}
+
+export type SwitcherColorFormat = 'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw';

--- a/packages/switcher/test/theme-switcher.test.tsx
+++ b/packages/switcher/test/theme-switcher.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type SwitcherAxis, ThemeSwitcher } from '#/index.ts';
+
+// Classic-JSX compile: every file using `<…/>` needs React in scope.
+void React;
+
+const AXES: readonly SwitcherAxis[] = [
+  {
+    name: 'mode',
+    contexts: ['Light', 'Dark'],
+    default: 'Light',
+    source: 'resolver',
+  },
+];
+
+function baseProps() {
+  return {
+    axes: AXES,
+    activeTuple: { mode: 'Light' },
+    defaults: { mode: 'Light' },
+    activeColorFormat: 'hex' as const,
+    lastApplied: null,
+    onAxisChange: vi.fn(),
+    onPresetApply: vi.fn(),
+    onColorFormatChange: vi.fn(),
+  };
+}
+
+describe('ThemeSwitcher', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders one pill per axis context and marks the active one', () => {
+    const props = baseProps();
+    render(<ThemeSwitcher {...props} />);
+
+    const switcher = screen.getByTestId('swatchbook-switcher');
+    const lightPill = within(switcher).getByRole('button', { name: 'Light' });
+    const darkPill = within(switcher).getByRole('button', { name: 'Dark' });
+
+    expect(lightPill.className).toContain('sb-switcher__pill--active');
+    expect(darkPill.className).not.toContain('sb-switcher__pill--active');
+  });
+
+  it('calls onAxisChange with the axis name and picked context', () => {
+    const props = baseProps();
+    render(<ThemeSwitcher {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Dark' }));
+    expect(props.onAxisChange).toHaveBeenCalledWith('mode', 'Dark');
+  });
+
+  it('calls onColorFormatChange when a color-format pill is picked', () => {
+    const props = baseProps();
+    render(<ThemeSwitcher {...props} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'OKLCH' }));
+    expect(props.onColorFormatChange).toHaveBeenCalledWith('oklch');
+  });
+
+  it('renders a preset pill and wires its click through to onPresetApply', () => {
+    const props = baseProps();
+    const preset = { name: 'Brand A Dark', axes: { mode: 'Dark' } };
+    render(<ThemeSwitcher {...props} presets={[preset]} />);
+
+    fireEvent.click(screen.getByRole('button', { name: preset.name }));
+    expect(props.onPresetApply).toHaveBeenCalledWith(preset);
+  });
+
+  it('marks a preset active when the tuple matches and shows a modified dot when it does not', () => {
+    const props = baseProps();
+    const preset = { name: 'Brand A Light', axes: { mode: 'Light' } };
+    const { rerender } = render(<ThemeSwitcher {...props} presets={[preset]} />);
+
+    const activeBtn = screen.getByRole('button', { name: preset.name });
+    expect(activeBtn.className).toContain('sb-switcher__pill--active');
+
+    rerender(
+      <ThemeSwitcher
+        {...props}
+        presets={[preset]}
+        activeTuple={{ mode: 'Dark' }}
+        lastApplied={preset.name}
+      />,
+    );
+    const modifiedBtn = screen.getByRole('button', { name: /Brand A Light/ });
+    expect(modifiedBtn.className).not.toContain('sb-switcher__pill--active');
+    expect(modifiedBtn.querySelector('.sb-switcher__pill-modified')).not.toBeNull();
+  });
+});

--- a/packages/switcher/tsconfig.json
+++ b/packages/switcher/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    // Classic JSX (React.createElement) rather than the automatic runtime.
+    // Storybook's manager bundle doesn't expose `react/jsx-runtime`, so any
+    // consumer that embeds the switcher in manager code (the swatchbook
+    // addon does exactly this) would crash with
+    // "Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')"
+    // on automatic-runtime output. Classic JSX emits `React.createElement`
+    // calls the manager can resolve against the React it already exposes.
+    "jsx": "react",
+    "types": []
+  },
+  "include": ["src", "test", "vitest.config.ts"]
+}

--- a/packages/switcher/tsdown.config.ts
+++ b/packages/switcher/tsdown.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: 'esm',
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  css: {
+    inject: true,
+  },
+  deps: {
+    neverBundle: ['react', 'react-dom'],
+  },
+});

--- a/packages/switcher/vitest.config.ts
+++ b/packages/switcher/vitest.config.ts
@@ -1,0 +1,17 @@
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [
+    react({
+      // Match the package's classic-JSX tsconfig so tests exercise the same
+      // compile output that consumers see.
+      jsxRuntime: 'classic',
+    }),
+  ],
+  test: {
+    include: ['test/**/*.test.{ts,tsx}'],
+    environment: 'jsdom',
+    reporters: ['default'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
       '@unpunnyfuns/swatchbook-core':
         specifier: workspace:*
         version: link:../core
+      '@unpunnyfuns/swatchbook-switcher':
+        specifier: workspace:*
+        version: link:../switcher
       jiti:
         specifier: ^2.4.0
         version: 2.6.1
@@ -256,6 +259,43 @@ importers:
       '@vitest/ui':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
+      tsdown:
+        specifier: ^0.21.9
+        version: 0.21.9(@tsdown/css@0.21.9)(typescript@6.0.3)
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+
+  packages/switcher:
+    dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+    devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@tsdown/css':
+        specifier: ^0.21.9
+        version: 0.21.9(jiti@2.6.1)(postcss@8.5.10)(tsdown@0.21.9)
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1))
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
+      react:
+        specifier: ^19.2.4
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.5(react@19.2.5)
       tsdown:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(typescript@6.0.3)


### PR DESCRIPTION
Phase 1 of the docs-site theme-switcher plan. Pulls the axis / preset / color-format popover out of `packages/addon/src/manager.tsx` into a new `@unpunnyfuns/swatchbook-switcher` package. Consumers pass props (axes, presets, activeTuple, defaults, activeColorFormat, lastApplied + change callbacks) and the component renders the pill UI. The addon's `AxesToolbar` now composes `<ThemeSwitcher>` inside its existing `WithTooltipPure` popover — same icon, shortcuts, and testids.

Compiled with classic JSX (`"jsx": "react"` tsconfig) so the emitted `React.createElement` calls survive embedding in Storybook's manager bundle, which does not expose `react/jsx-runtime`. Peer depends on React only.

Added to the Changesets fixed-version group alongside core / addon / blocks so the four ship together.

Storybook interaction tests still pass (128/128). New vitest unit suite exercises pill rendering, axis/preset/color-format clicks, and the "modified since applied" dot. No user-visible change — the addon behaves exactly as it did pre-refactor.

Milestone: Maintenance
Closes: #458
Plan impact: none