### PR TITLE
docs: add migration guide for @storybook/addon-themes users

### DIFF
--- a/.changeset/docs-addon-themes-migration.md
+++ b/.changeset/docs-addon-themes-migration.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Docs: new guide for migrating from `@storybook/addon-themes` — decorator-by-decorator mapping to the swatchbook equivalent, coverage for class-based / data-attribute / JSX-provider patterns, honest notes on what's lost (MUI-style resolved-value factories) and what's gained.

--- a/.changeset/docs-integrations-section.md
+++ b/.changeset/docs-integrations-section.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Docs: new Integrations section covering the `@unpunnyfuns/swatchbook-integrations` package. Overview page with the recipe-coverage table + philosophy, plus per-subpath recipes for `/tailwind` and `/css-in-js` (wiring, generated output, prefix collision story, customisation hooks).

--- a/apps/docs/docs/guides/migrating-from-addon-themes.mdx
+++ b/apps/docs/docs/guides/migrating-from-addon-themes.mdx
@@ -1,0 +1,166 @@
+---
+id: migrating-from-addon-themes
+title: Migrating from @storybook/addon-themes
+sidebar_position: 4
+---
+
+# Migrating from `@storybook/addon-themes`
+
+Swatchbook's addon replaces `@storybook/addon-themes` outright — same toolbar role, richer model (multi-axis, DTCG-native, HMR-aware). If you're coming from `addon-themes`, this guide maps each of its decorators to the swatchbook equivalent.
+
+## TL;DR
+
+| `addon-themes` | Swatchbook equivalent |
+| --- | --- |
+| `withThemeByClassName({ themes, defaultTheme })` | Remove — swatchbook's toolbar sets `data-<prefix>-*` attributes by default; rewrite any class-based CSS to target `[data-<prefix>-mode="Dark"]` etc. |
+| `withThemeByDataAttribute({ themes, defaultTheme, attributeName })` | Remove — swatchbook does exactly this, multi-axis. Your stylesheet already consumes the attributes; keep it. |
+| `withThemeFromJSXProvider({ Provider, GlobalStyles, themes })` | Keep using your provider, but feed it swatchbook's theme accessor. See [CSS-in-JS integration](../integrations/css-in-js.mdx). |
+
+Your app's CSS stays the same. Your stories stay the same. You delete one decorator and either lose it (class / data-attr cases) or rewire it against the swatchbook provider (JSX case).
+
+## Step by step
+
+### 1. Install the swatchbook addon
+
+```bash
+npm install -D @unpunnyfuns/swatchbook-addon
+```
+
+Register it in `.storybook/main.ts` alongside (or instead of) `@storybook/addon-themes`:
+
+```diff
+ export default {
+   addons: [
+-    '@storybook/addon-themes',
++    '@unpunnyfuns/swatchbook-addon',
+   ],
+ };
+```
+
+If you prefer a gradual migration, leave `@storybook/addon-themes` registered — both toolbars can coexist during the transition, though users will see two switchers.
+
+### 2. Define your axes
+
+`addon-themes` expects a flat `themes: Record<string, string>` map. Swatchbook expects a DTCG resolver or authored axes. The minimal `swatchbook.config.ts` for a single-axis setup:
+
+```ts
+// swatchbook.config.ts
+import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
+
+export default defineSwatchbookConfig({
+  tokens: ['tokens/base/**/*.json'],
+  axes: [
+    {
+      name: 'mode',
+      default: 'Light',
+      contexts: {
+        Light: [],
+        Dark: ['tokens/modes/dark.json'],
+      },
+    },
+  ],
+});
+```
+
+Multi-axis (mode × brand × contrast, for example) adds more `axes` entries — see the [multi-axis walkthrough](./multi-axis-walkthrough.mdx).
+
+If your tokens are already in DTCG 2025.10 resolver format, point at the resolver file instead:
+
+```ts
+export default defineSwatchbookConfig({ resolver: 'tokens/resolver.json' });
+```
+
+### 3. Drop the `addon-themes` decorator
+
+#### Were you using `withThemeByClassName`?
+
+Your stylesheet probably looks like:
+
+```css
+.dark { /* dark overrides */ }
+.light { /* light overrides */ }
+```
+
+**Option A: Rewire to `data-*` attrs.** Swatchbook's toolbar sets `data-<prefix>-mode="Dark"` on `<html>` by default. Replace your class selectors:
+
+```diff
+-.dark { … }
++[data-sb-mode="Dark"] { … }
+```
+
+If you want the class form instead, keep swatchbook's data attributes as the primary mechanism and add a `[data-sb-mode="Dark"] { }` → `class` bridge in your CSS:
+
+```css
+[data-sb-mode="Dark"] { }
+/* Synonym for anywhere you can't update `.dark` to the attribute selector: */
+.dark { /* your overrides */ }
+```
+
+**Option B: Emit CSS vars with `projectCss`.** The cleaner migration — once your DTCG tokens are authored, swatchbook emits per-tuple CSS that redefines `--<prefix>-*` vars under `[data-<prefix>-*]` selectors. Your components reference the vars directly; class names stop mattering for theming. See [the token pipeline](../concepts/token-pipeline.mdx).
+
+#### Were you using `withThemeByDataAttribute`?
+
+Your stylesheet already consumes `data-*` attributes. Swatchbook sets the same attributes (prefixed, by default — `data-sb-mode` rather than bare `data-theme`). Two choices:
+
+**Option A: Update your CSS to swatchbook's prefixed attrs.**
+
+```diff
+-[data-theme="dark"] { … }
++[data-sb-mode="Dark"] { … }
+```
+
+**Option B: Drop the prefix in swatchbook's config so the attribute matches your existing CSS.**
+
+```ts
+defineSwatchbookConfig({
+  cssVarPrefix: '',  // → `data-mode`, `data-brand`, etc., no prefix segment
+  // …
+});
+```
+
+Beware: with an empty prefix, `data-mode` can collide with other libraries' conventions. Prefer Option A.
+
+#### Were you using `withThemeFromJSXProvider`?
+
+You have a real theme-object shape the provider expects (emotion's `{ colors: {…} }`, styled-components' theme, MUI's `createTheme` output).
+
+**The migration depends on what the provider does with the theme.**
+
+- **If the provider just passes the theme through to `useTheme()` / `props.theme` and your styled components read values from it** — emotion, styled-components, and hand-rolled providers — use the [CSS-in-JS integration](../integrations/css-in-js.mdx). It ships a `virtual:swatchbook/theme` module with `var(--sb-*)` string leaves; drop-in for any provider, toolbar flip handled by cascade.
+
+- **If the provider derives dependent values from the theme at factory time** — MUI's `createTheme` computing `palette.primary.light` / `contrastText` from a base — you need per-tuple resolved values, not var refs. Swatchbook doesn't ship that integration yet; the machinery exists in [`emitViaTerrazzo`](../reference/core.mdx) (resolver-backed projects, `selection: 'presets'`, paired with `@terrazzo/plugin-js`), but you'd be wiring it yourself.
+
+- **Vuetify theme config, bootstrap SCSS** — same caveat as MUI. Same workaround.
+
+### 4. Drop the global
+
+`addon-themes`'s `theme` global (string) doesn't survive the migration — swatchbook uses per-axis globals (`swatchbookTheme`, and optionally per-axis `swatchbookAxes`). Stories that read `theme` from `globals` need to switch:
+
+```diff
+-const { theme } = context.globals;
++const { swatchbookTheme } = context.globals;
+```
+
+Per-story overrides change from `parameters: { themes: { themeOverride: 'dark' } }` to `parameters: { swatchbook: { themeOverride: 'Dark' } }`. Context key follows the axis-aware `swatchbook` namespace.
+
+### 5. Keep `addon-themes` around?
+
+No. Swatchbook's toolbar supersedes it fully. Once your decorators are rewired, remove `@storybook/addon-themes` from `addons[]` and uninstall.
+
+## Why no bridge package?
+
+It'd be tempting to ship a `@unpunnyfuns/swatchbook-integrations/addon-themes` subpath that auto-derives the `themes` / `defaultTheme` object `withThemeByDataAttribute` wants. We considered it and decided against: `addon-themes`' decorators are single-axis by design, and every bridge shape would either collapse multi-axis projects (losing expressiveness) or fight the addon's flat-string mental model. A documented migration path ends up cleaner than a bridge that half-works.
+
+## What you lose
+
+- `themes: Record<string, string>`'s flat mental model — swatchbook makes the multi-axis structure explicit, which is more accurate for most systems but requires one config decision (resolver vs layered axes).
+- `withThemeFromJSXProvider`'s direct theme-object passing — our provider equivalent is via the CSS-in-JS integration, and MUI-style resolved-value factories aren't covered yet.
+
+## What you gain
+
+- Multi-axis (mode × brand × contrast × density × whatever) without flattening to 18 theme names.
+- DTCG 2025.10 as the source of truth — `resolver.json` instead of hand-wired theme maps.
+- HMR on token edits: change a color value, preview re-renders in place without losing args / scroll state.
+- Doc blocks (`TokenTable`, `TokenNavigator`, `ColorPalette`, `TokenDetail`) that read from the same source.
+- MCP server for AI-agent introspection over the same token graph.
+- Compound `data-*` selectors for runtime theme switching that compose naturally with Tailwind v4 and every CSS-var-consuming library.

--- a/apps/docs/docs/integrations/css-in-js.mdx
+++ b/apps/docs/docs/integrations/css-in-js.mdx
@@ -1,0 +1,140 @@
+---
+id: css-in-js
+title: CSS-in-JS
+sidebar_position: 3
+---
+
+# CSS-in-JS integration
+
+[`@unpunnyfuns/swatchbook-integrations/css-in-js`](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-integrations) exposes a typed JS accessor whose leaves are `var(--<cssVarPrefix>-*)` string references. It's a drop-in for any `ThemeProvider` that passes its theme through as-is — emotion, styled-components, or a hand-rolled provider. The toolbar flips every value at once via CSS cascade.
+
+## Install
+
+```bash
+npm install -D @unpunnyfuns/swatchbook-integrations
+```
+
+No additional Vite plugins required — the virtual module is plain JavaScript.
+
+## Wire
+
+**`.storybook/main.ts`**:
+
+```ts
+import { defineMain } from '@storybook/react-vite/node';
+import cssInJsIntegration from '@unpunnyfuns/swatchbook-integrations/css-in-js';
+
+export default defineMain({
+  addons: [
+    {
+      name: '@unpunnyfuns/swatchbook-addon',
+      options: {
+        configPath: '../swatchbook.config.ts',
+        integrations: [cssInJsIntegration()],
+      },
+    },
+  ],
+});
+```
+
+**In any story or component**:
+
+```ts
+import { theme, color, space, radius, shadow } from 'virtual:swatchbook/theme';
+```
+
+## What gets generated
+
+Per-group exports plus an aggregate `theme` constant, one leaf per DTCG path:
+
+```js
+export const color = {
+  "accent": {
+    "bg": "var(--sb-color-accent-bg)",
+    "bgHover": "var(--sb-color-accent-bg-hover)",
+    "fg": "var(--sb-color-accent-fg)"
+  },
+  "surface": {
+    "default": "var(--sb-color-surface-default)",
+    // …
+  },
+  // …
+};
+export const space = {
+  "md": "var(--sb-space-md)",
+  // …
+};
+
+export const theme = { color, space, radius, shadow, typography /* … */ };
+```
+
+Values are **stable across tuples**. The swatchbook toolbar flipping `data-sb-mode="Dark"` doesn't change any value in this module — it changes what `--sb-color-surface-default` resolves to at the CSS level. That's the whole point: one theme object, any number of tuples, runtime switching via cascade.
+
+## Usage patterns
+
+### emotion / styled-components
+
+Wrap the preview in a `ThemeProvider`. Any `<Provider theme={theme}>` works because the theme is just a plain object.
+
+```ts
+// .storybook/preview.tsx
+import type { ReactElement } from 'react';
+import { ThemeProvider } from '@emotion/react';  // or 'styled-components'
+import { theme } from 'virtual:swatchbook/theme';
+
+export default {
+  decorators: [
+    (Story: () => ReactElement) => (
+      <ThemeProvider theme={theme}>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+```
+
+Your styled components interpolate as usual:
+
+```ts
+const Button = styled.button`
+  background: ${(props) => props.theme.color.accent.bg};
+  color: ${(props) => props.theme.color.accent.fg};
+  padding: ${(props) => props.theme.space.md};
+`;
+```
+
+`props.theme.color.accent.bg` returns `"var(--sb-color-accent-bg)"`; CSS resolves the var; toolbar flips redefine it.
+
+### Direct references (no provider)
+
+You don't need a provider. Named exports work anywhere a CSS value belongs — inline styles, `sx` props, template literals, plain CSS-in-JS:
+
+```tsx
+import { color, space, radius } from 'virtual:swatchbook/theme';
+
+<div style={{
+  background: color.surface.raised,
+  padding: space.lg,
+  borderRadius: radius.md,
+}} />
+```
+
+### Tailwind `sx`-style prop
+
+[Tailwind Variants](https://www.tailwind-variants.org/) / [Stitches](https://stitches.dev/) / [Vanilla Extract](https://vanilla-extract.style/): any library that takes theme keys and emits CSS can consume these leaves.
+
+## Naming
+
+- Dashed DTCG segments (`color.accent.bg-hover`) render as `color.accent.bgHover` in the accessor. CamelCased for valid JS identifiers without bracket notation.
+- Numeric DTCG segments render bare (`color.palette.neutral.500` → `color.palette.neutral[500]`). Leading-zero numerics (`size.050`) stay quoted because bare `050` is an octal under strict mode.
+- Top-level groups map to exports: `color`, `space`, `radius`, `shadow`, `typography`, etc.
+
+## HMR
+
+Editing token files re-renders the virtual module; the preview picks up the fresh accessor on the next request. React components re-render with the new theme without losing args or scroll state — same channel the tokens virtual module uses.
+
+## What this doesn't do
+
+- **Doesn't produce a resolved-value theme.** Leaves are `var()` references, not literal colours. This matters for libraries that derive dependent slots at factory time — MUI's `createTheme()` computes `palette.primary.light` / `contrastText` from the base, which can't happen from a string reference. For MUI, Vuetify configs, or Bootstrap SCSS maps that need literal values per named theme, you'd need a different emission story — see [`emitViaTerrazzo`](../reference/core.mdx) with `selection: 'presets'` and `@terrazzo/plugin-js`. Not currently shipped as an integration.
+- **Doesn't handle composite tokens structurally.** A DTCG `typography` composite lives as a single `var()` reference in the accessor — not as `{ fontFamily, fontSize, … }` sub-fields. If a library needs the sub-fields (MUI's typography slots), same caveat as above.
+- **Doesn't auto-inject a `ThemeProvider`.** You wire the provider yourself — the integration has no opinion on which library you pick.

--- a/apps/docs/docs/integrations/index.mdx
+++ b/apps/docs/docs/integrations/index.mdx
@@ -1,0 +1,90 @@
+---
+id: integrations
+title: Integrations
+sidebar_position: 1
+---
+
+# Integrations
+
+Display-side integrations that plug swatchbook's DTCG tokens into third-party tooling running inside Storybook. Each integration ships as a subpath of [`@unpunnyfuns/swatchbook-integrations`](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-integrations) and contributes a virtual module the preview imports.
+
+## Philosophy
+
+Swatchbook's purpose is **displaying DTCG tokens in Storybook**, not replacing downstream build pipelines. Integrations wire the token graph into whichever runtime library a story needs — Tailwind's `@theme` block, a JS theme accessor for CSS-in-JS, and so on — without requiring the addon itself to know anything about that library. The addon runs the integration's `render(project)` and serves the output as a virtual module; the integration package owns the library-specific logic.
+
+Production artifacts (writing `tokens.js` / `tailwind.config.css` to disk for a consumer's own build) are not swatchbook's job — `emitViaTerrazzo` in `@unpunnyfuns/swatchbook-core` gives you the same plumbing programmatically if you need artifacts outside Storybook.
+
+## Available integrations
+
+| Subpath | Covers | What it contributes |
+| --- | --- | --- |
+| [`/tailwind`](./tailwind.mdx) | Tailwind v4 | `virtual:swatchbook/tailwind.css` — an `@theme` block aliasing Tailwind utility scales to `var(--<cssVarPrefix>-*)` references |
+| [`/css-in-js`](./css-in-js.mdx) | emotion, styled-components, any ThemeProvider consuming a JS theme object | `virtual:swatchbook/theme` — typed JS accessor with `var(--<cssVarPrefix>-*)` leaves |
+
+## Recipe coverage
+
+Mapped against the `@storybook/addon-themes` getting-started recipes — swatchbook's toolbar replaces `addon-themes` outright (multi-axis, DTCG-native), and integrations cover the emitter side:
+
+| Library | Covered by |
+| --- | --- |
+| Tailwind | `/tailwind` integration |
+| Bootstrap | CSS-var consumption + toolbar `data-*` attrs (no integration needed — Bootstrap's `$theme-colors` aliases `--<prefix>-*` directly) |
+| PostCSS | CSS-var consumption + toolbar `data-*` attrs (same) |
+| emotion | `/css-in-js` integration |
+| styled-components | `/css-in-js` integration |
+| MUI | not covered — needs resolved-value emission at factory time. See the note in [`/css-in-js`](./css-in-js) |
+
+## Wiring an integration
+
+All integrations plug into the addon's options in `.storybook/main.ts`:
+
+```ts
+import { defineMain } from '@storybook/react-vite/node';
+import tailwindIntegration from '@unpunnyfuns/swatchbook-integrations/tailwind';
+import cssInJsIntegration from '@unpunnyfuns/swatchbook-integrations/css-in-js';
+
+export default defineMain({
+  addons: [
+    {
+      name: '@unpunnyfuns/swatchbook-addon',
+      options: {
+        configPath: '../swatchbook.config.ts',
+        integrations: [tailwindIntegration(), cssInJsIntegration()],
+      },
+    },
+  ],
+});
+```
+
+Each integration contributes a virtual module the preview imports:
+
+```ts
+// .storybook/preview.tsx
+import 'virtual:swatchbook/tailwind.css';    // from /tailwind
+import { theme } from 'virtual:swatchbook/theme';  // from /css-in-js
+```
+
+The addon's Vite plugin resolves the virtual IDs, runs `render(project)` on load, and invalidates the modules on token-file edits so the output stays in lockstep with the toolbar.
+
+## Writing your own integration
+
+An integration is a factory returning a `SwatchbookIntegration`:
+
+```ts
+import type { SwatchbookIntegration } from '@unpunnyfuns/swatchbook-core';
+
+export default function myIntegration(): SwatchbookIntegration {
+  return {
+    name: 'my-integration',
+    virtualModule: {
+      virtualId: 'virtual:swatchbook/my-module',
+      render: (project) => {
+        // Derive whatever string you want from the loaded Project.
+        return `/* generated from ${project.themes.length} themes */`;
+      },
+    },
+  };
+}
+```
+
+The `render` function receives the loaded `Project` — axes, themes, presets, resolved token maps, the configured `cssVarPrefix`, and the retained Terrazzo `parserInput` for plugin-pipeline emission. Return whatever string the virtual module should serve. The addon handles the rest.

--- a/apps/docs/docs/integrations/tailwind.mdx
+++ b/apps/docs/docs/integrations/tailwind.mdx
@@ -1,0 +1,120 @@
+---
+id: tailwind
+title: Tailwind
+sidebar_position: 2
+---
+
+# Tailwind integration
+
+[`@unpunnyfuns/swatchbook-integrations/tailwind`](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-integrations) aliases [Tailwind v4](https://tailwindcss.com/docs/v4-beta) utility scales to your DTCG tokens, so classes like `bg-sb-surface-default` / `p-sb-md` / `rounded-sb-lg` resolve through the same `var(--sb-*)` chain the swatchbook toolbar flips.
+
+## Install
+
+```bash
+npm install -D @unpunnyfuns/swatchbook-integrations tailwindcss @tailwindcss/vite
+```
+
+Tailwind v4's Vite plugin is required to process the `@theme` block the integration serves.
+
+## Wire
+
+**`.storybook/main.ts`** — plug the integration into the addon options and add Tailwind's Vite plugin:
+
+```ts
+import tailwindcss from '@tailwindcss/vite';
+import { defineMain } from '@storybook/react-vite/node';
+import tailwindIntegration from '@unpunnyfuns/swatchbook-integrations/tailwind';
+
+export default defineMain({
+  addons: [
+    {
+      name: '@unpunnyfuns/swatchbook-addon',
+      options: {
+        configPath: '../swatchbook.config.ts',
+        integrations: [tailwindIntegration()],
+      },
+    },
+  ],
+  viteFinal(config) {
+    const plugins = Array.isArray(config.plugins) ? [...config.plugins] : [];
+    plugins.push(tailwindcss());
+    return { ...config, plugins };
+  },
+});
+```
+
+**`.storybook/preview.tsx`** — import the virtual module:
+
+```ts
+import 'virtual:swatchbook/tailwind.css';
+```
+
+That's it. No hand-written `tailwind.css`, no `@theme` block to keep in sync.
+
+## What gets generated
+
+With `cssVarPrefix: 'sb'` in your swatchbook config, the virtual module serves an `@theme` block like:
+
+```css
+@import 'tailwindcss';
+
+@theme {
+  /* color */
+  --color-sb-surface-default: var(--sb-color-surface-default);
+  --color-sb-accent-bg: var(--sb-color-accent-bg);
+  /* spacing */
+  --spacing-sb-md: var(--sb-space-md);
+  /* radius */
+  --radius-sb-lg: var(--sb-radius-lg);
+  /* shadow */
+  --shadow-sb-md: var(--sb-shadow-md);
+}
+```
+
+Tailwind's compiler sees the `@theme` block and emits utilities:
+
+```css
+.bg-sb-surface-default { background-color: var(--color-sb-surface-default); }
+.p-sb-md { padding: var(--spacing-sb-md); }
+/* …and so on for every entry */
+```
+
+At runtime the swatchbook toolbar flips `data-sb-mode` / `data-sb-brand` / `data-sb-contrast` on `<html>`, the per-tuple stylesheet redefines `--sb-*` vars, and every Tailwind utility re-paints via cascade.
+
+## The `sb-` prefix (and why it's there)
+
+Every entry in the `@theme` block is nested under your project's `cssVarPrefix`. Tailwind's default scales (`--color-red-500`, `--spacing-4`, `--container-md`) stay intact — `bg-red-500` still works alongside `bg-sb-surface-default`, `p-4` alongside `p-sb-md`.
+
+This matters because Tailwind v4's `max-w-<name>` / `w-<name>` / `size-<name>` utilities read from the `--spacing-*` namespace. Without the prefix, a swatchbook entry named `--spacing-sm` would shadow Tailwind's default `--container-sm`, making `max-w-sm` tiny. The double-prefix (`--spacing-sb-sm`) sidesteps that collision entirely.
+
+## Customising the role map
+
+The integration ships a curated default role map covering the semantic DTCG roles — surface / text / accent / border / status colours, a 9-stop spacing scale, radii, shadows. If your project has different paths, pass your own map:
+
+```ts
+tailwindIntegration({
+  roles: {
+    color: [
+      ['brand', 'color.brand.primary'],
+      ['brand-fg', 'color.brand.primary-contrast'],
+      ['surface', 'color.surface.default'],
+    ],
+    spacing: [
+      ['tight', 'size.compact'],
+      ['loose', 'size.airy'],
+    ],
+  },
+});
+```
+
+The map replaces the default entirely — what you list is what you get. Tailwind scale names (`color`, `spacing`, `radius`, `shadow`) are keys; each entry is `[tailwindEntryName, dtcgPath]`.
+
+## HMR
+
+Editing any token file in your swatchbook project re-renders the `@theme` block and invalidates the virtual module. Tailwind's compiler picks up the change on the next request, utilities regenerate, and the preview repaints — no server restart.
+
+## What this doesn't do
+
+- **Doesn't write `tailwind.css` to disk.** The integration serves a virtual module for the Storybook preview. For your production build you run Tailwind's CLI / Vite plugin against your own `@theme` source.
+- **Doesn't enable `@tailwindcss/vite` outside Storybook.** You wire Tailwind's Vite plugin once in the Storybook config; your app's own build is independent.
+- **Doesn't proxy Tailwind's own plugin system.** Variants, plugins, darkMode config, arbitrary values — all pass through to Tailwind untouched.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -64,6 +64,7 @@ The [live Storybook](pathname:///storybook/) runs the addon against this repo's 
 - **Blocks** — the MDX doc blocks you'll spend most of your time with: the [reference](./reference/blocks) lists what's available and the [authoring guide](./guides/authoring-doc-stories) walks through composing them.
 - **Concepts** — the mental model: [why axes, not themes](./concepts/axes-vs-themes), [theming inputs](./concepts/theming-inputs), [axes](./concepts/axes), [theme reactivity](./concepts/theme-reactivity), [presets](./concepts/presets), [diagnostics](./concepts/diagnostics).
 - **Guides** — the [multi-axis walkthrough](./guides/multi-axis-walkthrough) covers one-time setup.
+- **Integrations** — [wiring swatchbook tokens into Tailwind / styled-components / emotion / any ThemeProvider-consumer](./integrations/) via the `@unpunnyfuns/swatchbook-integrations` package.
 - **Reference** — API surface for the remaining packages (`addon`, `core`, `config`, `mcp`).
 - **Developers** — contributing to swatchbook itself: [architecture](./developers/architecture) and [sharp corners](./developers/sharp-corners).
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -45,6 +45,11 @@ const sidebars: SidebarsConfig = {
     'guides/token-dashboard',
     'guides/multi-axis-walkthrough',
   ],
+  integrations: [
+    'integrations/integrations',
+    'integrations/tailwind',
+    'integrations/css-in-js',
+  ],
   reference: ['reference/addon', 'reference/core', 'reference/config', 'reference/mcp'],
   developers: [
     'developers/developers',

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -44,6 +44,7 @@ const sidebars: SidebarsConfig = {
     'guides/authoring-doc-stories',
     'guides/token-dashboard',
     'guides/multi-axis-walkthrough',
+    'guides/migrating-from-addon-themes',
   ],
   integrations: [
     'integrations/integrations',


### PR DESCRIPTION
## Summary

- New \`guides/migrating-from-addon-themes.mdx\` walking each of \`addon-themes\`' three decorator patterns to its swatchbook equivalent.
- Honest coverage: what to keep, what to drop, what to rewire. MUI-style resolved-value factories called out explicitly as not-covered.
- Global-name migration (\`theme\` → \`swatchbookTheme\`) + per-story override notes.
- Explains the "no bridge package" decision directly.

## Depends on

- #556 — cross-links to \`../integrations/css-in-js.mdx\` resolve there.

## Test plan

- [x] \`docusaurus build\` clean, zero broken-link warnings.
- [x] Guide appears under Guides sidebar.

Milestone: Maintenance
Closes: #559
Plan impact: none