### PR TITLE
chore(release): anchor 0.11.0 at switcher + mcp arriving on npm

### DIFF
--- a/.changeset/switcher-mcp-first-npm-publish.md
+++ b/.changeset/switcher-mcp-first-npm-publish.md
@@ -1,0 +1,12 @@
+---
+'@unpunnyfuns/swatchbook-switcher': minor
+'@unpunnyfuns/swatchbook-mcp': minor
+---
+
+feat(switcher, mcp): first npm publish
+
+Earlier releases listed these packages in the repo and docs, but they never reached the npm registry — `npm install @unpunnyfuns/swatchbook-switcher` and `npm install @unpunnyfuns/swatchbook-mcp` both 404'd because trusted publishing was configured for `core` / `addon` / `blocks` only, and the partial-publish failure caused `changesets/action` to skip the subsequent tag push too (which is why git tags stopped at 0.6.2).
+
+Bootstrapped via npm's pending-trusted-publisher flow on both package names. Subsequent releases publish alongside `core` / `addon` / `blocks` via the standard OIDC path, and the tag / GitHub-release step runs normally.
+
+This changeset also tips the fixed-version group to 0.11.0 — the arrival of these two packages on the registry is the right anchor for a minor bump.


### PR DESCRIPTION
## Summary

Adds a minor changeset targeting \`@unpunnyfuns/swatchbook-switcher\` and \`@unpunnyfuns/swatchbook-mcp\`. In the fixed-version group that tips the next release from 0.10.3 to **0.11.0**, which better captures the transition — those two packages arrive on npm for the first time this cycle, and it's worth anchoring a minor bump on that rather than folding it into a patch.

The changeset body documents the 404 history and the pending-trusted-publisher bootstrap so the CHANGELOG entry is self-explanatory for future readers.

Milestone: Release
Closes: #502
Plan impact: none

## Sequence to cut 0.11.0

1. Set up pending trusted publishers on npm for switcher + mcp (strict \"require 2FA + disallow tokens\" — OIDC still works).
2. Merge this PR + the other pending PRs (#501, anything else) so the next Version Packages PR picks them all up.
3. Merge the Version Packages PR — GitHub Actions runs trusted publishing for all five packages cleanly, pushes tags, creates GitHub releases.

## Test plan

- [x] \`pnpm -r format\` — clean.
- [ ] Verify the Version Packages PR body reflects a minor bump (0.11.0) after the changeset batch recombines on main.