### PR TITLE
docs: restore swatchbook-* prefix in each package README's title

### DIFF
--- a/.changeset/package-readme-headers.md
+++ b/.changeset/package-readme-headers.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+docs: restore `swatchbook-*` in each package README's title header
+
+Every package README was headed with a one-word title (`# Addon`, `# Blocks`, `# Core`, `# MCP`). On npm's package page that renders as a standalone word stripped of context — a reader who lands on the tarball's own page via a search, deep link, or alert sees "# Addon" and has to hunt for what it's an addon *of*. Restored the `swatchbook-*` prefix so each README's title matches its published package name and re-establishes context on first scroll.

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,4 +1,4 @@
-# Addon
+# swatchbook-addon
 
 Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders one toolbar dropdown per modifier axis (`mode`, `brand`, and so on) plus a unified Design Tokens panel (hierarchical tree + diagnostics), and ships a `useToken()` hook with typed paths.
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,4 +1,4 @@
-# Blocks
+# swatchbook-blocks
 
 Published as `@unpunnyfuns/swatchbook-blocks`. Storybook MDX doc blocks for DTCG design tokens. React components for rendering token documentation inside `.mdx` pages or regular stories. Self-mount the addon's CSS and react to axis changes from the toolbar; work inside the docs container even though story decorators don't.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,4 +1,4 @@
-# Core
+# swatchbook-core
 
 Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses token files via [Terrazzo](https://terrazzo.app/), resolves aliases, composes themes through a DTCG 2025.10 resolver, and emits CSS variables and TypeScript types.
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,4 +1,4 @@
-# MCP
+# swatchbook-mcp
 
 Published as `@unpunnyfuns/swatchbook-mcp`. Model Context Protocol server for swatchbook — exposes a DTCG project's tokens, axes, and diagnostics to AI agents without running Storybook.
 

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,4 +1,4 @@
-# Tokens
+# swatchbook-tokens
 
 Internal workspace package (`@unpunnyfuns/swatchbook-tokens`). Exhaustive DTCG 2025.10 fixture used as swatchbook's internal test bed and as a reference for consumers structuring their own token projects. Private — not published.
 


### PR DESCRIPTION
## Summary

Every package README was headed with a one-word title (\`# Addon\`, \`# Blocks\`, \`# Core\`, \`# MCP\`, \`# Tokens\`). On npm's package page that renders as a context-free word stripped of project identity — readers landing on the tarball's own page see \"# Addon\" and have to hunt for what it's the addon *of*.

Retitled each to match the published package name so first-line context is restored:

- \`# swatchbook-addon\`
- \`# swatchbook-blocks\`
- \`# swatchbook-core\`
- \`# swatchbook-mcp\`
- \`# swatchbook-tokens\` (internal workspace package, not published, but kept consistent)

Patch changeset against all four published packages — README files are bundled in the tarball, so the title change reaches npm on the next release.

Milestone: Maintenance
Closes: #508
Plan impact: none

### Switcher README follow-up

\`packages/switcher/README.md\` is created by PR #505 (currently open) with the same old pattern (\`# Switcher\`). Pushed a matching fix to that branch so the naming lands consistent if #505 merges after this PR.

## Test plan

- [x] \`pnpm -r format\` — clean.
- [ ] Manual: spot-check how each README renders on npmjs.com after the release — title should now read as \`swatchbook-<name>\` instead of a bare word.