### PR TITLE
docs: prose sweep for pitch residue + adopt two orphaned concept pages

### DIFF
--- a/.changeset/docs-prose-sweep-and-orphan-pages.md
+++ b/.changeset/docs-prose-sweep-and-orphan-pages.md
@@ -1,0 +1,14 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+docs: prose sweep + adopt two orphaned concept pages into the sidebar
+
+**Prose sweep.** An audit across every live `.mdx` and each package README surfaced six clear pitch-language tells. Fixed five (kept two borderline "why axes, not themes" link-title italics as-is since they're page titles, not strawman setups):
+
+- Root README and intro both had "Drop them into MDX pages and your token reference writes itself" — replaced with descriptive version naming the per-type previews explicitly.
+- Addon reference: "those hooks just work wherever the addon is registered" → "the hooks resolve wherever the addon is registered".
+- Authoring guide: "the blocks just work inside MDX" → "the blocks render inside MDX".
+- Quickstart: "Takes ~5 minutes if you already have a Storybook project." → "Assumes an existing Storybook 10 project with the Vite builder. Install, register, author the first doc page."
+
+**Orphan adoption.** `concepts/axes-vs-themes` and `concepts/theme-reactivity` existed as pages and were linked from the intro, but weren't listed in the home sidebar's Concepts category. Clicking those links landed on pages with no sidebar highlighting or breadcrumb context. Added both to the Concepts category; `axes-vs-themes` goes first (foundational "why"), `theme-reactivity` goes between diagnostics and token-pipeline (implementation-facing after the concept tour).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Storybook addon and MDX blocks for documenting [DTCG](https://www.designtokens
 
 Two things in one:
 
-- **Doc blocks** — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and more. Drop them into MDX pages and your token reference writes itself.
+- **Doc blocks** — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and per-type previews for motion, shadow, border, and gradient. React components for MDX.
 - **A multi-axis theme switcher** — flip dark mode, brand, contrast, density, whatever dimensions your design system has, from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown inside a single popover. (See [*why axes, not themes*](https://unpunnyfuns.github.io/swatchbook/concepts/axes-vs-themes).)
 
 **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) · **Live Storybook:** [/storybook](https://unpunnyfuns.github.io/swatchbook/storybook/)

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -16,7 +16,7 @@ Install the blocks package:
 npm install -D @unpunnyfuns/swatchbook-blocks
 ```
 
-The blocks read the active token graph from a `SwatchbookProvider`. The addon's preview decorator mounts that provider for every story, so as long as `@unpunnyfuns/swatchbook-addon` is registered in your Storybook, the blocks just work inside MDX.
+The blocks read the active token graph from a `SwatchbookProvider`. The addon's preview decorator mounts that provider for every story, so the blocks render inside MDX as long as `@unpunnyfuns/swatchbook-addon` is registered in your Storybook.
 
 ## A minimal docs page
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -11,7 +11,7 @@ A Storybook addon and MDX blocks for **documenting [DTCG design tokens](https://
 
 Two things in one:
 
-- **Doc blocks.** `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and a handful of type-specific previews. Drop them into MDX pages and your token reference writes itself.
+- **Doc blocks.** `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and per-type previews for motion, shadow, border, and gradient. React components for MDX.
 - **A multi-axis theme switcher.** Flip dark mode, brand, contrast, density — whatever dimensions your design system has — from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown in a single popover. Tokens repaint live as readers flip axes. See [**why axes, not themes**](./concepts/axes-vs-themes) for the shape.
 
 :::tip[Try it right here]

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Quickstart
 
-Takes ~5 minutes if you already have a Storybook project.
+Assumes an existing Storybook 10 project with the Vite builder. Install, register, author the first doc page.
 
 ## Install
 

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -106,7 +106,7 @@ Paths autocomplete from the generated `.swatchbook/tokens.d.ts`. Add `"include":
 
 `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the contexts that back them (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) are exported from `@unpunnyfuns/swatchbook-blocks` — see the [blocks reference](./blocks). They are **not** re-exported from the addon; import them from blocks.
 
-The preview decorator mounts a `SwatchbookProvider` (from blocks) that populates every context, so those hooks just work wherever the addon is registered.
+The preview decorator mounts a `SwatchbookProvider` (from blocks) that populates every context, so the hooks resolve wherever the addon is registered.
 
 ## Exported constants
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -22,10 +22,12 @@ const sidebars: SidebarsConfig = {
       label: 'Concepts',
       collapsed: false,
       items: [
+        'concepts/axes-vs-themes',
         'concepts/theming-inputs',
         'concepts/axes',
         'concepts/presets',
         'concepts/diagnostics',
+        'concepts/theme-reactivity',
         'concepts/token-pipeline',
       ],
     },


### PR DESCRIPTION
## Summary

Two related fixes bundled:

### Prose sweep

Audit of every live \`.mdx\` and package README (per the \"reference-manual register\" preference) surfaced six pitch-tell candidates. Fixed five:

- Root README + intro: \"Drop them into MDX pages and your token reference writes itself\" → descriptive list naming the per-type previews (motion, shadow, border, gradient) explicitly.
- Addon reference: \"those hooks just work wherever the addon is registered\" → \"the hooks resolve wherever the addon is registered\".
- Authoring guide: \"the blocks just work inside MDX\" → \"the blocks render inside MDX\".
- Quickstart: \"Takes ~5 minutes if you already have a Storybook project.\" → \"Assumes an existing Storybook 10 project with the Vite builder. Install, register, author the first doc page.\"

Skipped two borderline findings (the \"why axes, not themes\" italic link-titles) — those are page titles in italics, not strawman setups.

### Orphan concept pages

\`concepts/axes-vs-themes\` and \`concepts/theme-reactivity\` existed as pages and were linked from the intro, but weren't listed in the home sidebar's Concepts category. Clicking those links landed on pages with no sidebar highlighting or breadcrumb context. Added both — axes-vs-themes first (foundational \"why\"), theme-reactivity between diagnostics and token-pipeline.

Milestone: Maintenance
Closes: #531
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean, no broken-link warnings.
- [ ] Manual: \`pnpm dev\` the docs site, verify the Concepts sidebar now shows all seven pages in order and the previously orphaned pages render with correct nav highlighting.