### PR TITLE
feat(addon): re-export blocks + switcher APIs for one-stop install

### DIFF
--- a/.changeset/umbrella-addon-package.md
+++ b/.changeset/umbrella-addon-package.md
@@ -1,0 +1,25 @@
+---
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+feat(addon): one-stop meta package — re-export blocks + switcher APIs
+
+The addon package now re-exports every public API from
+`@unpunnyfuns/swatchbook-blocks` and `@unpunnyfuns/swatchbook-switcher`.
+Consumers can install a single package (`pnpm add
+@unpunnyfuns/swatchbook-addon`) and pull `TokenTable`, `ColorPalette`,
+`TokenDetail`, `ThemeSwitcher`, `useToken`, and the rest directly
+from it:
+
+```tsx
+import { TokenTable, ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon';
+```
+
+The blocks / switcher / core packages remain independently installable
+for consumers who only need a slice (e.g. the docs site imports just
+the switcher). No runtime change — the re-exports are external in the
+bundle, so the addon's dist stays the same size and tree-shaking keeps
+unused pieces out of consumer bundles.
+
+Subpath entries (`./preset`, `./manager`, `./preview`, `./hooks`) are
+unchanged; the meta re-export is on the main `.` entry point only.

--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@ Two things in one:
 
 | Package | Purpose |
 | --- | --- |
+| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Toolbar, preview decorator, `useToken()`. Re-exports the full blocks + switcher React surface so consumers can install just this one. |
 | [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Emits CSS variables and TypeScript types. |
-| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Toolbar, preview decorator, `useToken()` hook. |
 | [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks. Color swatches, dimension bars, typography samples, composite previews, per-token detail. |
+| [`@unpunnyfuns/swatchbook-switcher`](./packages/switcher) | Framework-agnostic axis / preset popover UI. Used by the addon toolbar and by the docs-site navbar. |
 
 ## Install
 
 ```sh
-npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
-# plus blocks if you want MDX doc blocks:
-npm install -D @unpunnyfuns/swatchbook-blocks
+npm install -D @unpunnyfuns/swatchbook-addon
 ```
+
+One package pulls the whole React surface — toolbar, preview decorator, MDX doc blocks, `ThemeSwitcher`, `useToken()`. The sibling packages (`-core`, `-blocks`, `-switcher`) come along transitively and stay independently installable for slice-only consumers (e.g. a Docusaurus site that only renders the switcher).
 
 Register the addon in `.storybook/main.ts`:
 
@@ -70,7 +71,7 @@ import {
   TokenDetail,
   TokenNavigator,
   TokenTable,
-} from '@unpunnyfuns/swatchbook-blocks';
+} from '@unpunnyfuns/swatchbook-addon';
 
 <Meta title="Docs/Tokens" />
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -30,6 +30,7 @@ Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable fr
 
 ## What the addon gives you
 
+- **One install, full surface** — `@unpunnyfuns/swatchbook-addon` pulls in the toolbar, preview decorator, MDX doc blocks, `ThemeSwitcher`, `useToken()`, and the supporting core / blocks / switcher packages transitively. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` works from any consumer file. Sub-packages stay independently installable for slice-only consumers (e.g. a Docusaurus site rendering just the switcher).
 - **Doc blocks** — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, `Diagnostics`, motion/shadow/border previews. Once the addon is wired up, *authoring pages with these blocks is the primary day-to-day swatchbook interaction*. See the [blocks reference](./reference/blocks), the [authoring guide](./guides/authoring-doc-stories), and the [token-dashboard template](./guides/token-dashboard) for a turnkey browsable tree + diagnostics + table composition.
 - **Toolbar** — a single Swatchbook icon button opens a popover with preset pills, one dropdown per modifier axis (so a reader can browse tokens in every context), and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`) that controls how blocks display colors.
 - **`useToken` hook** — typed lookups from component code, reactive to the active theme.

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -10,17 +10,13 @@ Takes ~5 minutes if you already have a Storybook project.
 
 ## Install
 
-Install the addon for the toolbar, preview decorator, and `useToken()` hook:
+One package pulls the whole surface — toolbar, preview decorator, `useToken()`, every MDX doc block, the standalone `ThemeSwitcher`:
 
 ```bash
-npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
+npm install -D @unpunnyfuns/swatchbook-addon
 ```
 
-Install the blocks package too if you want the MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `SwatchbookProvider`, and the block-side hooks):
-
-```bash
-npm install -D @unpunnyfuns/swatchbook-blocks
-```
+`swatchbook-core`, `-blocks`, and `-switcher` come along transitively. If you only need a slice (say, the switcher in a Docusaurus site), each is also published independently.
 
 Peer requirements: Storybook 10.3+ on the Vite builder, React 18+, Node 24+.
 
@@ -82,7 +78,7 @@ import {
   TokenDetail,
   TokenNavigator,
   TokenTable,
-} from '@unpunnyfuns/swatchbook-blocks';
+} from '@unpunnyfuns/swatchbook-addon';
 
 <Meta title="Docs/Tokens" />
 

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -7,14 +7,10 @@ Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design
 ## Install
 
 ```sh
-npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
+npm install -D @unpunnyfuns/swatchbook-addon
 ```
 
