### PR TITLE
feat(core): retain Terrazzo parser output + cwd on Project

### DIFF
--- a/.changeset/project-parser-input-retention.md
+++ b/.changeset/project-parser-input-retention.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Retain Terrazzo's parser output on `Project.parserInput` (`{ tokens, sources, resolver }`) and the loader's `cwd` on `Project.cwd`. Adds `SwatchbookIntegration` to the public type surface. All additive — no behaviour change for existing consumers. Unblocks library-level emission wrappers that drive Terrazzo's programmatic `build()` without re-parsing.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "format:check": "oxfmt --check -c ../../.oxfmtrc.json src"
   },
   "dependencies": {
+    "@terrazzo/json-schema-tools": "^0.2.1",
     "@terrazzo/parser": "^2.0.3",
     "@terrazzo/token-tools": "^2.0.3"
   },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,9 +13,11 @@ export type {
   Config,
   Diagnostic,
   DiagnosticSeverity,
+  ParserInput,
   Preset,
   Project,
   ResolvedTheme,
+  SwatchbookIntegration,
   Theme,
   TokenMap,
 } from '#/types.ts';

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -92,6 +92,8 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     themesResolved: filteredResolved,
     graph,
     sourceFiles: normalized.sourceFiles,
+    cwd,
+    ...(normalized.parserInput !== undefined && { parserInput: normalized.parserInput }),
     diagnostics: [
       ...toDiagnostics(logger),
       ...normalized.diagnostics,

--- a/packages/core/src/themes/normalize.ts
+++ b/packages/core/src/themes/normalize.ts
@@ -1,13 +1,15 @@
 import type { BufferedLogger } from '#/diagnostics.ts';
 import { loadLayeredThemes } from '#/themes/layered.ts';
 import { loadResolverThemes } from '#/themes/resolver.ts';
-import type { Axis, Config, Diagnostic, Theme, TokenMap } from '#/types.ts';
+import type { Axis, Config, Diagnostic, ParserInput, Theme, TokenMap } from '#/types.ts';
 
 export interface NormalizedThemes {
   axes: Axis[];
   themes: Theme[];
   resolved: Record<string, TokenMap>;
   sourceFiles: string[];
+  /** Present for resolver + plain-parse paths; undefined for layered. */
+  parserInput?: ParserInput;
   diagnostics: Diagnostic[];
 }
 

--- a/packages/core/src/themes/resolver.ts
+++ b/packages/core/src/themes/resolver.ts
@@ -2,7 +2,14 @@ import { readFile } from 'node:fs/promises';
 import { isAbsolute, resolve as resolvePath } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { defineConfig as defineTerrazzoConfig, loadResolver, parse } from '@terrazzo/parser';
-import { permutationID, type Axis, type Diagnostic, type Theme, type TokenMap } from '#/types.ts';
+import {
+  permutationID,
+  type Axis,
+  type Diagnostic,
+  type ParserInput,
+  type Theme,
+  type TokenMap,
+} from '#/types.ts';
 import type { BufferedLogger } from '#/diagnostics.ts';
 import { collectGlobbedFiles } from '#/themes/util.ts';
 
@@ -11,6 +18,8 @@ export interface ResolverLoadResult {
   themes: Theme[];
   resolved: Record<string, TokenMap>;
   sourceFiles: string[];
+  /** Retained Terrazzo parse output for downstream plugin emission. */
+  parserInput?: ParserInput;
   diagnostics: Diagnostic[];
 }
 
@@ -87,11 +96,16 @@ export async function loadResolverThemes(
       themes: [{ name, input: { theme: name }, sources: tokenFiles }],
       resolved: { [name]: parsed.tokens },
       sourceFiles: tokenFiles,
+      parserInput: {
+        tokens: parsed.tokens,
+        sources: parsed.sources,
+        resolver: parsed.resolver,
+      },
       diagnostics: [],
     };
   }
 
-  const { resolver } = loaded;
+  const { resolver, tokens: baseTokens, sources: parsedSources } = loaded;
   const permutations = resolver.listPermutations();
 
   const diagnostics: Diagnostic[] = [];
