### PR TITLE
docs: surface Integrations in the top navbar

### DIFF
--- a/.changeset/docs-integrations-navbar.md
+++ b/.changeset/docs-integrations-navbar.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Docs: add Integrations entry to the top navbar. Previously the section was only reachable via the intro page's reading guide, so users on `/next/` landed on the docs without any surfaced path to the integrations recipes.

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -102,6 +102,23 @@ const config: Config = {
         // duplicate what the left rail already shows.
         { type: 'docSidebar', sidebarId: 'blocks', position: 'left', label: 'Blocks' },
         { type: 'docSidebar', sidebarId: 'guides', position: 'left', label: 'Guides' },
+        // `href` with the fully-qualified `/next/integrations` path —
+        // the integrations docs currently only exist on the unreleased
+        // (Next) version; older versioned snapshots predate the
+        // integrations package. `href` is treated as an absolute URL
+        // so Docusaurus doesn't version-resolve it, and consumers on
+        // any doc version end up on the current-state integrations
+        // overview.
+        //
+        // Once a released version snapshots the integrations docs,
+        // swap this for `{ type: 'docSidebar', sidebarId: 'integrations' }`
+        // (which will version-resolve correctly because the sidebar
+        // will then exist in every versioned_sidebars/*.json).
+        {
+          href: '/swatchbook/next/integrations/',
+          label: 'Integrations',
+          position: 'left',
+        },
         { type: 'docSidebar', sidebarId: 'reference', position: 'left', label: 'Reference' },
         { type: 'docSidebar', sidebarId: 'developers', position: 'left', label: 'Developers' },
         { href: 'pathname:///storybook/', label: 'Live Storybook', position: 'left' },


### PR DESCRIPTION
## Summary

Adds \`{ href: '/swatchbook/next/integrations/', label: 'Integrations' }\` to the top navbar. Previously the Integrations section from #556 was only discoverable via the intro page's reading-guide link.

\`href\` bypasses Docusaurus's version resolver, so no broken-link warnings on versioned pages — the link works identically from every version context and always lands on the current-state integrations overview.

Swap to \`type: 'docSidebar'\` once a released version snapshots the integrations docs.

## Test plan

- [x] \`docusaurus build\` clean, zero broken-link warnings.
- [x] Built navbar HTML shows \`href="/swatchbook/next/integrations/"\`.
- [x] Target page exists at that path.

Milestone: Maintenance
Closes: #565
Plan impact: none