### PR TITLE
chore: strip archaeology comments that accumulated post-v0.10.0

### DIFF
--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -4,15 +4,14 @@ import type { SidebarsConfig } from '@docusaurus/plugin-content-docs';
  * One sidebar per top-nav section. The navbar uses `type: 'docSidebar'`
  * entries bound by `sidebarId`, which auto-link to each sidebar's first
  * doc and keep the nav pill active across all docs in that sidebar.
- * Splitting the sidebar per section removes the category-header
- * redundancy the old single `docs` sidebar had (the navbar already
- * names the section).
+ * Per-section sidebars keep category headers out of the doc tree — the
+ * navbar already labels each section.
  *
- * `home` covers the landing — Introduction, Quickstart, and the
- * concept pages — all reachable from the navbar logo since Quickstart
- * + Concepts aren't pulled out as separate navbar entries. Three
- * bookending top-level nav items (Blocks / Guides / Reference) plus
- * the logo-home group keeps the bar light.
+ * `home` covers the landing — Introduction, Quickstart, and the concept
+ * pages — all reachable from the navbar logo since Quickstart +
+ * Concepts aren't pulled out as separate navbar entries. Three top-level
+ * nav items (Blocks / Guides / Reference) plus the logo-home group keep
+ * the bar light.
  */
 const sidebars: SidebarsConfig = {
   home: [

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -35,10 +35,10 @@ export const MotionTypes = meta.story({
 });
 
 /**
- * Regression — typing a `root` / `type` arg that matches nothing used to
- * flip the component below a hook-order boundary and throw
- * "Rendered fewer hooks than expected." Verifies the empty-state render
- * runs after every hook has been called.
+ * Empty-state render for a `root` / `type` arg that matches no tokens.
+ * Exercises the path where the component's early return fires after every
+ * hook has run — a shape that's easy to regress on if a hook gets added
+ * below the empty-state guard.
  */
 export const NoMatches = meta.story({
   args: { root: 'does-not-exist' },

--- a/packages/blocks/src/internal/format-token-value.ts
+++ b/packages/blocks/src/internal/format-token-value.ts
@@ -5,9 +5,6 @@ import { type ColorFormat, formatColor } from '#/format-color.ts';
  * respecting the active color format for color-typed tokens and the
  * color sub-values of composite types (border, shadow, gradient).
  *
- * Replaces the old `formatValue` one-shot that hex-short-circuited
- * colors and fell through to raw JSON for known composites.
- *
  * Shape by type:
  * - `color`              → `formatColor(value, colorFormat)` — e.g. `#3b82f6`, `oklch(...)`, `raw` JSON.
  * - `dimension|duration` → `value + unit` — e.g. `16px`, `200ms`.

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -82,13 +82,13 @@ function snapshotToData(snapshot: ProjectSnapshot): ProjectData {
 /**
  * Reads project data either from a mounted {@link SwatchbookProvider}
  * (preferred — the addon's preview decorator installs one around every
- * story) or — as a back-compat fallback — directly from the virtual
- * module plus Storybook globals.
+ * story) or, when no provider is present, from the virtual module plus
+ * Storybook globals directly.
  *
- * The fallback path is what makes the hook safe to call from MDX doc
- * blocks and autodocs renders where no story is active. It self-mounts
- * the virtual module's per-theme CSS and tracks the active tuple via the
- * `globalsUpdated` channel event; {@link useGlobals} from
+ * The provider-less path is what makes the hook safe to call from MDX
+ * doc blocks and autodocs renders where no story is active. It
+ * self-mounts the virtual module's per-theme CSS and tracks the active
+ * tuple via the `globalsUpdated` channel event; {@link useGlobals} from
  * `storybook/preview-api` would throw outside a story render.
  */
 export function useProject(): ProjectData {

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -7,9 +7,10 @@ export interface EmitCssOptions {
   /** Override the prefix from project config (default: `config.cssVarPrefix ?? ''`). */
   prefix?: string;
   /**
-   * Project axes used to key per-tuple blocks on compound attribute selectors
-   * (`[data-<prefix>-mode="Dark"][data-<prefix>-brand="Brand A"] { … }`). When
-   * omitted or single-axis, emission collapses to the simpler single-attribute
+   * Project axes. Multi-axis projects key per-tuple blocks on compound
+   * attribute selectors
+   * (`[data-<prefix>-mode="Dark"][data-<prefix>-brand="Brand A"] { … }`).
+   * Omitted or single-axis projects collapse to the simpler single-attribute
    * form `[data-<prefix>-theme="…"]`.
    */
   axes?: Axis[];


### PR DESCRIPTION
## Summary

Follow-up to PR #467's repo-wide archaeology sweep. Post-v0.10.0 surface area (MCP package, partial-HMR work, blocks style migration, navigator hook fix) accumulated five fresh archaeological phrasings — comments that explain how the code *used to be* rather than what it *is*.

Fixes:

- \`packages/blocks/src/internal/format-token-value.ts\` — dropped \"Replaces the old formatValue one-shot...\" preamble; the docstring below already describes current behavior.
- \`packages/core/src/css.ts\` — reworded \`axes?\` JSDoc so \"used to key\" reads unambiguously as present tense.
- \`packages/blocks/src/internal/use-project.ts\` — \"back-compat fallback\" was factually wrong — the no-provider path exists for MDX / autodocs renders, not back-compat. Renamed to \"provider-less path\".
- \`apps/storybook/src/stories/TokenNavigator.stories.tsx\` — NoMatches story docblock described the past bug rather than the render path it exercises. Rewrote to name the current intent.
- \`apps/docs/sidebars.ts\` — dropped \"the old single \`docs\` sidebar had\" archaeology from the rationale.

Milestone: Maintenance
Closes: #490
Plan impact: none

## Test plan

- [x] \`pnpm turbo run lint typecheck test\` — 25 tasks green.
- [ ] Skim the final diff once more on GitHub.