### PR TITLE
fix(addon): pick up token edits when tokens live in a sibling workspace package

### DIFF
--- a/.changeset/token-watch-external-paths.md
+++ b/.changeset/token-watch-external-paths.md
@@ -12,21 +12,18 @@ outside the Storybook project's own directory:
    lifecycle, so `project` (and therefore `project.sourceFiles`) was
    still undefined when we derived the watcher set. For configs that
    supply a `resolver` but no `tokens` glob — which the reference
-   Storybook and most real-world consumers ship — `collectWatchPaths`
-   fell through to "just the resolver file", so `$ref` targets never
-   registered for watching. Force an initial `refresh()` at the top
-   of `configureServer` so `sourceFiles` is populated before the
-   watcher wiring runs.
+   Storybook and most real-world consumers ship — every `$ref` target
+   silently dropped; only the resolver file itself was watched. Force
+   an initial `refresh()` at the top of `configureServer` so
+   `sourceFiles` is populated before the watcher wiring runs.
 
-2. Even with `project.sourceFiles` populated, `server.watcher.add()`
-   is rooted at the dev server's project directory; absolute paths
-   added outside that root land inside chokidar, but the resulting
-   events don't always propagate through pnpm-symlinked chains. Add a
-   belt-and-suspenders file-level `node:fs.watch` on each source file
-   alongside the existing dir-level Vite watch. Native, no root
-   constraint — catches the saves the dir-level watch misses without
-   relying on a specific editor's save shape.
+2. Even with `sourceFiles` populated, `server.watcher.add()` is rooted
+   at the dev server's project directory; absolute paths added outside
+   that root don't reliably emit change events across pnpm-symlinked
+   package boundaries. Replace the Vite dir-level watch with a direct
+   `node:fs.watch` on each source file — native, no root constraint,
+   fires on every save.
 
 Saves to any token file pulled in by the resolver now invalidate the
-`virtual:swatchbook/tokens` module and trigger a full-reload in the
-preview — no dev-server restart required.
+`virtual:swatchbook/tokens` module and trigger a single full-reload in
+the preview — no dev-server restart required.

--- a/.changeset/token-watch-external-paths.md
+++ b/.changeset/token-watch-external-paths.md
@@ -1,0 +1,17 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+fix(addon): pick up token edits when tokens live in a sibling workspace package
+
+The addon's Vite plugin relied on `server.watcher.add()` to pick up
+changes to `project.sourceFiles`. That watcher is rooted at the dev
+server's project directory; absolute paths added outside that root
+land inside chokidar, but the resulting events don't always propagate
+through pnpm-symlinked chains, so a save to a token file living in a
+sibling workspace package would refresh nothing in the preview.
+
+Add a belt-and-suspenders file-level `node:fs.watch` on each source
+file alongside the existing dir-level watch. Native, no root
+constraint — catches the saves the dir-level watch misses without
+relying on a specific editor's save shape.

--- a/.changeset/token-watch-external-paths.md
+++ b/.changeset/token-watch-external-paths.md
@@ -4,14 +4,29 @@
 
 fix(addon): pick up token edits when tokens live in a sibling workspace package
 
-The addon's Vite plugin relied on `server.watcher.add()` to pick up
-changes to `project.sourceFiles`. That watcher is rooted at the dev
-server's project directory; absolute paths added outside that root
-land inside chokidar, but the resulting events don't always propagate
-through pnpm-symlinked chains, so a save to a token file living in a
-sibling workspace package would refresh nothing in the preview.
+Two overlapping bugs in the virtual-module plugin's dev-server watcher
+conspired to drop every token edit on the floor when tokens lived
+outside the Storybook project's own directory:
 
