### PR TITLE
docs: reference/core + architecture additions for emitViaTerrazzo

### DIFF
--- a/.changeset/docs-integrations-section.md
+++ b/.changeset/docs-integrations-section.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Docs: new Integrations section covering the `@unpunnyfuns/swatchbook-integrations` package. Overview page with the recipe-coverage table + philosophy, plus per-subpath recipes for `/tailwind` and `/css-in-js` (wiring, generated output, prefix collision story, customisation hooks).

--- a/.changeset/docs-reference-emit-via-terrazzo.md
+++ b/.changeset/docs-reference-emit-via-terrazzo.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Docs: reference/core gains an `emitViaTerrazzo` section, `ParserInput` + `SwatchbookIntegration` type documentation, and the new `Project.cwd` + `Project.parserInput` fields. Architecture doc picks up `parserInput` + the display-side integrations plugin system.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -50,6 +50,8 @@ interface Project {
   themesResolved: Record<string, TokenMap>; // theme.name → resolved tokens
   graph: TokenMap;             // default theme's resolved tokens
   sourceFiles: string[];       // every file that fed the build (for watchers)
+  cwd: string;                 // loader cwd — config-relative paths resolve here
+  parserInput?: ParserInput;   // raw Terrazzo parse output (resolver path only) — see `emitViaTerrazzo`
   diagnostics: Diagnostic[];   // parser / validator / resolver findings
 }
 ```
@@ -60,8 +62,27 @@ Properties:
 - **`sourceFiles` is the canonical watch set.** The addon's Vite plugin and the MCP server both use it to decide what to watch for HMR / live-reload.
 - **Diagnostics flow as data, not exceptions.** Parse errors, unresolved aliases, invalid preset axis values — all land in `project.diagnostics` with a severity. The `<Diagnostics />` block renders them.
 - **One axis type.** `Axis.source` is `'resolver'` (DTCG resolver modifier), `'layered'` (authored per-axis layer globs), or `'synthetic'` (single-axis fallback for projects without a resolver or layers). Everything downstream treats them uniformly.
+- **`parserInput` is the Terrazzo escape hatch.** The `{ tokens, sources, resolver }` triple Terrazzo's programmatic `build()` wants. Retained on the Project so [`emitViaTerrazzo`](../reference/core.mdx) drives the Terrazzo plugin pipeline without re-parsing. Undefined for layered + plain-parse paths; resolver-backed only.
 
 `ProjectSnapshot` (in `packages/blocks/src/types.ts`) is the JSON-safe slice of `Project` that the addon's virtual module and provider deal in. It's intentionally pruned — no raw Terrazzo `TokenNormalized` shapes, just the fields blocks need.
+
+## Display-side integrations
+
+The addon is tool-agnostic. Third-party integrations (Tailwind v4, CSS-in-JS for emotion / styled-components, future emitters) ship as separate packages under `@unpunnyfuns/swatchbook-integrations/*` and plug into the addon via its `integrations: SwatchbookIntegration[]` option.
+
+```ts
+interface SwatchbookIntegration {
+  name: string;
+  virtualModule?: {
+    virtualId: string;
+    render(project: Project): string;
+  };
+}
+```
+
+The addon's Vite plugin iterates `integrations[]`, resolves each `virtualId`, serves whatever `render(project)` produces, and invalidates every integration-contributed module on HMR alongside `virtual:swatchbook/tokens`. The addon itself learns nothing about Tailwind, emotion, or anything else — integrations own their library-specific logic.
+
+The `Project` snapshot passed to `render` carries everything: axes, themes, presets, resolved maps, `cssVarPrefix`, plus `parserInput` for integrations that want to drive Terrazzo's plugin pipeline. See the [Integrations section](../integrations/) for factory usage.
 
 ## Data flow — static build path
 

--- a/apps/docs/docs/integrations/css-in-js.mdx
+++ b/apps/docs/docs/integrations/css-in-js.mdx
@@ -1,0 +1,140 @@
+---
+id: css-in-js
+title: CSS-in-JS
+sidebar_position: 3
+---
+
+# CSS-in-JS integration
+
+[`@unpunnyfuns/swatchbook-integrations/css-in-js`](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-integrations) exposes a typed JS accessor whose leaves are `var(--<cssVarPrefix>-*)` string references. It's a drop-in for any `ThemeProvider` that passes its theme through as-is — emotion, styled-components, or a hand-rolled provider. The toolbar flips every value at once via CSS cascade.
+
+## Install
+
+```bash
+npm install -D @unpunnyfuns/swatchbook-integrations
+```
+
+No additional Vite plugins required — the virtual module is plain JavaScript.
+
+## Wire
+
+**`.storybook/main.ts`**:
+
+```ts
+import { defineMain } from '@storybook/react-vite/node';
+import cssInJsIntegration from '@unpunnyfuns/swatchbook-integrations/css-in-js';
+
+export default defineMain({
+  addons: [
+    {
+      name: '@unpunnyfuns/swatchbook-addon',
+      options: {
+        configPath: '../swatchbook.config.ts',
+        integrations: [cssInJsIntegration()],
+      },
+    },
+  ],
+});
+```
+
+**In any story or component**:
+
+```ts
+import { theme, color, space, radius, shadow } from 'virtual:swatchbook/theme';
+```
+
+## What gets generated
+
+Per-group exports plus an aggregate `theme` constant, one leaf per DTCG path:
+
+```js
+export const color = {
+  "accent": {
+    "bg": "var(--sb-color-accent-bg)",
+    "bgHover": "var(--sb-color-accent-bg-hover)",
+    "fg": "var(--sb-color-accent-fg)"
+  },
+  "surface": {
+    "default": "var(--sb-color-surface-default)",
+    // …
+  },
+  // …
+};
+export const space = {
+  "md": "var(--sb-space-md)",
+  // …
+};
+
+export const theme = { color, space, radius, shadow, typography /* … */ };
+```
+
+Values are **stable across tuples**. The swatchbook toolbar flipping `data-sb-mode="Dark"` doesn't change any value in this module — it changes what `--sb-color-surface-default` resolves to at the CSS level. That's the whole point: one theme object, any number of tuples, runtime switching via cascade.
+
+## Usage patterns
+
+### emotion / styled-components
+
+Wrap the preview in a `ThemeProvider`. Any `<Provider theme={theme}>` works because the theme is just a plain object.
+
+```ts
+// .storybook/preview.tsx
+import type { ReactElement } from 'react';
+import { ThemeProvider } from '@emotion/react';  // or 'styled-components'
+import { theme } from 'virtual:swatchbook/theme';
+
+export default {
+  decorators: [
+    (Story: () => ReactElement) => (
+      <ThemeProvider theme={theme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+```
+
+Your styled components interpolate as usual:
+
+```ts
+const Button = styled.button`
+  background: ${(props) => props.theme.color.accent.bg};
+  color: ${(props) => props.theme.color.accent.fg};
+  padding: ${(props) => props.theme.space.md};
+`;
+```
+
+`props.theme.color.accent.bg` returns `"var(--sb-color-accent-bg)"`; CSS resolves the var; toolbar flips redefine it.
+
+### Direct references (no provider)
+
+You don't need a provider. Named exports work anywhere a CSS value belongs — inline styles, `sx` props, template literals, plain CSS-in-JS:
+
+```tsx
+import { color, space, radius } from 'virtual:swatchbook/theme';
+
+<div style={{
+  background: color.surface.raised,
+  padding: space.lg,
+  borderRadius: radius.md,
+}} />
+```
+
+### Tailwind `sx`-style prop
+
+[Tailwind Variants](https://www.tailwind-variants.org/) / [Stitches](https://stitches.dev/) / [Vanilla Extract](https://vanilla-extract.style/): any library that takes theme keys and emits CSS can consume these leaves.
+
+## Naming
+
+- Dashed DTCG segments (`color.accent.bg-hover`) render as `color.accent.bgHover` in the accessor. CamelCased for valid JS identifiers without bracket notation.
+- Numeric DTCG segments render bare (`color.palette.neutral.500` → `color.palette.neutral[500]`). Leading-zero numerics (`size.050`) stay quoted because bare `050` is an octal under strict mode.
+- Top-level groups map to exports: `color`, `space`, `radius`, `shadow`, `typography`, etc.
+
+## HMR
+
+Editing token files re-renders the virtual module; the preview picks up the fresh accessor on the next request. React components re-render with the new theme without losing args or scroll state — same channel the tokens virtual module uses.
+
+## What this doesn't do
+
+- **Doesn't produce a resolved-value theme.** Leaves are `var()` references, not literal colours. This matters for libraries that derive dependent slots at factory time — MUI's `createTheme()` computes `palette.primary.light` / `contrastText` from the base, which can't happen from a string reference. For MUI, Vuetify configs, or Bootstrap SCSS maps that need literal values per named theme, you'd need a different emission story — see [`emitViaTerrazzo`](../reference/core.mdx) with `selection: 'presets'` and `@terrazzo/plugin-js`. Not currently shipped as an integration.
+- **Doesn't handle composite tokens structurally.** A DTCG `typography` composite lives as a single `var()` reference in the accessor — not as `{ fontFamily, fontSize, … }` sub-fields. If a library needs the sub-fields (MUI's typography slots), same caveat as above.
+- **Doesn't auto-inject a `ThemeProvider`.** You wire the provider yourself — the integration has no opinion on which library you pick.

--- a/apps/docs/docs/integrations/index.mdx
+++ b/apps/docs/docs/integrations/index.mdx
@@ -1,0 +1,90 @@
+---
+id: integrations
+title: Integrations
+sidebar_position: 1
+---
+
+# Integrations
+
+Display-side integrations that plug swatchbook's DTCG tokens into third-party tooling running inside Storybook. Each integration ships as a subpath of [`@unpunnyfuns/swatchbook-integrations`](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-integrations) and contributes a virtual module the preview imports.
+
+## Philosophy
+
+Swatchbook's purpose is **displaying DTCG tokens in Storybook**, not replacing downstream build pipelines. Integrations wire the token graph into whichever runtime library a story needs — Tailwind's `@theme` block, a JS theme accessor for CSS-in-JS, and so on — without requiring the addon itself to know anything about that library. The addon runs the integration's `render(project)` and serves the output as a virtual module; the integration package owns the library-specific logic.
+
+Production artifacts (writing `tokens.js` / `tailwind.config.css` to disk for a consumer's own build) are not swatchbook's job — `emitViaTerrazzo` in `@unpunnyfuns/swatchbook-core` gives you the same plumbing programmatically if you need artifacts outside Storybook.
+
+## Available integrations
+
+| Subpath | Covers | What it contributes |
+| --- | --- | --- |
+| [`/tailwind`](./tailwind.mdx) | Tailwind v4 | `virtual:swatchbook/tailwind.css` — an `@theme` block aliasing Tailwind utility scales to `var(--<cssVarPrefix>-*)` references |
+| [`/css-in-js`](./css-in-js.mdx) | emotion, styled-components, any ThemeProvider consuming a JS theme object | `virtual:swatchbook/theme` — typed JS accessor with `var(--<cssVarPrefix>-*)` leaves |
+
+## Recipe coverage
+
+Mapped against the `@storybook/addon-themes` getting-started recipes — swatchbook's toolbar replaces `addon-themes` outright (multi-axis, DTCG-native), and integrations cover the emitter side:
+
+| Library | Covered by |
+| --- | --- |
+| Tailwind | `/tailwind` integration |
+| Bootstrap | CSS-var consumption + toolbar `data-*` attrs (no integration needed — Bootstrap's `$theme-colors` aliases `--<prefix>-*` directly) |
+| PostCSS | CSS-var consumption + toolbar `data-*` attrs (same) |
+| emotion | `/css-in-js` integration |
+| styled-components | `/css-in-js` integration |
+| MUI | not covered — needs resolved-value emission at factory time. See the note in [`/css-in-js`](./css-in-js) |
+
+## Wiring an integration
+
+All integrations plug into the addon's options in `.storybook/main.ts`:
+
+```ts
+import { defineMain } from '@storybook/react-vite/node';
+import tailwindIntegration from '@unpunnyfuns/swatchbook-integrations/tailwind';
+import cssInJsIntegration from '@unpunnyfuns/swatchbook-integrations/css-in-js';
+
+export default defineMain({
+  addons: [
+    {
+      name: '@unpunnyfuns/swatchbook-addon',
+      options: {
+        configPath: '../swatchbook.config.ts',
+        integrations: [tailwindIntegration(), cssInJsIntegration()],
+      },
+    },
+  ],
+});
+```
+
+Each integration contributes a virtual module the preview imports:
+
+```ts
+// .storybook/preview.tsx
+import 'virtual:swatchbook/tailwind.css';    // from /tailwind
+import { theme } from 'virtual:swatchbook/theme';  // from /css-in-js
+```
+
+The addon's Vite plugin resolves the virtual IDs, runs `render(project)` on load, and invalidates the modules on token-file edits so the output stays in lockstep with the toolbar.
+
+## Writing your own integration
+
+An integration is a factory returning a `SwatchbookIntegration`:
+
+```ts
+import type { SwatchbookIntegration } from '@unpunnyfuns/swatchbook-core';
+
+export default function myIntegration(): SwatchbookIntegration {
+  return {
+    name: 'my-integration',
+    virtualModule: {
+      virtualId: 'virtual:swatchbook/my-module',
+      render: (project) => {
+        // Derive whatever string you want from the loaded Project.
+        return `/* generated from ${project.themes.length} themes */`;
+      },
+    },
+  };
+}
+```
+
+The `render` function receives the loaded `Project` — axes, themes, presets, resolved token maps, the configured `cssVarPrefix`, and the retained Terrazzo `parserInput` for plugin-pipeline emission. Return whatever string the virtual module should serve. The addon handles the rest.

--- a/apps/docs/docs/integrations/tailwind.mdx
+++ b/apps/docs/docs/integrations/tailwind.mdx
@@ -1,0 +1,120 @@
+---
+id: tailwind
+title: Tailwind
+sidebar_position: 2
+---
+
+# Tailwind integration
+
+[`@unpunnyfuns/swatchbook-integrations/tailwind`](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-integrations) aliases [Tailwind v4](https://tailwindcss.com/docs/v4-beta) utility scales to your DTCG tokens, so classes like `bg-sb-surface-default` / `p-sb-md` / `rounded-sb-lg` resolve through the same `var(--sb-*)` chain the swatchbook toolbar flips.
+
+## Install
+
+```bash
+npm install -D @unpunnyfuns/swatchbook-integrations tailwindcss @tailwindcss/vite
+```
+
+Tailwind v4's Vite plugin is required to process the `@theme` block the integration serves.
+
+## Wire
+
+**`.storybook/main.ts`** — plug the integration into the addon options and add Tailwind's Vite plugin:
+
+```ts
+import tailwindcss from '@tailwindcss/vite';
+import { defineMain } from '@storybook/react-vite/node';
+import tailwindIntegration from '@unpunnyfuns/swatchbook-integrations/tailwind';
+
+export default defineMain({
+  addons: [
+    {
+      name: '@unpunnyfuns/swatchbook-addon',
+      options: {
+        configPath: '../swatchbook.config.ts',
+        integrations: [tailwindIntegration()],
+      },
+    },
+  ],
+  viteFinal(config) {
+    const plugins = Array.isArray(config.plugins) ? [...config.plugins] : [];
+    plugins.push(tailwindcss());
+    return { ...config, plugins };
+  },
+});
+```
+
+**`.storybook/preview.tsx`** — import the virtual module:
+
+```ts
+import 'virtual:swatchbook/tailwind.css';
+```
+
+That's it. No hand-written `tailwind.css`, no `@theme` block to keep in sync.
+
+## What gets generated
+
+With `cssVarPrefix: 'sb'` in your swatchbook config, the virtual module serves an `@theme` block like:
+
+```css
+@import 'tailwindcss';
+
+@theme {
+  /* color */
+  --color-sb-surface-default: var(--sb-color-surface-default);
+  --color-sb-accent-bg: var(--sb-color-accent-bg);
+  /* spacing */
+  --spacing-sb-md: var(--sb-space-md);
+  /* radius */
+  --radius-sb-lg: var(--sb-radius-lg);
+  /* shadow */
+  --shadow-sb-md: var(--sb-shadow-md);
+}
+```
+
+Tailwind's compiler sees the `@theme` block and emits utilities:
+
+```css
+.bg-sb-surface-default { background-color: var(--color-sb-surface-default); }
+.p-sb-md { padding: var(--spacing-sb-md); }
+/* …and so on for every entry */
+```
+
+At runtime the swatchbook toolbar flips `data-sb-mode` / `data-sb-brand` / `data-sb-contrast` on `<html>`, the per-tuple stylesheet redefines `--sb-*` vars, and every Tailwind utility re-paints via cascade.
+
+## The `sb-` prefix (and why it's there)
+
+Every entry in the `@theme` block is nested under your project's `cssVarPrefix`. Tailwind's default scales (`--color-red-500`, `--spacing-4`, `--container-md`) stay intact — `bg-red-500` still works alongside `bg-sb-surface-default`, `p-4` alongside `p-sb-md`.
+
+This matters because Tailwind v4's `max-w-<name>` / `w-<name>` / `size-<name>` utilities read from the `--spacing-*` namespace. Without the prefix, a swatchbook entry named `--spacing-sm` would shadow Tailwind's default `--container-sm`, making `max-w-sm` tiny. The double-prefix (`--spacing-sb-sm`) sidesteps that collision entirely.
+
+## Customising the role map
+
+The integration ships a curated default role map covering the semantic DTCG roles — surface / text / accent / border / status colours, a 9-stop spacing scale, radii, shadows. If your project has different paths, pass your own map:
+
+```ts
+tailwindIntegration({
+  roles: {
+    color: [
+      ['brand', 'color.brand.primary'],
+      ['brand-fg', 'color.brand.primary-contrast'],
+      ['surface', 'color.surface.default'],
+    ],
+    spacing: [
+      ['tight', 'size.compact'],
+      ['loose', 'size.airy'],
+    ],
+  },
+});
+```
+
+The map replaces the default entirely — what you list is what you get. Tailwind scale names (`color`, `spacing`, `radius`, `shadow`) are keys; each entry is `[tailwindEntryName, dtcgPath]`.
+
+## HMR
+
+Editing any token file in your swatchbook project re-renders the `@theme` block and invalidates the virtual module. Tailwind's compiler picks up the change on the next request, utilities regenerate, and the preview repaints — no server restart.
+
+## What this doesn't do
+
+- **Doesn't write `tailwind.css` to disk.** The integration serves a virtual module for the Storybook preview. For your production build you run Tailwind's CLI / Vite plugin against your own `@theme` source.
+- **Doesn't enable `@tailwindcss/vite` outside Storybook.** You wire Tailwind's Vite plugin once in the Storybook config; your app's own build is independent.
+- **Doesn't proxy Tailwind's own plugin system.** Variants, plugins, darkMode config, arbitrary values — all pass through to Tailwind untouched.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -64,6 +64,7 @@ The [live Storybook](pathname:///storybook/) runs the addon against this repo's 
 - **Blocks** — the MDX doc blocks you'll spend most of your time with: the [reference](./reference/blocks) lists what's available and the [authoring guide](./guides/authoring-doc-stories) walks through composing them.
 - **Concepts** — the mental model: [why axes, not themes](./concepts/axes-vs-themes), [theming inputs](./concepts/theming-inputs), [axes](./concepts/axes), [theme reactivity](./concepts/theme-reactivity), [presets](./concepts/presets), [diagnostics](./concepts/diagnostics).
 - **Guides** — the [multi-axis walkthrough](./guides/multi-axis-walkthrough) covers one-time setup.
+- **Integrations** — [wiring swatchbook tokens into Tailwind / styled-components / emotion / any ThemeProvider-consumer](./integrations/) via the `@unpunnyfuns/swatchbook-integrations` package.
 - **Reference** — API surface for the remaining packages (`addon`, `core`, `config`, `mcp`).
 - **Developers** — contributing to swatchbook itself: [architecture](./developers/architecture) and [sharp corners](./developers/sharp-corners).
 

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -81,6 +81,39 @@ permutationID({ mode: 'Dark', brand: 'Brand A' }); // → "Dark · Brand A"
 permutationID({ theme: 'Light' }); // → "Light"
 ```
 
+### `emitViaTerrazzo(project, options?)`
+
+Axis-aware wrapper around Terrazzo's programmatic `build()`. Derives compound-selector permutations from `project.themes` (or `project.presets` via `selection`), pins `@terrazzo/plugin-css`'s `variableName` to the project's `cssVarPrefix`, and runs whatever additional Terrazzo plugins you pass — `plugin-css-in-js`, `plugin-tailwind`, `plugin-swift`, `plugin-js`, `plugin-sass`, `plugin-vanilla-extract`, `plugin-token-listing`.
+
+```ts
+import { loadProject, emitViaTerrazzo } from '@unpunnyfuns/swatchbook-core';
+import cssInJsPlugin from '@terrazzo/plugin-css-in-js';
+import tailwindPlugin from '@terrazzo/plugin-tailwind';
+
+const project = await loadProject(config, cwd);
+const files = await emitViaTerrazzo(project, {
+  cssOptions: { filename: 'tokens.css' },
+  plugins: [
+    cssInJsPlugin({ filename: 'tokens.js' }),
+    tailwindPlugin({ filename: 'tailwind.tokens.css' }),
+  ],
+  selection: 'themes', // default — full cartesian fan-out for runtime CSS
+});
+// files → [{ filename, contents }, ...]
+```
+
+Options:
+
+| Option | What |
+| --- | --- |
+| `selection` | `'themes'` (default, full cartesian), `'presets'` (one entry per declared preset), or explicit `Array<{ input, name? }>`. Library consumers (MUI / Vuetify) usually want `'presets'`. |
+| `cssOptions` | Extra `@terrazzo/plugin-css` options (filename, include / exclude, transform, utility, colorDepth). `permutations` and `variableName` are managed internally — passing them here is a no-op. |
+| `plugins` | Additional Terrazzo plugins to run alongside `plugin-css`. |
+
+**Requires a resolver-backed project.** Layered (`config.axes`) and plain-parse paths don't populate `parserInput`; the wrapper throws with a clear error on those.
+
+**Not the addon's emission path.** Storybook's runtime CSS still comes from `projectCss` with chrome aliases. `emitViaTerrazzo` is for library-level consumers driving their own build or for future display-side integrations.
+
 ## Types
 
 ### `Config`
@@ -152,9 +185,41 @@ interface Project {
   graph: TokenMap; // default theme's resolved tokens
   /** Absolute paths of every file loaded while building the project (resolver + `$ref` targets, overlay files, or globbed plain-parse files). */
   sourceFiles: string[];
+  /** Loader cwd — what all config-relative paths resolved against. */
+  cwd: string;
+  /** Retained Terrazzo parse output for `emitViaTerrazzo`. Present for resolver-backed projects; undefined for layered / plain-parse paths. */
+  parserInput?: ParserInput;
   diagnostics: Diagnostic[];
 }
 ```
+
+### `ParserInput`
+
+Pass-through bag of the three values Terrazzo's programmatic `build()` needs. Consumers treat it as opaque — feed the whole object into `build()` (or into `emitViaTerrazzo`, which handles that for you).
+
+```ts
+interface ParserInput {
+  tokens: Record<string, TokenNormalized>; // unified pre-permutation token graph
+  sources: InputSourceWithDocument[];       // parser's input sources
+  resolver: Resolver;                        // the Terrazzo resolver object
+}
+```
+
+### `SwatchbookIntegration`
+
+Contract for display-side integrations plugged into the addon via its `integrations[]` option. An integration names a virtual module; the addon's Vite plugin serves whatever `render(project)` produces.
+
+```ts
+interface SwatchbookIntegration {
+  name: string;
+  virtualModule?: {
+    virtualId: string;                 // e.g. 'virtual:swatchbook/tailwind.css'
+    render(project: Project): string;  // produce the module body
+  };
+}
+```
+
+See the [Integrations section](../integrations/) for factories that build these for Tailwind and CSS-in-JS.
 
 ### `Theme`
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -45,6 +45,11 @@ const sidebars: SidebarsConfig = {
     'guides/token-dashboard',
     'guides/multi-axis-walkthrough',
   ],
+  integrations: [
+    'integrations/integrations',
+    'integrations/tailwind',
+    'integrations/css-in-js',
+  ],
   reference: ['reference/addon', 'reference/core', 'reference/config', 'reference/mcp'],
   developers: [
     'developers/developers',


### PR DESCRIPTION
## Summary

- \`reference/core\` gains \`emitViaTerrazzo\` section with options table + usage example.
- \`ParserInput\` and \`SwatchbookIntegration\` types documented alongside existing type reference entries.
- \`Project\` picks up \`cwd\` + \`parserInput?\` fields.
- \`developers/architecture\` picks up the \`parserInput\` bullet + a new "Display-side integrations" section covering the plugin contract and how the addon serves integration virtual modules.

## Depends on

- #556 — cross-links to \`../integrations/\` resolve there.

## Test plan

- [x] \`docusaurus build\` runs clean, zero broken-link warnings.
- [x] Pages render with working in-page links.

Milestone: Maintenance
Closes: #557
Plan impact: none