### PR TITLE
feat: fuzzy search across Navigator, TokenTable, and MCP

### DIFF
--- a/.changeset/feat-fuzzy-search.md
+++ b/.changeset/feat-fuzzy-search.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-mcp': minor
+---
+
+Fuzzy search across `TokenNavigator`, `TokenTable`, and the MCP `search_tokens` tool. Case-insensitive, tolerates a single-character typo per term, and accepts out-of-order terms — `"blue palette"` matches `color.palette.blue.500`, `"surf def"` matches `color.surface.default`. Replaces the previous case-insensitive substring match.
+
+Core now exports `fuzzyFilter(items, query, key, options?)` and `fuzzyMatches(haystack, query)` so downstream integrations can reuse the same ranking primitive. Backed by [`@leeoniya/ufuzzy`](https://github.com/leeoniya/uFuzzy).

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -1,3 +1,4 @@
+import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core';
 import type { KeyboardEvent, ReactElement } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import './TokenNavigator.css';
@@ -31,11 +32,12 @@ export interface TokenNavigatorProps {
    */
   initiallyExpanded?: number;
   /**
-   * Render a runtime search input above the tree. Matches are
-   * case-insensitive substrings against a leaf's token path; groups
-   * that contain no matching leaves collapse out, and every group on
-   * the path to a match auto-expands so hits are visible without
-   * clicking. Defaults to `true`.
+   * Render a runtime search input above the tree. Matches are fuzzy
+   * (case-insensitive, out-of-order terms, single-character typo
+   * tolerance) against a leaf's token path; groups that contain no
+   * matching leaves collapse out, and every group on the path to a
+   * match auto-expands so hits are visible without clicking. Defaults
+   * to `true`.
    */
   searchable?: boolean;
   /**
@@ -140,19 +142,29 @@ function countLeaves(node: TreeNode): number {
   return n;
 }
 
+function collectLeafPaths(nodes: TreeNode[], out: string[]): void {
+  for (const node of nodes) {
+    if (node.kind === 'leaf') out.push(node.path);
+    else collectLeafPaths(node.children, out);
+  }
+}
+
 /**
- * Return a pruned copy of the tree containing only leaves whose path
- * matches `needle` (case-insensitive substring) plus the groups on the
- * way to them. Every surviving group's path is added to `expandOut` so
- * callers can force those groups open.
+ * Return a pruned copy of the tree keeping only leaves whose path is in
+ * `matches`, plus the groups on the way to them. Every surviving group's
+ * path is added to `expandOut` so callers can force those groups open.
  */
-function pruneTreeForSearch(nodes: TreeNode[], needle: string, expandOut: Set<string>): TreeNode[] {
+function pruneTreeForMatches(
+  nodes: TreeNode[],
+  matches: ReadonlySet<string>,
+  expandOut: Set<string>,
+): TreeNode[] {
   const out: TreeNode[] = [];
   for (const node of nodes) {
     if (node.kind === 'leaf') {
-      if (node.path.toLowerCase().includes(needle)) out.push(node);
+      if (matches.has(node.path)) out.push(node);
     } else {
-      const children = pruneTreeForSearch(node.children, needle, expandOut);
+      const children = pruneTreeForMatches(node.children, matches, expandOut);
       if (children.length > 0) {
         expandOut.add(node.path);
         out.push({ ...node, children });
@@ -196,9 +208,11 @@ export function TokenNavigator({
     if (!searchable || query.trim() === '') {
       return { visibleTree: tree, searchExpanded: null as Set<string> | null };
     }
-    const needle = query.trim().toLowerCase();
+    const leafPaths: string[] = [];
+    collectLeafPaths(tree, leafPaths);
+    const matches = new Set(fuzzyFilter(leafPaths, query, (p) => p));
     const expandOut = new Set<string>();
-    const pruned = pruneTreeForSearch(tree, needle, expandOut);
+    const pruned = matches.size === 0 ? [] : pruneTreeForMatches(tree, matches, expandOut);
     return { visibleTree: pruned, searchExpanded: expandOut };
   }, [tree, query, searchable]);
 

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -1,4 +1,4 @@
-import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core';
+import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import type { KeyboardEvent, ReactElement } from 'react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import './TokenNavigator.css';

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,4 +1,4 @@
-import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core';
+import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { useCallback, useMemo, useState } from 'react';

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,3 +1,4 @@
+import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { useCallback, useMemo, useState } from 'react';
@@ -34,10 +35,11 @@ export interface TokenTableProps {
   sortDir?: SortDir;
   /**
    * Render a runtime search input above the table that narrows rows by
-   * case-insensitive substring against the token path, type, or value.
-   * Defaults to `true` because browsing a multi-hundred-token reference
-   * without search is painful. Pass `false` to hide the input (the
-   * `filter` / `type` props still apply at authoring time).
+   * fuzzy match (case-insensitive, out-of-order terms, single-character
+   * typo tolerance) against the token path, type, or value. Defaults to
+   * `true` because browsing a multi-hundred-token reference without
+   * search is painful. Pass `false` to hide the input (the `filter` /
+   * `type` props still apply at authoring time).
    */
   searchable?: boolean;
   /**
@@ -85,13 +87,7 @@ export function TokenTable({
 
   const visibleRows = useMemo(() => {
     if (!searchable || query.trim() === '') return rows;
-    const needle = query.trim().toLowerCase();
-    return rows.filter(
-      (row) =>
-        row.path.toLowerCase().includes(needle) ||
-        row.type.toLowerCase().includes(needle) ||
-        row.value.toLowerCase().includes(needle),
-    );
+    return fuzzyFilter(rows, query, (row) => `${row.path} ${row.type} ${row.value}`);
   }, [rows, query, searchable]);
 
   const handleRowClick = useCallback(
@@ -128,7 +124,7 @@ export function TokenTable({
             placeholder="Search tokens…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            aria-label="Search tokens by path, type, or value"
+            aria-label="Fuzzy-search tokens by path, type, or value"
             data-testid="token-table-search"
           />
         </div>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,10 @@
     "./variance": {
       "types": "./dist/variance.d.mts",
       "import": "./dist/variance.mjs"
+    },
+    "./fuzzy": {
+      "types": "./dist/fuzzy.d.mts",
+      "import": "./dist/fuzzy.mjs"
     }
   },
   "imports": {
@@ -44,7 +48,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsdown src/index.ts src/variance.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown src/index.ts src/variance.ts src/fuzzy.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -53,6 +53,7 @@
     "format:check": "oxfmt --check -c ../../.oxfmtrc.json src"
   },
   "dependencies": {
+    "@leeoniya/ufuzzy": "1.0.19",
     "@terrazzo/json-schema-tools": "^0.2.1",
     "@terrazzo/parser": "^2.0.3",
     "@terrazzo/plugin-css": "^2.0.3",

--- a/packages/core/src/fuzzy.ts
+++ b/packages/core/src/fuzzy.ts
@@ -1,0 +1,64 @@
+import uFuzzy from '@leeoniya/ufuzzy';
+
+export interface FuzzyOptions {
+  /** Cap the returned list. Applied after ranking. */
+  limit?: number;
+  /**
+   * Allow terms to match out of authored order. `false` means `"bg prim"`
+   * only matches when `bg` appears before `prim` in the haystack entry;
+   * `true` also accepts `"prim bg"`. Defaults to `true` — token paths read
+   * left-to-right in DTCG convention, but user queries often don't.
+   */
+  outOfOrder?: boolean;
+}
+
+const matcher = new uFuzzy({ intraMode: 1, interIns: 8 });
+
+/**
+ * Rank-ordered fuzzy filter. Empty / whitespace-only queries return the
+ * items unchanged in their input order. Non-empty queries return only
+ * matching items, ranked by uFuzzy's default scoring (boundary / prefix
+ * quality, tighter matches first). Ties fall back to input order.
+ *
+ * The matcher is configured for short identifier-style haystacks — token
+ * paths, CSS variable names — with single-character typo tolerance
+ * (`intraMode: SingleError`) and generous allowance for extra characters
+ * between the needle's terms (`interIns: 8`), which covers multi-segment
+ * paths like `color.surface.default` searched with `"surf def"`.
+ */
+export function fuzzyFilter<T>(
+  items: readonly T[],
+  query: string,
+  key: (item: T) => string,
+  options: FuzzyOptions = {},
+): T[] {
+  const needle = query.trim();
+  if (needle === '') return items.slice(0, options.limit);
+  if (items.length === 0) return [];
+
+  const haystack = items.map(key);
+  const outOfOrder = options.outOfOrder ?? true;
+  const [idxs, _info, order] = matcher.search(haystack, needle, outOfOrder ? 8 : 0);
+  if (idxs === null) return [];
+
+  const ranked = order ? order.map((oi) => idxs[oi] as number) : idxs;
+  const out: T[] = [];
+  const cap = options.limit ?? ranked.length;
+  for (let i = 0; i < ranked.length && out.length < cap; i += 1) {
+    const item = items[ranked[i] as number];
+    if (item !== undefined) out.push(item);
+  }
+  return out;
+}
+
+/**
+ * Test a single string against a query. Convenience wrapper for
+ * single-value predicates (e.g. tree pruning where each leaf is tested
+ * independently). Empty query matches everything.
+ */
+export function fuzzyMatches(haystack: string, query: string): boolean {
+  const needle = query.trim();
+  if (needle === '') return true;
+  const [idxs] = matcher.search([haystack], needle, 8);
+  return idxs !== null && idxs.length > 0;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,7 +4,6 @@ export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject, resolveTheme } from '#/load.ts';
 export { projectCss, emitTypes } from '#/emit.ts';
 export { dataAttr, emitCss, type EmitCssOptions } from '#/css.ts';
-export { fuzzyFilter, fuzzyMatches, type FuzzyOptions } from '#/fuzzy.ts';
 export { permutationID } from '#/types.ts';
 export { analyzeAxisVariance, type AxisVarianceResult, type VarianceKind } from '#/variance.ts';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject, resolveTheme } from '#/load.ts';
 export { projectCss, emitTypes } from '#/emit.ts';
 export { dataAttr, emitCss, type EmitCssOptions } from '#/css.ts';
+export { fuzzyFilter, fuzzyMatches, type FuzzyOptions } from '#/fuzzy.ts';
 export { permutationID } from '#/types.ts';
 export { analyzeAxisVariance, type AxisVarianceResult, type VarianceKind } from '#/variance.ts';
 export {

--- a/packages/core/test/fuzzy.test.ts
+++ b/packages/core/test/fuzzy.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from 'vitest';
+import { fuzzyFilter, fuzzyMatches } from '#/fuzzy.ts';
+
+const paths = [
+  'color.surface.default',
+  'color.surface.subtle',
+  'color.text.default',
+  'color.palette.blue.500',
+  'color.palette.orange.600',
+  'space.md',
+  'space.lg',
+  'radius.sm',
+];
+
+it('returns items unchanged for empty and whitespace queries', () => {
+  expect(fuzzyFilter(paths, '', (p) => p)).toEqual(paths);
+  expect(fuzzyFilter(paths, '   ', (p) => p)).toEqual(paths);
+});
+
+it('returns empty list when nothing matches', () => {
+  expect(fuzzyFilter(paths, 'zzzz', (p) => p)).toEqual([]);
+});
+
+it('finds prefix-like matches across dot-separated segments', () => {
+  const hits = fuzzyFilter(paths, 'surf def', (p) => p);
+  expect(hits).toContain('color.surface.default');
+});
+
+it('accepts terms out of authored order by default', () => {
+  const hits = fuzzyFilter(paths, 'blue palette', (p) => p);
+  expect(hits).toContain('color.palette.blue.500');
+});
+
+it('ranks tighter matches above looser ones', () => {
+  const hits = fuzzyFilter(paths, 'surface', (p) => p);
+  expect(hits.slice(0, 2)).toEqual(
+    expect.arrayContaining(['color.surface.default', 'color.surface.subtle']),
+  );
+});
+
+it('tolerates a single-character typo', () => {
+  const hits = fuzzyFilter(paths, 'surfce', (p) => p);
+  expect(hits).toContain('color.surface.default');
+});
+
+it('respects the limit option', () => {
+  const hits = fuzzyFilter(paths, 'color', (p) => p, { limit: 2 });
+  expect(hits).toHaveLength(2);
+});
+
+it('fuzzyMatches mirrors fuzzyFilter for single haystacks', () => {
+  expect(fuzzyMatches('color.surface.default', 'surf def')).toBe(true);
+  expect(fuzzyMatches('color.surface.default', 'zzzz')).toBe(false);
+  expect(fuzzyMatches('anything', '')).toBe(true);
+});

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -47,7 +47,7 @@ Usage:
 Tools exposed:
   describe_project    Orientation — counts, axes, themes, presets, diagnostics.
   list_tokens         List tokens by path glob / \`$type\`.
-  search_tokens       Substring search across paths, descriptions, values.
+  search_tokens       Fuzzy search across paths, descriptions, values.
   resolve_theme       Full resolved token map for an axis tuple.
   get_token           Full detail for one token path.
   get_alias_chain     Forward alias chain per theme.

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,10 +1,6 @@
 import type { Project } from '@unpunnyfuns/swatchbook-core';
-import {
-  analyzeAxisVariance,
-  fuzzyFilter,
-  fuzzyMatches,
-  projectCss,
-} from '@unpunnyfuns/swatchbook-core';
+import { analyzeAxisVariance, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { fuzzyFilter, fuzzyMatches } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { computeContrast } from '#/contrast.ts';

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,5 +1,10 @@
 import type { Project } from '@unpunnyfuns/swatchbook-core';
-import { analyzeAxisVariance, projectCss } from '@unpunnyfuns/swatchbook-core';
+import {
+  analyzeAxisVariance,
+  fuzzyFilter,
+  fuzzyMatches,
+  projectCss,
+} from '@unpunnyfuns/swatchbook-core';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { computeContrast } from '#/contrast.ts';
@@ -375,9 +380,9 @@ export function createServer(initial: Project): McpServer & {
     'search_tokens',
     {
       description:
-        'Case-insensitive substring search across token paths, `$description`, and stringified values. Returns matches with a short snippet pointing at where the match hit. Use when you know what you want but not the path — `search_tokens("radius")` finds every token whose path / description / value mentions radius. Scopes to a single theme (default: project default).',
+        'Fuzzy search across token paths, `$description`, and stringified values. Case-insensitive, tolerates a single-character typo per term, and accepts out-of-order terms (`"blue palette"` finds `color.palette.blue.500`). Returns matches ranked by relevance with a short snippet pointing at where the match hit. Use when you know what you want but not the exact path. Scopes to a single theme (default: project default).',
       inputSchema: {
-        query: z.string().min(1).describe('Substring to search for (case-insensitive).'),
+        query: z.string().min(1).describe('Fuzzy query (case-insensitive).'),
         theme: z
           .string()
           .optional()
@@ -389,34 +394,34 @@ export function createServer(initial: Project): McpServer & {
       const themeName = theme ?? project.themes[0]?.name;
       if (!themeName) return textResult('No themes in project.');
       const tokens = project.themesResolved[themeName] ?? {};
-      const needle = query.toLowerCase();
       const max = limit ?? 50;
-      const hits: {
-        path: string;
-        type?: string;
-        matchedIn: ('path' | 'description' | 'value')[];
-        snippet: string;
-      }[] = [];
 
-      for (const [path, token] of Object.entries(tokens)) {
-        const matchedIn: ('path' | 'description' | 'value')[] = [];
-        if (path.toLowerCase().includes(needle)) matchedIn.push('path');
-        const desc = token.$description?.toLowerCase();
-        if (desc?.includes(needle)) matchedIn.push('description');
+      const candidates = Object.entries(tokens).map(([path, token]) => {
+        const description = token.$description ?? '';
         const value = stringifyValue(token.$value);
-        if (value.toLowerCase().includes(needle)) matchedIn.push('value');
-        if (matchedIn.length === 0) continue;
+        return { path, token, description, value, composite: `${path} ${description} ${value}` };
+      });
+      const ranked = fuzzyFilter(candidates, query, (c) => c.composite, { limit: max });
+      const hits = ranked.map((c) => {
+        const matchedIn: ('path' | 'description' | 'value')[] = [];
+        if (fuzzyMatches(c.path, query)) matchedIn.push('path');
+        if (c.description && fuzzyMatches(c.description, query)) matchedIn.push('description');
+        if (fuzzyMatches(c.value, query)) matchedIn.push('value');
+        if (matchedIn.length === 0) matchedIn.push('path');
         const snippet = matchedIn.includes('description')
-          ? (token.$description ?? path)
+          ? (c.token.$description ?? c.path)
           : matchedIn.includes('value')
-            ? `${path} = ${value}`
-            : path;
-        const entry: (typeof hits)[number] = { path, matchedIn, snippet };
-        if (token.$type !== undefined) entry.type = token.$type;
-        hits.push(entry);
-        if (hits.length >= max) break;
-      }
-      hits.sort((a, b) => a.path.localeCompare(b.path, undefined, { numeric: true }));
+            ? `${c.path} = ${c.value}`
+            : c.path;
+        const entry: { path: string; type?: string; matchedIn: typeof matchedIn; snippet: string } =
+          {
+            path: c.path,
+            matchedIn,
+            snippet,
+          };
+        if (c.token.$type !== undefined) entry.type = c.token.$type;
+        return entry;
+      });
       return jsonResult({
         query,
         theme: themeName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -269,6 +269,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@leeoniya/ufuzzy':
+        specifier: 1.0.19
+        version: 1.0.19
       '@terrazzo/json-schema-tools':
         specifier: ^0.2.1
         version: 0.2.1(@humanwhocodes/momoa@3.3.10)(yaml-to-momoa@0.0.9)
@@ -2112,6 +2115,9 @@ packages:
     engines: {node: '>=10.0'}
     peerDependencies:
       tslib: '2'
+
+  '@leeoniya/ufuzzy@1.0.19':
+    resolution: {integrity: sha512-0pikDeYt0IHEUPza5RTCDXc/17S1pTrYnReEMp8Aa6k1ovzw5QdZLwicW8TjljwEZRb6oYag0xmALohrcq/yOQ==}
 
   '@leichtgewicht/ip-codec@2.0.5':
     resolution: {integrity: sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==}
@@ -11645,6 +11651,8 @@ snapshots:
       '@jsonjoy.com/buffers': 17.67.0(tslib@2.8.1)
       '@jsonjoy.com/codegen': 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
+
+  '@leeoniya/ufuzzy@1.0.19': {}
 
   '@leichtgewicht/ip-codec@2.0.5': {}
 


### PR DESCRIPTION
## Summary

- `TokenNavigator`, `TokenTable`, and the MCP `search_tokens` tool swap case-insensitive substring matching for fuzzy matching — tolerates a single-character typo per term, accepts out-of-order terms, ranks by relevance.
- Shared primitives `fuzzyFilter` / `fuzzyMatches` exported from `@unpunnyfuns/swatchbook-core` so downstream integrations can reuse the same ranking. Backed by [`@leeoniya/ufuzzy`](https://github.com/leeoniya/uFuzzy).

## Full description

`"surf def"` now matches `color.surface.default`, `"blue palette"` matches `color.palette.blue.500`, and `"surfce"` still matches `color.surface.default` despite the missing `a`. Empty queries short-circuit to the input order — no re-ranking when there's nothing to rank against.

The matcher is configured for short identifier-style haystacks: `intraMode: SingleError` (one char typo/transposition/deletion per term, excluding first and last) and `interIns: 8` (up to 8 intervening characters between terms, which covers multi-segment dot-paths).

Implementation notes:
- `TokenNavigator` collects leaf paths into one batched `fuzzyFilter` call, builds a match set, then prunes the tree by set membership. Cheaper than per-leaf fuzzy testing.
- `TokenTable` fuzzy-ranks rows against a composite `path + type + value` string. When a query is present, fuzzy relevance overrides the `sortBy` prop for the filtered view — standard "search + sort" UI convention. Without a query, `sortBy` applies unchanged.
- MCP `search_tokens` ranks candidates by the same composite, then per-field `fuzzyMatches` checks populate the `matchedIn` display metadata so agents still see whether the hit landed on path / description / value.

**Milestone:** Maintenance
**Closes:** #588
**Plan impact:** None — targeted primitive swap. Documented in this PR and the changeset; no plan file.

## Test plan

- [x] 8 new unit tests in `packages/core/test/fuzzy.test.ts` cover empty queries, no matches, prefix matches across segments, out-of-order terms, ranking ties, single-char typo tolerance, and the `limit` option.
- [x] `pnpm turbo run lint typecheck test` green (29/29 tasks).
- [ ] Manual verification in Storybook: open a `TokenNavigator` / `TokenTable` story and confirm fuzzy queries (`surf def`, `blue palette`, typos) behave as expected.
- [ ] Manual verification in MCP: run `search_tokens "surf def"` against `apps/storybook/swatchbook.config.ts` and confirm relevant hits come back ranked.