### PR TITLE
feat(mcp): live-reload on token + config edits

### DIFF
--- a/.changeset/swatchbook-mcp-package.md
+++ b/.changeset/swatchbook-mcp-package.md
@@ -12,7 +12,10 @@ Exposes a swatchbook DTCG project to AI agents — `describe_project`,
 compound `[data-…]` selector + HTML attrs), `get_color_formats` (hex
 / rgb / hsl / oklch / raw, each with an out-of-gamut flag),
 `list_axes`, `get_diagnostics`, `emit_css`. Runs without Storybook,
-parses the project once at startup via `@unpunnyfuns/swatchbook-core`.
+parses the project via `@unpunnyfuns/swatchbook-core`, and watches
+resolved source files + the config so token edits flow into subsequent
+tool calls without restarting the transport (opt out with
+`--no-watch`).
 
 Consume as a CLI:
 
@@ -24,4 +27,6 @@ npx @unpunnyfuns/swatchbook-mcp --config tokens/resolver.json
 
 Or wire into an MCP client (Claude Desktop, etc.) via the same
 command. Ships with `createServer` + `loadFromConfig` exports for
-programmatic embedding in larger toolchains.
+programmatic embedding in larger toolchains; `createServer(project)`
+returns the server augmented with a `setProject(next)` method for
+callers that want to orchestrate their own reload policy.

--- a/.mcp.json
+++ b/.mcp.json
@@ -5,6 +5,16 @@
       "type": "http",
       "url": "http://localhost:6006/mcp",
       "description": "Storybook MCP server for swatchbook. Only reachable while `pnpm dev` (turbo run storybook) is running."
+    },
+    "swatchbook": {
+      "type": "stdio",
+      "command": "node",
+      "args": [
+        "packages/mcp/dist/bin.mjs",
+        "--config",
+        "apps/storybook/swatchbook.config.ts"
+      ],
+      "description": "swatchbook-mcp — DTCG project introspection (tokens, axes, aliases, diagnostics) backed by the apps/storybook config. Requires packages/mcp to be built (pnpm -r build)."
     }
   }
 }

--- a/apps/docs/docs/reference/mcp.mdx
+++ b/apps/docs/docs/reference/mcp.mdx
@@ -36,6 +36,7 @@ CLI flags:
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | `--config <path>`  | Required. A `swatchbook.config.{ts,mts,js,mjs}` (full config) or a DTCG `resolver.json` (bare — other options at defaults).       |
 | `--cwd <path>`     | Override the working directory for resolving relative `resolver` / `tokens` paths.                                                |
+| `--no-watch`       | Disable live-reload. By default the server watches the config + resolved source files and swaps in fresh data on edits.           |
 | `--help`, `-h`     | Print usage and exit.                                                                                                             |
 
 ## Wire into an MCP client
@@ -92,7 +93,7 @@ const server = createServer(project);
 await server.connect(new StdioServerTransport());
 ```
 
-`loadFromConfig` accepts the same `.ts` / `.mts` / `.js` / `.mjs` / `.json` shapes the CLI does. `createServer(project)` is stateless beyond the project reference — rebind with a fresh `Project` to pick up token edits without restarting the MCP transport.
+`loadFromConfig` accepts the same `.ts` / `.mts` / `.js` / `.mjs` / `.json` shapes the CLI does. `createServer(project)` returns the server augmented with `setProject(next)` — call it after re-loading the project to swap in fresh data without restarting the MCP transport. The CLI uses this to live-reload on token edits.
 
 ## See also
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -33,6 +33,7 @@ CLI flags:
 | ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `--config <path>` | Required. Either a `swatchbook.config.{ts,mts,js,mjs}` (full config) or a DTCG `resolver.json` (bare — other options at defaults). |
 | `--cwd <path>`    | Override the working directory for resolving relative `resolver` / `tokens` paths.                                                |
+| `--no-watch`      | Disable live-reload. By default the server watches the config + resolved source files and swaps in fresh data on edits.            |
 | `--help`          | Print usage and exit.                                                                                                            |
 
 ## Tools

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -2,16 +2,26 @@
 /**
  * Stdio entry for `npx @unpunnyfuns/swatchbook-mcp --config <path>`.
  *
- * Minimal CLI: parses `--config <path>`, optional `--cwd <path>`, loads the
- * project, and binds an MCP server to stdio. Any loader error prints to
- * stderr with a non-zero exit; anything else happens over the MCP protocol.
+ * Parses `--config <path>`, optional `--cwd <path>`, loads the project, and
+ * binds an MCP server to stdio. Watches the resolved source files + config
+ * file so token edits land in subsequent tool calls without restarting the
+ * transport. Pass `--no-watch` to opt out (e.g. CI). Loader / watcher errors
+ * print to stderr — stdout is reserved for MCP protocol frames.
  */
+import { type FSWatcher, watch as fsWatch } from 'node:fs';
+import { basename, dirname, isAbsolute, resolve } from 'node:path';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { loadFromConfig } from '#/load-config.ts';
 import { createServer } from '#/server.ts';
 
-function parseArgs(argv: readonly string[]): { config?: string; cwd?: string } {
-  const out: { config?: string; cwd?: string } = {};
+interface CliArgs {
+  config?: string;
+  cwd?: string;
+  watch: boolean;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  const out: CliArgs = { watch: true };
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
     const next = argv[i + 1];
@@ -21,6 +31,8 @@ function parseArgs(argv: readonly string[]): { config?: string; cwd?: string } {
     } else if (arg === '--cwd' && next) {
       out.cwd = next;
       i++;
+    } else if (arg === '--no-watch') {
+      out.watch = false;
     } else if (arg === '--help' || arg === '-h') {
       console.log(`swatchbook-mcp — Model Context Protocol server for swatchbook projects
 
