### PR TITLE
docs(tokens): rename brand→typeface, amber a11y primary, Monotype via comic-mono

### DIFF
--- a/.changeset/docs-tokens-typeface-amber-comic-mono.md
+++ b/.changeset/docs-tokens-typeface-amber-comic-mono.md
@@ -1,0 +1,13 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs(tokens): rename `brand` axis to `typeface`, swap a11y primary to amber, route Monotype through a comic-monospace stack
+
+Three coordinated edits on the docs-site fixture that bring the axes' names in line with what they actually do and sharpen the accessibility signal:
+
+- **Axis rename.** `brand` was never a brand axis — it chose between a variable-width and a monospaced typeface. Renamed to `typeface` with contexts `Variable` / `Monotype`; the data-attribute selector becomes `[data-sb-typeface="…"]`. The storybook reference fixture's `brand` axis (an actual brand variation) is unchanged.
+- **A11y primary → amber.** `color.accessible.primary.*` in both mode files now aliases to a new `color.palette.amber.*` ramp instead of `color.palette.brand.*`. a11y=High-contrast gets yellow/burnt-orange links that read as high-visibility accessibility signal rather than brand voice — burnt-orange (amber.800) on white for Light + High-contrast, bright yellow (amber.300) on dark for Dark + High-contrast, both well above AAA contrast.
+- **Monotype = comic-monospace.** New `font.family.comic-mono` fontFamily stack that prefers playful free monospaces (Comic Mono, Fantasque Sans Mono, Comic Shanns Mono) then falls through to Comic Sans MS and the system monospace. The Monotype overlay uses this stack, so toggling typeface=Monotype now reads as slightly-unhinged teletype rather than plain code font.
+
+No bundled font files — readers with Comic Mono / Fantasque Sans Mono installed locally get the playful face, everyone else gets Comic Sans MS or the system monospace fallback.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -15,7 +15,7 @@ Two things in one:
 - **A multi-axis theme switcher.** Flip dark mode, brand, contrast, density — whatever dimensions your design system has — from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown in a single popover. Tokens repaint live as readers flip axes. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape.
 
 :::tip[Try it right here]
-The yinyang icon in the top-right of this page drives the same switcher against this docs site's own DTCG tokens — flip **mode**, **a11y**, or **brand** to see the concept in action on the page you're reading.
+The yinyang icon in the top-right of this page drives the same switcher against this docs site's own DTCG tokens — flip **mode**, **a11y**, or **typeface** to see the concept in action on the page you're reading.
 :::
 
 ## Who it's for

--- a/apps/docs/tokens/color.json
+++ b/apps/docs/tokens/color.json
@@ -25,6 +25,19 @@
         "800": { "$value": { "colorSpace": "srgb", "components": [0.1176, 0.1608, 0.2314] } },
         "900": { "$value": { "colorSpace": "srgb", "components": [0.0588, 0.0902, 0.1647] } },
         "950": { "$value": { "colorSpace": "srgb", "components": [0.0235, 0.0431, 0.0902] } }
+      },
+      "amber": {
+        "$description": "Yellow / orange ramp used by the a11y High-contrast overlay for link + primary tokens. Swaps in place of the brand blues when contrast matters more than brand voice — bright yellow on dark surfaces, deep burnt-orange on light surfaces, both well above AAA contrast ratios.",
+        "50":  { "$value": { "colorSpace": "srgb", "components": [1, 0.9843, 0.9216] } },
+        "100": { "$value": { "colorSpace": "srgb", "components": [0.9961, 0.9529, 0.7804] } },
+        "200": { "$value": { "colorSpace": "srgb", "components": [0.9922, 0.9020, 0.5412] } },
+        "300": { "$value": { "colorSpace": "srgb", "components": [0.9882, 0.8275, 0.3020] } },
+        "400": { "$value": { "colorSpace": "srgb", "components": [0.9843, 0.7490, 0.1412] } },
+        "500": { "$value": { "colorSpace": "srgb", "components": [0.9608, 0.6196, 0.0431] } },
+        "600": { "$value": { "colorSpace": "srgb", "components": [0.8510, 0.4667, 0.0235] } },
+        "700": { "$value": { "colorSpace": "srgb", "components": [0.7059, 0.3255, 0.0353] } },
+        "800": { "$value": { "colorSpace": "srgb", "components": [0.5725, 0.2510, 0.0549] } },
+        "900": { "$value": { "colorSpace": "srgb", "components": [0.4706, 0.2078, 0.0588] } }
       }
     }
   }

--- a/apps/docs/tokens/font.json
+++ b/apps/docs/tokens/font.json
@@ -26,6 +26,22 @@
           "Liberation Mono",
           "monospace"
         ]
