### PR TITLE
fix(docs): route latest release at / and main-branch at /next/

### DIFF
--- a/.changeset/docs-version-routing-fix.md
+++ b/.changeset/docs-version-routing-fix.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix(docs): route latest release at `/` and main-branch at `/next/`
+
+The docusaurus site's versioning config had drifted — `lastVersion: 'current'` pinned the main-branch docs to `/`, which caused Docusaurus to flag the released 0.10 snapshot as "out of date" even though 0.10 is the currently-shipping version. Visitors landing on `/` were reading unreleased content by default.
+
+Now matches the intent described in CLAUDE.md: `/` serves the latest released snapshot (implicit `lastVersion` from the first entry in `versions.json`); main-branch docs move to `/next/` with an "unreleased documentation" banner. Visitors shipping against `@unpunnyfuns/swatchbook-*@0.10.2` land on docs that match their installed code.
+
+No content changes — this is a routing-config fix.

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -63,14 +63,14 @@ const config: Config = {
           editUrl: 'https://github.com/unpunnyfuns/swatchbook/tree/main/apps/docs/',
           includeCurrentVersion: true,
           ...(hasReleasedVersion && {
-            // `lastVersion: 'current'` pins main-branch docs to / so visitors
-            // land on the active work rather than the last cut release. The
-            // released snapshots remain reachable at /<version>/ via the
-            // version dropdown. Suppress the default "unreleased" banner on
-            // current — nothing to warn about when current *is* the headline.
-            lastVersion: 'current',
+            // Once a snapshot exists, the newest released version in
+            // versions.json becomes the implicit lastVersion and serves at /,
+            // so visitors shipping against `@unpunnyfuns/swatchbook-*@X.Y.Z`
+            // land on docs that match their installed code. Main-branch docs
+            // move to /next/ with an "unreleased" banner that warns visitors
+            // they're on pre-release content.
             versions: {
-              current: { label: 'Next', banner: 'none' },
+              current: { label: 'Next', path: 'next', banner: 'unreleased' },
             },
           }),
         },


### PR DESCRIPTION
## Summary

\`apps/docs/docusaurus.config.ts\` had \`lastVersion: 'current'\`, which was telling Docusaurus that main-branch docs are the \"latest stable\" version. That caused the released 0.10 snapshot to be flagged as \"no longer actively maintained\" even though 0.10.2 is the currently-shipping release on npm — a misleading banner for visitors shipping against the 0.10 line.

Drops the override. With no \`lastVersion\` set, Docusaurus uses the first entry in \`versions.json\` as the implicit lastVersion — 0.10, today — and serves it at \`/\`. Main-branch docs relocate to \`/next/\` with an \"unreleased documentation\" banner.

This matches the intended behavior CLAUDE.md already describes: \`/\` for the latest release, \`/next/\` for main.

### Verified post-build

- \`/\` — 0.10 snapshot, **no banner** (it's the latest).
- \`/next/\` — main-branch content, **\"unreleased documentation\"** banner.
- \`/0.9/\`, \`/0.8/\`, … — older release snapshots, **\"no longer actively maintained\"** banner.

Milestone: Maintenance
Closes: #500
Plan impact: none

## Caveat

Bookmarked URLs into the main-branch docs (e.g. \`/concepts/theming-inputs\`) now land on the 0.10 snapshot. The equivalent main-branch URL becomes \`/next/concepts/theming-inputs\`. Not catastrophic, but worth a heads-up for anyone who had bookmarks; the 0.10 content is close enough that most links still read correctly.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [x] Grep the built HTML on \`/\`, \`/next/\`, \`/0.9/\` — each carries the correct banner (or lack of one).
- [ ] Manual: \`pnpm dev\` the docs site, verify the version dropdown in the navbar lists 0.10 first, click through to 0.9 and confirm the \"no longer maintained\" banner renders.