### PR TITLE
docs(tokens): separate a11y from typeface in the docs-site fixture

### DIFF
--- a/.changeset/docs-tokens-separate-a11y-from-typeface.md
+++ b/.changeset/docs-tokens-separate-a11y-from-typeface.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs(tokens): separate a11y from typeface in the docs-site fixture
+
+`high-contrast.json` used to also swap the base font family to `{font.family.comic}` — a leftover from when a11y carried a typography signal on top of its contrast role. Now that the `typeface` axis owns font-family independently (Variable vs Monotype), having a11y also touch it meant `typeface=Variable + a11y=High-contrast` reshuffled the font regardless of the reader's typeface pick.
+
+Drops the `font.family` block from the a11y overlay. a11y now owns **contrast only** — amber primary ramp via alias indirection, neutral shifts for muted text, plus the 108% base-size bump kept as a readability signal. Font family is entirely the typeface axis's domain: Variable ⇒ system, Monotype ⇒ comic-mono, regardless of a11y.

--- a/.changeset/docs-tokens-typeface-amber-comic-mono.md
+++ b/.changeset/docs-tokens-typeface-amber-comic-mono.md
@@ -1,0 +1,13 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs(tokens): rename `brand` axis to `typeface`, swap a11y primary to amber, route Monotype through a comic-monospace stack
+
+Three coordinated edits on the docs-site fixture that bring the axes' names in line with what they actually do and sharpen the accessibility signal:
+
+- **Axis rename.** `brand` was never a brand axis — it chose between a variable-width and a monospaced typeface. Renamed to `typeface` with contexts `Variable` / `Monotype`; the data-attribute selector becomes `[data-sb-typeface="…"]`. The storybook reference fixture's `brand` axis (an actual brand variation) is unchanged.
+- **A11y primary → amber.** `color.accessible.primary.*` in both mode files now aliases to a new `color.palette.amber.*` ramp instead of `color.palette.brand.*`. a11y=High-contrast gets yellow/burnt-orange links that read as high-visibility accessibility signal rather than brand voice — burnt-orange (amber.800) on white for Light + High-contrast, bright yellow (amber.300) on dark for Dark + High-contrast, both well above AAA contrast.
+- **Monotype = comic-monospace.** New `font.family.comic-mono` fontFamily stack that prefers playful free monospaces (Comic Mono, Fantasque Sans Mono, Comic Shanns Mono) then falls through to Comic Sans MS and the system monospace. The Monotype overlay uses this stack, so toggling typeface=Monotype now reads as slightly-unhinged teletype rather than plain code font.
+
+No bundled font files — readers with Comic Mono / Fantasque Sans Mono installed locally get the playful face, everyone else gets Comic Sans MS or the system monospace fallback.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -15,7 +15,7 @@ Two things in one:
 - **A multi-axis theme switcher.** Flip dark mode, brand, contrast, density — whatever dimensions your design system has — from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown in a single popover. Tokens repaint live as readers flip axes. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape.
 
 :::tip[Try it right here]
-The yinyang icon in the top-right of this page drives the same switcher against this docs site's own DTCG tokens — flip **mode**, **a11y**, or **brand** to see the concept in action on the page you're reading.
+The yinyang icon in the top-right of this page drives the same switcher against this docs site's own DTCG tokens — flip **mode**, **a11y**, or **typeface** to see the concept in action on the page you're reading.
 :::
 
 ## Who it's for

--- a/apps/docs/tokens/color.json
+++ b/apps/docs/tokens/color.json
@@ -25,6 +25,19 @@
         "800": { "$value": { "colorSpace": "srgb", "components": [0.1176, 0.1608, 0.2314] } },
         "900": { "$value": { "colorSpace": "srgb", "components": [0.0588, 0.0902, 0.1647] } },
         "950": { "$value": { "colorSpace": "srgb", "components": [0.0235, 0.0431, 0.0902] } }
