### PR TITLE
docs(tokens): a11y=High-contrast escalates base font through each typeface's accessibility slot

### DIFF
--- a/.changeset/docs-tokens-typeface-aware-a11y-escalation.md
+++ b/.changeset/docs-tokens-typeface-aware-a11y-escalation.md
@@ -1,0 +1,22 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs(tokens): a11y=High-contrast escalates base font through each typeface's accessibility slot
+
+Partial re-introduction of typography into a11y=High-contrast — but typeface-aware this time, so the axes stay conceptually separate in their overlay files while composing into different outcomes per tuple.
+
+Shape:
+
+- Every typeface context declares `font.family.base-accessible` alongside `font.family.base`. Mode-level Variable default: `base = system`, `base-accessible = comic`. Monotype overlay: `base = mono`, `base-accessible = comic-mono`.
+- `high-contrast.json` aliases `font.family.base = {font.family.base-accessible}` — doesn't mention any typeface name; resolves through whichever typeface slot is active.
+- `resolutionOrder` flipped to `[tokens, mode, typeface, a11y]` so a11y gets the last word after typeface has declared its accessibility slot.
+
+Outcomes per tuple:
+
+- typeface=Variable + a11y=Normal → system
+- typeface=Variable + a11y=High-contrast → Comic Sans (variable-width comic signal)
+- typeface=Monotype + a11y=Normal → monospace
+- typeface=Monotype + a11y=High-contrast → Comic Mono (comic-monospace signal)
+
+Same alias-indirection pattern as `color.accessible.primary.*` — just applied to font-family now.

--- a/apps/docs/tokens/font.json
+++ b/apps/docs/tokens/font.json
@@ -13,9 +13,6 @@
           "sans-serif"
         ]
       },
-      "comic": {
-        "$value": ["Comic Sans MS", "Comic Neue", "Chalkboard SE", "Marker Felt", "cursive"]
-      },
       "mono": {
         "$value": [
           "ui-monospace",
@@ -27,8 +24,12 @@
           "monospace"
         ]
       },
