### PR TITLE
docs: surface switcher + mcp across package indexes and intro

### DIFF
--- a/.changeset/docs-surface-mcp-switcher.md
+++ b/.changeset/docs-surface-mcp-switcher.md
@@ -1,0 +1,12 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs: surface the full package set across indexes
+
+Several places still listed the pre-v0.10 three-package story (core / addon / blocks) and omitted switcher + mcp:
+
+- Root `README.md` — added the `mcp` row to the package table.
+- `CONTRIBUTING.md` — expanded the "everything user-facing lives under…" list and the changeset rule to cover all five published packages.
+- `packages/switcher/README.md` — created from scratch; the package shipped without one. Covers install, usage, exported surface, and where it's consumed inside the repo.
+- `apps/docs/docs/intro.mdx` — added a short "For AI agents" section pointing at the MCP server, plus updated "How to read these docs" to include `mcp` in the Reference list and added the new Developers section.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thanks for considering a contribution. Swatchbook is a Storybook addon for DTCG design tokens; everything user-facing lives under `packages/core`, `packages/addon`, `packages/blocks`, with a dogfood Storybook in `apps/storybook` and the docs site in `apps/docs`.
+Thanks for considering a contribution. Swatchbook is a Storybook addon for DTCG design tokens; everything user-facing lives under `packages/core`, `packages/addon`, `packages/blocks`, `packages/switcher`, and `packages/mcp`, with a dogfood Storybook in `apps/storybook` and the docs site in `apps/docs`.
 
 By participating, you agree to the [Code of Conduct](./CODE_OF_CONDUCT.md).
 
@@ -102,13 +102,13 @@ All PRs are squash-merged. One PR → one commit on `main`.
 
 ## Changesets
 
-Any PR with a user-visible change to `@unpunnyfuns/swatchbook-core`, `@unpunnyfuns/swatchbook-addon`, or `@unpunnyfuns/swatchbook-blocks` carries a changeset:
+Any PR with a user-visible change to `@unpunnyfuns/swatchbook-core`, `@unpunnyfuns/swatchbook-addon`, `@unpunnyfuns/swatchbook-blocks`, `@unpunnyfuns/swatchbook-switcher`, or `@unpunnyfuns/swatchbook-mcp` carries a changeset:
 
 ```sh
 pnpm changeset
 ```
 
