### PR TITLE
ci: allow `a11y` scope on PR titles

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -39,6 +39,7 @@ jobs:
             storybook
             docs
             ci
+            a11y
           requireScope: false
           subjectPattern: ^(?![A-Z]).+$
           subjectPatternError: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ Format: `<type>(<scope>): <description>`.
 
 **Types:** `feat` / `fix` / `chore` / `docs` / `test` / `ci` / `refactor` / `perf` / `build` / `revert`.
 
-**Scopes:** one of `core`, `addon`, `blocks`, `switcher`, `mcp`, `tokens`, `storybook`, `docs`, `ci` — or omitted when a change spans multiple packages.
+**Scopes:** one of `core`, `addon`, `blocks`, `switcher`, `mcp`, `tokens`, `storybook`, `docs`, `ci`, `a11y` — or omitted when a change spans multiple packages. `a11y` is the accessibility scope — use it for cross-cutting WCAG / axe / focus / contrast / keyboard-nav fixes that don't sit neatly inside one package.
 
 **Subject:** imperative verb first, lowercase even for proper nouns. `feat(addon): rebind keyboard shortcut` — not `Feat(Addon): Rebinding the keyboard shortcut`.
 


### PR DESCRIPTION
## Summary

Adds \`a11y\` to the Conventional Commits scope allow-list:

- \`.github/workflows/pr-lint.yml\` — the scope list the \`amannn/action-semantic-pull-request\` check enforces.
- \`CONTRIBUTING.md\` — the documented allow-list, with a short gloss on when \`a11y\` is the right pick (cross-cutting axe / WCAG / focus / contrast / keyboard-nav work that doesn't sit neatly inside a single package).

Recent PR #534 (link underlining) is the shape the new scope is for — an accessibility fix that touches docs-site CSS and wouldn't be well-scoped as \`docs\` or \`core\` alone.

Milestone: Maintenance
Closes: #537
Plan impact: none