### PR TITLE
fix(docs): raise Prism light-theme token contrast above WCAG AA

### DIFF
--- a/.changeset/fix-docs-prism-contrast.md
+++ b/.changeset/fix-docs-prism-contrast.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Docs: raise contrast on light-theme Prism syntax highlighting for `.token.function`, `.keyword`, `.deleted`, `.builtin`, and `.attr-name` from `#d73a49` (4.29:1 against `#f6f8fa` — below WCAG AA) to `#b31d28` (~6.4:1). Axe-reported in bash code blocks like `npm install …`.

--- a/apps/docs/src/css/custom.css
+++ b/apps/docs/src/css/custom.css
@@ -69,3 +69,22 @@
   text-underline-offset: 0.15em;
   text-decoration-thickness: from-font;
 }
+
+/*
+ * Accessibility — WCAG 2.1 SC 1.4.3 (Contrast). The default Prism
+ * `github` theme colours several token classes (`function`, `keyword`,
+ * `deleted`, `built-in`, `attr-name`) with `#d73a49`, which hits only
+ * 4.29:1 against the code-block background `#f6f8fa` — axe flags this
+ * as failing the 4.5:1 AA threshold for text. Darkening to `#b31d28`
+ * (GitHub's own "danger" red) clears AA at ~6.4:1 while staying
+ * visually in-family with the rest of the light Prism palette.
+ *
+ * Light-theme only; the `dracula` dark theme is unaffected.
+ */
+html:not([data-theme='dark']) .prism-code .token.function,
+html:not([data-theme='dark']) .prism-code .token.keyword,
+html:not([data-theme='dark']) .prism-code .token.deleted,
+html:not([data-theme='dark']) .prism-code .token.builtin,
+html:not([data-theme='dark']) .prism-code .token.attr-name {
+  color: #b31d28;
+}


### PR DESCRIPTION
## Summary

Axe flagged \`.token.function\` on bash code blocks (contrast 4.29:1, below the 4.5:1 AA threshold). The default \`github\` Prism theme colours five token classes with \`#d73a49\`; overriding to \`#b31d28\` in light theme clears AA at ~6.4:1. Dark theme unchanged.

## Test plan

- [x] \`docusaurus build\` clean.
- [x] Inspect built CSS — override lands on \`.token.function / .keyword / .deleted / .builtin / .attr-name\` in \`html:not([data-theme='dark']) .prism-code\`.
- [ ] Re-run the axe check in-browser on a docs page with a bash code block (e.g. the integrations recipes) to confirm the warning clears.

Milestone: Maintenance
Closes: #563
Plan impact: none