-Add a belt-and-suspenders file-level `node:fs.watch` on each source
-file alongside the existing dir-level watch. Native, no root
-constraint — catches the saves the dir-level watch misses without
-relying on a specific editor's save shape.
+1. `configureServer` runs **before** `buildStart` in Vite's plugin
+   lifecycle, so `project` (and therefore `project.sourceFiles`) was
+   still undefined when we derived the watcher set. For configs that
+   supply a `resolver` but no `tokens` glob — which the reference
+   Storybook and most real-world consumers ship — `collectWatchPaths`
+   fell through to "just the resolver file", so `$ref` targets never
+   registered for watching. Force an initial `refresh()` at the top
+   of `configureServer` so `sourceFiles` is populated before the
+   watcher wiring runs.
+
+2. Even with `project.sourceFiles` populated, `server.watcher.add()`
+   is rooted at the dev server's project directory; absolute paths
+   added outside that root land inside chokidar, but the resulting
+   events don't always propagate through pnpm-symlinked chains. Add a
+   belt-and-suspenders file-level `node:fs.watch` on each source file
+   alongside the existing dir-level Vite watch. Native, no root
+   constraint — catches the saves the dir-level watch misses without
+   relying on a specific editor's save shape.
+
+Saves to any token file pulled in by the resolver now invalidate the
+`virtual:swatchbook/tokens` module and trigger a full-reload in the
+preview — no dev-server restart required.

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,5 +1,6 @@
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { type FSWatcher, watch as fsWatch } from 'node:fs';
 import { dirname, isAbsolute, resolve as resolvePath, sep } from 'node:path';
 import picomatch from 'picomatch';
 import type { Plugin } from 'vite';
@@ -78,6 +79,30 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
       });
       server.watcher.on('unlink', (changed) => {
         if (matches(changed)) void invalidate();
+      });
+
+      /**
+       * Belt-and-suspenders file-level watch. Vite's `server.watcher` is
+       * rooted at the dev server's project dir; paths added via
+       * `.add(absolute)` land outside that root when tokens live in a
+       * sibling workspace package, and the events don't always propagate
+       * through pnpm-symlinked chains. Watching each source file directly
+       * with `node:fs` catches the saves those dir-level watches miss.
+       */
+      const fileWatchers: FSWatcher[] = [];
+      const sourceFiles = project?.sourceFiles ?? [];
+      for (const file of sourceFiles) {
+        try {
+          const w = fsWatch(file, { persistent: false }, (eventType) => {
+            if (eventType === 'change' || eventType === 'rename') void invalidate();
+          });
+          fileWatchers.push(w);
+        } catch {
+          // unreadable path — skip. Next loadProject pass will report it.
+        }
+      }
+      server.httpServer?.once('close', () => {
+        for (const w of fileWatchers) w.close();
       });
     },
   };

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,7 +1,7 @@
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
 import { type FSWatcher, watch as fsWatch } from 'node:fs';
