### PR TITLE
fix(a11y): underline body-content links so colour isn't the sole distinguisher

### DIFF
--- a/.changeset/a11y-underline-content-links.md
+++ b/.changeset/a11y-underline-content-links.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix(a11y): underline body-content links so colour isn't the sole distinguisher
+
+Axe flagged two related WCAG violations: **1.4.1 (Use of Color)** — links in body text weren't distinguishable without colour — and **1.4.11 (Non-text Contrast)** — the a11y=High-contrast amber primary (#fcd34d) only reached 1.31:1 against surrounding Dark-mode text (#f1f5f9), below the 3:1 non-text contrast minimum.
+
+Underlining body links addresses both: colour is no longer the sole distinguisher, and 1.4.11's ratio requirement only applies when colour is carrying the signal on its own.
+
+Rule scoped to `.markdown a` — Docusaurus's rendered-MDX container — so navbar, sidebar, footer, and button-style links are untouched. Those carry affordances via position and chrome instead of inline prose context.

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -48,3 +48,24 @@
 [data-theme='dark'] {
   --docusaurus-highlighted-code-line-bg: rgba(255, 255, 255, 0.08);
 }
+
+/*
+ * Accessibility — WCAG 2.1 SC 1.4.1 (Use of Color) + 1.4.11 (Non-text
+ * Contrast). Axe reported that links in body content weren't
+ * distinguishable from surrounding text without colour, and that the
+ * a11y=High-contrast amber primary (light yellow on light-text
+ * neutral) fell below the 3:1 link-vs-surrounding-text contrast
+ * threshold. Underlining body links sidesteps both: colour is no
+ * longer the sole distinguisher, and the 1.4.11 ratio requirement
+ * only applies when colour is carrying the signal.
+ *
+ * Scoped to rendered MDX content (`.markdown`) so navbar / sidebar /
+ * footer / button-style links stay untouched — those land
+ * affordances via position and chrome rather than inline prose
+ * context.
+ */
+.markdown a {
+  text-decoration: underline;
+  text-underline-offset: 0.15em;
+  text-decoration-thickness: from-font;
+}


### PR DESCRIPTION
## Summary

Axe flagged two WCAG violations on the docs site:

- **1.4.1 (Use of Color)** — links in body content distinguished from surrounding text only by colour.
- **1.4.11 (Non-text Contrast)** — the a11y=High-contrast amber primary (\`#fcd34d\`, amber.300) against surrounding Dark-mode text (\`#f1f5f9\`, neutral.100) is **1.31:1**, below the 3:1 non-text-contrast minimum.

Underlining body links addresses both: colour is no longer the sole link distinguisher, and 1.4.11's ratio requirement only applies when colour is carrying the signal.

Rule scoped to \`.markdown a\` (Docusaurus's rendered-MDX container). Navbar / sidebar / footer / button-style links stay unaffected — those land affordances via position and chrome, not inline prose context.

Styling details:

- \`text-decoration: underline\`
- \`text-underline-offset: 0.15em\` — keeps the line off the baseline for readability
- \`text-decoration-thickness: from-font\` — scales with font weight, looks right on headings and body

Patch changeset on \`@unpunnyfuns/swatchbook-blocks\`.

Milestone: Maintenance
Closes: #533
Plan impact: none

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-docs run build\` — clean.
- [ ] Manual: \`pnpm dev\`, cycle through a11y=Normal / High-contrast on both Light and Dark, verify body links show underlines and navbar / sidebar / footer links don't.
- [ ] Re-run axe against the rendered intro page — both 1.4.1 and 1.4.11 should clear.