+      "comic": {
+        "$description": "Variable-width comic stack, used as the a11y=High-contrast escalation for typeface=Variable.",
+        "$value": ["Comic Sans MS", "Comic Neue", "Chalkboard SE", "Marker Felt", "cursive"]
+      },
       "comic-mono": {
-        "$description": "Playful monospace stack for the Monotype typeface overlay — prefers comic-flavoured monospace faces if the reader has them locally installed (Comic Mono, Fantasque Sans Mono, Comic Shanns Mono), then falls through to Comic Sans MS (widely installed on consumer machines), then the same system-monospace fallback as `mono` so rendering never regresses past a plain fixed-pitch face.",
+        "$description": "Comic-flavoured monospace stack, used as the a11y=High-contrast escalation for typeface=Monotype — prefers Comic Mono / Fantasque Sans Mono / Comic Shanns Mono if installed locally, falls through to Comic Sans MS and the system monospace so rendering never regresses past a plain fixed-pitch face.",
         "$value": [
           "Comic Mono",
           "Fantasque Sans Mono",

--- a/apps/docs/tokens/resolver.json
+++ b/apps/docs/tokens/resolver.json
@@ -2,7 +2,7 @@
   "$schema": "https://design-tokens.org/tr/2025/drafts/resolver/",
   "version": "2025.10",
   "name": "swatchbook-docs",
-  "description": "Docusaurus-site tokens. Mode (Light / Dark) picks surface + text + primary role tokens; a11y layers a High-contrast overlay that bumps colour contrast and swaps link shades to amber for a sharper accessibility signal; typeface adds a Monotype variation that swaps the base font to a comic-monospace stack. All three compose cleanly because the overlays stay in their lanes (mode owns colour, a11y reinforces contrast via amber primary, typeface owns font-family variation).",
+  "description": "Docusaurus-site tokens. Mode (Light / Dark) picks surface + text + primary role tokens; typeface picks the font-family baseline (Variable ⇒ system, Monotype ⇒ monospace) and declares each typeface's accessibility escalation slot (`font.family.base-accessible`); a11y=High-contrast bumps colour contrast via alias-indirected amber primary shades, bumps base size 8%, and escalates the base font through `font.family.base-accessible` so each typeface flips into its comic variant (Variable ⇒ Comic Sans; Monotype ⇒ Comic Mono). Resolution order is mode → typeface → a11y so a11y gets the last word on every token it needs to influence.",
   "sets": {
     "tokens": {
       "description": "Palette + font-family primitives.",
@@ -35,7 +35,7 @@
   "resolutionOrder": [
     { "$ref": "#/sets/tokens" },
     { "$ref": "#/modifiers/mode" },
-    { "$ref": "#/modifiers/a11y" },
-    { "$ref": "#/modifiers/typeface" }
+    { "$ref": "#/modifiers/typeface" },
+    { "$ref": "#/modifiers/a11y" }
   ]
 }

--- a/apps/docs/tokens/themes/dark.json
+++ b/apps/docs/tokens/themes/dark.json
@@ -44,7 +44,8 @@
   "font": {
     "family": {
       "$type": "fontFamily",
-      "base": { "$value": "{font.family.system}" }
+      "base":            { "$value": "{font.family.system}" },
+      "base-accessible": { "$value": "{font.family.comic}" }
     },
     "size": {
       "$type": "dimension",

--- a/apps/docs/tokens/themes/high-contrast.json
+++ b/apps/docs/tokens/themes/high-contrast.json
@@ -1,5 +1,5 @@
 {
-  "$description": "High-contrast a11y overlay. Owns contrast only — no typography changes beyond a small base-size bump for readability. Colour boosts use alias indirection: role tokens re-route through each mode's `color.accessible.*` namespace so the resolved values stay mode-aware (darker amber on Light, bright amber on Dark) without this file having to branch per mode. Typeface (Variable vs Monotype) is a separate axis.",
+  "$description": "High-contrast a11y overlay. Colour boosts re-route role tokens through each mode's `color.accessible.*` namespace (amber primary; darker neutrals for muted text). Font-family boosts re-route the base font through `font.family.base-accessible`, which each typeface declares — Variable ⇒ comic, Monotype ⇒ comic-mono — so escalation stays typeface-aware without this file branching. Plus a 108% base-size bump as a readability signal.",
   "color": {
     "$type": "color",
     "text": {
@@ -16,6 +16,10 @@
     }
   },
   "font": {
+    "family": {
+      "$type": "fontFamily",
+      "base": { "$value": "{font.family.base-accessible}" }
+    },
     "size": {
       "$type": "dimension",
       "base": { "$value": { "value": 108, "unit": "%" } }

--- a/apps/docs/tokens/themes/light.json
+++ b/apps/docs/tokens/themes/light.json
@@ -44,7 +44,8 @@
   "font": {
     "family": {
       "$type": "fontFamily",
-      "base": { "$value": "{font.family.system}" }
+      "base":            { "$value": "{font.family.system}" },
+      "base-accessible": { "$value": "{font.family.comic}" }
     },
     "size": {
       "$type": "dimension",

--- a/apps/docs/tokens/themes/monotype.json
+++ b/apps/docs/tokens/themes/monotype.json
@@ -1,9 +1,10 @@
 {
-  "$description": "`typeface = Monotype` overlay — swaps the base font family to the comic-monospace stack so the whole docs site reads as slightly-unhinged teletype. Pure typography variation; leaves colour roles alone so it composes cleanly with mode + a11y.",
+  "$description": "`typeface = Monotype` overlay. Sets the base font to the plain monospace stack for a11y=Normal, and declares `font.family.base-accessible` = comic-monospace as the escalation slot the a11y=High-contrast overlay re-routes to. The active-mode's light.json / dark.json sets the Variable-context defaults for the same two slots (system + comic), so toggling a11y=High-contrast flips each typeface into its playful-accessibility variant without this file branching per a11y context.",
   "font": {
     "family": {
       "$type": "fontFamily",
-      "base": { "$value": "{font.family.comic-mono}" }
+      "base":            { "$value": "{font.family.mono}" },
+      "base-accessible": { "$value": "{font.family.comic-mono}" }
     }
   }
 }


### PR DESCRIPTION
## Summary

Revisit of #519's clean separation. The "a11y shifts typography too" signal is worth keeping as accessibility reinforcement — but it has to be typeface-aware so a Monotype reader doesn't silently lose their typeface when they toggle a11y=HC.

### Design — alias indirection (same pattern as \`color.accessible.primary.*\`)

1. **Every typeface context declares a paired \`base-accessible\` slot** alongside \`base\`.
   - Mode-level Variable default (light.json / dark.json): \`base = system\`, \`base-accessible = comic\`
   - Monotype overlay: \`base = mono\`, \`base-accessible = comic-mono\`
2. **\`high-contrast.json\` aliases \`font.family.base = {font.family.base-accessible}\`** — no typeface names in the overlay file; resolves through whichever slot is active.
3. **\`resolutionOrder\` flipped to \`[tokens, mode, typeface, a11y]\`** so a11y runs after typeface and can pick up each typeface's accessibility declaration.

### Outcomes per tuple

| typeface | a11y | base font |
| --- | --- | --- |
| Variable | Normal | \`system\` (via \`:root\`) |
| Variable | High-contrast | **\`comic\`** (Comic Sans stack) |
| Monotype | Normal | \`mono\` |
| Monotype | High-contrast | **\`comic-mono\`** (Comic Mono stack) |

All four verified end-to-end in the generated CSS.

### Keeps

- a11y still owns colour contrast (amber primary via \`color.accessible.*\`).
- a11y keeps the 108% base-size bump.
- Typeface overlay file doesn't reference a11y at all; a11y overlay file doesn't reference any typeface. Each axis stays conceptually clean in its own overlay — composition happens via the alias slot.

Milestone: Maintenance
Closes: #521
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [x] Spot-checked all four tuples on Light (Dark parallels) — each resolves \`--sb-font-family-base\` to the expected chain.
- [ ] Manual: \`pnpm dev\` the docs site, cycle typeface × a11y, confirm the four combinations render as tabled.