+      },
+      "amber": {
+        "$description": "Yellow / orange ramp used by the a11y High-contrast overlay for link + primary tokens. Swaps in place of the brand blues when contrast matters more than brand voice — bright yellow on dark surfaces, deep burnt-orange on light surfaces, both well above AAA contrast ratios.",
+        "50":  { "$value": { "colorSpace": "srgb", "components": [1, 0.9843, 0.9216] } },
+        "100": { "$value": { "colorSpace": "srgb", "components": [0.9961, 0.9529, 0.7804] } },
+        "200": { "$value": { "colorSpace": "srgb", "components": [0.9922, 0.9020, 0.5412] } },
+        "300": { "$value": { "colorSpace": "srgb", "components": [0.9882, 0.8275, 0.3020] } },
+        "400": { "$value": { "colorSpace": "srgb", "components": [0.9843, 0.7490, 0.1412] } },
+        "500": { "$value": { "colorSpace": "srgb", "components": [0.9608, 0.6196, 0.0431] } },
+        "600": { "$value": { "colorSpace": "srgb", "components": [0.8510, 0.4667, 0.0235] } },
+        "700": { "$value": { "colorSpace": "srgb", "components": [0.7059, 0.3255, 0.0353] } },
+        "800": { "$value": { "colorSpace": "srgb", "components": [0.5725, 0.2510, 0.0549] } },
+        "900": { "$value": { "colorSpace": "srgb", "components": [0.4706, 0.2078, 0.0588] } }
       }
     }
   }

--- a/apps/docs/tokens/font.json
+++ b/apps/docs/tokens/font.json
@@ -26,6 +26,22 @@
           "Liberation Mono",
           "monospace"
         ]
+      },
+      "comic-mono": {
+        "$description": "Playful monospace stack for the Monotype typeface overlay — prefers comic-flavoured monospace faces if the reader has them locally installed (Comic Mono, Fantasque Sans Mono, Comic Shanns Mono), then falls through to Comic Sans MS (widely installed on consumer machines), then the same system-monospace fallback as `mono` so rendering never regresses past a plain fixed-pitch face.",
+        "$value": [
+          "Comic Mono",
+          "Fantasque Sans Mono",
+          "Comic Shanns Mono",
+          "Comic Sans MS",
+          "ui-monospace",
+          "SFMono-Regular",
+          "SF Mono",
+          "Menlo",
+          "Consolas",
+          "Liberation Mono",
+          "monospace"
+        ]
       }
     }
   }

--- a/apps/docs/tokens/resolver.json
+++ b/apps/docs/tokens/resolver.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/tr/2025/drafts/resolver/",
   "version": "2025.10",
   "name": "swatchbook-docs",
-  "description": "Docusaurus-site tokens. Mode (Light / Dark) picks surface + text + primary role tokens; a11y layers a comic-font High-contrast overlay on top; brand adds a Monotype variation that swaps the base font to a monospaced stack. All three compose cleanly because the overlays stay in their lanes (mode owns colour, a11y owns comic-font accessibility signal, brand owns font-family variation).",
+  "description": "Docusaurus-site tokens. Mode (Light / Dark) picks surface + text + primary role tokens; a11y layers a High-contrast overlay that bumps colour contrast and swaps link shades to amber for a sharper accessibility signal; typeface adds a Monotype variation that swaps the base font to a comic-monospace stack. All three compose cleanly because the overlays stay in their lanes (mode owns colour, a11y reinforces contrast via amber primary, typeface owns font-family variation).",
   "sets": {
     "tokens": {
       "description": "Palette + font-family primitives.",
@@ -24,18 +24,18 @@
       },
       "default": "Normal"
     },
-    "brand": {
+    "typeface": {
       "contexts": {
-        "Default": [],
+        "Variable": [],
         "Monotype": [{ "$ref": "./themes/monotype.json" }]
       },
-      "default": "Default"
+      "default": "Variable"
     }
   },
   "resolutionOrder": [
     { "$ref": "#/sets/tokens" },
     { "$ref": "#/modifiers/mode" },
     { "$ref": "#/modifiers/a11y" },
-    { "$ref": "#/modifiers/brand" }
+    { "$ref": "#/modifiers/typeface" }
   ]
 }

