### PR TITLE
chore: strip archaeology from source comments across the repo

### DIFF
--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -545,8 +545,7 @@ export const TokenDetailMissing = meta.story({
 /**
  * `TokenDetail` for a token that varies only with the `brand` axis must
  * render a compact 1-axis values table listing each brand context
- * (Default, Brand A) exactly once — matching the axis-aware view from
- * issue #136.
+ * (Default, Brand A) exactly once.
  */
 export const TokenDetailOneAxisBrand = meta.story({
   render: () => <TokenDetail path="color.accent.bg" />,

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -168,19 +168,9 @@ function AxesToolbar(): ReactElement {
 
   useEffect(() => {
     if (presets.length === 0) return;
-    /**
-     * `alt+shift+C` cycles through the project's presets, applying the
-     * next one each press. When no preset has been applied yet, starts
-     * from the first. Stays out of Storybook's core shortcut surface —
-     * the earlier default (`alt+T`) collided with the built-in "toggle
-     * addon panel" binding on some platforms. Users can still rebind it
-     * through Storybook's own keyboard-shortcuts panel.
-     *
-     * Only registers when the project actually defines presets. For
-     * projects without presets the cycle would have nothing to cycle
-     * through, so the shortcut disappears entirely rather than sitting
-     * dead in the menu.
-     */
+    // `alt+shift+C` rather than `alt+T` — the latter conflicts with
+    // Storybook's built-in "toggle addon panel" binding on some
+    // platforms. Rebindable from Storybook's keyboard-shortcuts panel.
     api.setAddonShortcut(ADDON_ID, {
       label: `Cycle swatchbook presets (${presets.length})`,
       defaultShortcut: ['alt', 'shift', 'C'],

--- a/packages/blocks/src/internal/DetailOverlay.tsx
+++ b/packages/blocks/src/internal/DetailOverlay.tsx
@@ -8,8 +8,8 @@ import { TokenDetail } from '#/TokenDetail.tsx';
  * and `<TokenTable />` so both land on the same opener and the same styling.
  *
  * Dismisses on backdrop click, Escape, and the close button. `role="dialog"`
- * + `aria-modal="true"` hints to AT that focus is trapped here; actual focus
- * management is tracked in the open-issue #253.
+ * + `aria-modal="true"` hints to AT that focus is trapped here, but full
+ * focus-trap implementation is still outstanding.
  */
 
 export interface DetailOverlayProps {


### PR DESCRIPTION
Broader follow-up to #465. Ran an Explore-agent survey over every TS/TSX/CSS source file under `packages/*/src`, `packages/*/test`, `apps/docs/src`, `apps/docs/scripts`, and `apps/storybook/src` looking for archaeological comments, PR/issue references, and note-to-self author-voice. Kept every WHY-note, API-contract JSDoc, and cross-file pointer that carries non-obvious information.

Three clear violations found and trimmed:

- `packages/addon/src/manager.tsx` — collapse the multi-paragraph `alt+shift+C` rationale to a single inline reason. Drop past-tense "the earlier default was `alt+T`" archaeology; keep the present-tense conflict ("conflicts with Storybook's built-in 'toggle addon panel' binding") so the shortcut choice stays legible.
- `packages/blocks/src/internal/DetailOverlay.tsx` — drop the "tracked in issue #253" reference on the focus-management note; state the outstanding-work invariant in prose instead.
- `apps/storybook/src/stories/BlockAssertions.stories.tsx` — drop the "matching issue #136" suffix on the `TokenDetailOneAxisBrand` story docstring.

The rest of the repo's comments pass the WHY / API-contract bar without drift — neutral-voice \"we\" in rationale (\"the narrow subset we need\"), cross-package pointers, and workaround explanations are all retained as load-bearing.

Milestone: Maintenance
Closes: #466
Plan impact: none