### PR TITLE
docs: rewrite intro's "What the addon gives you" as prose under subheads

### DIFF
--- a/.changeset/docs-intro-whats-addon-gives-prose.md
+++ b/.changeset/docs-intro-whats-addon-gives-prose.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs: rewrite the intro's "What the addon gives you" section as prose under subheadings
+
+Replaces the five **bold** — em-dash — sentence bullets with short subheaded paragraphs (Installation, No external compile step, Doc blocks, Toolbar, `useToken` hook). Also strips the editorial scaffolding — phrases like "Day-to-day authoring", "ready-made starting point", "without per-page wiring", "so typos surface at compile time rather than runtime" — that read as sales framing rather than description. The subsections now state what each feature is and where to read more, without pitching.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -30,11 +30,25 @@ Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable fr
 
 ## What the addon gives you
 
-- **No external compile step** — tokens reach the blocks through a Vite virtual module the addon publishes, not a prebuild script. No generated CSS files to check in, no config drift. Edit a token and the preview repaints. DTCG parsing is powered by [Terrazzo](https://terrazzo.app/) under the hood; see [the token pipeline](./concepts/token-pipeline) for the full mechanism.
-- **One install, full surface** — `@unpunnyfuns/swatchbook-addon` pulls in the toolbar, preview decorator, MDX doc blocks, `ThemeSwitcher`, `useToken()`, and the supporting core / blocks / switcher packages transitively. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` works from any consumer file. Sub-packages stay independently installable for slice-only consumers (e.g. a Docusaurus site rendering just the switcher).
-- **Doc blocks** — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, `Diagnostics`, motion/shadow/border previews. Once the addon is wired up, *authoring pages with these blocks is the primary day-to-day swatchbook interaction*. See the [blocks reference](./reference/blocks), the [authoring guide](./guides/authoring-doc-stories), and the [token-dashboard template](./guides/token-dashboard) for a turnkey browsable tree + diagnostics + table composition.
-- **Toolbar** — a single Swatchbook icon button opens a popover with preset pills, one dropdown per modifier axis (so a reader can browse tokens in every context), and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`) that controls how blocks display colors.
-- **`useToken` hook** — typed lookups from component code, reactive to the active theme.
+### Installation
+
+`@unpunnyfuns/swatchbook-addon` is the top-level entry point. Registering it in `.storybook/main.ts` brings in the toolbar, preview decorator, MDX blocks, `ThemeSwitcher`, and `useToken()`, along with `swatchbook-core`, `swatchbook-blocks`, and `swatchbook-switcher` as transitive dependencies. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` resolves from any consumer file. The sub-packages remain independently installable for slice use — a Docusaurus site that only needs the switcher, or a build script that wants `swatchbook-core`'s loader without any React.
+
+### No external compile step
+
+Tokens reach the Storybook preview through a Vite virtual module the addon publishes on demand. Nothing is written to disk, no prebuild step runs, and edits to token files flow through Vite's HMR. Parsing itself is [Terrazzo](https://terrazzo.app/); [the token pipeline](./concepts/token-pipeline) covers the mechanism.
+
+### Doc blocks
+
+Most authoring happens in MDX. The blocks — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, `Diagnostics`, and the motion, shadow, border, and gradient previews — are React components that read the active tuple from the preview decorator's provider and re-render when the toolbar flips an axis. They accept filter, scoping, and sort props; `<ColorPalette filter="color.*" />` renders the full swatch grid. The [blocks reference](./reference/blocks) lists each block's props; the [authoring guide](./guides/authoring-doc-stories) covers composition; the [token-dashboard template](./guides/token-dashboard) is an example assembly.
+
+### Toolbar
+
+A single Swatchbook icon in the Storybook toolbar opens a popover with preset pills, one dropdown per modifier axis, and a color-format picker (`hex`, `rgb`, `hsl`, `oklch`, `raw`) that governs how blocks render colors.
+
+### `useToken` hook
+
+`useToken(path)` returns `{ value, cssVar, type?, description? }` and reacts to the active theme. Paths come from a generated `.swatchbook/tokens.d.ts`.
 
 ## For AI agents
 


### PR DESCRIPTION
## Summary

Five bold-em-dash sentence bullets → five short subheaded paragraphs. Dropped the editorial framing (\"Day-to-day\", \"ready-made starting point\", \"without per-page wiring\", \"typos surface at compile time rather than runtime\") in favour of descriptive prose that states what each feature is and points at the reference for detail.

New subheadings: **Installation**, **No external compile step**, **Doc blocks**, **Toolbar**, **\`useToken\` hook**.

Patch changeset on \`@unpunnyfuns/swatchbook-blocks\` so the docs snapshot rebuilds on the next release.

Milestone: Maintenance
Closes: #527
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [ ] Eyeball the rendered section — verify the prose reads naturally and the subheadings appear in the page ToC.