### PR TITLE
docs: add a For developers section to the docs site

### DIFF
--- a/.changeset/docs-developers-section.md
+++ b/.changeset/docs-developers-section.md
@@ -1,0 +1,13 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs: add a "For developers" section to the docs site
+
+New top-level navbar entry alongside Blocks / Guides / Reference, with three pages aimed at people who want to work on swatchbook's code rather than consume it:
+
+- **For developers** — landing page, the repo map, pointers to typical work shapes.
+- **Architecture** — the one data structure everything revolves around (`Project`), plus the static build path and the dev/HMR path from token file to rendered block. Includes how the MCP server plugs in.
+- **Sharp corners** — the "someone will bleed on this" list: Storybook manager-bundle JSX trap, atomic-save watcher pattern, React rules-of-hooks regressions, etc.
+
+CONTRIBUTING.md on GitHub stays as the dev-setup source of truth; the docs-site section covers the how-does-it-work reference new contributors need for a mental model.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -1,0 +1,178 @@
+---
+id: architecture
+title: Architecture
+sidebar_position: 1
+---
+
+# Architecture
+
+Map of the repo, the one data structure everything revolves around, and how data moves from a DTCG token file on disk to a rendered doc block. Written for contributors — if you're consuming swatchbook as a user, the [Reference](../reference/core) section is the right door.
+
+## Repo map
+
+Monorepo under `@unpunnyfuns`. pnpm workspaces + Turborepo orchestration. Every package is `"type": "module"` and ships ESM only (`tsdown` builds).
+
+### Published packages (fixed-version group — always release together)
+
+| Package | Role | Depends on |
+| --- | --- | --- |
+| `@unpunnyfuns/swatchbook-core` | Framework-free DTCG loader. Parses a resolver, normalizes axes, resolves themes, emits CSS and diagnostics. | — |
+| `@unpunnyfuns/swatchbook-addon` | Storybook 10 addon. Toolbar, preview decorator, Vite plugin that publishes a virtual module. Re-exports `-blocks` + `-switcher`. | core, blocks, switcher |
+| `@unpunnyfuns/swatchbook-blocks` | MDX doc blocks + the `SwatchbookProvider` + hooks. Pure React, framework-agnostic beyond Storybook. | — (peer: storybook) |
+| `@unpunnyfuns/swatchbook-switcher` | Framework-agnostic axis / preset popover UI. Used by the addon toolbar and the docs-site navbar. | — |
+| `@unpunnyfuns/swatchbook-mcp` | Model Context Protocol server exposing a project to AI agents. Runs without Storybook. | core |
+
+### Apps (private workspaces, not published)
+
+| App | Role |
+| --- | --- |
+| `apps/storybook` | Dogfood Storybook that runs the addon against `packages/tokens`. Every block lives here as a story. |
+| `apps/docs` | This Docusaurus site. |
+
+### Fixtures
+
+| Path | Role |
+| --- | --- |
+| `packages/tokens` | Multi-axis DTCG reference fixture — colors, sizes, type, motion, borders, shadows, gradients. The demo Storybook renders against this. |
+
+## The Project snapshot
+
+Everything flows through one shape: `Project` in `packages/core/src/types.ts`.
+
+```ts
+interface Project {
+  config: Config;              // the resolved user config
+  axes: Axis[];                // axes driving composition (mode, brand, contrast…)
+  disabledAxes: DisabledAxis[];// axes the consumer explicitly suppressed
+  presets: Preset[];           // named quick-select axis tuples
+  chrome: Record<string, string>; // block-chrome → consumer-token alias map
+  themes: Theme[];             // cartesian product of axis contexts
+  themesResolved: Record<string, TokenMap>; // theme.name → resolved tokens
+  graph: TokenMap;             // default theme's resolved tokens
+  sourceFiles: string[];       // every file that fed the build (for watchers)
+  diagnostics: Diagnostic[];   // parser / validator / resolver findings
+}
+```
+
+Properties:
+
+- **Themes are eagerly resolved.** `project.themesResolved[name]` is ready at load time — no lazy I/O.
+- **`sourceFiles` is the canonical watch set.** The addon's Vite plugin and the MCP server both use it to decide what to watch for HMR / live-reload.
+- **Diagnostics flow as data, not exceptions.** Parse errors, unresolved aliases, invalid preset axis values — all land in `project.diagnostics` with a severity. The `<Diagnostics />` block renders them.
+- **One axis type.** `Axis.source` is `'resolver'` (DTCG resolver modifier), `'layered'` (authored per-axis layer globs), or `'synthetic'` (single-axis fallback for projects without a resolver or layers). Everything downstream treats them uniformly.
+
+`ProjectSnapshot` (in `packages/blocks/src/types.ts`) is the JSON-safe slice of `Project` that the addon's virtual module and provider deal in. It's intentionally pruned — no raw Terrazzo `TokenNormalized` shapes, just the fields blocks need.
+
+## Data flow — static build path
+
+The simpler of the two flows. Applies to the docs site, emitted CSS for consumers, and the MCP server at startup.
+
+```
+tokens/resolver.json
+       ↓
+   loadProject(config, cwd)        ← packages/core/src/load.ts
+       ↓
+     Project                       ← the one shape
+       ↓
+   projectCss(project)             ← packages/core/src/css.ts
+       ↓
+ :root { --prefix-color-…: … }
+ [data-prefix-mode="Dark"] { … }
+```
+
+The same `Project` also feeds:
+
+- `resolveTheme(project, name)` — look up a single theme's resolved tokens
+- `project.diagnostics` — the `<Diagnostics />` block reads this
+- the MCP server's tool handlers (all twelve read straight from the project)
+- TypeScript type emission (via Terrazzo's token-tools; not currently exposed as a CLI)
+
+## Data flow — dev / HMR path
+
+Inside Storybook, the pipeline grows two links so edits to token files re-render blocks without a full preview reload.
+
+```
+tokens/*.json + resolver.json
+       ↓     (fs.watch on parent dirs, 100ms debounce)
+ swatchbookTokensPlugin         ← packages/addon/src/virtual/plugin.ts
+       ↓                          (Vite plugin; runs in node)
+   re-run loadProject
+       ↓
+  invalidate virtual:swatchbook/tokens
+       ↓                          (preview iframe)
+   Vite HMR push → preview-side listener
+       ↓
+  addons.getChannel().emit(TOKENS_UPDATED_EVENT, snapshot)
+       ↓
+  useTokenSnapshot() store      ← packages/blocks/src/internal/channel-tokens.ts
+       ↓                          (useSyncExternalStore)
+   every block re-renders with fresh data
+```
+
+Key points:
+
+- **Watchers live on parent directories, not on files.** Atomic-save editors (VS Code, vim, Zed) unlink + recreate the file inode, which kills file-level watchers. Dir-level + filename filter survives the dance. Same pattern in the MCP server's bin.
+- **The addon publishes a channel event rather than a full reload.** A full reload would drop toolbar state, `args`, scroll position. Broadcasting a snapshot through Storybook's channel lets blocks re-render in place via `useSyncExternalStore`.
+- **Outside the preview iframe, the channel never fires.** The docs site renders blocks against the virtual module's baked-at-build values — correct behavior for static docs.
+- **MCP mirrors the pattern.** `packages/mcp/src/bin.ts` watches the same sourceFiles, reloads via `loadFromConfig`, and calls `setProject(next)` on the already-connected MCP server.
+
+## The reactivity model
+
+Separately from token-file edits, swatchbook reacts to user actions — the toolbar axis popover, the color-format menu.
+
+Path:
+
+```
+user clicks a context in the toolbar popover
+   ↓
+ Storybook globals update           (e.g. `swatchbookAxes: { mode: 'Dark' }`)
+   ↓
+addons.getChannel().emit('globalsUpdated', …)
+   ↓
+useChannelGlobals() store            ← packages/blocks/src/internal/channel-globals.ts
+   ↓
+useProject() recomputes activeTheme  ← packages/blocks/src/internal/use-project.ts
+   ↓
+blocks re-render with new active theme / resolved tokens
+```
+
+Two paths through `useProject`:
+
+- **Inside story renders** — the addon's preview decorator mounts `SwatchbookProvider` around every story, seeding context from the virtual module. `useOptionalSwatchbookData()` finds it, and the hook is cheap.
+- **MDX doc blocks + autodocs** — no story render is active, so no provider. The hook falls back to `useVirtualModuleFallback(enabled=true)` which reads the virtual module directly and subscribes to `globalsUpdated` via the channel. `useGlobals()` from `storybook/preview-api` wouldn't work here — it throws outside a story render.
+
+Why the channel instead of `useGlobals`: MDX doc blocks render in a context where Storybook's preview `HooksContext` isn't mounted. The channel is the one communication surface that works in both story render and MDX contexts.
+
+## MCP server
+
+`@unpunnyfuns/swatchbook-mcp` is a standalone stdio-transport Model Context Protocol server that exposes a project to AI agents without Storybook.
+
+```
+npx @unpunnyfuns/swatchbook-mcp --config swatchbook.config.ts
+   ↓
+ loadFromConfig(path)               ← packages/mcp/src/load-config.ts
+   ↓
+ createServer(project)              ← packages/mcp/src/server.ts
+   ↓
+ StdioServerTransport → MCP client (Claude Desktop, Claude Code, …)
+```
+
+Twelve tools, all stateless reads against the in-memory `Project`:
+
+- Orientation: `describe_project`, `list_axes`, `get_diagnostics`
+- Discovery: `list_tokens`, `search_tokens`, `resolve_theme`
+- Detail: `get_token`, `get_alias_chain`, `get_aliased_by`, `get_color_formats`, `get_consumer_output`
+- Emission: `emit_css`
+
+`createServer` returns the server augmented with `setProject(next)` so live-reload (the default) can swap in a fresh project without restarting the transport. See [Reference → MCP](../reference/mcp) for the tool signatures.
+
+## Where to read next
+
+- `packages/core/src/load.ts` — the loader entry. Start here.
+- `packages/core/src/types.ts` — every shape flowing through the rest.
+- `packages/addon/src/virtual/plugin.ts` — the HMR plumbing.
+- `packages/addon/src/preview.tsx` — how the preview decorator wires the provider + channel.
+- `packages/blocks/src/internal/use-project.ts` — the hook every block pulls state through.
+- `packages/mcp/src/server.ts` — the twelve MCP tools in one file.
+
+And the companion [Sharp corners](./sharp-corners) page for the "don't step there" list.

--- a/apps/docs/docs/developers/index.mdx
+++ b/apps/docs/docs/developers/index.mdx
@@ -1,0 +1,39 @@
+---
+id: developers
+title: For developers
+sidebar_position: 0
+---
+
+# For developers
+
+You're reading the right section if you want to **work on swatchbook's code** — fix bugs, add blocks, extend the MCP tool set, rewrite how HMR flows. If you want to *use* swatchbook in your own Storybook, the [Quickstart](../quickstart) and [Reference](../reference/core) are the right doors.
+
+This section assumes you've already skimmed [**CONTRIBUTING.md**](https://github.com/unpunnyfuns/swatchbook/blob/main/CONTRIBUTING.md) on GitHub, which covers dev setup, checks, commit conventions, and the release flow. What lives here is the *how-does-the-code-work* reference — the kind of thing a new contributor needs to build a mental model before making their first real change.
+
+## What's in this section
+
+- [**Architecture**](./architecture) — the repo map, the one data structure everything revolves around (`Project`), and how data moves from a token file on disk to a rendered doc block. Includes the static build path, the dev/HMR path, and how the MCP server plugs in.
+- [**Sharp corners**](./sharp-corners) — the "someone will bleed on this" list. Shapes that trip newcomers. Read this after *Architecture* so the rules have context.
+
+## Where the source lives
+
+```
+.
+├── packages/
+│   ├── core/        # DTCG loader, CSS emission
+│   ├── addon/       # Storybook addon (toolbar, preview, virtual module)
+│   ├── blocks/      # MDX doc blocks + provider + hooks
+│   ├── switcher/    # Framework-agnostic axis popover UI
+│   └── mcp/         # MCP server for AI agents
+├── apps/
+│   ├── storybook/   # Dogfood Storybook — runs the addon against the reference fixture
+│   └── docs/        # This Docusaurus site
+└── packages/tokens/ # Multi-axis DTCG reference fixture
+```
+
+## Quick orientation — typical work shapes
+
+- **Fixing a block's rendering** — start in `packages/blocks/src/<BlockName>.tsx`. Look at `packages/blocks/test/<block>.test.tsx` for the existing assertions. Add your story under `apps/storybook/src/stories/`.
+- **Changing how tokens load** — `packages/core/src/load.ts` is the entry; `packages/core/src/themes/` has the resolver and layered paths; `packages/core/src/types.ts` is the shape that flows out.
+- **Adding an MCP tool** — `packages/mcp/src/server.ts` — one file, one `server.registerTool(…)` call per tool. The MCP server is stateless beyond its in-memory `Project` reference.
+- **Tweaking HMR behavior** — `packages/addon/src/virtual/plugin.ts` is the addon-side watcher + channel broadcaster. `packages/mcp/src/bin.ts` mirrors the pattern for the MCP server. Keep them in lockstep.

--- a/apps/docs/docs/developers/sharp-corners.mdx
+++ b/apps/docs/docs/developers/sharp-corners.mdx
@@ -1,0 +1,179 @@
+---
+id: sharp-corners
+title: Sharp corners
+sidebar_position: 2
+---
+
+# Sharp corners
+
+The "someone will bleed on this" list. Shapes that trip newcomers and sometimes trip returnees. Each entry states the shape, the reason, and the defensive rule.
+
+## Storybook addon gotchas
+
+### Manager code cannot use JSX
+
+**Shape:** the Storybook manager bundle runs React 18 and doesn't expose `react/jsx-runtime`'s React-19 dispatcher. JSX in manager code crashes with `Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')`.
+
+**Rule:** use `React.createElement` (or a local `h` alias) in every file under `packages/addon/src/manager/`. Preview code is fine with JSX — it runs on the consumer's React.
+
+### Register manager tools with `render: () => h(Component)`, not `render: Component`
+
+**Shape:** passing a component function directly as `render` invokes hooks outside React's render cycle.
+
+**Rule:** always wrap in an element-returning arrow: `render: () => h(ThemeToolbar)`.
+
+### MDX doc blocks cannot use Storybook preview hooks
+
+**Shape:** `useGlobals` / `useArgs` / `useChannel` / `useParameter` from `storybook/preview-api` require the preview `HooksContext`, which only exists while a story is rendering. Called from an MDX doc block they throw *"Storybook preview hooks can only be called inside decorators and story functions."*
+
+**Rule:** for cross-story reactivity in MDX, subscribe to `addons.getChannel()` directly (`globalsUpdated` is the event) and manage state with plain React hooks. That's what the provider-less path in `useProject` does.
+
+### Preview ↔ manager communication goes through the channel
+
+**Shape:** the manager can't import preview-side Vite virtual modules. The preview can't import manager-side React either.
+
+**Rule:** `addons.getChannel()` + `emit`/`on`. Named events only — see `packages/addon/src/constants.ts` for the roster.
+
+## HMR / file watching
+
+### Watch parent directories, not files
+
+**Shape:** atomic-save editors unlink the old file inode and write a new one. A watcher on the original file either fires a one-shot 'rename' and goes deaf, or on some platforms loops on ghost events for the old inode.
+
+**Rule:** watch `dirname(file)` with a filename filter. The dir inode is stable across the rename dance. Both the addon (`virtual/plugin.ts`) and the MCP bin (`mcp/src/bin.ts`) follow this.
+
+### Vite's watcher doesn't carry events across pnpm symlink boundaries
+
+**Shape:** `server.watcher.add(file)` works fine for files inside the Vite root, but tokens often live in a sibling workspace package reached through a pnpm symlink. Vite's watcher silently drops events across the symlink boundary.
+
+**Rule:** run your own `fs.watch` — don't try to bolt onto Vite's watcher for token files.
+
+### Debounce the reload
+
+**Shape:** a single save in most editors emits 2–3 filesystem events (atomic rename + rewrite + metadata). Naively triggering a reload per event runs `loadProject` three times in a row.
+
+**Rule:** 100 ms trailing debounce. Both the addon plugin and the MCP bin use the same number; keep them in lockstep.
+
+## React rules-of-hooks
+
+### Don't hoist hooks below empty-state early returns
+
+**Shape:** if `<Block />` has an empty-state early return (`if (items.length === 0) return <Empty/>`), **all hooks must be called before that `return`**. Adding a new `useMemo` after the guard works the first time the tree is non-empty, but the first time it flips to empty the hook is skipped. The next non-empty render sees one fewer hook than before and React throws `Rendered fewer hooks than expected. This may be caused by an accidental early return statement.`
+
+**Rule:** all hooks at the top of the component body, guards at the bottom. We've hit this once in `TokenNavigator`; scan every block with an empty-state branch when adding a memo or effect.
+
+### Hook the channel, not the Storybook `preview-api` hooks, from MDX
+
+See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, different angle.
+
+## Virtual module + provider
+
+### Import block hooks from either `-blocks` or `-addon`
+
+**Shape:** historically the hooks were only exported from `@unpunnyfuns/swatchbook-blocks`. Today the addon re-exports everything via `export * from '@unpunnyfuns/swatchbook-blocks'`, so `import { useSwatchbookData } from '@unpunnyfuns/swatchbook-addon'` works too. Both import paths resolve to the same symbols.
+
+**Rule:** either is fine. Pick whichever package the consumer already has.
+
+### Never import `virtual:swatchbook/tokens` from consumer code
+
+**Shape:** the virtual module is addon-internal plumbing. Its shape, its event names, its field set are subject to change between minor versions without a changeset entry.
+
+**Rule:** consumers go through `SwatchbookProvider` + hooks. Inside this repo, only the preview decorator and the blocks' internal reactivity plumbing touch the virtual module directly.
+
+## Import specifiers
+
+### Always carry the on-disk extension
+
+**Shape:** every import in this repo names the file extension — `.ts`, `.tsx`, `.css`, `.json`, `.svg`. No inference, no "fake `.js`".
+
+**Rule:** `import { emitCss } from '#/css.ts'` — not `'#/css'` or `'../css'`. Vite, Vitest, tsdown, and Node strip-types all resolve TS-extension specifiers natively.
+
+### Use `#/*` for internal paths
+
+**Shape:** every package has `"imports": { "#/*": "./src/*" }` in `package.json`. That one entry handles every filetype.
+
+**Rule:** `#/foo.ts` beats `../../foo.ts` for any file within the package's own `src/`. Cross-package imports go through the published name.
+
+## Tests
+
+### Flat structure, no nested describes, no beforeEach for cosmetics
+
+**Shape:** nested describes and cosmetic `beforeEach` make each `it` require scrolling up to reconstruct the world it's running in.
+
+**Rule:** one top-level `describe` at most, inline `setup()` helpers when shared code is cheap, `beforeAll` only as a perf escape hatch with an annotated reason. See [Avoid Nesting When You're Testing](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
+
+### Storybook interaction tests via `addon-vitest`
+
+**Shape:** `play` functions in `.stories.tsx` run through `@storybook/addon-vitest`, not directly as Vitest tests. `pnpm turbo run test:storybook` is the runner.
+
+**Rule:** keep `play` functions short and deterministic. If a test needs elaborate setup, write a unit test instead.
+
+## Changesets
+
+### Pre-1.0 breaking changes bump `minor`, not `major`
+
+**Shape:** in semver pre-1.0, `0.x` treats `minor` as the major-ish position. Bumping `major` now is reserved for the 1.0 cut itself.
+
+**Rule:** breaking changes → `minor`. Features → `minor`. Bug fixes → `patch`. Docs-only PRs → `patch` (so the snapshot rebuild picks them up on the next release).
+
+### One changeset per PR, fixed-version group bumps together
+
+**Shape:** `-core`, `-addon`, `-blocks`, `-switcher`, `-mcp` are a fixed version group in `.changeset/config.json`. The bump level you pick applies to all of them.
+
+**Rule:** don't try to bump them independently. Either the whole group moves or none of them do.
+
+## Styling
+
+### Blocks use colocated CSS files, not CSS-in-JS
+
+**Shape:** every block has a sibling `.css` file with `sb-<block>__<part>--<modifier>` BEM-ish class names. Inline `style={{...}}` objects are gone.
+
+**Rule:** new block styles → new `.css` file, colocated with the block. Compose classes with `clsx` at the JSX site. Don't import `styled-components` or Emotion; they're not in the dep tree.
+
+### Chrome variables read from a fixed `--swatchbook-*` namespace
+
+**Shape:** blocks read ten chrome variables (surface colors, text colors, border roles) from a fixed `--swatchbook-*` namespace that's independent of the consumer's `cssVarPrefix`. The `DEFAULT_CHROME_MAP` provides `light-dark()` defaults so zero-config chrome auto-flips with OS color-scheme.
+
+**Rule:** when adding a new chrome role, add it to `CHROME_ROLES` in `packages/core/src/chrome.ts` and provide a `DEFAULT_CHROME_MAP` entry. Consumers wire roles to their own tokens via `config.chrome`.
+
+## Releases
+
+### Docs-only PRs still need a patch changeset
+
+**Shape:** `scripts/snapshot-docs-version.mjs` rebuilds the current minor's docs snapshot on every release. Docs fixes without a changeset only reach `/next/`, never `/`.
+
+**Rule:** if your PR touches `apps/docs/`, file a patch changeset. Even if nothing functional changed.
+
+### Turbo's `build` task inputs include versioned snapshots
+
+**Shape:** `turbo.json`'s `build` inputs list `versioned_docs/**`, `versioned_sidebars/**`, `versions.json`. This is load-bearing for the remote cache — a fresh minor snapshot invalidates cache entries for downstream builds that depend on it.
+
+**Rule:** don't prune those entries from the `build` inputs. If you add a new versioned docs artifact, include it too.
+
+## MCP
+
+### stderr for logs, stdout reserved for protocol frames
+
+**Shape:** the stdio transport sends JSON-RPC frames over stdout. Any accidental `console.log` call there corrupts the channel and the MCP client reports malformed JSON.
+
+**Rule:** use `console.error` for everything diagnostic. The reload notice, the `--help` text, error messages, all go to stderr. Only the transport writes to stdout.
+
+### Deferred tool schemas from MCP
+
+**Shape:** MCP tools registered by a connected server don't have their schemas loaded into the agent's prompt by default. The agent sees tool names only and has to call `ToolSearch` to fetch schemas before invoking.
+
+**Rule:** design tool descriptions to be self-sufficient — the description is what makes the agent decide to fetch the schema. Be specific, list the shape of the return value in prose.
+
+## Plan + issue governance
+
+### Every PR links an issue
+
+**Shape:** project convention — every PR body has a `Closes: #N` line, milestone assignment, and `Plan impact` note.
+
+**Rule:** file the issue first (`gh issue create --milestone "Maintenance" --title "…"`). Merging the PR auto-closes the issue.
+
+### PR titles: verb-first lowercase, Conventional Commits scope
+
+**Shape:** imperative verb as first word; lowercase even for proper nouns; scope matches a package slug.
+
+**Rule:** `fix(blocks): hoist navigator hooks above empty-state early return` — not `Fix(Blocks): TokenNavigator hooks run before empty-state early return`.

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -103,6 +103,7 @@ const config: Config = {
         { type: 'docSidebar', sidebarId: 'blocks', position: 'left', label: 'Blocks' },
         { type: 'docSidebar', sidebarId: 'guides', position: 'left', label: 'Guides' },
         { type: 'docSidebar', sidebarId: 'reference', position: 'left', label: 'Reference' },
+        { type: 'docSidebar', sidebarId: 'developers', position: 'left', label: 'Developers' },
         { href: 'pathname:///storybook/', label: 'Live Storybook', position: 'left' },
         ...(hasReleasedVersion
           ? [{ type: 'docsVersionDropdown' as const, position: 'right' as const }]

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -44,6 +44,11 @@ const sidebars: SidebarsConfig = {
     'guides/multi-axis-walkthrough',
   ],
   reference: ['reference/addon', 'reference/core', 'reference/config', 'reference/mcp'],
+  developers: [
+    'developers/developers',
+    'developers/architecture',
+    'developers/sharp-corners',
+  ],
 };
 
 export default sidebars;


### PR DESCRIPTION
## Summary

- New top-level **Developers** sidebar + navbar entry alongside Blocks / Guides / Reference.
- Three pages: **For developers** (landing, repo map, typical work shapes), **Architecture** (the \`Project\` data structure, static + HMR data flow, reactivity model, MCP plumbing, where to read next), and **Sharp corners** (the consolidated gotchas list).
- CONTRIBUTING.md on GitHub stays authoritative for dev setup and process; the docs-site section covers the code-understanding side that was previously scattered across CLAUDE.md, source comments, and oral tradition.
- Patch changeset on \`@unpunnyfuns/swatchbook-blocks\` so the docs snapshot rebuilds on the next release.

Milestone: Maintenance
Closes: #492
Plan impact: none

## Review guidance

- **Accuracy check.** The architecture page makes concrete claims about file paths, event names, and the HMR dance. If any of that has drifted, flag it — it's easy to correct.
- **Tone.** Matched the existing site voice (terse, factual, no marketing). Push back on anything that reads as puffery.
- **Coverage.** Two pages feels right for a v1 of the section; expand if a workflow keeps coming up in PRs that we have no doc for.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — green, no broken-link warnings.
- [ ] Manual: \`pnpm dev\` the docs site, navigate Developers → For developers → Architecture → Sharp corners, confirm the sidebar order and cross-links work.