-Pick a bump level and write a short description. The three published packages are a **fixed group** (always the same version), so the bump level you pick applies to all of them.
+Pick a bump level and write a short description. All five published packages are a **fixed group** (always the same version), so the bump level you pick applies to every one of them.
 
 **Bump levels, pre-1.0:**
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Two things in one:
 | [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Emits CSS variables and TypeScript types. |
 | [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks. Color swatches, dimension bars, typography samples, composite previews, per-token detail. |
 | [`@unpunnyfuns/swatchbook-switcher`](./packages/switcher) | Framework-agnostic axis / preset popover UI. Used by the addon toolbar and by the docs-site navbar. |
+| [`@unpunnyfuns/swatchbook-mcp`](./packages/mcp) | Model Context Protocol server exposing a DTCG project's tokens, axes, and diagnostics to AI agents. Runs without Storybook. |
 
 ## Install
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -36,6 +36,10 @@ Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable fr
 - **Toolbar** — a single Swatchbook icon button opens a popover with preset pills, one dropdown per modifier axis (so a reader can browse tokens in every context), and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`) that controls how blocks display colors.
 - **`useToken` hook** — typed lookups from component code, reactive to the active theme.
 
+## For AI agents
+
+The optional [`@unpunnyfuns/swatchbook-mcp`](./reference/mcp) package ships a stdio [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes your token graph — paths, axes, alias chains, diagnostics, per-theme resolved values — to AI assistants like Claude Desktop or Claude Code. Point it at your `swatchbook.config.ts` (or a bare DTCG resolver) and an agent can introspect and reason about the system without spinning up Storybook. Twelve read-only tools; live-reloads on token edits.
+
 ## See it live
 
 The [live Storybook](pathname:///storybook/) runs the addon against this repo's [`tokens-reference`](https://github.com/unpunnyfuns/swatchbook/tree/main/packages/tokens-reference) fixture — a multi-file DTCG token set organized per-`$type` (one file for each of `color`, `size`, `typography`, `motion`, `border`, `shadow`, `gradient`, `stroke`, `font`, `number`), with resolver-driven `mode × brand × contrast` axes. Every block, panel, and toolbar control is wired up against those tokens.
@@ -46,7 +50,8 @@ The [live Storybook](pathname:///storybook/) runs the addon against this repo's 
 - **Blocks** — the MDX doc blocks you'll spend most of your time with: the [reference](./reference/blocks) lists what's available and the [authoring guide](./guides/authoring-doc-stories) walks through composing them.
 - **Concepts** — the mental model: [why axes, not themes](./concepts/axes-vs-themes), [theming inputs](./concepts/theming-inputs), [axes](./concepts/axes), [theme reactivity](./concepts/theme-reactivity), [presets](./concepts/presets), [diagnostics](./concepts/diagnostics).
 - **Guides** — the [multi-axis walkthrough](./guides/multi-axis-walkthrough) covers one-time setup.
-- **Reference** — API surface for the remaining packages (`addon`, `core`, `config`).
+- **Reference** — API surface for the remaining packages (`addon`, `core`, `config`, `mcp`).
+- **Developers** — contributing to swatchbook itself: [architecture](./developers/architecture) and [sharp corners](./developers/sharp-corners).
 
 ## What these docs assume
 

--- a/packages/switcher/README.md
+++ b/packages/switcher/README.md
@@ -1,4 +1,4 @@
-# Switcher
+# swatchbook-switcher
 
 Published as `@unpunnyfuns/swatchbook-switcher`. Framework-agnostic theme-switcher UI for swatchbook — axis pills, preset pills, color-format selector. Consumed by the Storybook addon toolbar and by any React host that knows how to set `data-*` attributes on the document to drive per-theme CSS.
 

--- a/packages/switcher/README.md
+++ b/packages/switcher/README.md
@@ -1,0 +1,60 @@
+# Switcher
+
+Published as `@unpunnyfuns/swatchbook-switcher`. Framework-agnostic theme-switcher UI for swatchbook — axis pills, preset pills, color-format selector. Consumed by the Storybook addon toolbar and by any React host that knows how to set `data-*` attributes on the document to drive per-theme CSS.
+
+> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
+
+## Install
+
+Most consumers pick this up transitively via `@unpunnyfuns/swatchbook-addon` — the addon re-exports the full switcher API, so `import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` works and you don't need a second install line. Reach for this package directly when you want the switcher *without* the Storybook addon (a docs-site navbar, a standalone React app using swatchbook tokens):
+
+```sh
+npm install @unpunnyfuns/swatchbook-switcher
+```
+
+## Usage
+
+```tsx
+import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-switcher';
+
+function SiteHeader({ axes, presets, themes }) {
+  return (
+    <ThemeSwitcher
+      axes={axes}
+      presets={presets}
+      themes={themes}
+      activeAxes={{ mode: 'Dark' }}
+      colorFormat="oklch"
+      onAxisChange={(axis, context) => {
+        document.documentElement.setAttribute(`data-sb-${axis}`, context);
+      }}
+      onColorFormatChange={(format) => {
+        document.documentElement.setAttribute('data-sb-color-format', format);
+      }}
+    />
+  );
+}
+```
+
+The component is pure — it doesn't read or write to storage, and it doesn't bake in any particular way of applying the active tuple. The caller decides how to translate `onAxisChange` into DOM updates, routing changes, or global state.
+
+## Exports
+
+| Name | Shape |
+| --- | --- |
+| `ThemeSwitcher` | The popover component. |
+| `ThemeSwitcherProps` | Prop types — axes, presets, themes, active axis tuple, color format, change callbacks, optional `className`. |
+| `SwitcherAxis` / `SwitcherPreset` / `SwitcherTheme` | JSON-friendly shapes the component accepts. Cross-compatible with `@unpunnyfuns/swatchbook-core`'s `Project.axes` / `.presets` / `.themes` — pass them through directly. |
+
+## Where it's used inside this repo
+
+- The Storybook addon's toolbar popover (`packages/addon/src/manager/toolbar.ts`).
+- The docs site's navbar (`apps/docs/src/theme/Navbar/SwatchbookSwitcher/index.tsx`).
+
+Both cases feed `ThemeSwitcher` a snapshot of the active `Project` and wire the callbacks to `document.documentElement.setAttribute` calls. If you're rendering swatchbook tokens on a site that isn't Storybook, mirror that pattern.
+
+## See also
+
+- [`@unpunnyfuns/swatchbook-addon`](../addon) — Storybook addon. Re-exports `ThemeSwitcher` along with the full blocks surface.
+- [`@unpunnyfuns/swatchbook-blocks`](../blocks) — MDX doc blocks that the switcher-driven axis changes propagate to.
+- [`@unpunnyfuns/swatchbook-core`](../core) — the DTCG loader whose output feeds this component.


### PR DESCRIPTION
## Summary

Three-published-package docs phrasings survived long past switcher and mcp joining the fixed-version group. This catches indexes + intro up:

- **Root \`README.md\`** — added the \`mcp\` row to the package table.
- **\`CONTRIBUTING.md\`** — the \"everything user-facing lives under …\" line and the changeset rule now name all five published packages.
- **\`packages/switcher/README.md\`** — created from scratch. The package shipped without one. New file matches the style of the other package READMEs (install, usage, exported surface, where it's consumed inside this repo, see-also).
- **\`apps/docs/docs/intro.mdx\`** — added a short \"For AI agents\" section pointing at the MCP server so it's visible on the entry page, plus updated \"How to read these docs\" to include \`mcp\` in the Reference list and add the new Developers section.
- Patch changeset on \`@unpunnyfuns/swatchbook-blocks\` so the docs snapshot rebuilds on the next release.

Milestone: Maintenance
Closes: #504
Plan impact: none

### Flagged for a separate follow-up

- \`packages/addon/README.md\` line 3 still describes the removed-in-v0.3.0 \"Design Tokens panel\" (\"a unified Design Tokens panel (hierarchical tree + diagnostics)\"). That description is pre-v0.3.0 archaeology — deserves its own small cleanup commit, out of scope here.
- \`@unpunnyfuns/swatchbook-switcher\` is stuck at 0.10.2 on npm while the other four are at 0.11.0. Likely the trusted-publishing config on npmjs.com isn't in place for that package yet — worth checking before the next release cycle.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean, no broken links.
- [x] Spot-checked each edited file for tone + style consistency with neighboring prose.
- [ ] Manual: \`pnpm dev\` the docs site, land on the intro, confirm the new \"For AI agents\" section reads right and the MCP reference link resolves.