### PR TITLE
chore(blocks): drop misleading 'storybook-addon' npm keyword

### DIFF
--- a/.changeset/chore-blocks-drop-storybook-addon-keyword.md
+++ b/.changeset/chore-blocks-drop-storybook-addon-keyword.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+chore(blocks): drop misleading "storybook-addon" npm keyword
+
+`@unpunnyfuns/swatchbook-blocks` ships MDX doc blocks; the Storybook addon surface lives in the sibling `@unpunnyfuns/swatchbook-addon` package. Keeping the `storybook-addon` keyword here surfaced blocks in npm searches people really wanted the addon for.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -12,7 +12,6 @@
     "directory": "packages/blocks"
   },
   "keywords": [
-    "storybook-addon",
     "storybook-blocks",
     "storybook",
     "design-tokens",


### PR DESCRIPTION
## Summary

- \`@unpunnyfuns/swatchbook-blocks\` ships MDX doc blocks. The Storybook addon surface is in the sibling \`@unpunnyfuns/swatchbook-addon\` package.
- Drop \`storybook-addon\` from \`packages/blocks/package.json\`'s keyword list so npm searches for that keyword land on the addon package instead of the blocks.
- Patch changeset on \`@unpunnyfuns/swatchbook-blocks\`.

Milestone: Maintenance
Closes: #488
Plan impact: none

## Test plan

- [x] Visually verify the remaining keywords (\`storybook-blocks\`, \`storybook\`, \`design-tokens\`, …) still describe the package accurately.
- [ ] After release, spot-check the npm listing.