### PR TITLE
docs(tokens): switcher axis order — swap modifiers to match resolutionOrder

### DIFF
--- a/.changeset/docs-modifiers-order-match-resolution.md
+++ b/.changeset/docs-modifiers-order-match-resolution.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs(tokens): match the switcher's axis order to the resolution order
+
+`resolutionOrder` controls which overlay wins when two touch the same token; the `modifiers` object's key order controls how the switcher UI enumerates the axes. The previous PR swapped resolutionOrder to `mode → typeface → a11y` but left modifiers in the old `mode → a11y → typeface` shape, so the switcher still rendered a11y before typeface.
+
+Swapping modifiers to match. Switcher now shows **mode → typeface → a11y**, which matches the conceptual flow: pick your base font, then opt in to the accessibility overlay on top.

--- a/apps/docs/tokens/resolver.json
+++ b/apps/docs/tokens/resolver.json
@@ -17,19 +17,19 @@
       },
       "default": "Light"
     },
-    "a11y": {
-      "contexts": {
-        "Normal": [],
-        "High-contrast": [{ "$ref": "./themes/high-contrast.json" }]
-      },
-      "default": "Normal"
-    },
     "typeface": {
       "contexts": {
         "Variable": [],
         "Monotype": [{ "$ref": "./themes/monotype.json" }]
       },
       "default": "Variable"
+    },
+    "a11y": {
+      "contexts": {
+        "Normal": [],
+        "High-contrast": [{ "$ref": "./themes/high-contrast.json" }]
+      },
+      "default": "Normal"
     }
   },
   "resolutionOrder": [


### PR DESCRIPTION
## Summary

Follow-up to #522. I swapped \`resolutionOrder\` to \`[tokens, mode, typeface, a11y]\` for layering semantics, but the switcher UI and the virtual module's axis enumeration read from the \`modifiers\` object's key order — which I left untouched. Net result: tokens resolved correctly but the switcher still rendered the dropdowns as \`mode → a11y → typeface\`.

Swap the two modifier keys so the switcher surfaces \`mode → typeface → a11y\`, matching the layering order and the conceptual flow (pick your baseline font, then opt into the accessibility overlay on top).

Verified via the built snapshot — \`axes[]\` comes out as \`[mode, typeface, a11y]\` now.

Milestone: Maintenance
Closes: #524
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [x] \`jq .axes[].name apps/docs/src/tokens.snapshot.json\` returns \`mode\`, \`typeface\`, \`a11y\` in order.
- [ ] Manual: \`pnpm dev\` the docs site, open the switcher, confirm dropdowns render mode first, then typeface, then a11y.