@@ -137,5 +151,12 @@ export async function loadResolverThemes(
   // want HMR to watch directories broader than the resolver references.
   for (const f of tokenFiles) if (!sourceFiles.includes(f)) sourceFiles.push(f);
 
-  return { axes, themes, resolved, sourceFiles: sourceFiles.toSorted(), diagnostics };
+  return {
+    axes,
+    themes,
+    resolved,
+    sourceFiles: sourceFiles.toSorted(),
+    parserInput: { tokens: baseTokens, sources: parsedSources, resolver },
+    diagnostics,
+  };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,5 @@
-import type { TokenNormalized } from '@terrazzo/parser';
+import type { InputSourceWithDocument } from '@terrazzo/json-schema-tools';
+import type { Resolver, TokenNormalized } from '@terrazzo/parser';
 
 export type TokenMap = Record<string, TokenNormalized>;
 
@@ -158,7 +159,35 @@ export interface Project {
    * (the addon's Vite plugin does exactly that).
    */
   sourceFiles: string[];
+  /**
+   * Absolute path of the directory all config-relative paths (resolver,
+   * token globs, layered overlays) resolved against. Passed into
+   * `loadProject(config, cwd)`; retained here because downstream emitters
+   * need it for `defineConfig({ cwd })` in Terrazzo's JS API.
+   */
+  cwd: string;
+  /**
+   * Raw Terrazzo parse output retained so downstream emitters can drive
+   * Terrazzo's plugin pipeline (`emitViaTerrazzo(project, [...plugins])`)
+   * without re-parsing from disk. Present for resolver-backed projects;
+   * currently `undefined` for layered + plain-parse paths — those would
+   * need a synthesized resolver before `build()` accepts them.
+   */
+  parserInput?: ParserInput;
   diagnostics: Diagnostic[];
+}
+
+/**
+ * Pass-through bag of the three values `@terrazzo/parser`'s `build()`
+ * requires alongside a config. Retained verbatim from `loadResolver()`
+ * so the wrapper call is zero-I/O. Consumers should treat this as opaque
+ * (feed the whole object into `build()`); swatchbook itself does not read
+ * individual fields.
+ */
+export interface ParserInput {
+  tokens: Record<string, TokenNormalized>;
+  sources: InputSourceWithDocument[];
+  resolver: Resolver;
 }
 
 /**
@@ -178,4 +207,33 @@ export function permutationID(input: Record<string, string>): string {
 export interface ResolvedTheme {
   name: string;
   tokens: TokenMap;
+}
+
+/**
+ * Display-side integration the Storybook addon exposes for a third-party
+ * tool (Tailwind v4, emotion, vanilla-extract, bootstrap, whatever).
+ * Each integration contributes at most one virtual module whose body is
+ * derived from the loaded `Project`. The addon's Vite plugin serves the
+ * virtual module under `integration.virtualModule.virtualId` and
+ * re-renders it on HMR so the output stays in lockstep with whatever
+ * the toolbar / config / tokens currently say.
+ *
+ * Integrations are published as their own packages
+ * (`@unpunnyfuns/swatchbook-integrations/tailwind`, …) and composed into
+ * the addon via its options; the addon itself stays tool-agnostic.
+ */
+export interface SwatchbookIntegration {
+  /** Stable identifier for logs + diagnostics. */
+  name: string;
+  /**
+   * Optional virtual module this integration serves. Users import
+   * `virtualId` from their preview (or main) and receive whatever
+   * `render(project)` produces for the current project state.
+   */
+  virtualModule?: {
+    /** e.g. `'virtual:swatchbook/tailwind.css'`. Must be unique. */
+    virtualId: string;
+    /** Produce the module body for the currently-loaded project. */
+    render(project: Project): string;
+  };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@terrazzo/json-schema-tools':
+        specifier: ^0.2.1
+        version: 0.2.1(@humanwhocodes/momoa@3.3.10)
       '@terrazzo/parser':
         specifier: ^2.0.3
         version: 2.0.3


### PR DESCRIPTION
## Summary

- Hoists the `{ tokens, sources, resolver }` triple that `loadResolver` already returns onto `Project.parserInput`, and retains the loader's `cwd` on `Project.cwd`.
- Adds the `SwatchbookIntegration` contract for display-side addon integrations — a tiny `{ name, virtualModule: { virtualId, render } }` shape consumed by the addon's Vite plugin in a follow-up.
- No behaviour change for existing consumers; all additive.

Foundation for a Terrazzo-plugin emission wrapper (`emitViaTerrazzo`) and the display-side integrations plumbing, both landing in follow-up PRs.

## Test plan

- [x] `pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-core --filter=@unpunnyfuns/swatchbook-addon --filter=@unpunnyfuns/swatchbook-blocks --filter=@unpunnyfuns/swatchbook-mcp --filter=@unpunnyfuns/swatchbook-switcher` — green, 94/94 core tests pass.
- [x] No type changes are breaking — additive fields only. Confirmed by clean typecheck across addon / blocks / mcp / switcher.

Milestone: Maintenance
Closes: #546
Plan impact: none