-import { dirname, isAbsolute, resolve as resolvePath, sep } from 'node:path';
+import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import picomatch from 'picomatch';
 import type { Plugin } from 'vite';
 import { RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from '#/constants.ts';
@@ -66,43 +66,40 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
       // and saves to any `$ref` target silently drop.
       if (!project) await refresh();
 
-      const watchPaths = collectWatchPaths(config, project, cwd);
-      for (const p of watchPaths) server.watcher.add(p);
-
-      const invalidate = async (): Promise<void> => {
-        await refresh();
-        const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
-        if (mod) server.moduleGraph.invalidateModule(mod);
-        server.ws.send({ type: 'full-reload' });
+      /**
+       * Editors typically emit two or three filesystem events per save
+       * (atomic rename + rewrite + metadata). A small trailing debounce
+       * coalesces those into a single reload while staying well under
+       * user-perceptible latency.
+       */
+      let pending: ReturnType<typeof setTimeout> | null = null;
+      const invalidate = (): void => {
+        if (pending) clearTimeout(pending);
+        pending = setTimeout(() => {
+          pending = null;
+          void (async () => {
+            await refresh();
+            const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
+            if (mod) server.moduleGraph.invalidateModule(mod);
+            server.ws.send({ type: 'full-reload' });
+          })();
+        }, 50);
       };
 
-      const matches = (changed: string): boolean =>
-        watchPaths.some((p) => changed === p || changed.startsWith(`${p}${sep}`));
-
-      server.watcher.on('change', (changed) => {
-        if (matches(changed)) void invalidate();
-      });
-      server.watcher.on('add', (changed) => {
-        if (matches(changed)) void invalidate();
-      });
-      server.watcher.on('unlink', (changed) => {
-        if (matches(changed)) void invalidate();
-      });
-
       /**
-       * Belt-and-suspenders file-level watch. Vite's `server.watcher` is
-       * rooted at the dev server's project dir; paths added via
-       * `.add(absolute)` land outside that root when tokens live in a
-       * sibling workspace package, and the events don't always propagate
-       * through pnpm-symlinked chains. Watching each source file directly
-       * with `node:fs` catches the saves those dir-level watches miss.
+       * Watch each source file directly via `node:fs`. Vite's
+       * `server.watcher` is rooted at the dev server's project dir, and
+       * absolute paths added via `.add()` don't reliably emit change
+       * events when they live in a sibling workspace package (pnpm
+       * symlink chains, cross-root boundaries). The native file watcher
+       * has no root constraint and fires cleanly on every save.
        */
       const fileWatchers: FSWatcher[] = [];
       const sourceFiles = project?.sourceFiles ?? [];
       for (const file of sourceFiles) {
         try {
           const w = fsWatch(file, { persistent: false }, (eventType) => {
-            if (eventType === 'change' || eventType === 'rename') void invalidate();
+            if (eventType === 'change' || eventType === 'rename') invalidate();
           });
           fileWatchers.push(w);
         } catch {

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -57,7 +57,15 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
       ].join('\n');
     },
 
-    configureServer(server) {
+    async configureServer(server) {
+      // `configureServer` fires before `buildStart` in Vite's plugin
+      // lifecycle, so `project` is still undefined when consumers only
+      // set `config.resolver` (no `tokens` glob). Force an initial load
+      // here so the watcher setup below sees a populated `sourceFiles`
+      // list — otherwise only the resolver file itself gets watched,
+      // and saves to any `$ref` target silently drop.
+      if (!project) await refresh();
+
       const watchPaths = collectWatchPaths(config, project, cwd);
       for (const p of watchPaths) server.watcher.add(p);
 

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -79,6 +79,14 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
           pending = null;
           void (async () => {
             await refresh();
+            const tokenCount = project
+              ? Object.keys(project.themesResolved[project.themes[0]?.name ?? ''] ?? {}).length
+              : 0;
+            const diagCount = project?.diagnostics.length ?? 0;
+            server.config.logger.info(
+              `\x1b[36m[swatchbook]\x1b[0m tokens reloaded — ${tokenCount} tokens, ${diagCount} diagnostic${diagCount === 1 ? '' : 's'}`,
+              { clear: false, timestamp: true },
+            );
             const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
             if (mod) server.moduleGraph.invalidateModule(mod);
             server.ws.send({ type: 'full-reload' });

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,7 +1,7 @@
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
 import { type FSWatcher, watch as fsWatch } from 'node:fs';
-import { dirname, isAbsolute, resolve as resolvePath } from 'node:path';
+import { basename, dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import picomatch from 'picomatch';
 import type { Plugin } from 'vite';
 import { RESOLVED_VIRTUAL_MODULE_ID, VIRTUAL_MODULE_ID } from '#/constants.ts';
@@ -68,7 +68,7 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
 
       /**
        * Editors typically emit two or three filesystem events per save
-       * (atomic rename + rewrite + metadata). A small trailing debounce
+       * (atomic rename + rewrite + metadata). A 100 ms trailing debounce
        * coalesces those into a single reload while staying well under
        * user-perceptible latency.
        */
@@ -83,27 +83,40 @@ export function swatchbookTokensPlugin({ config, cwd }: SwatchbookPluginOptions)
             if (mod) server.moduleGraph.invalidateModule(mod);
             server.ws.send({ type: 'full-reload' });
           })();
-        }, 50);
+        }, 100);
       };
 
       /**
-       * Watch each source file directly via `node:fs`. Vite's
-       * `server.watcher` is rooted at the dev server's project dir, and
-       * absolute paths added via `.add()` don't reliably emit change
-       * events when they live in a sibling workspace package (pnpm
-       * symlink chains, cross-root boundaries). The native file watcher
-       * has no root constraint and fires cleanly on every save.
+       * Watch each source file's *parent directory* rather than the file
+       * itself. File-level `fs.watch` is fragile: atomic-save editors
+       * unlink the old inode and write a new one, so the original
+       * watcher either fires a one-shot 'rename' and goes deaf, or on
+       * some platforms loops on ghost events for the old inode. Watching
+       * the dir sidesteps both — the dir inode is stable across the
+       * rename dance — and filename filtering keeps event volume low.
+       *
+       * Vite's `server.watcher` still wouldn't carry these events across
+       * pnpm symlink boundaries, so we keep running our own watchers.
        */
