### PR TITLE
docs: regroup demo components under Integrations/CSS in Storybook

### DIFF
--- a/apps/storybook/src/stories/Button.stories.tsx
+++ b/apps/storybook/src/stories/Button.stories.tsx
@@ -2,7 +2,7 @@ import preview from '../../.storybook/preview.tsx';
 import { Button } from '../components/Button.tsx';
 
 const meta = preview.meta({
-  title: 'Components/Button',
+  title: 'Integrations/CSS/Button',
   component: Button,
   tags: ['autodocs'],
   argTypes: {

--- a/apps/storybook/src/stories/Card.stories.tsx
+++ b/apps/storybook/src/stories/Card.stories.tsx
@@ -2,7 +2,7 @@ import preview from '../../.storybook/preview.tsx';
 import { Card } from '../components/Card.tsx';
 
 const meta = preview.meta({
-  title: 'Components/Card',
+  title: 'Integrations/CSS/Card',
   component: Card,
   tags: ['autodocs'],
   args: {

--- a/apps/storybook/src/stories/Input.stories.tsx
+++ b/apps/storybook/src/stories/Input.stories.tsx
@@ -2,7 +2,7 @@ import preview from '../../.storybook/preview.tsx';
 import { Input } from '../components/Input.tsx';
 
 const meta = preview.meta({
-  title: 'Components/Input',
+  title: 'Integrations/CSS/Input',
   component: Input,
   tags: ['autodocs'],
   args: { placeholder: 'Type a theme name…' },


### PR DESCRIPTION
## Summary

Retitles \`Button\` / \`Card\` / \`Input\` demo stories from \`Components/*\` → \`Integrations/CSS/*\`. They consume swatchbook tokens via plain CSS Modules referencing \`--sb-*\` vars, which is the vanilla-CSS integration pattern; sits naturally alongside \`Integrations/Tailwind\` and \`Integrations/CSS-in-JS\`.

## Test plan

- [x] \`storybook build\` succeeds.
- [x] \`pnpm test:storybook\` green (33 test files, 133 tests).
- [x] \`grep -rn "Components/Button\\|Components/Input\\|Components/Card" apps/storybook/\` finds no residue outside the three \`title\` fields we retitled.

Milestone: Maintenance
Closes: #577
Plan impact: none