### PR TITLE
feat(mcp): add get_color_contrast tool for pair-wise contrast queries

### DIFF
--- a/.changeset/mcp-color-contrast-tool.md
+++ b/.changeset/mcp-color-contrast-tool.md
@@ -1,0 +1,14 @@
+---
+'@unpunnyfuns/swatchbook-mcp': minor
+---
+
+feat(mcp): `get_color_contrast` tool for pair-wise contrast queries
+
+New tool that computes the contrast between two color tokens against a given theme. Two algorithms:
+
+- **`wcag21`** (default) — classic 1–21 ratio plus boolean pass flags for WCAG 2.1 AA (normal + large text) and AAA (normal + large text).
+- **`apca`** — signed Lc value (polarity-preserving; negative = dark foreground on light background, positive = light on dark) plus body / large-text / non-text pass flags against the Silver-draft bronze thresholds (`|Lc| ≥ 75 / 60 / 45`).
+
+Closes the loop on the accessibility work — the same computation axe runs against rendered HTML becomes queryable from an agent *about the tokens themselves*, per-theme. Useful for reasoning about link legibility, focus-ring visibility, border contrast, muted-text readability, without having to re-implement luminance math in the agent or pick between three competing algorithms.
+
+Built on `colorjs.io`'s contrast primitives, which the MCP package already depended on for `get_color_formats`. No new dependencies.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -157,11 +157,11 @@ npx @unpunnyfuns/swatchbook-mcp --config swatchbook.config.ts
  StdioServerTransport → MCP client (Claude Desktop, Claude Code, …)
 ```
 
-Twelve tools, all stateless reads against the in-memory `Project`:
+Thirteen tools, all stateless reads against the in-memory `Project`:
 
 - Orientation: `describe_project`, `list_axes`, `get_diagnostics`
 - Discovery: `list_tokens`, `search_tokens`, `resolve_theme`
-- Detail: `get_token`, `get_alias_chain`, `get_aliased_by`, `get_color_formats`, `get_consumer_output`
+- Detail: `get_token`, `get_alias_chain`, `get_aliased_by`, `get_color_formats`, `get_color_contrast`, `get_consumer_output`
 - Emission: `emit_css`
 
 `createServer` returns the server augmented with `setProject(next)` so live-reload (the default) can swap in a fresh project without restarting the transport. See [Reference → MCP](../reference/mcp) for the tool signatures.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -52,7 +52,7 @@ The Swatchbook icon in Storybook's toolbar opens a popover containing preset pil
 
 ## For AI agents
 
-The optional [`@unpunnyfuns/swatchbook-mcp`](./reference/mcp) package ships a stdio [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes your token graph — paths, axes, alias chains, diagnostics, per-theme resolved values — to AI assistants like Claude Desktop or Claude Code. Point it at your `swatchbook.config.ts` (or a bare DTCG resolver) and an agent can introspect and reason about the system without spinning up Storybook. Twelve read-only tools; live-reloads on token edits.
+The optional [`@unpunnyfuns/swatchbook-mcp`](./reference/mcp) package ships a stdio [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes your token graph — paths, axes, alias chains, diagnostics, per-theme resolved values — to AI assistants like Claude Desktop or Claude Code. Point it at your `swatchbook.config.ts` (or a bare DTCG resolver) and an agent can introspect and reason about the system without spinning up Storybook. Thirteen read-only tools; live-reloads on token edits.
 
 ## See it live
 

--- a/apps/docs/docs/reference/mcp.mdx
+++ b/apps/docs/docs/reference/mcp.mdx
@@ -74,6 +74,7 @@ Restart the client and ask it about your tokens — it'll call `describe_project
 | `get_aliased_by`      | `path`, `maxDepth?`                                       | Backward alias tree — every token that resolves through this path. Breadth-first with cycle protection.       |
 | `get_consumer_output` | `path`, `tuple?`                                          | CSS var, resolved value, compound `[data-…]` selector + HTML attrs needed to pin the tuple on `<html>`.        |
 | `get_color_formats`   | `path`, `theme?`                                          | Color token rendered in `hex` / `rgb` / `hsl` / `oklch` / `raw`, each with an `outOfGamut` flag.                |
