### PR TITLE
chore: polish stale / narrative comments in docs-switcher work

### DIFF
--- a/apps/docs/scripts/build-tokens.mts
+++ b/apps/docs/scripts/build-tokens.mts
@@ -6,8 +6,8 @@
  * small `tokens.snapshot.json` next to it so the navbar switcher can
  * render axes / presets without re-parsing tokens at runtime.
  *
- * `custom.css` imports the CSS; `src/ThemeSwitcher/` imports the JSON.
- * Changes in `apps/docs/tokens/*.json` flow into both outputs on
+ * `custom.css` imports the CSS; `SwatchbookSwitcherContext` imports the
+ * JSON. Changes in `apps/docs/tokens/*.json` flow into both outputs on
  * rebuild (no manual Infima hex retyping, no snapshot drift).
  *
  * Runs as a prebuild / prestart step from `apps/docs/package.json`.

--- a/apps/docs/src/components/SwatchbookSwitcherButton.tsx
+++ b/apps/docs/src/components/SwatchbookSwitcherButton.tsx
@@ -97,8 +97,6 @@ export function SwatchbookSwitcherButton(): React.ReactElement {
     [modeAxis, setColorMode, applyNonModeFromPreset, setLastApplied],
   );
 
-  // With the built-in colour-mode toggle removed from the navbar, this
-  // popover owns every axis the project ships.
   if (axes.length === 0 && presets.length === 0) return <></>;
 
   return (

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -2,11 +2,13 @@
  * Hook Docusaurus's Infima theme variables up to swatchbook tokens.
  *
  * `tokens.generated.css` is emitted from `apps/docs/tokens/*.json` by
- * `scripts/build-tokens.ts` (runs as prebuild / prestart). It writes
- * `--sb-color-*` vars at `:root` and flips per-mode values based on
- * `[data-theme="light"]` / `[data-theme="dark"]` — the same attribute
- * Docusaurus toggles on `<html>` — so the Infima mapping below only
- * needs one declaration block per variable.
+ * `scripts/build-tokens.mts` (runs as prebuild / prestart). It writes
+ * `--sb-color-*` / `--sb-font-*` vars at `:root` and flips per-tuple
+ * values via compound attribute selectors — `[data-theme]` for mode
+ * (owned by Docusaurus) plus `[data-sb-<axis>]` for a11y + brand
+ * (owned by `SwatchbookSwitcherProvider`). The Infima mapping below
+ * only needs one declaration block per variable; the underlying
+ * swatchbook vars do the flipping.
  */
 @import './tokens.generated.css';
 

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -281,11 +281,10 @@ function AxesToolbar(): ReactElement {
     onPresetApply: applyPreset,
     onKeyDown: handleKeyDown,
     /**
-     * Color-format is Storybook-addon-specific chrome — the pill row
-     * drives how swatchbook blocks stringify colors inside stories and
-     * docs. The shared switcher doesn't render it by default; it slots
-     * in through the `footer` escape hatch so the toolbar popover keeps
-     * the same layout it had pre-extraction.
+     * Color format is addon-local chrome — drives how swatchbook blocks
+     * stringify colors inside stories and docs. Slotted through the
+     * switcher's `footer` escape hatch so shared theming UI stays free
+     * of this concern.
      */
     footer: h(ColorFormatSelector, {
       active: activeColorFormat,


### PR DESCRIPTION
Sweep of comments added during #457 / #459 / #461. Each file's WHY-comments stay; archaeology (past-tense references, removed code) and stale paths get trimmed:

- `SwatchbookSwitcherButton.tsx` — drop the "built-in toggle removed from the navbar" past-tense note next to the empty-state guard.
- `manager.tsx` — shorten the `footer:` comment; keep the "addon-local chrome, slotted via escape hatch" WHY, drop "pre-extraction" archaeology.
- `custom.css` — fix `build-tokens.ts` → `.mts`, update "per-mode" language to "per-tuple" + mention both `data-theme` (Docusaurus-owned) and `data-sb-<axis>` (provider-owned) selectors.
- `build-tokens.mts` — fix stale path reference (`src/ThemeSwitcher/` → `SwatchbookSwitcherContext`).

Milestone: Maintenance
Closes: #464
Plan impact: none