### PR TITLE
fix(blocks): hoist navigator hooks above empty-state early return

### DIFF
--- a/.changeset/fix-navigator-empty-hook-order.md
+++ b/.changeset/fix-navigator-empty-hook-order.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix(blocks): TokenNavigator hooks run before empty-state early return
+
+Typing a `root` or `type` arg that matches zero tokens used to cross a
+hook-order boundary — the `matchCount` `useMemo` sat after the
+`tree.length === 0` early return, so the first non-empty render threw
+"Rendered fewer hooks than expected". Hoisted the memo above the
+guard. Added a `NoMatches` story as a regression check.

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -34,6 +34,23 @@ export const MotionTypes = meta.story({
   args: { type: ['duration', 'cubicBezier', 'transition'], initiallyExpanded: 2 },
 });
 
+/**
+ * Regression — typing a `root` / `type` arg that matches nothing used to
+ * flip the component below a hook-order boundary and throw
+ * "Rendered fewer hooks than expected." Verifies the empty-state render
+ * runs after every hook has been called.
+ */
+export const NoMatches = meta.story({
+  args: { root: 'does-not-exist' },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      if (!canvasElement.textContent?.includes('No tokens under "does-not-exist"')) {
+        throw new Error('expected empty-state caption for a nonexistent root');
+      }
+    });
+  },
+});
+
 function RecordingNavigator() {
   const [last, setLast] = useState<string | null>(null);
   return (

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -227,6 +227,16 @@ export function TokenNavigator({
   );
 
   const typeLabel = typeFilter ? ` · ${[...typeFilter].map((t) => `$type=${t}`).join(', ')}` : '';
+  const trimmedQuery = query.trim();
+  // Must run every render — React's rules of hooks forbid the earlier empty-state
+  // early return from skipping it, or the next non-empty render throws
+  // "Rendered fewer hooks than expected".
+  const matchCount = useMemo(() => {
+    if (!searchExpanded) return 0;
+    let n = 0;
+    for (const node of visibleTree) n += countLeaves(node);
+    return n;
+  }, [visibleTree, searchExpanded]);
 
   if (tree.length === 0) {
     return (
@@ -241,14 +251,6 @@ export function TokenNavigator({
       </div>
     );
   }
-
-  const trimmedQuery = query.trim();
-  const matchCount = useMemo(() => {
-    if (!searchExpanded) return 0;
-    let n = 0;
-    for (const node of visibleTree) n += countLeaves(node);
-    return n;
-  }, [visibleTree, searchExpanded]);
 
   return (
     <div {...themeAttrs(cssVarPrefix, activeTheme)}>


### PR DESCRIPTION
## Summary

- Hoist the \`matchCount\` \`useMemo\` above the \`if (tree.length === 0) return …\` guard in \`TokenNavigator\`. Previously, flipping filters between empty and non-empty (e.g. typing \`color\` into the \`type\` arg control) threw \"Rendered fewer hooks than expected\" because the memo sat below an early return.
- Add a \`NoMatches\` story that sets \`root=does-not-exist\` and asserts the empty-state caption renders — regression guard against the same shape coming back.
- \`patch\` changeset against \`@unpunnyfuns/swatchbook-blocks\`.

Milestone: Maintenance
Closes: #483
Plan impact: none

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks\` — 65 tests green.
- [x] Story tests for every TokenNavigator story + partial \`type\` values (\`c\`, \`co\`, \`col\`, \`color\`) and invalid \`root\` — all pass.
- [ ] Manual: hard-refresh Storybook, open \`Blocks/TokenNavigator · Default\`, type \`color\` into the \`type\` arg control, confirm no crash and the expected empty → non-empty transitions.