+| `get_color_contrast`  | `foreground`, `background`, `theme?`, `algorithm?`        | Pair-wise contrast between two color tokens. `wcag21` → ratio + AA/AAA pass flags (normal + large text). `apca` → signed Lc + body / large-text / non-text pass flags. |
 | `list_axes`           | (none)                                                    | Axes + contexts + themes + presets from the project config.                                                   |
 | `get_diagnostics`     | `severity?` `'error' \| 'warn' \| 'info'`                 | Parser / resolver / validation diagnostics.                                                                   |
 | `emit_css`            | (none)                                                    | Full project stylesheet — `:root` default + per-tuple compound-selector blocks.                                |

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -49,6 +49,7 @@ CLI flags:
 | `get_aliased_by`      | `path`, `maxDepth?`                                       | Backward alias tree — every token that resolves through this path. Breadth-first with cycle protection; default max depth 6. |
 | `get_consumer_output` | `path`, `tuple?`                                          | CSS var, resolved value, compound `[data-…]` selector + HTML attrs needed to pin the tuple on `<html>`.        |
 | `get_color_formats`   | `path`, `theme?`                                          | Color token rendered in `hex` / `rgb` / `hsl` / `oklch` / `raw`, each with an `outOfGamut` flag.                |
+| `get_color_contrast`  | `foreground`, `background`, `theme?`, `algorithm?`        | Pair-wise contrast between two color tokens. `wcag21` returns the 1–21 ratio + AA/AAA pass flags (normal + large text); `apca` returns the signed Lc + body / large-text / non-text pass flags. |
 | `list_axes`           | (none)                                                    | Axes + contexts + themes + presets from the project config.                                                   |
 | `get_diagnostics`     | `severity?` `'error' \| 'warn' \| 'info'`                 | Parser / resolver / validation diagnostics.                                                                   |
 | `emit_css`            | (none)                                                    | Full project stylesheet — `:root` default + per-tuple compound-selector blocks. |

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -54,6 +54,7 @@ Tools exposed:
   get_aliased_by      Backward alias tree.
   get_consumer_output CSS var + data-attribute activation for a tuple.
   get_color_formats   hex / rgb / hsl / oklch / raw for a color token.