--- a/apps/docs/tokens/themes/dark.json
+++ b/apps/docs/tokens/themes/dark.json
@@ -26,18 +26,18 @@
       "border": { "$value": "{color.palette.neutral.700}" }
     },
     "accessible": {
-      "$description": "High-contrast alternates for Dark. Lighter neutrals for muted text, lighter brand shades for primary — pushes link/muted-text contrast up against the dark surface ramp. Parallel shape to light's `color.accessible`; the a11y overlay aliases role tokens to this namespace and the active mode's definitions decide the resolved value.",
+      "$description": "High-contrast alternates for Dark. Lighter neutrals for muted text; amber ramp for primary — bright yellow sits high above the dark surface ramp for unmistakable link contrast. Parallel shape to light's `color.accessible`; the a11y overlay aliases role tokens to this namespace and the active mode's definitions decide the resolved value.",
       "text": {
         "muted": { "$value": "{color.palette.neutral.100}" }
       },
       "primary": {
-        "lightest": { "$value": "{color.palette.brand.100}" },
-        "lighter":  { "$value": "{color.palette.brand.200}" },
-        "light":    { "$value": "{color.palette.brand.300}" },
-        "default":  { "$value": "{color.palette.brand.300}" },
-        "dark":     { "$value": "{color.palette.brand.400}" },
-        "darker":   { "$value": "{color.palette.brand.500}" },
-        "darkest":  { "$value": "{color.palette.brand.600}" }
+        "lightest": { "$value": "{color.palette.amber.100}" },
+        "lighter":  { "$value": "{color.palette.amber.200}" },
+        "light":    { "$value": "{color.palette.amber.300}" },
+        "default":  { "$value": "{color.palette.amber.300}" },
+        "dark":     { "$value": "{color.palette.amber.400}" },
+        "darker":   { "$value": "{color.palette.amber.500}" },
+        "darkest":  { "$value": "{color.palette.amber.600}" }
       }
     }
   },

