### PR TITLE
docs: soften the intro's 'What it's not' paragraph

### DIFF
--- a/.changeset/docs-soften-intro-whats-not.md
+++ b/.changeset/docs-soften-intro-whats-not.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs: soften the intro's "What it's not" paragraph
+
+Dropped the "— that's a documentation affordance, not a production theming API." aside, which restated the scope twice and read as pushing readers away. Tweaked the production-theming redirect to frame `emitCss` as the same-shape output available to consumer apps, rather than a consolation path.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -26,7 +26,7 @@ If your system has exactly one dimension and no plans for more, [`@storybook/add
 
 ## What it's not
 
-Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable framework, or a component styling system. It emits CSS variables and `data-<prefix>-*` attributes on `<html>` inside the Storybook preview so tokens repaint when an author toggles an axis — that's a documentation affordance, not a production theming API. For production theme switching, use your framework's theming tools (or call `@unpunnyfuns/swatchbook-core`'s `emitCss` at build time and wire it up yourself). For how your stories react to toolbar flips, see [theme reactivity](./concepts/theme-reactivity).
+Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable framework, or a component styling system. It emits CSS variables and `data-<prefix>-*` attributes on `<html>` inside the Storybook preview so tokens repaint when an author toggles an axis. For production theme switching, use your framework's theming tools or call `@unpunnyfuns/swatchbook-core`'s `emitCss` at build time and wire it up yourself — the emitted CSS is the same shape either way. For how your stories react to toolbar flips, see [theme reactivity](./concepts/theme-reactivity).
 
 ## What the addon gives you
 


### PR DESCRIPTION
## Summary

One-sentence edit in \`apps/docs/docs/intro.mdx\`. Dropped the aside that restated the opening-sentence scope and read as pushing readers away:

> It emits CSS variables and \`data-<prefix>-*\` attributes on \`<html>\` inside the Storybook preview so tokens repaint when an author toggles an axis ~~— that's a documentation affordance, not a production theming API~~.

Also lightly reframed the production-theming redirect — instead of \"use your framework's tools for production,\" it's now \"use your framework's tools *or* \`emitCss\` from core; the emitted CSS is the same shape either way.\" Reads as a handshake rather than a wall.

Patch changeset on \`@unpunnyfuns/swatchbook-blocks\` so the docs snapshot rebuilds on the next release.

Milestone: Maintenance
Closes: #515
Plan impact: none

## Before / after

**Before:**
> Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable framework, or a component styling system. It emits CSS variables and \`data-<prefix>-*\` attributes on \`<html>\` inside the Storybook preview so tokens repaint when an author toggles an axis — that's a documentation affordance, not a production theming API. For production theme switching, use your framework's theming tools (or call \`@unpunnyfuns/swatchbook-core\`'s \`emitCss\` at build time and wire it up yourself).

**After:**
> Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable framework, or a component styling system. It emits CSS variables and \`data-<prefix>-*\` attributes on \`<html>\` inside the Storybook preview so tokens repaint when an author toggles an axis. For production theme switching, use your framework's theming tools or call \`@unpunnyfuns/swatchbook-core\`'s \`emitCss\` at build time and wire it up yourself — the emitted CSS is the same shape either way.

## Test plan

- [x] \`pnpm -r format\` — clean.
- [ ] Manual: eyeball the rendered intro page after merge.