### PR TITLE
test(addon): cover the integration-side-effects aggregate virtual module

### DIFF
--- a/.changeset/test-addon-integration-side-effects.md
+++ b/.changeset/test-addon-integration-side-effects.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Add unit tests for the integration-side-effects aggregate virtual module. Covers `resolveId` mapping, empty-integration bodies (no integrations + all opted-out), auto-inject filtering across a mixed list, and the fall-through path for unrelated IDs. Closes a hole where the aggregation logic added in 0.14 was only exercised end-to-end through Storybook builds.

--- a/packages/addon/test/virtual-plugin.test.ts
+++ b/packages/addon/test/virtual-plugin.test.ts
@@ -113,11 +113,7 @@ function invokeLoad(
   );
 }
 
-function integration(
-  name: string,
-  virtualId: string,
-  autoInject: boolean,
-): SwatchbookIntegration {
+function integration(name: string, virtualId: string, autoInject: boolean): SwatchbookIntegration {
   return {
     name,
     virtualModule: {
@@ -145,9 +141,7 @@ describe('integration-side-effects aggregate virtual module', () => {
     const plugin = swatchbookTokensPlugin({
       config: NOOP_CONFIG,
       cwd: CWD,
-      integrations: [
-        integration('opaque', 'virtual:swatchbook/opaque', false),
-      ],
+      integrations: [integration('opaque', 'virtual:swatchbook/opaque', false)],
     });
     expect(invokeLoad(plugin, RESOLVED_INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID)).toBe('');
   });

--- a/packages/addon/test/virtual-plugin.test.ts
+++ b/packages/addon/test/virtual-plugin.test.ts
@@ -70,3 +70,108 @@ describe('collectWatchPaths', () => {
     expect(paths).toEqual(['/abs/tokens']);
   });
 });
+
+// Pragmatic exception: `swatchbookTokensPlugin`'s runtime surface is the
+// Storybook preview build; exercising that end-to-end needs a real Vite
+// dev server. The `resolveId` / `load` hooks for the integration-side-
+// effects aggregate module are pure (no dependency on the async `project`
+// state set in `buildStart`), so calling them as plain functions catches
+// the common regressions — empty body, `autoInject` filtering,
+// import-statement shape — at a fraction of the cost.
+import type { SwatchbookIntegration } from '@unpunnyfuns/swatchbook-core';
+import { swatchbookTokensPlugin } from '#/virtual/plugin.ts';
+import {
+  INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID,
+  RESOLVED_INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID,
+} from '#/constants.ts';
+
+const NOOP_CONFIG: Config = { tokens: ['tokens/**/*.json'] };
+
+function invokeResolve(
+  plugin: ReturnType<typeof swatchbookTokensPlugin>,
+  id: string,
+): string | null | undefined {
+  const hook = plugin.resolveId;
+  if (typeof hook !== 'function') return undefined;
+  // `this: void` — the hooks don't use the rollup plugin context in
+  // our implementation, so `undefined` for `this` works.
+  return (hook as (this: void, id: string) => string | null | undefined).call(
+    undefined as unknown as void,
+    id,
+  );
+}
+
+function invokeLoad(
+  plugin: ReturnType<typeof swatchbookTokensPlugin>,
+  id: string,
+): string | null | undefined {
+  const hook = plugin.load;
+  if (typeof hook !== 'function') return undefined;
+  return (hook as (this: void, id: string) => string | null | undefined).call(
+    undefined as unknown as void,
+    id,
+  );
+}
+
+function integration(
+  name: string,
+  virtualId: string,
+  autoInject: boolean,
+): SwatchbookIntegration {
+  return {
+    name,
+    virtualModule: {
+      virtualId,
+      render: () => `/* ${name} */`,
+      autoInject,
+    },
+  };
+}
+
+describe('integration-side-effects aggregate virtual module', () => {
+  it('resolveId maps the public virtual ID to the resolved form', () => {
+    const plugin = swatchbookTokensPlugin({ config: NOOP_CONFIG, cwd: CWD });
+    expect(invokeResolve(plugin, INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID)).toBe(
+      RESOLVED_INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID,
+    );
+  });
+
+  it('load returns an empty body when no integration opts in', () => {
+    const plugin = swatchbookTokensPlugin({ config: NOOP_CONFIG, cwd: CWD });
+    expect(invokeLoad(plugin, RESOLVED_INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID)).toBe('');
+  });
+
+  it('load returns an empty body when every integration opts out', () => {
+    const plugin = swatchbookTokensPlugin({
+      config: NOOP_CONFIG,
+      cwd: CWD,
+      integrations: [
+        integration('opaque', 'virtual:swatchbook/opaque', false),
+      ],
+    });
+    expect(invokeLoad(plugin, RESOLVED_INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID)).toBe('');
+  });
+
+  it('load emits one side-effect import per auto-inject integration, skipping opt-outs', () => {
+    const plugin = swatchbookTokensPlugin({
+      config: NOOP_CONFIG,
+      cwd: CWD,
+      integrations: [
+        integration('tailwind', 'virtual:swatchbook/tailwind.css', true),
+        integration('theme', 'virtual:swatchbook/theme', false),
+        integration('another', 'virtual:swatchbook/another.css', true),
+      ],
+    });
+    const body = invokeLoad(plugin, RESOLVED_INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID);
+    expect(body).toBe(
+      `import "virtual:swatchbook/tailwind.css";\nimport "virtual:swatchbook/another.css";`,
+    );
+    // Opted-out integration must not appear in the aggregate.
+    expect(body).not.toContain('virtual:swatchbook/theme');
+  });
+
+  it('load returns null for unrelated IDs so Vite can fall through to the next plugin', () => {
+    const plugin = swatchbookTokensPlugin({ config: NOOP_CONFIG, cwd: CWD });
+    expect(invokeLoad(plugin, '\0some-other-virtual')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Five unit tests covering the \`resolveId\` / \`load\` paths for \`INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID\` that landed in #581. Previously exercised only end-to-end through Storybook builds; a regression in \`autoInjectIds\` filtering or import-statement generation would have failed silently as an unexpectedly-empty preview.

Coverage:
- \`resolveId\` maps the public virtual ID to the resolved form
- Empty-body paths — no integrations, and all integrations opted out
- Auto-inject filtering across a mixed list (keeps \`autoInject: true\`, skips \`autoInject: false\`)
- \`load\` returns \`null\` for unrelated IDs so Vite falls through

## Test plan

- [x] \`pnpm turbo run lint typecheck test --filter=@unpunnyfuns/swatchbook-addon --force\` — 6 tasks green, 16 tests (11 previous + 5 new).

Milestone: Maintenance
Closes: #583
Plan impact: none