-This gives you the toolbar, Design Tokens panel (hierarchical tree view with diagnostics), preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks) live in the sibling package — add it alongside if you want them:
-
-```sh
-npm install @unpunnyfuns/swatchbook-blocks
-```
+One package pulls the whole React surface — toolbar, preview decorator, `useToken()`, every MDX doc block (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks), and the standalone `ThemeSwitcher`. `swatchbook-core`, `-blocks`, and `-switcher` come along transitively; each is still independently installable for slice-only consumers.
 
 Peer requirements: `storybook@^10.3`, `react` / `react-dom` 18+.
 
@@ -64,7 +60,7 @@ export default definePreview({
 ## `useToken`
 
 ```ts
-import { useToken } from '@unpunnyfuns/swatchbook-addon/hooks';
+import { useToken } from '@unpunnyfuns/swatchbook-addon';
 
 function Card() {
   const bg = useToken('color.surface.default');

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -11,6 +11,19 @@ export {
 export type { AddonOptions } from '#/options.ts';
 
 /**
+ * Re-export the full user-facing surface from `@unpunnyfuns/swatchbook-blocks`
+ * and `@unpunnyfuns/swatchbook-switcher` so consumers can
+ * `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'`
+ * without adding the sibling packages to their own package.json. Both are
+ * declared as regular dependencies of the addon, so they come along for the
+ * ride. Subpath entries (`./preset`, `./manager`, `./preview`, `./hooks`)
+ * still exist for Storybook's preset loader — this meta re-export is just
+ * for the React / MDX consumer path.
+ */
+export * from '@unpunnyfuns/swatchbook-blocks';
+export * from '@unpunnyfuns/swatchbook-switcher';
+
+/**
  * CSF Next factory. Consumers call this inside
  * `definePreview({ addons: [swatchbookAddon()] })` so the preview annotations
  * (decorator, globalTypes, initialGlobals) are added to the preview bundle.

--- a/packages/addon/tsdown.config.ts
+++ b/packages/addon/tsdown.config.ts
@@ -17,6 +17,7 @@ export default defineConfig({
       /^vite($|\/)/,
       /^@storybook\//,
       /^virtual:/,
+      /^@unpunnyfuns\/swatchbook-/,
       'storybook',
       'react',
       'react-dom',

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -6,11 +6,13 @@ Published as `@unpunnyfuns/swatchbook-blocks`. Storybook MDX doc blocks for DTCG
 
 ## Install
 
+Most consumers pick this up transitively via `@unpunnyfuns/swatchbook-addon` — the addon re-exports the full blocks API, so `import { TokenTable } from '@unpunnyfuns/swatchbook-addon'` works and you don't need a second install line. Reach for this package directly when you want blocks *without* the Storybook addon (unit tests, a standalone React app wrapping tokens in a custom surface):
+
 ```sh
 npm install @unpunnyfuns/swatchbook-blocks
 ```
 
-Blocks read the token graph from a `SwatchbookProvider`. Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these blocks — its preview decorator mounts the provider automatically. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly (see [Outside Storybook](#outside-storybook) below).
+Blocks read the token graph from a `SwatchbookProvider`. Inside Storybook, the addon's preview decorator mounts the provider automatically. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly (see [Outside Storybook](#outside-storybook) below).
 
 ## Blocks
 
@@ -46,7 +48,7 @@ Shared: every block accepts a `caption` override and renders against the addon's
 The addon's preview decorator wraps every story in a `SwatchbookProvider` for you, so MDX and story authors drop blocks in directly:
 
 ```mdx
-import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-addon';
 
 # Color tokens
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -10,6 +10,8 @@ Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses 
 npm install @unpunnyfuns/swatchbook-core
 ```
 
+Install directly when you're using `loadProject` / `emitCss` outside Storybook (build scripts, CLIs, docs-site generators). Storybook consumers already get core transitively via `@unpunnyfuns/swatchbook-addon` — no separate install needed unless you're calling the loader from your own tooling.
+
 ## Public API
 
 | Export | Purpose |


### PR DESCRIPTION
The addon now re-exports every public API from `@unpunnyfuns/swatchbook-blocks` and `@unpunnyfuns/swatchbook-switcher`, so consumers can install a single package and pull everything from one import:

\`\`\`tsx
import { TokenTable, ColorPalette, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon';
\`\`\`

Both sibling packages were already regular \`dependencies\` of the addon, so they come along transitively on \`pnpm add @unpunnyfuns/swatchbook-addon\`. Only thing missing was the top-level re-export.

The sibling packages are marked \`neverBundle\` in the addon's tsdown config so the dist stays a thin re-export shell (~100 KB total, unchanged after the re-exports land). Consumer tree-shaking still drops unused blocks. Subpath entries (\`./preset\`, \`./manager\`, \`./preview\`, \`./hooks\`) are unchanged — the meta re-export is on the main \`.\` entry point only.

The blocks / switcher / core packages remain independently installable for consumers who only need a slice — the docs site imports just the switcher and continues to work unchanged.

Milestone: Maintenance
Closes: #475
Plan impact: none