### PR TITLE
fix(integrations): use dependencies, not peerDependencies, for core

### DIFF
--- a/.changeset/fix-integrations-dep-not-peer.md
+++ b/.changeset/fix-integrations-dep-not-peer.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-integrations': patch
+---
+
+Move `@unpunnyfuns/swatchbook-core` from `peerDependencies` to `dependencies`. The two packages ship together in the fixed-version group, so the peer-dep framing buys nothing and triggers Changesets' peer-dep safety cascade (forcing a major bump across the entire fixed group when any member's version moves).

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -52,12 +52,11 @@
     "format": "oxfmt -c ../../.oxfmtrc.json src test",
     "format:check": "oxfmt --check -c ../../.oxfmtrc.json src test"
   },
-  "peerDependencies": {
+  "dependencies": {
     "@unpunnyfuns/swatchbook-core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "@unpunnyfuns/swatchbook-core": "workspace:*",
     "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,13 +305,14 @@ importers:
         version: 4.1.4(@types/node@25.6.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@29.0.2)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
   packages/integrations:
+    dependencies:
+      '@unpunnyfuns/swatchbook-core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
-      '@unpunnyfuns/swatchbook-core':
-        specifier: workspace:*
-        version: link:../core
       '@unpunnyfuns/swatchbook-tokens':
         specifier: workspace:*
         version: link:../tokens


### PR DESCRIPTION
## Summary

\`swatchbook-core\` is in the same fixed-version group as \`swatchbook-integrations\`; they always publish together. The \`peerDependencies\` framing buys nothing here and triggers Changesets' safety heuristic that cascades the entire fixed group to a major bump.

Moving to \`dependencies\` cuts the cascade. Release PR should re-settle to the queued \`minor\` → \`0.13.0\`.

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-integrations --force\` green.
- [ ] After merge, re-check the refreshed #544 — expect all fixed-group packages at \`0.13.0\`, none at \`1.0.0\`.

Milestone: Release
Closes: #570
Plan impact: none