@@ -29,17 +41,83 @@ Usage:
                                               or a DTCG resolver.json directly. Bare
                                               resolvers boot with every other config
                                               option at defaults.
-  swatchbook-mcp --config <path> --cwd <path> Override the project cwd for relative paths
+  swatchbook-mcp --config <path> --cwd <path> Override the project cwd for relative paths.
+  swatchbook-mcp --config <path> --no-watch   Disable live-reload on token / config edits.
 
 Tools exposed:
-  list_tokens       List tokens by path glob / \`$type\`.
-  get_token         Full detail for one token path.
-  list_axes         Axes + contexts + themes + presets.
-  get_diagnostics   Project diagnostics (optional severity filter).`);
+  describe_project    Orientation — counts, axes, themes, presets, diagnostics.
+  list_tokens         List tokens by path glob / \`$type\`.
+  search_tokens       Substring search across paths, descriptions, values.
+  resolve_theme       Full resolved token map for an axis tuple.
+  get_token           Full detail for one token path.
+  get_alias_chain     Forward alias chain per theme.
+  get_aliased_by      Backward alias tree.
+  get_consumer_output CSS var + data-attribute activation for a tuple.
+  get_color_formats   hex / rgb / hsl / oklch / raw for a color token.
+  list_axes           Axes + contexts + themes + presets.
+  get_diagnostics     Project diagnostics (optional severity filter).
+  emit_css            Full project stylesheet.`);
       process.exit(0);
     }
   }
   return out;