+  get_color_contrast  Pair-wise contrast (WCAG 2.1 ratio or APCA Lc) + pass flags.
   list_axes           Axes + contexts + themes + presets.
   get_diagnostics     Project diagnostics (optional severity filter).
   emit_css            Full project stylesheet.`);

--- a/packages/mcp/src/contrast.ts
+++ b/packages/mcp/src/contrast.ts
@@ -1,0 +1,103 @@
+import Color from 'colorjs.io';
+
+/**
+ * Pair-wise contrast between two DTCG color `$value`s. Wraps
+ * `colorjs.io`'s contrast primitives with pass/fail grids for the
+ * thresholds agents typically reason against (WCAG 2.1 AA/AAA
+ * normal/large; APCA body / large text / non-text).
+ *
+ * Kept separate from `format-color.ts` even though both build
+ * `Color` instances from the same DTCG shape — the color-format
+ * formatter stringifies, this one does arithmetic, and they're
+ * called from different tool paths.
+ */
+
+interface ColorInput {
+  colorSpace?: string;
+  components?: readonly (number | null)[];
+  channels?: readonly (number | null)[];
+  alpha?: number;
+}
+
+function toColor(raw: unknown): Color | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const n = raw as ColorInput;
+  const components = n.components ?? n.channels;
+  if (!components || !n.colorSpace) return null;
+  const coords = components.map((c) => (c == null ? 0 : c));
+  const [r = 0, g = 0, b = 0] = coords;
+  try {
+    return new Color(n.colorSpace, [r, g, b], n.alpha ?? 1);
+  } catch {
+    return null;
+  }
+}
+
+export type ContrastAlgorithm = 'wcag21' | 'apca';
+
+export interface WcagPasses {
+  aa: { normal: boolean; large: boolean };
+  aaa: { normal: boolean; large: boolean };
+}
+
+export interface ApcaPasses {
+  lc: number;
+  body: boolean;
+  largeText: boolean;
+  nonText: boolean;
+}
+
+export interface ContrastResult {
+  algorithm: ContrastAlgorithm;
+  /**
+   * WCAG 2.1 returns the contrast ratio (1–21). APCA returns a signed
+   * Lc value (-108..+106); the sign marks polarity (negative = dark
+   * text on light background; positive = light on dark). Consumers
+   * usually care about `Math.abs(ratio)` for threshold checks.
+   */
+  ratio: number;
+  wcag?: WcagPasses;
+  apca?: ApcaPasses;
+}
+
+export function computeContrast(
+  foreground: unknown,
+  background: unknown,
+  algorithm: ContrastAlgorithm = 'wcag21',
+): ContrastResult | null {
+  const fg = toColor(foreground);
+  const bg = toColor(background);
+  if (!fg || !bg) return null;
+
+  if (algorithm === 'wcag21') {
+    const ratio = fg.contrast(bg, 'WCAG21');
+    return {
+      algorithm: 'wcag21',
+      ratio,
+      wcag: {
+        aa: { normal: ratio >= 4.5, large: ratio >= 3 },
+        aaa: { normal: ratio >= 7, large: ratio >= 4.5 },
+      },
+    };
+  }
+
+  /**
+   * APCA thresholds from the Silver draft guidance. These are the
+   * "body text / large text / non-text" bronze tier thresholds most
+   * tooling settles on; the full table has more gradations but
+   * agents rarely need them. Non-text = icons, focus rings, UI
+   * borders.
+   */
+  const lc = fg.contrast(bg, 'APCA');
+  const absLc = Math.abs(lc);
+  return {
+    algorithm: 'apca',
+    ratio: lc,
+    apca: {
+      lc,
+      body: absLc >= 75,
+      largeText: absLc >= 60,
+      nonText: absLc >= 45,
+    },
+  };
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -2,6 +2,7 @@ import type { Project } from '@unpunnyfuns/swatchbook-core';
 import { projectCss } from '@unpunnyfuns/swatchbook-core';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import { computeContrast } from '#/contrast.ts';
 import { formatColorEveryWay } from '#/format-color.ts';
 import { matchPath } from '#/match.ts';
 
@@ -294,6 +295,59 @@ export function createServer(initial: Project): McpServer & {
         path,
         theme: themeName,
         formats: formatColorEveryWay(token.$value),
+      });
+    },
+  );
+
+  server.registerTool(
+    'get_color_contrast',
+    {
+      description:
+        'Compute the contrast between two color tokens for a given theme. WCAG 2.1 returns the ratio (1–21) plus AA/AAA pass flags for normal + large text; APCA returns the signed Lc value plus body / large-text / non-text pass flags (absolute-value thresholds 75 / 60 / 45). Use this when reasoning about text legibility, focus-ring visibility, border contrast, etc., without having to reimplement the luminance math in the agent. Per-theme so the same pair can be checked against Light, Dark, High-contrast, etc.',
+      inputSchema: {
+        foreground: z
+          .string()
+          .describe('Dot-path of the foreground color token, e.g. `color.text.default`.'),
+        background: z
+          .string()
+          .describe('Dot-path of the background color token, e.g. `color.surface.default`.'),
+        theme: z.string().optional().describe('Theme name. Defaults to the project default theme.'),
+        algorithm: z
+          .enum(['wcag21', 'apca'])
+          .optional()
+          .describe(
+            'Contrast algorithm. `wcag21` is the classic 4.5:1 ratio; `apca` is the perceptually-weighted Silver-draft successor. Defaults to `wcag21`.',
+          ),
+      },
+    },
+    ({ foreground, background, theme, algorithm }) => {
+      const themeName = theme ?? project.themes[0]?.name;
+      if (!themeName) return textResult('No themes in project.');
+      const fgTok = project.themesResolved[themeName]?.[foreground];
+      const bgTok = project.themesResolved[themeName]?.[background];
+      if (!fgTok) return textResult(`Foreground token not found: ${foreground}`);
+      if (!bgTok) return textResult(`Background token not found: ${background}`);
+      if (fgTok.$type !== 'color') {
+        return textResult(
+          `Foreground ${foreground} is not a color (got $type=${fgTok.$type ?? 'unknown'}).`,
+        );
+      }
+      if (bgTok.$type !== 'color') {
+        return textResult(
+          `Background ${background} is not a color (got $type=${bgTok.$type ?? 'unknown'}).`,
+        );
+      }
+      const result = computeContrast(fgTok.$value, bgTok.$value, algorithm ?? 'wcag21');
+      if (!result) {
+        return textResult(
+          'Could not compute contrast — one or both values failed to parse as a color.',
+        );
+      }
+      return jsonResult({
+        theme: themeName,
+        foreground: { path: foreground, value: stringifyValue(fgTok.$value) },
+        background: { path: background, value: stringifyValue(bgTok.$value) },
+        ...result,
       });
     },
   );


### PR DESCRIPTION
## Summary

New MCP tool that computes the contrast between two color tokens against a given theme:

\`\`\`
get_color_contrast
  Inputs:  { foreground: <token-path>, background: <token-path>,
             theme?: <theme-name>, algorithm?: 'wcag21' | 'apca' }
  Returns: { theme, foreground, background, algorithm, ratio, wcag? | apca? }
\`\`\`

**\`wcag21\`** (default) — 1–21 ratio plus AA / AAA pass flags for normal + large text.

**\`apca\`** — signed Lc value (polarity marks foreground/background lightness direction) plus body / large-text / non-text pass flags against the Silver-draft bronze thresholds (\`|Lc| ≥ 75 / 60 / 45\`).

Built on \`colorjs.io\`'s contrast primitives, which the MCP package already depended on for \`get_color_formats\`. No new dependencies; 90-line helper at \`packages/mcp/src/contrast.ts\`, ~55-line tool handler in \`server.ts\`.

Closes the loop on the recent a11y work — the same computation axe runs against the rendered HTML becomes queryable from an agent *about the tokens themselves*, per-theme. Supports reasoning about link legibility, focus-ring visibility, border contrast, muted-text readability — all without re-implementing luminance math on the agent side, and without making agents pick between competing algorithms.

### What's NOT in this PR

- \`list_contrast_issues\` / \`find_accessible_pairs\` (sweep tools) — would require the MCP server to decide which pairs matter in a project, which is consumer-config. Agents can compose the pair-wise primitive into sweeps when the task needs one.
- Non-WCAG, non-APCA algorithms (Michelson, Weber, Delta Phi Star) — colorjs supports them but nobody asks for them.

Minor changeset on \`@unpunnyfuns/swatchbook-mcp\` — new user-visible tool.

Milestone: Maintenance
Closes: #535
Plan impact: none

## Test plan

- [x] \`pnpm turbo run build typecheck test --filter=@unpunnyfuns/swatchbook-mcp\` — green.
- [x] \`--help\` output lists the new tool (13 total).
- [ ] Manual: restart MCP client, run \`get_color_contrast({ foreground: 'color.text.accent', background: 'color.surface.default', theme: 'Dark · Default · High' })\` — verify WCAG ratio + pass flags.
- [ ] Manual with APCA: same pair, \`algorithm: 'apca'\` — verify Lc value + pass flags.