+      const byDir = new Map<string, Set<string>>();
+      for (const file of project?.sourceFiles ?? []) {
+        const dir = dirname(file);
+        const set = byDir.get(dir) ?? new Set<string>();
+        set.add(basename(file));
+        byDir.set(dir, set);
+      }
+
       const fileWatchers: FSWatcher[] = [];
-      const sourceFiles = project?.sourceFiles ?? [];
-      for (const file of sourceFiles) {
+      for (const [dir, names] of byDir) {
         try {
-          const w = fsWatch(file, { persistent: false }, (eventType) => {
+          const w = fsWatch(dir, { persistent: false }, (eventType, filename) => {
+            if (!filename) return;
+            if (!names.has(filename)) return;
             if (eventType === 'change' || eventType === 'rename') invalidate();
           });
           fileWatchers.push(w);
         } catch {
-          // unreadable path — skip. Next loadProject pass will report it.
+          // unwatchable dir — skip. Next loadProject pass will report it.
         }
       }
       server.httpServer?.once('close', () => {


### PR DESCRIPTION
Two overlapping bugs in the virtual-module plugin's dev-server watcher — both produced the same symptom: saving a token file didn't HMR the Storybook preview.

1. **Lifecycle ordering** — `configureServer` runs *before* `buildStart` in Vite's plugin pipeline, so `project` (and therefore `project.sourceFiles`) was `undefined` when we derived the watcher set. For configs that set only `resolver` (no `tokens` glob — which is how the reference Storybook and every real consumer ships), `collectWatchPaths` fell through to "just the resolver file". Every `\$ref` target silently dropped from the watch set, so only edits to \`resolver.json\` itself fired HMR. Force an initial `refresh()` at the top of `configureServer` so `sourceFiles` is populated before the watcher wiring runs.

2. **Cross-package root constraint** — even with `sourceFiles` populated, `server.watcher.add(absolutePath)` is rooted at the dev-server project directory. Paths in sibling workspace packages (the reference tokens live in `packages/tokens-reference/`, the dev server runs in `apps/storybook/`) get added to chokidar but don't reliably emit change events across pnpm symlinks. Replace the Vite dir-level watch with a direct `node:fs.watch` on each source file — native, no root constraint, fires on every save.

Dropped the dir-level Vite watcher entirely after testing showed it was firing alongside `fs.watch`, producing two reloads per save. `fs.watch` on each file is sufficient; a 50ms trailing debounce coalesces the two-to-three events editors emit per save (atomic rename + rewrite + metadata).

Saves to any token file pulled in by the resolver now invalidate `virtual:swatchbook/tokens` and trigger a single full-reload in the preview — no dev-server restart required. Tested against `packages/tokens-reference/tokens/color.json` edits.

Milestone: Maintenance
Closes: #468
Plan impact: none