--- a/apps/docs/tokens/themes/high-contrast.json
+++ b/apps/docs/tokens/themes/high-contrast.json
@@ -1,5 +1,5 @@
 {
-  "$description": "High-contrast a11y overlay. Typography signal — swaps the base font family for a comic display face and bumps base size — plus colour boosts via alias indirection: role tokens re-route through each mode's `color.accessible.*` namespace so the resolved values stay mode-aware (darker on Light, brighter on Dark) without this file having to branch per mode.",
+  "$description": "High-contrast a11y overlay. Owns contrast only — no typography changes beyond a small base-size bump for readability. Colour boosts use alias indirection: role tokens re-route through each mode's `color.accessible.*` namespace so the resolved values stay mode-aware (darker amber on Light, bright amber on Dark) without this file having to branch per mode. Typeface (Variable vs Monotype) is a separate axis.",
   "color": {
     "$type": "color",
     "text": {
@@ -16,10 +16,6 @@
     }
   },
   "font": {
-    "family": {
-      "$type": "fontFamily",
-      "base": { "$value": "{font.family.comic}" }
-    },
     "size": {
       "$type": "dimension",
       "base": { "$value": { "value": 108, "unit": "%" } }

--- a/apps/docs/tokens/themes/light.json
+++ b/apps/docs/tokens/themes/light.json
@@ -26,18 +26,18 @@
       "border": { "$value": "{color.palette.neutral.200}" }
     },
     "accessible": {
-      "$description": "High-contrast alternates for Light. The a11y overlay aliases role tokens to this namespace so it stays mode-agnostic at the file level while the resolved values remain mode-aware. Darker neutrals for text, deeper brand shades for primary — pushes link/muted-text contrast up from AA-borderline to AAA on white surfaces.",
+      "$description": "High-contrast alternates for Light. The a11y overlay aliases role tokens to this namespace so it stays mode-agnostic at the file level while the resolved values remain mode-aware. Darker neutrals for muted text; amber ramp for primary — swaps the brand blue for burnt-orange so links read as high-contrast accessibility signal rather than brand voice.",
       "text": {
         "muted": { "$value": "{color.palette.neutral.700}" }
       },
       "primary": {
-        "lightest": { "$value": "{color.palette.brand.500}" },
-        "lighter":  { "$value": "{color.palette.brand.600}" },
-        "light":    { "$value": "{color.palette.brand.700}" },
-        "default":  { "$value": "{color.palette.brand.800}" },
-        "dark":     { "$value": "{color.palette.brand.900}" },
-        "darker":   { "$value": "{color.palette.brand.900}" },
-        "darkest":  { "$value": "{color.palette.brand.900}" }
+        "lightest": { "$value": "{color.palette.amber.500}" },
+        "lighter":  { "$value": "{color.palette.amber.600}" },
+        "light":    { "$value": "{color.palette.amber.700}" },
+        "default":  { "$value": "{color.palette.amber.800}" },
+        "dark":     { "$value": "{color.palette.amber.900}" },
+        "darker":   { "$value": "{color.palette.amber.900}" },
+        "darkest":  { "$value": "{color.palette.amber.900}" }
       }
     }
   },

--- a/apps/docs/tokens/themes/monotype.json
+++ b/apps/docs/tokens/themes/monotype.json
@@ -1,9 +1,9 @@
 {
-  "$description": "Brand `Monotype` overlay — swaps the base font family to a monospaced stack so the whole docs site reads as code. Pure typography variation; leaves colour roles alone so it composes cleanly with mode + a11y.",
+  "$description": "`typeface = Monotype` overlay — swaps the base font family to the comic-monospace stack so the whole docs site reads as slightly-unhinged teletype. Pure typography variation; leaves colour roles alone so it composes cleanly with mode + a11y.",
   "font": {
     "family": {
       "$type": "fontFamily",
-      "base": { "$value": "{font.family.mono}" }
+      "base": { "$value": "{font.family.comic-mono}" }
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #514. Stacks on top of it — once #514 merges, this PR's diff collapses to just the one-file change.

### The gotcha

After the \`brand\` → \`typeface\` rename in #514, the a11y overlay still carried leftover typography: \`high-contrast.json\` sets \`font.family.base = {font.family.comic}\`. That was fine when a11y was the only modifier touching fonts, but now the typeface axis owns font-family too. Result: \`typeface=Variable + a11y=High-contrast\` silently reshuffled the font to comic regardless of the reader's typeface pick, because a11y runs after typeface in \`resolutionOrder\` and the last overlay wins.

### The fix

Drop the \`font.family\` block from \`high-contrast.json\`. a11y now owns **contrast only** — amber primary via alias indirection, neutral shifts, plus the 108% size bump kept as a readability signal. typeface is the sole lever for font-family: Variable ⇒ system, Monotype ⇒ comic-mono, regardless of a11y.

### Verified end-to-end

In the generated CSS:
- \`[data-theme=\"light\"][data-sb-a11y=\"High-contrast\"][data-sb-typeface=\"Variable\"]\` → \`--sb-font-family-base\` chains to **system** (a11y no longer overrides).
- \`[data-theme=\"light\"][data-sb-a11y=\"High-contrast\"][data-sb-typeface=\"Monotype\"]\` → \`--sb-font-family-base\` chains to **comic-mono** (typeface overlay still applies).
- Both keep \`--sb-font-size-base: 108%\` from the a11y overlay.

Milestone: Maintenance
Closes: #518
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [x] Spot-checked the generated CSS for both Variable+HC and Monotype+HC blocks.
- [ ] Manual: \`pnpm dev\` the docs site, cycle typeface × a11y combinations, confirm font only changes with typeface.