### PR TITLE
chore(core): mark internal emitters with @internal JSDoc

### DIFF
--- a/.changeset/chore-mark-core-emitters-internal.md
+++ b/.changeset/chore-mark-core-emitters-internal.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Mark `emitCss`, `projectCss`, `emitTypes`, `emitViaTerrazzo`, and their associated option / result types (`EmitCssOptions`, `EmitViaTerrazzoOptions`, `EmitSelectionEntry`, `EmittedFile`, `ParserInput`) as `@internal`. Exports stay in place to preserve 0.13-era call sites, but editors that honour the tag will stop suggesting them to consumers. Actual removal waits for a future breaking window.

--- a/packages/core/src/css.ts
+++ b/packages/core/src/css.ts
@@ -3,6 +3,7 @@ import { generateShorthand, makeCSSVar, transformCSSValue } from '@terrazzo/toke
 import { CHROME_ROLES, CHROME_VAR_PREFIX, DEFAULT_CHROME_MAP } from '#/chrome.ts';
 import type { Axis, Theme, TokenMap } from '#/types.ts';
 
+/** @internal Addon-internal CSS emitter options. Not part of the public API. */
 export interface EmitCssOptions {
   /** Override the prefix from project config (default: `config.cssVarPrefix ?? ''`). */
   prefix?: string;
@@ -35,6 +36,11 @@ export interface EmitCssOptions {
  *
  * For single-axis projects (resolver with one modifier, or synthetic `theme`),
  * emission keeps the familiar `[data-theme="…"]` shape.
+ *
+ * @internal Consumers should not depend on this function. The addon calls
+ * it to populate the Storybook virtual module; external consumers driving
+ * their own build pipeline should use Terrazzo's CLI against the DTCG
+ * sources directly.
  */
 export function emitCss(
   themes: Theme[],

--- a/packages/core/src/emit-via-terrazzo.ts
+++ b/packages/core/src/emit-via-terrazzo.ts
@@ -8,12 +8,16 @@ import type { Axis, Project, Theme } from '#/types.ts';
  * subset of axis names → context values); `name` is optional display metadata
  * downstream emitters may pick up. Matches the shape of `Theme` / `Preset`
  * without forcing consumers to construct a full project type.
+ *
+ * @internal Used by the addon + integrations for axis-aware emission.
+ * Not part of the public API.
  */
 export interface EmitSelectionEntry {
   input: Record<string, string>;
   name?: string;
 }
 
+/** @internal Options for the addon-internal Terrazzo emission wrapper. */
 export interface EmitViaTerrazzoOptions {
   /**
    * Which tuples to fan out across. Defaults to `'themes'` — the full
@@ -45,6 +49,7 @@ export interface EmitViaTerrazzoOptions {
   plugins?: readonly Plugin[];
 }
 
+/** @internal Output file shape from the Terrazzo emission wrapper. */
 export interface EmittedFile {
   filename: string;
   contents: string | Uint8Array;
@@ -62,6 +67,11 @@ export interface EmittedFile {
  * (layered / plain-parse paths). Resolver-backed projects work out of the
  * box because `loadResolver()` already returns the unified `{ tokens,
  * sources, resolver }` triple we thread onto `Project.parserInput`.
+ *
+ * @internal Consumers should not depend on this function. It exists for
+ * the addon + integrations to drive Terrazzo's plugin pipeline with
+ * swatchbook's axis composition. External consumers driving their own
+ * build should use Terrazzo's CLI against the DTCG sources directly.
  */
 export async function emitViaTerrazzo(
   project: Project,

--- a/packages/core/src/emit.ts
+++ b/packages/core/src/emit.ts
@@ -1,7 +1,14 @@
 import type { Project } from '#/types.ts';
 import { emitCss, type EmitCssOptions } from '#/css.ts';
 
-/** Emit the full CSS stylesheet for a project. */
+/**
+ * Emit the full CSS stylesheet for a project.
+ *
+ * @internal Consumers should not depend on this function. The addon calls
+ * it to populate the Storybook virtual module; external consumers driving
+ * their own build pipeline should use Terrazzo's CLI against the DTCG
+ * sources directly.
+ */
 export function projectCss(project: Project, options: EmitCssOptions = {}): string {
   const merged: EmitCssOptions = { ...options };
   if (merged.prefix === undefined && project.config.cssVarPrefix) {
@@ -20,6 +27,11 @@ export function projectCss(project: Project, options: EmitCssOptions = {}): stri
  * Emit a TypeScript module exporting typed unions for token paths and theme
  * names. The preset writes this to `<outDir>/tokens.d.ts` so `useToken()` can
  * autocomplete against the loaded project.
+ *
+ * @internal Consumers should not depend on this function. The addon preset
+ * calls it to populate a generated `.d.ts` for `useToken()` autocomplete;
+ * external consumers should drive their own typegen from the loaded
+ * `Project` if they need something different.
  */
 export function emitTypes(project: Project): string {
   const allPaths = new Set<string>();

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -180,9 +180,12 @@ export interface Project {
 /**
  * Pass-through bag of the three values `@terrazzo/parser`'s `build()`
  * requires alongside a config. Retained verbatim from `loadResolver()`
- * so the wrapper call is zero-I/O. Consumers should treat this as opaque
- * (feed the whole object into `build()`); swatchbook itself does not read
- * individual fields.
+ * so the addon-internal Terrazzo emission wrapper can re-run builds
+ * without re-parsing from disk.
+ *
+ * @internal Consumers should not depend on this shape. It exists for
+ * the addon + integrations; external consumers driving their own build
+ * should use Terrazzo's CLI against the DTCG sources directly.
  */
 export interface ParserInput {
   tokens: Record<string, TokenNormalized>;


### PR DESCRIPTION
## Summary

\`emitCss\`, \`projectCss\`, \`emitTypes\`, \`emitViaTerrazzo\`, and their option / result types (\`EmitCssOptions\`, \`EmitViaTerrazzoOptions\`, \`EmitSelectionEntry\`, \`EmittedFile\`, \`ParserInput\`) are barrel-exported from \`packages/core/src/index.ts\` but the docs site no longer promotes them (PR #576). They remain reachable via the barrel for any 0.13-era caller; just tagging \`@internal\` so editors that honour the tag stop suggesting them to new consumers.

Zero runtime change, zero API removal. Pure hygiene.

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-core --force\` — 3 tasks green.
- [x] All existing callers in the workspace still resolve (addon, integrations, mcp all consume these through the barrel).

Milestone: Maintenance
Closes: #582
Plan impact: none