### PR TITLE
docs(blocks): split hooks onto their own reference page

### DIFF
--- a/.changeset/docs-blocks-hooks-reference.md
+++ b/.changeset/docs-blocks-hooks-reference.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs(blocks): move hooks into a dedicated reference page; correct stale "not re-exported from addon" claims
+
+The addon has re-exported the full blocks surface (hooks, provider, contexts) since the one-stop-install work landed, so `import { useSwatchbookData } from '@unpunnyfuns/swatchbook-addon'` works the same as importing from blocks. The intro page and do/don't list still asserted the opposite; updated both. Hooks now have their own reference page under Blocks → Hooks.

--- a/apps/docs/docs/reference/blocks/hooks.mdx
+++ b/apps/docs/docs/reference/blocks/hooks.mdx
@@ -1,0 +1,31 @@
+---
+id: hooks
+title: Hooks
+sidebar_position: 6
+---
+
+# Hooks
+
+Context-reading hooks for authoring custom blocks. Source of truth lives in `@unpunnyfuns/swatchbook-blocks`; `@unpunnyfuns/swatchbook-addon` re-exports everything so a one-stop `import { useSwatchbookData } from '@unpunnyfuns/swatchbook-addon'` works too. Either entry reads from the nearest `SwatchbookProvider` (mounted automatically by the addon's preview decorator inside Storybook).
+
+Outside Storybook, wrap the tree in `SwatchbookProvider` and pass a `ProjectSnapshot` so the hooks have something to resolve against — see the [blocks intro](./) for the wiring.
+
+## `useSwatchbookData()`
+
+Returns the full `ProjectSnapshot` the provider is holding (themes, axes, presets, tokens, diagnostics, …). Useful for custom blocks that need graph-level information the canned blocks don't expose.
+
+## `useActiveTheme()`
+
+Returns the current composed permutation ID as a string (e.g. `"Dark · Brand A"`).
+
+## `useActiveAxes()`
+
+Returns the active tuple as `Readonly<Record<string, string>>`.
+
+## `useColorFormat()`
+
+Returns the active color format (`'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw'`) — the display setting toggled from the toolbar popover. Pair with `formatColor(value, format)` (also exported) to render colors the same way the built-in blocks do. `hex` falls back to space-separated `rgb()` for out-of-gamut colors, marked with a ⚠ warning.
+
+## Reactivity
+
+Hook consumers re-render on the same Storybook `globalsUpdated` channel event the built-in blocks subscribe to, so the active axis tuple and color format both stay in sync without a story re-render. This works both inside story renders and inside MDX doc blocks (where the preview HooksContext isn't available — we use the channel directly).

--- a/apps/docs/docs/reference/blocks/index.mdx
+++ b/apps/docs/docs/reference/blocks/index.mdx
@@ -16,7 +16,7 @@ npm install -D @unpunnyfuns/swatchbook-blocks
 
 Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these blocks — its preview decorator mounts a `SwatchbookProvider` (exported from this package) that the blocks read from. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly.
 
-`SwatchbookProvider`, `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the backing contexts (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) are exported from **`@unpunnyfuns/swatchbook-blocks` only**. The addon does not re-export them.
+`SwatchbookProvider`, `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the backing contexts (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) live in `@unpunnyfuns/swatchbook-blocks`. `@unpunnyfuns/swatchbook-addon` re-exports them verbatim, so either import path works depending on which packages your consumer already pulls in.
 
 ## Usage
 
@@ -62,25 +62,7 @@ Four groups by shape of use:
 
 Most overview blocks take `filter?` (path glob), `sortBy?`, `sortDir?`, and `caption?`.
 
-## Hooks
-
-All hooks live in this package — they are **not** re-exported from `@unpunnyfuns/swatchbook-addon`. They read from the nearest `SwatchbookProvider` (mounted automatically by the addon's preview decorator inside Storybook).
-
-### `useSwatchbookData()`
-
-Returns the full `ProjectSnapshot` the provider is holding (themes, axes, presets, tokens, diagnostics, …). Useful for custom blocks that need graph-level information the canned blocks don't expose.
-
-### `useActiveTheme()`
-
-Returns the current composed permutation ID as a string (e.g. `"Dark · Brand A"`).
-
-### `useActiveAxes()`
-
-Returns the active tuple as `Readonly<Record<string, string>>`.
-
-### `useColorFormat()`
-
-Returns the active color format (`'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw'`) — the display setting toggled from the toolbar popover. Pair with `formatColor(value, format)` (also exported) to render colors the same way the built-in blocks do. `hex` falls back to space-separated `rgb()` for out-of-gamut colors, marked with a ⚠ warning.
+For authoring custom blocks against the same provider the built-ins read from, see the [**Hooks reference**](./hooks) — `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`.
 
 ## Reactivity
 
@@ -91,4 +73,4 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
 - ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
-- ❌ Don't import block-side hooks or contexts from `@unpunnyfuns/swatchbook-addon` — they live in this package only.
+- ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -36,6 +36,7 @@ const sidebars: SidebarsConfig = {
     'reference/blocks/inspector',
     'reference/blocks/samples',
     'reference/blocks/utility',
+    'reference/blocks/hooks',
   ],
   guides: [
     'guides/authoring-doc-stories',


### PR DESCRIPTION
## Summary

- New \`apps/docs/docs/reference/blocks/hooks.mdx\` covering \`useSwatchbookData\`, \`useActiveTheme\`, \`useActiveAxes\`, \`useColorFormat\`, plus a brief reactivity note. Wired into the \`blocks\` sidebar after Utility.
- Trimmed the inline \"## Hooks\" section from \`reference/blocks/index.mdx\`; replaced with a one-line pointer from the Groups section.
- Corrected two stale claims on the intro page: it previously asserted the hooks / provider / contexts are **not** re-exported from \`@unpunnyfuns/swatchbook-addon\`. That stopped being true in PR #476 — \`export * from '@unpunnyfuns/swatchbook-blocks'\` now makes every symbol available from either import path. Updated the prose + the do/don't bullet accordingly.
- Patch changeset on \`@unpunnyfuns/swatchbook-blocks\` so the docs snapshot rebuilds on the next release (otherwise the fix only reaches \`/next/\`).

Milestone: Maintenance
Closes: #486
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — Docusaurus build passes, no broken-link warnings.
- [ ] Manual: spot-check the rendered Blocks → Hooks page locally and verify the sidebar order.