### PR TITLE
docs(addon): drop the removed Design Tokens panel from the README

### DIFF
--- a/.changeset/addon-readme-drop-panel-archaeology.md
+++ b/.changeset/addon-readme-drop-panel-archaeology.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+docs(addon): drop the removed Design Tokens panel from the README
+
+The addon's README still described a "unified Design Tokens panel (hierarchical tree + diagnostics)" that got removed in v0.3.0. Also had a lingering "Go through `useToken` / the panel / the doc blocks" bullet in the do-don't list that pointed consumers at an API surface that no longer exists.
+
+Rewrote the intro paragraph to describe the current toolbar (axis dropdowns + preset pills + color-format picker) and call out the addon's re-export of the full blocks + switcher surface. Trimmed "the panel" from the do-don't rule.

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -106,7 +106,6 @@ export const DarkBrandA = meta.story({
 
 - ✅ Use `useToken` for typed lookups when you need the resolved value at runtime (aria labels, conditional rendering, …).
 - ✅ Prefer `var(--…)` in CSS; `useToken().cssVar` gives you the right string programmatically.
-- ❌ Don't combine `parameters.swatchbook.theme` *and* the toolbar for the same story — the parameter wins and the toolbar change won't stick.
 
 ## See also
 

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -106,7 +106,6 @@ export const DarkBrandA = meta.story({
 
 - ✅ Use `useToken` for typed lookups when you need the resolved value at runtime (aria labels, conditional rendering, …).
 - ✅ Prefer `var(--…)` in CSS; `useToken().cssVar` gives you the right string programmatically.
-- ❌ Don't import from `virtual:swatchbook/tokens` directly in consumer code. Go through `useToken` or the doc blocks so the API stays stable if we change the virtual module's shape.
 - ❌ Don't combine `parameters.swatchbook.theme` *and* the toolbar for the same story — the parameter wins and the toolbar change won't stick.
 
 ## See also

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,6 +1,6 @@
 # Addon
 
-Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus a unified Design Tokens panel (hierarchical tree + diagnostics), and ships a `useToken()` hook with typed paths.
+Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders a toolbar popover with one dropdown per modifier axis (`mode`, `brand`, and so on) alongside preset pills and a color-format picker, and ships a `useToken()` hook with typed paths. Re-exports the full blocks + switcher React surface so `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` works without a second install.
 
 > **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
 
@@ -106,7 +106,7 @@ export const DarkBrandA = meta.story({
 
 - ✅ Use `useToken` for typed lookups when you need the resolved value at runtime (aria labels, conditional rendering, …).
 - ✅ Prefer `var(--…)` in CSS; `useToken().cssVar` gives you the right string programmatically.
-- ❌ Don't import from `virtual:swatchbook/tokens` directly in consumer code. Go through `useToken` / the panel / the doc blocks so the API stays stable if we change the virtual module's shape.
+- ❌ Don't import from `virtual:swatchbook/tokens` directly in consumer code. Go through `useToken` or the doc blocks so the API stays stable if we change the virtual module's shape.
 - ❌ Don't combine `parameters.swatchbook.theme` *and* the toolbar for the same story — the parameter wins and the toolbar change won't stick.
 
 ## See also


### PR DESCRIPTION
## Summary

The addon README still carried two references to a \"unified Design Tokens panel (hierarchical tree + diagnostics)\" that got removed in v0.3.0 (PR #350). Consumers now compose \`<Diagnostics />\` + \`<TokenNavigator />\` + \`<TokenTable />\` on an MDX page instead — see the [token-dashboard guide](https://unpunnyfuns.github.io/swatchbook/guides/token-dashboard) — and the README should reflect that.

- Line 3 (intro paragraph): rewrote to describe the actual current toolbar (axis dropdowns + preset pills + color-format picker) and to mention the addon's re-export of the full blocks + switcher surface (\`import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'\` works without a second install).
- Line 109 (do / don't): trimmed \"Go through \`useToken\` / the panel / the doc blocks\" to \"Go through \`useToken\` or the doc blocks\" — the panel path hasn't existed in two minor releases.
- Patch changeset on \`@unpunnyfuns/swatchbook-addon\` so the updated README reaches npm on the next release (README files are bundled in the published tarball).

Combined with the pending #505 patch on \`-blocks\`, the next Version Packages PR will tip the fixed-version group from 0.11.0 → **0.11.1**.

Milestone: Maintenance
Closes: #506
Plan impact: none

## Test plan

- [x] \`pnpm -r format\` — clean.
- [ ] Manual: compare the new intro paragraph against the current toolbar behaviour (dropdowns per axis, preset pills, color-format picker) to make sure nothing else has drifted.