+      },
+      "comic-mono": {
+        "$description": "Playful monospace stack for the Monotype typeface overlay — prefers comic-flavoured monospace faces if the reader has them locally installed (Comic Mono, Fantasque Sans Mono, Comic Shanns Mono), then falls through to Comic Sans MS (widely installed on consumer machines), then the same system-monospace fallback as `mono` so rendering never regresses past a plain fixed-pitch face.",
+        "$value": [
+          "Comic Mono",
+          "Fantasque Sans Mono",
+          "Comic Shanns Mono",
+          "Comic Sans MS",
+          "ui-monospace",
+          "SFMono-Regular",
+          "SF Mono",
+          "Menlo",
+          "Consolas",
+          "Liberation Mono",
+          "monospace"
+        ]
       }
     }
   }

--- a/apps/docs/tokens/resolver.json
+++ b/apps/docs/tokens/resolver.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/tr/2025/drafts/resolver/",
   "version": "2025.10",
   "name": "swatchbook-docs",
-  "description": "Docusaurus-site tokens. Mode (Light / Dark) picks surface + text + primary role tokens; a11y layers a comic-font High-contrast overlay on top; brand adds a Monotype variation that swaps the base font to a monospaced stack. All three compose cleanly because the overlays stay in their lanes (mode owns colour, a11y owns comic-font accessibility signal, brand owns font-family variation).",
+  "description": "Docusaurus-site tokens. Mode (Light / Dark) picks surface + text + primary role tokens; a11y layers a High-contrast overlay that bumps colour contrast and swaps link shades to amber for a sharper accessibility signal; typeface adds a Monotype variation that swaps the base font to a comic-monospace stack. All three compose cleanly because the overlays stay in their lanes (mode owns colour, a11y reinforces contrast via amber primary, typeface owns font-family variation).",
   "sets": {
     "tokens": {
       "description": "Palette + font-family primitives.",
@@ -24,18 +24,18 @@
       },
       "default": "Normal"
     },
-    "brand": {
+    "typeface": {
       "contexts": {
-        "Default": [],
+        "Variable": [],
         "Monotype": [{ "$ref": "./themes/monotype.json" }]
       },
-      "default": "Default"
+      "default": "Variable"
     }
   },
   "resolutionOrder": [
     { "$ref": "#/sets/tokens" },
     { "$ref": "#/modifiers/mode" },
     { "$ref": "#/modifiers/a11y" },
-    { "$ref": "#/modifiers/brand" }
+    { "$ref": "#/modifiers/typeface" }
   ]
 }

--- a/apps/docs/tokens/themes/dark.json
+++ b/apps/docs/tokens/themes/dark.json
@@ -26,18 +26,18 @@
       "border": { "$value": "{color.palette.neutral.700}" }
     },
     "accessible": {
-      "$description": "High-contrast alternates for Dark. Lighter neutrals for muted text, lighter brand shades for primary — pushes link/muted-text contrast up against the dark surface ramp. Parallel shape to light's `color.accessible`; the a11y overlay aliases role tokens to this namespace and the active mode's definitions decide the resolved value.",
+      "$description": "High-contrast alternates for Dark. Lighter neutrals for muted text; amber ramp for primary — bright yellow sits high above the dark surface ramp for unmistakable link contrast. Parallel shape to light's `color.accessible`; the a11y overlay aliases role tokens to this namespace and the active mode's definitions decide the resolved value.",
       "text": {
         "muted": { "$value": "{color.palette.neutral.100}" }
       },
       "primary": {
-        "lightest": { "$value": "{color.palette.brand.100}" },
-        "lighter":  { "$value": "{color.palette.brand.200}" },
-        "light":    { "$value": "{color.palette.brand.300}" },
-        "default":  { "$value": "{color.palette.brand.300}" },
-        "dark":     { "$value": "{color.palette.brand.400}" },
-        "darker":   { "$value": "{color.palette.brand.500}" },
-        "darkest":  { "$value": "{color.palette.brand.600}" }
+        "lightest": { "$value": "{color.palette.amber.100}" },
+        "lighter":  { "$value": "{color.palette.amber.200}" },
+        "light":    { "$value": "{color.palette.amber.300}" },
+        "default":  { "$value": "{color.palette.amber.300}" },
+        "dark":     { "$value": "{color.palette.amber.400}" },
+        "darker":   { "$value": "{color.palette.amber.500}" },
+        "darkest":  { "$value": "{color.palette.amber.600}" }
       }
     }
   },

