### PR TITLE
docs(tokens): high-contrast axis should actually change contrast

### DIFF
--- a/.changeset/docs-high-contrast-boost.md
+++ b/.changeset/docs-high-contrast-boost.md
@@ -1,0 +1,16 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs(tokens): give the docs-site's high-contrast axis real contrast boost
+
+The a11y axis on the docs-site tokens used to only swap the base font to a comic display face and bump font size by 8%. Colors stayed identical — which undersold the accessibility signal and didn't meaningfully improve the site's contrast on either Light or Dark.
+
+Adds mode-aware contrast-boosted values via alias indirection: each mode file (`themes/light.json`, `themes/dark.json`) now carries a parallel `color.accessible.*` namespace with darker-on-light / brighter-on-dark variants of `text.muted` and the full primary ramp. `themes/high-contrast.json` aliases role tokens to that namespace, so the a11y overlay stays mode-agnostic at the file level while the resolved values remain mode-aware.
+
+Visible outcomes on a11y=High-contrast:
+
+- Light: `primary.default` from `brand.600` (contrast ~4.8:1 on white) to `brand.800` (~9.5:1); `text.muted` from `neutral.500` (~4.5:1) to `neutral.700` (~10:1).
+- Dark: `primary.default` from `brand.500` to `brand.300`; `text.muted` from `neutral.300` to `neutral.100`.
+
+No change to Normal-contrast Light or Dark — this is purely the a11y overlay gaining colour where before it only carried typography.

--- a/apps/docs/tokens/themes/dark.json
+++ b/apps/docs/tokens/themes/dark.json
@@ -24,6 +24,21 @@
     "code": {
       "bg":     { "$value": "{color.palette.neutral.800}" },
       "border": { "$value": "{color.palette.neutral.700}" }
+    },
+    "accessible": {
+      "$description": "High-contrast alternates for Dark. Lighter neutrals for muted text, lighter brand shades for primary — pushes link/muted-text contrast up against the dark surface ramp. Parallel shape to light's `color.accessible`; the a11y overlay aliases role tokens to this namespace and the active mode's definitions decide the resolved value.",
+      "text": {
+        "muted": { "$value": "{color.palette.neutral.100}" }
+      },
+      "primary": {
+        "lightest": { "$value": "{color.palette.brand.100}" },
+        "lighter":  { "$value": "{color.palette.brand.200}" },
+        "light":    { "$value": "{color.palette.brand.300}" },
+        "default":  { "$value": "{color.palette.brand.300}" },
+        "dark":     { "$value": "{color.palette.brand.400}" },
+        "darker":   { "$value": "{color.palette.brand.500}" },
+        "darkest":  { "$value": "{color.palette.brand.600}" }
+      }
     }
   },
   "font": {

--- a/apps/docs/tokens/themes/high-contrast.json
+++ b/apps/docs/tokens/themes/high-contrast.json
@@ -1,5 +1,20 @@
 {
-  "$description": "High-contrast a11y overlay — swaps the base font family for a comic display face and bumps base size. Intentionally leaves colour alone: layering mode-agnostic colour overrides on top of mode (which picks opposite ends of the neutral / brand ramps for Light vs Dark) dragged primary into dark-on-dark territory on Dark + High-contrast. Contrast comes from mode's own role tokens; a11y carries the typography signal.",
+  "$description": "High-contrast a11y overlay. Typography signal — swaps the base font family for a comic display face and bumps base size — plus colour boosts via alias indirection: role tokens re-route through each mode's `color.accessible.*` namespace so the resolved values stay mode-aware (darker on Light, brighter on Dark) without this file having to branch per mode.",
+  "color": {
+    "$type": "color",
+    "text": {
+      "muted": { "$value": "{color.accessible.text.muted}" }
+    },
+    "primary": {
+      "lightest": { "$value": "{color.accessible.primary.lightest}" },
+      "lighter":  { "$value": "{color.accessible.primary.lighter}" },
+      "light":    { "$value": "{color.accessible.primary.light}" },
+      "default":  { "$value": "{color.accessible.primary.default}" },
+      "dark":     { "$value": "{color.accessible.primary.dark}" },
+      "darker":   { "$value": "{color.accessible.primary.darker}" },
+      "darkest":  { "$value": "{color.accessible.primary.darkest}" }
+    }
+  },
   "font": {
     "family": {
       "$type": "fontFamily",

--- a/apps/docs/tokens/themes/light.json
+++ b/apps/docs/tokens/themes/light.json
@@ -24,6 +24,21 @@
     "code": {
       "bg":     { "$value": "{color.palette.neutral.100}" },
       "border": { "$value": "{color.palette.neutral.200}" }
+    },
+    "accessible": {
+      "$description": "High-contrast alternates for Light. The a11y overlay aliases role tokens to this namespace so it stays mode-agnostic at the file level while the resolved values remain mode-aware. Darker neutrals for text, deeper brand shades for primary — pushes link/muted-text contrast up from AA-borderline to AAA on white surfaces.",
+      "text": {
+        "muted": { "$value": "{color.palette.neutral.700}" }
+      },
+      "primary": {
+        "lightest": { "$value": "{color.palette.brand.500}" },
+        "lighter":  { "$value": "{color.palette.brand.600}" },
+        "light":    { "$value": "{color.palette.brand.700}" },
+        "default":  { "$value": "{color.palette.brand.800}" },
+        "dark":     { "$value": "{color.palette.brand.900}" },
+        "darker":   { "$value": "{color.palette.brand.900}" },
+        "darkest":  { "$value": "{color.palette.brand.900}" }
+      }
     }
   },
   "font": {


### PR DESCRIPTION
## Summary

- Adds a \`color.accessible.*\` namespace to each mode file (\`light.json\`, \`dark.json\`) with high-contrast-boosted alternates — darker neutrals/primary for Light, brighter for Dark.
- \`high-contrast.json\` now aliases \`color.text.muted\` and \`color.primary.*\` to that namespace. Kept the font swap + size bump.
- The previous constraint (mode-agnostic colour overrides dragged primary into dark-on-dark on Dark + High-contrast) is respected because each mode declares its own \`accessible.*\` values and the a11y overlay resolves mode-aware through alias chains. Nothing in the overlay file branches per mode.
- Patch changeset on \`@unpunnyfuns/swatchbook-blocks\` so the docs snapshot rebuilds next release.

### Before / after (on a11y=High-contrast)

| token | Light before → after | Dark before → after |
| --- | --- | --- |
| \`primary.default\` | \`brand.600\` (~4.8:1) → \`brand.800\` (~9.5:1) | \`brand.500\` (~5.5:1) → \`brand.300\` (~11:1) |
| \`text.muted\` | \`neutral.500\` (~4.5:1) → \`neutral.700\` (~10:1) | \`neutral.300\` (~11:1) → \`neutral.100\` (~14:1) |
| full primary ramp | unchanged | shifts brighter |
| \`text.default\`, surfaces, code.* | unchanged (already at max contrast) | unchanged |

Milestone: Maintenance
Closes: #498
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean, tokens.generated.css emits mode-scoped \`--sb-color-accessible-*\` values plus a11y-gated re-routes to them.
- [x] Spot-checked the compiled CSS: in \`[data-theme=\"light\"][data-sb-a11y=\"High-contrast\"]\`, \`--sb-color-primary-default\` chains to \`brand.800\`; in \`[data-theme=\"dark\"]...\`, it chains to \`brand.300\`.
- [ ] Manual: \`pnpm dev\` the docs site, toggle a11y=High-contrast on Light and Dark, eyeball link colour + muted text on both.