### PR TITLE
docs: strip remaining pitch residue from intro's "What the addon includes" section

### DIFF
--- a/.changeset/docs-intro-prose-second-pass.md
+++ b/.changeset/docs-intro-prose-second-pass.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs: strip remaining pitch residue from the intro's "What the addon includes" section
+
+Follow-up to the prose conversion. A second read found eight smaller tells still reading as marketing framing: section heading ("gives you" → "includes"), action verbs ("brings in" → "includes"), tour-guide framing ("Most authoring happens in MDX"), a mid-prose `<ColorPalette filter="color.*" />` example that acted as a sales moment, an emphasised "A single Swatchbook icon" ("single" → dropped), a redundant gloss after the color-format selector's own name, and a three-parallel-clauses "nothing is written / no prebuild / HMR propagates" stack that worked as a strawman — consolidated to one descriptive clause. Section now reads as a reference entry.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -28,27 +28,27 @@ If your system has exactly one dimension and no plans for more, [`@storybook/add
 
 Swatchbook isn't a runtime theme-switcher for production apps, a CSS-variable framework, or a component styling system. It emits CSS variables and `data-<prefix>-*` attributes on `<html>` inside the Storybook preview so tokens repaint when an author toggles an axis. For production theme switching, use your framework's theming tools or call `@unpunnyfuns/swatchbook-core`'s `emitCss` at build time and wire it up yourself — the emitted CSS is the same shape either way. For how your stories react to toolbar flips, see [theme reactivity](./concepts/theme-reactivity).
 
-## What the addon gives you
+## What the addon includes
 
 ### Installation
 
-`@unpunnyfuns/swatchbook-addon` is the top-level entry point. Registering it in `.storybook/main.ts` brings in the toolbar, preview decorator, MDX blocks, `ThemeSwitcher`, and `useToken()`, along with `swatchbook-core`, `swatchbook-blocks`, and `swatchbook-switcher` as transitive dependencies. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` resolves from any consumer file. The sub-packages remain independently installable for slice use — a Docusaurus site that only needs the switcher, or a build script that wants `swatchbook-core`'s loader without any React.
+Register `@unpunnyfuns/swatchbook-addon` in `.storybook/main.ts`. It includes the toolbar, preview decorator, MDX blocks, `ThemeSwitcher`, and `useToken()`, and takes `swatchbook-core`, `swatchbook-blocks`, and `swatchbook-switcher` as transitive dependencies. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` resolves from any consumer file. Each sub-package is also publishable on its own for projects that want only a slice — the switcher in a Docusaurus navbar, say, or the core loader in a build script without React.
 
 ### No external compile step
 
-Tokens reach the Storybook preview through a Vite virtual module the addon publishes on demand. Nothing is written to disk, no prebuild step runs, and edits to token files flow through Vite's HMR. Parsing itself is [Terrazzo](https://terrazzo.app/); [the token pipeline](./concepts/token-pipeline) covers the mechanism.
+The addon publishes tokens to the Storybook preview through a Vite virtual module, recomputed on each reload. Edits to token files propagate via Vite's HMR. Parsing uses [Terrazzo](https://terrazzo.app/); [the token pipeline](./concepts/token-pipeline) covers the mechanism.
 
 ### Doc blocks
 
-Most authoring happens in MDX. The blocks — `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, `Diagnostics`, and the motion, shadow, border, and gradient previews — are React components that read the active tuple from the preview decorator's provider and re-render when the toolbar flips an axis. They accept filter, scoping, and sort props; `<ColorPalette filter="color.*" />` renders the full swatch grid. The [blocks reference](./reference/blocks) lists each block's props; the [authoring guide](./guides/authoring-doc-stories) covers composition; the [token-dashboard template](./guides/token-dashboard) is an example assembly.
+The blocks are React components for MDX: `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, `FontFamilySample`, `FontWeightScale`, `StrokeStyleSample`, `Diagnostics`, and per-type previews for motion, shadow, border, and gradient. They read the active tuple from the preview decorator's provider and re-render when the toolbar flips an axis. Filter, scoping, and sort props are supported. See the [blocks reference](./reference/blocks), the [authoring guide](./guides/authoring-doc-stories), and the [token-dashboard template](./guides/token-dashboard).
 
 ### Toolbar
 
-A single Swatchbook icon in the Storybook toolbar opens a popover with preset pills, one dropdown per modifier axis, and a color-format picker (`hex`, `rgb`, `hsl`, `oklch`, `raw`) that governs how blocks render colors.
+The Swatchbook icon in Storybook's toolbar opens a popover containing preset pills, one dropdown per modifier axis, and a color-format selector: `hex`, `rgb`, `hsl`, `oklch`, or `raw`.
 
 ### `useToken` hook
 
-`useToken(path)` returns `{ value, cssVar, type?, description? }` and reacts to the active theme. Paths come from a generated `.swatchbook/tokens.d.ts`.
+`useToken(path)` returns `{ value, cssVar, type?, description? }` and re-runs on theme change. Paths come from a generated `.swatchbook/tokens.d.ts`.
 
 ## For AI agents
 


### PR DESCRIPTION
## Summary

Follow-up to #528. On re-read, eight smaller tells still read as marketing framing. This pass removes them:

- Section heading: \"What the addon gives you\" → \"What the addon includes\"
- \"brings in the toolbar\" → \"includes the toolbar\" (stative over action verb for composition)
- Dropped \"Most authoring happens in MDX\" — tour-guide framing
- Dropped the \`<ColorPalette filter=\"color.*\" />\` example from the expository paragraph; inline examples mid-prose read as a sales moment
- \"A single Swatchbook icon…\" → \"The Swatchbook icon…\"
- Dropped \"governs how blocks render colors\" — the color-format selector names itself
- \"Tokens reach the preview / Nothing is written to disk / no prebuild step runs / edits flow through HMR\" (four clauses setting up a strawman) → \"The addon publishes tokens to the Storybook preview through a Vite virtual module, recomputed on each reload. Edits to token files propagate via Vite's HMR.\" (two descriptive sentences)

Patch changeset on \`@unpunnyfuns/swatchbook-blocks\`.

Milestone: Maintenance
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [ ] Eyeball the rendered section — verify subheadings still anchor properly and the ToC behaves.