--- a/apps/docs/tokens/themes/light.json
+++ b/apps/docs/tokens/themes/light.json
@@ -26,18 +26,18 @@
       "border": { "$value": "{color.palette.neutral.200}" }
     },
     "accessible": {
-      "$description": "High-contrast alternates for Light. The a11y overlay aliases role tokens to this namespace so it stays mode-agnostic at the file level while the resolved values remain mode-aware. Darker neutrals for text, deeper brand shades for primary — pushes link/muted-text contrast up from AA-borderline to AAA on white surfaces.",
+      "$description": "High-contrast alternates for Light. The a11y overlay aliases role tokens to this namespace so it stays mode-agnostic at the file level while the resolved values remain mode-aware. Darker neutrals for muted text; amber ramp for primary — swaps the brand blue for burnt-orange so links read as high-contrast accessibility signal rather than brand voice.",
       "text": {
         "muted": { "$value": "{color.palette.neutral.700}" }
       },
       "primary": {
-        "lightest": { "$value": "{color.palette.brand.500}" },
-        "lighter":  { "$value": "{color.palette.brand.600}" },
-        "light":    { "$value": "{color.palette.brand.700}" },
-        "default":  { "$value": "{color.palette.brand.800}" },
-        "dark":     { "$value": "{color.palette.brand.900}" },
-        "darker":   { "$value": "{color.palette.brand.900}" },
-        "darkest":  { "$value": "{color.palette.brand.900}" }
+        "lightest": { "$value": "{color.palette.amber.500}" },
+        "lighter":  { "$value": "{color.palette.amber.600}" },
+        "light":    { "$value": "{color.palette.amber.700}" },
+        "default":  { "$value": "{color.palette.amber.800}" },
+        "dark":     { "$value": "{color.palette.amber.900}" },
+        "darker":   { "$value": "{color.palette.amber.900}" },
+        "darkest":  { "$value": "{color.palette.amber.900}" }
       }
     }
   },

--- a/apps/docs/tokens/themes/monotype.json
+++ b/apps/docs/tokens/themes/monotype.json
@@ -1,9 +1,9 @@
 {
-  "$description": "Brand `Monotype` overlay — swaps the base font family to a monospaced stack so the whole docs site reads as code. Pure typography variation; leaves colour roles alone so it composes cleanly with mode + a11y.",
+  "$description": "`typeface = Monotype` overlay — swaps the base font family to the comic-monospace stack so the whole docs site reads as slightly-unhinged teletype. Pure typography variation; leaves colour roles alone so it composes cleanly with mode + a11y.",
   "font": {
     "family": {
       "$type": "fontFamily",
-      "base": { "$value": "{font.family.mono}" }
+      "base": { "$value": "{font.family.comic-mono}" }
     }
   }
 }


### PR DESCRIPTION
## Summary

Three coordinated edits on \`apps/docs/tokens/\`:

1. **Axis rename — \`brand\` → \`typeface\`.** The modifier never actually picked a brand; its two contexts are a variable-width typeface and a monospace typeface. Renamed to \`typeface\` with contexts \`Variable\` / \`Monotype\` so the name matches what it does. Emitted selector: \`[data-sb-typeface=\"…\"]\`. Storybook reference fixture (which does have a real brand axis) is unaffected.

2. **A11y primary ramp → amber.** New \`color.palette.amber.*\` (50–900) palette; \`color.accessible.primary.*\` in both mode files now aliases to amber shades instead of brand blues. Resolved outcomes:
   - Light + High-contrast: \`primary.default\` = amber.800 (burnt-orange, ~9:1 on white)
   - Dark + High-contrast: \`primary.default\` = amber.300 (bright yellow, ~11:1 on neutral.900)
   - Reads as accessibility signal (traffic-sign yellow/amber), not brand voice.

3. **Monotype = comic-monospace.** New \`font.family.comic-mono\` stack: Comic Mono → Fantasque Sans Mono → Comic Shanns Mono → Comic Sans MS → system monospace. Monotype overlay points at it. No bundled font files — readers with the comic faces installed locally get the playful face, everyone else falls through to Comic Sans MS or system monospace.

Intro's docs-site-axes callout updated from \"mode, a11y, or brand\" to \"mode, a11y, or typeface\" to match.

Milestone: Maintenance
Closes: #513
Plan impact: none

## Spot-checks (verified end-to-end in the generated CSS)

- ✅ \`[data-sb-typeface=\"…\"]\` appears 7 times, \`data-sb-brand\` is gone.
- ✅ Light + High-contrast \`--sb-color-primary-default\` chains to \`amber.800\`.
- ✅ Dark + High-contrast \`--sb-color-primary-default\` chains to \`amber.300\`.
- ✅ Monotype's \`--sb-font-family-base\` chains to \`font.family.comic-mono\` (the new stack).

## Follow-ups (out of scope)

- Bundling Comic Mono or Fantasque Sans Mono as a local webfont is a separate decision — current PR ships no font files, relies on reader-local installs.
- Berkeley Mono was floated but requires an Open Source Project license we don't currently hold, so it's not in scope.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [x] Spot-checked generated CSS for each of the three changes.
- [ ] Manual: \`pnpm dev\` the docs site, cycle typeface between Variable / Monotype, toggle a11y=High-contrast on Light and Dark, eyeball the colours.