+}
+
+/**
+ * Watch the project's source files + config path for edits. Debounces
+ * filesystem events (editors fire 2-3 per save) into a single reload per
+ * 100 ms burst; on each settle, calls `loadFromConfig` again and swaps the
+ * fresh project into the already-connected MCP server.
+ *
+ * Watches parent directories rather than files themselves. Atomic-save
+ * editors unlink + recreate the target inode, which kills file-level
+ * watchers on the first save; a dir watcher with filename filtering
+ * survives that dance. Mirrors the addon's plugin strategy.
+ */
+function setupReload(
+  initialSourceFiles: readonly string[],
+  configPath: string,
+  reload: () => Promise<void>,
+): () => void {
+  const dirs = new Map<string, Set<string>>();
+  const add = (file: string): void => {
+    const dir = dirname(file);
+    const set = dirs.get(dir) ?? new Set<string>();
+    set.add(basename(file));
+    dirs.set(dir, set);
+  };
+  for (const file of initialSourceFiles) add(file);
+  add(configPath);
+
+  let pending: ReturnType<typeof setTimeout> | null = null;
+  const schedule = (): void => {
+    if (pending) clearTimeout(pending);
+    pending = setTimeout(() => {
+      pending = null;
+      reload().catch((err) => {
+        console.error('swatchbook-mcp: reload failed —', err);
+      });
+    }, 100);
+  };
+
+  const watchers: FSWatcher[] = [];
+  for (const [dir, names] of dirs) {
+    try {
+      const w = fsWatch(dir, { persistent: false }, (eventType, filename) => {
+        if (!filename) return;
+        if (!names.has(filename)) return;
+        if (eventType === 'change' || eventType === 'rename') schedule();
+      });
+      watchers.push(w);
+    } catch {
+      // unwatchable dir — skip. The initial load already succeeded, so the
+      // server keeps serving the current snapshot.
+    }
+  }
+  return () => {
+    if (pending) clearTimeout(pending);
+    for (const w of watchers) w.close();
+  };
 }
 
 async function main(): Promise<void> {
@@ -48,10 +126,31 @@ async function main(): Promise<void> {
     console.error('swatchbook-mcp: --config <path> is required. Use --help for usage.');
     process.exit(1);
   }
-  const { project } = await loadFromConfig(args.config, args.cwd);
+  const configAbsolute = isAbsolute(args.config)
+    ? args.config
+    : resolve(process.cwd(), args.config);
+
+  const { project } = await loadFromConfig(configAbsolute, args.cwd);
   const server = createServer(project);
   const transport = new StdioServerTransport();
   await server.connect(transport);
+
+  if (args.watch) {
+    let stopWatchers = setupReload(project.sourceFiles, configAbsolute, () => reload());
+    async function reload(): Promise<void> {
+      const { project: next } = await loadFromConfig(configAbsolute, args.cwd);
+      server.setProject(next);
+      const themeCount = next.themes.length;
+      const tokenCount = Object.keys(next.themesResolved[next.themes[0]?.name ?? ''] ?? {}).length;
+      console.error(
+        `swatchbook-mcp: project reloaded — ${tokenCount} tokens across ${themeCount} theme${themeCount === 1 ? '' : 's'}.`,
+      );
+      // Rebind watchers against the fresh source-file set so newly-referenced
+      // tokens / resolvers pick up edits from here on.
+      stopWatchers();
+      stopWatchers = setupReload(next.sourceFiles, configAbsolute, () => reload());
+    }
+  }
 }
 
 main().catch((err) => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -8,13 +8,14 @@ import { matchPath } from '#/match.ts';
 /**
  * Build a swatchbook MCP server bound to a loaded project. Tools expose the
  * project's tokens, axes, and diagnostics so an AI agent can query them
- * without running Storybook. The server is stateless beyond the project
- * reference — all tools operate on the supplied snapshot.
- *
- * Exported as a factory so callers can reload the project on config changes
- * and rebind without restarting the MCP transport.
+ * without running Storybook. Tool handlers close over a live `project`
+ * reference — call the returned `setProject` to swap in a freshly loaded
+ * project (e.g. after token edits) without re-binding the transport.
  */
-export function createServer(project: Project): McpServer {
+export function createServer(initial: Project): McpServer & {
+  setProject: (next: Project) => void;
+} {
+  let project = initial;
   const server = new McpServer(
     {
       name: '@unpunnyfuns/swatchbook-mcp',
@@ -24,7 +25,10 @@ export function createServer(project: Project): McpServer {
       instructions:
         'Query a swatchbook DTCG project: list tokens by path glob, inspect individual tokens (value, $type, alias chain, per-theme resolved values), read axes / presets, and inspect diagnostics.',
     },
-  );
+  ) as McpServer & { setProject: (next: Project) => void };
+  server.setProject = (next: Project) => {
+    project = next;
+  };
 
   server.registerTool(
     'describe_project',


### PR DESCRIPTION
## Summary

- `fs.watch` the parent directories of `project.sourceFiles` + the config file (dir-level + filename filter survives atomic-save rename) and debounce 100 ms — matching the Storybook addon's plugin strategy. On each settle, call `loadFromConfig` again and swap the in-memory project via a new `setProject(next)` method on the returned `McpServer`.
- Watchers rebind against the fresh source-file set after every successful reload, so newly-referenced resolvers / token files get picked up going forward.
- Opt out with `--no-watch`. Stderr carries reload notices; stdout stays reserved for MCP protocol frames.
- Register a local `swatchbook` MCP entry in `.mcp.json` pointing at the built bin, so contributors get the server wired into Claude Code after `pnpm -r build`.

Milestone: Maintenance
Closes: #481
Plan impact: none

## Test plan

- [x] `pnpm turbo run lint typecheck test` — 25 tasks green.
- [x] `node packages/mcp/dist/bin.mjs --help` — flag table + tool list render as expected.
- [ ] Manual: restart the MCP client, edit a token in `apps/storybook/tokens/…`, confirm the next `get_token` call returns the new value (stderr shows the reload notice).