### PR TITLE
ci: allow switcher scope in conventional-commit PR title check

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -33,6 +33,7 @@ jobs:
             core
             addon
             blocks
+            switcher
             tokens-reference
             tokens-starter
             storybook


### PR DESCRIPTION
The new `@unpunnyfuns/swatchbook-switcher` package (PR #459) uses `feat(switcher): …` titles, but the `amannn/action-semantic-pull-request` allowlist in `.github/workflows/pr-lint.yml` still lists only the pre-switcher scopes. Adds `switcher` so #459's Conventional Commits title check goes green.

Milestone: Maintenance
Closes: #462
Plan impact: none