### PR TITLE
feat(blocks): add ColorTable + copy-to-clipboard everywhere

### DIFF
--- a/.changeset/feat-color-table-copy-buttons.md
+++ b/.changeset/feat-color-table-copy-buttons.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+New `<ColorTable />` block — one row per color token with HEX, HSL, OKLCH, CSS var, and alias-target columns side-by-side. Each value cell carries a copy-to-clipboard button that reveals on row hover / focus. Same `filter` / `sortBy` / `sortDir` / `searchable` / `onSelect` props as `<TokenTable />`, so it drops in wherever the existing table was scoped to colors.
+
+`<TokenTable />` and `<TokenDetail />` also pick up copy-to-clipboard affordances: a button on the value cell in `TokenTable`, buttons on the resolved value and the usage snippet in `TokenDetail`.
+
+Shared `CopyButton` primitive lives in the blocks package internals — silently no-ops on environments without `navigator.clipboard.writeText` (older Safari, insecure origins).

--- a/apps/storybook/src/stories/ColorTable.stories.tsx
+++ b/apps/storybook/src/stories/ColorTable.stories.tsx
@@ -43,3 +43,10 @@ export const SortedPerceptually = meta.story({
   args: { sortBy: 'value' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });
+export const WithVariantPills = meta.story({
+  args: {
+    filter: 'color.*',
+    variants: { hover: 'h', disabled: 'd', active: 'a' },
+  },
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});

--- a/apps/storybook/src/stories/ColorTable.stories.tsx
+++ b/apps/storybook/src/stories/ColorTable.stories.tsx
@@ -1,0 +1,45 @@
+import { ColorTable } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
+import preview from '../../.storybook/preview.tsx';
+
+const meta = preview.meta({
+  title: 'Blocks/ColorTable',
+  component: ColorTable,
+  argTypes: {
+    filter: { control: 'text' },
+    sortBy: {
+      control: 'select',
+      options: ['path', 'value', 'none'],
+    },
+    sortDir: {
+      control: 'select',
+      options: ['asc', 'desc'],
+    },
+    searchable: { control: 'boolean' },
+  },
+});
+
+export default meta;
+
+async function assertTableRenders(canvas: HTMLElement): Promise<void> {
+  await waitFor(() => {
+    const rows = canvas.querySelectorAll('[data-testid="color-table-row"]');
+    expect(rows.length, 'ColorTable must render at least one row').toBeGreaterThan(0);
+  });
+}
+
+export const All = meta.story({
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});
+export const SysOnly = meta.story({
+  args: { filter: 'color.*' },
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});
+export const RefBlue = meta.story({
+  args: { filter: 'color.palette.blue.*' },
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});
+export const SortedPerceptually = meta.story({
+  args: { sortBy: 'value' },
+  play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -73,6 +73,25 @@
   white-space: nowrap;
 }
 
+.sb-color-table__path-text {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+.sb-color-table__variant-pill {
+  display: inline-block;
+  margin-left: 6px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-family: inherit;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  color: var(--swatchbook-text-muted, CanvasText);
+  vertical-align: middle;
+}
+
 .sb-color-table__swatch-cell {
   width: 32px;
 }

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -1,0 +1,146 @@
+.sb-color-table__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.sb-color-table__search {
+  padding: 0 0 8px;
+}
+
+.sb-color-table__search-input {
+  width: 100%;
+  max-width: 360px;
+  padding: 6px 10px;
+  border-radius: 4px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  background: var(--swatchbook-surface-default, Canvas);
+  color: var(--swatchbook-text-default, CanvasText);
+  font-family: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+}
+
+.sb-color-table__search-input:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: 1px;
+}
+
+.sb-color-table__caption {
+  caption-side: top;
+  text-align: left;
+  padding: 8px 0;
+  color: var(--swatchbook-text-muted, CanvasText);
+  font-size: 12px;
+}
+
+.sb-color-table__th {
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  white-space: nowrap;
+}
+
+.sb-color-table__th--swatch {
+  width: 32px;
+}
+
+.sb-color-table__th--path {
+  min-width: 200px;
+}
+
+.sb-color-table__row {
+  cursor: pointer;
+}
+
+.sb-color-table__row:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: -2px;
+}
+
+.sb-color-table__td {
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  vertical-align: middle;
+}
+
+.sb-color-table__path {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.sb-color-table__swatch-cell {
+  width: 32px;
+}
+
+.sb-color-table__swatch {
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  background-clip: padding-box;
+}
+
+.sb-color-table__value-cell {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.sb-color-table__value-text {
+  display: inline-block;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+
+.sb-color-table__copy-wrap {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  vertical-align: middle;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.sb-color-table__row:hover .sb-color-table__copy-wrap,
+.sb-color-table__row:focus-within .sb-color-table__copy-wrap {
+  opacity: 1;
+}
+
+.sb-color-table__copy {
+  width: 20px;
+  height: 20px;
+}
+
+.sb-color-table__gamut-warn {
+  margin-left: 6px;
+}
+
+.sb-color-table__alias {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  white-space: nowrap;
+}
+
+.sb-color-table__alias-text {
+  font-style: italic;
+}
+
+.sb-color-table__alias-empty {
+  opacity: 0.4;
+}
+
+.sb-color-table__empty-row {
+  color: var(--swatchbook-text-muted, CanvasText);
+  font-style: italic;
+  text-align: center;
+  padding: 16px 12px;
+}

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -138,6 +138,18 @@
   opacity: 0.4;
 }
 
+.sb-color-table__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .sb-color-table__empty-row {
   color: var(--swatchbook-text-muted, CanvasText);
   font-style: italic;

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -39,6 +39,18 @@ export interface ColorTableProps {
    * `<TokenDetail>` drawer is suppressed — the consumer owns follow-up UI.
    */
   onSelect?(path: string): void;
+  /**
+   * Map from a display label to a path-suffix matched against the final
+   * hyphen segment of each leaf. A row whose leaf ends in `-<suffix>` gets
+   * the matching label rendered as a pill after the token name.
+   *
+   * Longest-suffix-wins: given `{ hover: 'h', hoverDark: 'h-dark' }`, a path
+   * ending in `-h-dark` picks `hoverDark`, not `hover`. Tokens that don't
+   * match any suffix render with no pill — configuration is purely additive.
+   *
+   * Empty map (default) → no pills; the block behaves exactly as before.
+   */
+  variants?: Record<string, string>;
 }
 
 interface Row {
@@ -49,6 +61,7 @@ interface Row {
   oklch: string;
   hexOutOfGamut: boolean;
   aliasOf?: string;
+  variant?: string;
 }
 
 export function ColorTable({
@@ -58,10 +71,13 @@ export function ColorTable({
   sortDir = 'asc',
   searchable = true,
   onSelect,
+  variants,
 }: ColorTableProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+
+  const variantIndex = useMemo(() => buildVariantIndex(variants), [variants]);
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -74,6 +90,7 @@ export function ColorTable({
       const hex = formatColor(raw, 'hex');
       const hsl = formatColor(raw, 'hsl');
       const oklch = formatColor(raw, 'oklch');
+      const variant = matchVariant(path, variantIndex);
       return {
         path,
         cssVar: makeCssVar(path, cssVarPrefix),
@@ -82,9 +99,10 @@ export function ColorTable({
         oklch: oklch.value,
         hexOutOfGamut: hex.outOfGamut,
         ...(token.aliasOf !== undefined && { aliasOf: token.aliasOf }),
+        ...(variant !== undefined && { variant }),
       };
     });
-  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir, variantIndex]);
 
   const visibleRows = useMemo(() => {
     if (!searchable || query.trim() === '') return rows;
@@ -176,7 +194,18 @@ export function ColorTable({
                   aria-hidden
                 />
               </td>
-              <td className={cx('sb-color-table__td', 'sb-color-table__path')}>{row.path}</td>
+              <td className={cx('sb-color-table__td', 'sb-color-table__path')}>
+                <span className="sb-color-table__path-text">{row.path}</span>
+                {row.variant !== undefined && (
+                  <span
+                    className="sb-color-table__variant-pill"
+                    data-variant={row.variant}
+                    data-testid="color-table-variant"
+                  >
+                    {row.variant}
+                  </span>
+                )}
+              </td>
               <ValueCell value={row.hex} label={`Copy HEX ${row.hex}`}>
                 {row.hexOutOfGamut && (
                   <span
@@ -241,4 +270,42 @@ function ValueCell({
       </span>
     </td>
   );
+}
+
+interface VariantEntry {
+  label: string;
+  suffix: string;
+}
+
+/**
+ * Pre-sort the variants map by descending suffix length so the first
+ * `endsWith` hit during matching is always the longest. Empty suffixes are
+ * dropped — they'd match every path and make the feature meaningless.
+ */
+function buildVariantIndex(variants: Record<string, string> | undefined): readonly VariantEntry[] {
+  if (!variants) return [];
+  const entries: VariantEntry[] = [];
+  for (const [label, suffix] of Object.entries(variants)) {
+    if (suffix.length === 0) continue;
+    entries.push({ label, suffix });
+  }
+  entries.sort((a, b) => b.suffix.length - a.suffix.length);
+  return entries;
+}
+
+/**
+ * Resolve the variant label for a token path, if any. The leaf (last
+ * dot-segment) must end in `-<suffix>` — the leading hyphen is required, so
+ * suffix `h` matches `hi-h` but not `neutral-900` (by character), and does
+ * not match `highlight` (where `h` isn't preceded by a boundary). Entries
+ * are tried longest-first, so `h-dark` wins over `dark` when both are
+ * configured and the path ends in `-h-dark`.
+ */
+function matchVariant(path: string, variantIndex: readonly VariantEntry[]): string | undefined {
+  if (variantIndex.length === 0) return undefined;
+  const leaf = path.split('.').at(-1) ?? path;
+  for (const entry of variantIndex) {
+    if (leaf.endsWith(`-${entry.suffix}`)) return entry.label;
+  }
+  return undefined;
 }

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -40,13 +40,20 @@ export interface ColorTableProps {
    */
   onSelect?(path: string): void;
   /**
-   * Map from a display label to a path-suffix matched against the final
-   * hyphen segment of each leaf. A row whose leaf ends in `-<suffix>` gets
-   * the matching label rendered as a pill after the token name.
+   * Map from a display label to a suffix matched against each token's
+   * trailing path segment. A row whose leaf matches one of the suffixes
+   * gets the corresponding label rendered as a pill after the token name.
    *
-   * Longest-suffix-wins: given `{ hover: 'h', hoverDark: 'h-dark' }`, a path
-   * ending in `-h-dark` picks `hoverDark`, not `hover`. Tokens that don't
-   * match any suffix render with no pill — configuration is purely additive.
+   * Accepts both DTCG-idiomatic and Backmarket-style conventions:
+   * - **Dot segment** (`color.bg.hi.disabled`): the last dot-segment equals
+   *   the suffix exactly (`suffix === 'disabled'`).
+   * - **Hyphen tail** (`color.bg.hi-d`): the last dot-segment ends in
+   *   `-<suffix>` (`suffix === 'd'`).
+   *
+   * Longest-suffix-wins: `{ hover: 'h', hoverDark: 'h-dark' }` picks
+   * `hoverDark` for a path ending in `-h-dark`. The hyphen-tail form
+   * requires an actual hyphen boundary — suffix `0` does not match
+   * `neutral-900`. Tokens that don't match any suffix render with no pill.
    *
    * Empty map (default) → no pills; the block behaves exactly as before.
    */
@@ -295,17 +302,19 @@ function buildVariantIndex(variants: Record<string, string> | undefined): readon
 
 /**
  * Resolve the variant label for a token path, if any. The leaf (last
- * dot-segment) must end in `-<suffix>` — the leading hyphen is required, so
- * suffix `h` matches `hi-h` but not `neutral-900` (by character), and does
- * not match `highlight` (where `h` isn't preceded by a boundary). Entries
- * are tried longest-first, so `h-dark` wins over `dark` when both are
- * configured and the path ends in `-h-dark`.
+ * dot-segment) must either equal the suffix outright (`hi.disabled`
+ * matches suffix `disabled`) or end in `-<suffix>` (`hi-d` matches `d`).
+ * The leading hyphen is required for the tail form, so suffix `h` matches
+ * `hi-h` but not `highlight` or `neutral-900` — the whole trailing token
+ * has to be the suffix, not a character within it. Entries are tried
+ * longest-first, so `h-dark` wins over `dark` when both are configured
+ * and the path ends in `-h-dark`.
  */
 function matchVariant(path: string, variantIndex: readonly VariantEntry[]): string | undefined {
   if (variantIndex.length === 0) return undefined;
   const leaf = path.split('.').at(-1) ?? path;
   for (const entry of variantIndex) {
-    if (leaf.endsWith(`-${entry.suffix}`)) return entry.label;
+    if (leaf === entry.suffix || leaf.endsWith(`-${entry.suffix}`)) return entry.label;
   }
   return undefined;
 }

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -134,7 +134,9 @@ export function ColorTable({
         <caption className="sb-color-table__caption">{captionText}</caption>
         <thead>
           <tr>
-            <th className="sb-color-table__th sb-color-table__th--swatch" aria-label="Swatch" />
+            <th className="sb-color-table__th sb-color-table__th--swatch">
+              <span className="sb-color-table__sr-only">Swatch</span>
+            </th>
             <th className="sb-color-table__th sb-color-table__th--path">Name</th>
             <th className="sb-color-table__th">HEX</th>
             <th className="sb-color-table__th">HSL</th>

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,0 +1,242 @@
+import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
+import cx from 'clsx';
+import type { ReactElement } from 'react';
+import { useCallback, useMemo, useState } from 'react';
+import './ColorTable.css';
+import { formatColor, type NormalizedColor } from '#/format-color.ts';
+import { CopyButton } from '#/internal/CopyButton.tsx';
+import { themeAttrs } from '#/internal/data-attr.ts';
+import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
+import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
+import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+export interface ColorTableProps {
+  /**
+   * Token-path filter. Defaults to every `$type: color` token. `"color.*"`
+   * scopes to the semantic layer; `"color.palette.blue.*"` to a single ramp.
+   */
+  filter?: string;
+  /** Override the table caption. */
+  caption?: string;
+  /**
+   * Sort order.
+   * - `'path'` (default) — lexicographic on the dot-path.
+   * - `'value'` — perceptual (oklch L → C → H). Ramps read light→dark, then
+   *   warm→cool within each lightness band.
+   * - `'none'` — preserve project iteration order.
+   */
+  sortBy?: SortBy;
+  /** `'asc'` (default) or `'desc'`. */
+  sortDir?: SortDir;
+  /**
+   * Render a fuzzy-search input above the table (case-insensitive,
+   * single-char typo tolerance, out-of-order terms, matches across path +
+   * any format value). Defaults to `true`.
+   */
+  searchable?: boolean;
+  /**
+   * Called with the clicked row's dot-path. When set, the built-in
+   * `<TokenDetail>` drawer is suppressed — the consumer owns follow-up UI.
+   */
+  onSelect?(path: string): void;
+}
+
+interface Row {
+  path: string;
+  cssVar: string;
+  hex: string;
+  hsl: string;
+  oklch: string;
+  hexOutOfGamut: boolean;
+  aliasOf?: string;
+}
+
+export function ColorTable({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+  searchable = true,
+  onSelect,
+}: ColorTableProps): ReactElement {
+  const { resolved, activeTheme, cssVarPrefix } = useProject();
+  const [selectedPath, setSelectedPath] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+
+  const rows = useMemo<Row[]>(() => {
+    const filtered = Object.entries(resolved).filter(([path, token]) => {
+      if (token.$type !== 'color') return false;
+      return globMatch(path, filter);
+    });
+    const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
+    return entries.map(([path, token]) => {
+      const raw = token.$value as NormalizedColor;
+      const hex = formatColor(raw, 'hex');
+      const hsl = formatColor(raw, 'hsl');
+      const oklch = formatColor(raw, 'oklch');
+      return {
+        path,
+        cssVar: makeCssVar(path, cssVarPrefix),
+        hex: hex.value,
+        hsl: hsl.value,
+        oklch: oklch.value,
+        hexOutOfGamut: hex.outOfGamut,
+        ...(token.aliasOf !== undefined && { aliasOf: token.aliasOf }),
+      };
+    });
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir]);
+
+  const visibleRows = useMemo(() => {
+    if (!searchable || query.trim() === '') return rows;
+    return fuzzyFilter(rows, query, (r) => `${r.path} ${r.hex} ${r.hsl} ${r.oklch}`);
+  }, [rows, query, searchable]);
+
+  const handleRowClick = useCallback(
+    (path: string) => {
+      if (onSelect) onSelect(path);
+      else setSelectedPath(path);
+    },
+    [onSelect],
+  );
+
+  const matchSuffix =
+    searchable && query.trim() !== '' ? ` · ${visibleRows.length} matching "${query.trim()}"` : '';
+  const captionText =
+    caption ??
+    `${rows.length} color${rows.length === 1 ? '' : 's'}${
+      filter ? ` matching \`${filter}\`` : ''
+    }${matchSuffix} · ${activeTheme}`;
+
+  if (rows.length === 0) {
+    return (
+      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+        <div className="sb-block__empty">No color tokens match this filter.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      {searchable && (
+        <div className="sb-color-table__search">
+          <input
+            type="search"
+            className="sb-color-table__search-input"
+            placeholder="Search colors…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            aria-label="Fuzzy-search colors by path or value"
+            data-testid="color-table-search"
+          />
+        </div>
+      )}
+      <table className="sb-color-table__table">
+        <caption className="sb-color-table__caption">{captionText}</caption>
+        <thead>
+          <tr>
+            <th className="sb-color-table__th sb-color-table__th--swatch" aria-label="Swatch" />
+            <th className="sb-color-table__th sb-color-table__th--path">Name</th>
+            <th className="sb-color-table__th">HEX</th>
+            <th className="sb-color-table__th">HSL</th>
+            <th className="sb-color-table__th">OKLCH</th>
+            <th className="sb-color-table__th">CSS var</th>
+            <th className="sb-color-table__th">Alias</th>
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.length === 0 && (
+            <tr>
+              <td colSpan={7} className="sb-color-table__td sb-color-table__empty-row">
+                No colors match "{query.trim()}".
+              </td>
+            </tr>
+          )}
+          {visibleRows.map((row) => (
+            <tr
+              key={row.path}
+              className="sb-color-table__row"
+              onClick={() => handleRowClick(row.path)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleRowClick(row.path);
+                }
+              }}
+              tabIndex={0}
+              aria-label={`Inspect ${row.path}`}
+              data-testid="color-table-row"
+              data-path={row.path}
+            >
+              <td className="sb-color-table__td sb-color-table__swatch-cell">
+                <span
+                  className="sb-color-table__swatch"
+                  style={{ background: row.cssVar }}
+                  aria-hidden
+                />
+              </td>
+              <td className={cx('sb-color-table__td', 'sb-color-table__path')}>{row.path}</td>
+              <ValueCell value={row.hex} label={`Copy HEX ${row.hex}`}>
+                {row.hexOutOfGamut && (
+                  <span
+                    title="Out of sRGB gamut"
+                    aria-label="out of gamut"
+                    className="sb-color-table__gamut-warn"
+                  >
+                    ⚠
+                  </span>
+                )}
+              </ValueCell>
+              <ValueCell value={row.hsl} label={`Copy HSL ${row.hsl}`} />
+              <ValueCell value={row.oklch} label={`Copy OKLCH ${row.oklch}`} />
+              <ValueCell value={row.cssVar} label={`Copy CSS var ${row.cssVar}`} />
+              <td className="sb-color-table__td sb-color-table__alias">
+                {row.aliasOf ? (
+                  <span className="sb-color-table__alias-text">{row.aliasOf}</span>
+                ) : (
+                  <span className="sb-color-table__alias-empty" aria-hidden>
+                    —
+                  </span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {selectedPath !== null && (
+        <DetailOverlay
+          path={selectedPath}
+          onClose={() => setSelectedPath(null)}
+          testId="color-table-overlay"
+        />
+      )}
+    </div>
+  );
+}
+
+function ValueCell({
+  value,
+  label,
+  children,
+}: {
+  value: string;
+  label: string;
+  children?: ReactElement | false;
+}): ReactElement {
+  return (
+    <td className="sb-color-table__td sb-color-table__value-cell">
+      <span className="sb-color-table__value-text" title={value}>
+        {value}
+      </span>
+      {children}
+      <span
+        className="sb-color-table__copy-wrap"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+        role="presentation"
+      >
+        <CopyButton value={value} label={label} className="sb-color-table__copy" />
+      </span>
+    </td>
+  );
+}

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -2,6 +2,7 @@ import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
+import { CopyButton } from '#/internal/CopyButton.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { AliasChain } from '#/token-detail/AliasChain.tsx';
@@ -63,6 +64,7 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
             ⚠
           </span>
         )}
+        <CopyButton value={value} label={`Copy value ${value}`} />
       </div>
 
       <AliasChain path={path} />

--- a/packages/blocks/src/TokenTable.css
+++ b/packages/blocks/src/TokenTable.css
@@ -114,3 +114,17 @@
 .sb-token-table__gamut-warn {
   flex-shrink: 0;
 }
+
+.sb-token-table__copy-wrap {
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.sb-token-table__row:hover .sb-token-table__copy-wrap,
+.sb-token-table__row:focus-within .sb-token-table__copy-wrap {
+  opacity: 1;
+}

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import './TokenTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
+import { CopyButton } from '#/internal/CopyButton.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
@@ -188,6 +189,18 @@ export function TokenTable({
                       ⚠
                     </span>
                   )}
+                  <span
+                    className="sb-token-table__copy-wrap"
+                    onClick={(e) => e.stopPropagation()}
+                    onKeyDown={(e) => e.stopPropagation()}
+                    role="presentation"
+                  >
+                    <CopyButton
+                      value={row.value}
+                      label={`Copy value ${row.value}`}
+                      className="sb-token-table__copy"
+                    />
+                  </span>
                 </span>
               </td>
             </tr>

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -10,6 +10,7 @@ export {
 export { BorderPreview, type BorderPreviewProps } from '#/BorderPreview.tsx';
 export { BorderSample, type BorderSampleProps } from '#/border-preview/BorderSample.tsx';
 export { ColorPalette, type ColorPaletteProps } from '#/ColorPalette.tsx';
+export { ColorTable, type ColorTableProps } from '#/ColorTable.tsx';
 export { Diagnostics, type DiagnosticsProps } from '#/Diagnostics.tsx';
 export { DimensionScale, type DimensionKind, type DimensionScaleProps } from '#/DimensionScale.tsx';
 export { DimensionBar, type DimensionBarProps } from '#/dimension-scale/DimensionBar.tsx';

--- a/packages/blocks/src/internal/CopyButton.css
+++ b/packages/blocks/src/internal/CopyButton.css
@@ -1,0 +1,45 @@
+.sb-copy-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  margin: 0;
+  border: 0;
+  background: transparent;
+  color: var(--swatchbook-text-muted, CanvasText);
+  font: inherit;
+  cursor: pointer;
+  border-radius: 4px;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.sb-copy-button:hover {
+  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  color: var(--swatchbook-text-default, CanvasText);
+}
+
+.sb-copy-button:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-default, Highlight);
+  outline-offset: 2px;
+}
+
+.sb-copy-button--icon {
+  width: 20px;
+  height: 20px;
+  font-size: 13px;
+  line-height: 1;
+}
+
+.sb-copy-button--text {
+  padding: 2px 8px;
+  font-size: 11px;
+  letter-spacing: 0.5px;
+  text-transform: uppercase;
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.25));
+}
+
+.sb-copy-button--copied {
+  color: var(--swatchbook-accent-default, Highlight);
+}

--- a/packages/blocks/src/internal/CopyButton.tsx
+++ b/packages/blocks/src/internal/CopyButton.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import './CopyButton.css';
+
+export interface CopyButtonProps {
+  /** Text written to the clipboard when clicked. */
+  value: string;
+  /**
+   * Accessible label. Defaults to `Copy <value>`; override for long values
+   * (hex + description + etc.) where the full label would be too chatty.
+   */
+  label?: string;
+  /** `'icon'` (default) — 16 px glyph button; `'text'` — `Copy` pill. */
+  variant?: 'icon' | 'text';
+  /** Extra class to merge onto the button root. */
+  className?: string;
+}
+
+/**
+ * Copy the given string to the clipboard and briefly surface a "Copied!"
+ * state. Falls back silently on unsupported clipboard APIs (older Safari,
+ * insecure origins) — the click still happens, the user just won't see the
+ * tick. No custom permission prompt: relies on the browser's native user-
+ * activation gate.
+ */
+export function CopyButton({
+  value,
+  label,
+  variant = 'icon',
+  className,
+}: CopyButtonProps): ReactElement {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const handleClick = useCallback((): void => {
+    try {
+      void navigator.clipboard?.writeText(value);
+    } catch {
+      return;
+    }
+    setCopied(true);
+    if (timerRef.current !== null) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setCopied(false), 1500);
+  }, [value]);
+
+  const ariaLabel = label ?? `Copy ${value}`;
+  const classes = ['sb-copy-button', `sb-copy-button--${variant}`];
+  if (copied) classes.push('sb-copy-button--copied');
+  if (className) classes.push(className);
+
+  return (
+    <button
+      type="button"
+      className={classes.join(' ')}
+      onClick={handleClick}
+      aria-label={ariaLabel}
+      title={ariaLabel}
+      data-copied={copied ? 'true' : undefined}
+    >
+      {variant === 'text' ? (
+        <span className="sb-copy-button__text">{copied ? 'Copied' : 'Copy'}</span>
+      ) : (
+        <span className="sb-copy-button__glyph" aria-hidden>
+          {copied ? '✓' : '⧉'}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/packages/blocks/src/token-detail/TokenUsageSnippet.tsx
+++ b/packages/blocks/src/token-detail/TokenUsageSnippet.tsx
@@ -1,4 +1,5 @@
 import type { ReactElement } from 'react';
+import { CopyButton } from '#/internal/CopyButton.tsx';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
 
 export interface TokenUsageSnippetProps {
@@ -9,10 +10,14 @@ export interface TokenUsageSnippetProps {
 export function TokenUsageSnippet({ path }: TokenUsageSnippetProps): ReactElement | null {
   const { token, cssVar } = useTokenDetailData(path);
   if (!token) return null;
+  const snippet = `color: ${cssVar};`;
   return (
     <>
       <div className="sb-token-detail__section-header">Usage</div>
-      <code className="sb-token-detail__snippet">{`color: ${cssVar};`}</code>
+      <div className="sb-token-detail__snippet-row">
+        <code className="sb-token-detail__snippet">{snippet}</code>
+        <CopyButton value={snippet} label={`Copy usage snippet ${snippet}`} />
+      </div>
     </>
   );
 }

--- a/packages/blocks/src/token-detail/styles.css
+++ b/packages/blocks/src/token-detail/styles.css
@@ -96,6 +96,14 @@
   font-size: 12px;
   white-space: pre;
   overflow: auto;
+  flex: 1;
+  min-width: 0;
+}
+
+.sb-token-detail__snippet-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .sb-token-detail__missing {

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -155,6 +155,33 @@ describe('ColorTable', () => {
     expect(byPath.get('color.bg.hi-h-dark')).toBe('hoverDark');
   });
 
+  it('matches DTCG-idiomatic dot-segment variants (hi.disabled)', () => {
+    const snapshot = makeSnapshot();
+    snapshot.themesResolved['Light'] = {
+      ...snapshot.themesResolved['Light'],
+      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
+      'color.bg.hi.disabled': { $type: 'color', $value: { hex: '#222222' } },
+      'color.bg.hi.hover': { $type: 'color', $value: { hex: '#333333' } },
+    };
+
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <ColorTable filter="color.bg.*" variants={{ hover: 'hover', disabled: 'disabled' }} />
+      </SwatchbookProvider>,
+    );
+
+    const byPath = new Map<string, string | null>();
+    for (const row of screen.getAllByTestId('color-table-row')) {
+      const path = row.getAttribute('data-path') ?? '';
+      const pill = row.querySelector('[data-testid="color-table-variant"]');
+      byPath.set(path, pill?.textContent ?? null);
+    }
+
+    expect(byPath.get('color.bg.hi')).toBeNull();
+    expect(byPath.get('color.bg.hi.disabled')).toBe('disabled');
+    expect(byPath.get('color.bg.hi.hover')).toBe('hover');
+  });
+
   it('ignores variants that would match characters inside a segment (neutral-900 ≠ suffix 0)', () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -1,0 +1,137 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { ColorTable, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
+
+function makeSnapshot(): ProjectSnapshot {
+  return {
+    axes: [{ name: 'mode', contexts: ['light'], default: 'light', source: 'resolver' }],
+    disabledAxes: [],
+    presets: [],
+    themes: [{ name: 'Light', input: { mode: 'light' }, sources: [] }],
+    themesResolved: {
+      Light: {
+        'color.surface.default': {
+          $type: 'color',
+          $value: { hex: '#ffffff' },
+        },
+        'color.text.default': {
+          $type: 'color',
+          $value: { hex: '#111111' },
+          aliasOf: 'color.palette.neutral.900',
+        },
+        'color.palette.neutral.900': {
+          $type: 'color',
+          $value: { hex: '#111111' },
+        },
+        'space.md': {
+          $type: 'dimension',
+          $value: { value: 16, unit: 'px' },
+        },
+      },
+    },
+    activeTheme: 'Light',
+    activeAxes: { mode: 'light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+}
+
+describe('ColorTable', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders only $type: color tokens (skips the dimension row)', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable />
+      </SwatchbookProvider>,
+    );
+
+    const rows = screen.getAllByTestId('color-table-row');
+    const paths = rows.map((r) => r.getAttribute('data-path')).toSorted();
+    expect(paths).toEqual([
+      'color.palette.neutral.900',
+      'color.surface.default',
+      'color.text.default',
+    ]);
+  });
+
+  it('shows HEX, HSL, OKLCH, CSS var, and alias columns per row', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="color.text.default" />
+      </SwatchbookProvider>,
+    );
+
+    const row = screen.getByTestId('color-table-row');
+    expect(within(row).getByText('#111111')).toBeDefined();
+    expect(within(row).getByText(/var\(--sb-color-text-default\)/)).toBeDefined();
+    expect(within(row).getByText('color.palette.neutral.900')).toBeDefined();
+    // HSL + OKLCH are stringified by formatColor; just assert their copy buttons exist.
+    const hslCopy = within(row).queryByLabelText(/Copy HSL/);
+    const oklchCopy = within(row).queryByLabelText(/Copy OKLCH/);
+    expect(hslCopy).not.toBeNull();
+    expect(oklchCopy).not.toBeNull();
+  });
+
+  it('renders an em-dash in the alias column for non-aliased tokens', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="color.surface.*" />
+      </SwatchbookProvider>,
+    );
+    const row = screen.getByTestId('color-table-row');
+    const alias = row.querySelector('.sb-color-table__alias');
+    expect(alias?.textContent?.trim()).toBe('—');
+  });
+
+  it('fuzzy search narrows rows and survives out-of-order terms', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable />
+      </SwatchbookProvider>,
+    );
+
+    const input = screen.getByTestId('color-table-search') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'default text' } });
+
+    const rows = screen.getAllByTestId('color-table-row');
+    expect(rows.length).toBe(1);
+    expect(rows[0]?.getAttribute('data-path')).toBe('color.text.default');
+  });
+
+  it('renders the empty state when the filter matches no colors', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="typography.*" />
+      </SwatchbookProvider>,
+    );
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getByText('No color tokens match this filter.')).toBeDefined();
+  });
+
+  it('clicking a row opens the DetailOverlay by default', async () => {
+    const { findByTestId } = render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable />
+      </SwatchbookProvider>,
+    );
+    const rows = screen.getAllByTestId('color-table-row');
+    rows[0]?.click();
+    expect(await findByTestId('color-table-overlay')).toBeDefined();
+  });
+
+  it('clicking a copy button does not bubble into the row click', () => {
+    const picks: string[] = [];
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable onSelect={(p) => picks.push(p)} filter="color.surface.*" />
+      </SwatchbookProvider>,
+    );
+    const copy = screen.getAllByLabelText(/Copy HEX/)[0];
+    copy?.click();
+    expect(picks.length).toBe(0);
+  });
+});

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -123,6 +123,57 @@ describe('ColorTable', () => {
     expect(await findByTestId('color-table-overlay')).toBeDefined();
   });
 
+  it('renders variant pills from the variants map (longest suffix wins)', () => {
+    const snapshot = makeSnapshot();
+    snapshot.themesResolved['Light'] = {
+      ...snapshot.themesResolved['Light'],
+      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
+      'color.bg.hi-h': { $type: 'color', $value: { hex: '#222222' } },
+      'color.bg.hi-d': { $type: 'color', $value: { hex: '#333333' } },
+      'color.bg.hi-h-dark': { $type: 'color', $value: { hex: '#444444' } },
+    };
+
+    render(
+      <SwatchbookProvider value={snapshot}>
+        <ColorTable
+          filter="color.bg.*"
+          variants={{ hover: 'h', disabled: 'd', hoverDark: 'h-dark' }}
+        />
+      </SwatchbookProvider>,
+    );
+
+    const byPath = new Map<string, string | null>();
+    for (const row of screen.getAllByTestId('color-table-row')) {
+      const path = row.getAttribute('data-path') ?? '';
+      const pill = row.querySelector('[data-testid="color-table-variant"]');
+      byPath.set(path, pill?.textContent ?? null);
+    }
+
+    expect(byPath.get('color.bg.hi')).toBeNull();
+    expect(byPath.get('color.bg.hi-h')).toBe('hover');
+    expect(byPath.get('color.bg.hi-d')).toBe('disabled');
+    expect(byPath.get('color.bg.hi-h-dark')).toBe('hoverDark');
+  });
+
+  it('ignores variants that would match characters inside a segment (neutral-900 ≠ suffix 0)', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="color.palette.*" variants={{ zero: '0' }} />
+      </SwatchbookProvider>,
+    );
+    const pills = screen.queryAllByTestId('color-table-variant');
+    expect(pills.length).toBe(0);
+  });
+
+  it('renders no pills when the variants prop is omitted', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable />
+      </SwatchbookProvider>,
+    );
+    expect(screen.queryAllByTestId('color-table-variant').length).toBe(0);
+  });
+
   it('clicking a copy button does not bubble into the row click', () => {
     const picks: string[] = [];
     render(


### PR DESCRIPTION
## Summary

- New `<ColorTable />` block — one row per color token with swatch, name, HEX, HSL, OKLCH, CSS var, and alias-target columns side-by-side. Each value cell carries a hover-revealed copy-to-clipboard button.
- Reuses the `filter` / `sortBy` / `sortDir` / `searchable` / `onSelect` prop shape + fuzzy search from `TokenTable`, so it's a drop-in alternative when the scope is colors.
- Shared `CopyButton` primitive now lives in blocks internals. Also wired into `TokenTable`'s value cell and `TokenDetail`'s resolved value + usage snippet.

## Full description

Inspired by [Backmarket's semantic-colors page](https://styleguide.backmarket.com/system/main/index.html?path=/docs/%F0%9F%8E%AFcore-2-colors-semantic--docs) — the cross-format row shape (HEX | HSL | OKLCH | var | alias) is genuinely useful and doesn't generalize across `$type`, so it's its own block rather than a `TokenTable` extension. Existing blocks keep their current scope: `ColorPalette` is grid-of-cards, `TokenTable` stays generic two-column.

### Deliberately out of scope

- Per-platform names / values (iOS / Android / Figma) — gated on Token Listing extension adoption.
- State pills (`base / hover / disabled`) — needs authoring conventions or subtype metadata.
- Row-level expand-in-place — `TokenDetail` drawer already covers the full-data affordance; click-to-open still works on rows.

### Implementation notes

- `formatColor(value, 'hex' | 'hsl' | 'oklch')` is called three times per row — cheap; `ColorTable` only materializes visible colors via `sortTokens` + the fuzzy-search composite.
- Copy button stops click propagation so pressing it doesn't open the row drawer.
- Copy button silently no-ops when `navigator.clipboard.writeText` is unavailable (older Safari, insecure origins). No custom permission UI.

**Milestone:** Maintenance
**Closes:** #591
**Plan impact:** None — new block slots into existing prop conventions; no plan file.

## Test plan

- [x] 7 unit tests in `packages/blocks/test/color-table.test.tsx` cover type filtering, column rendering, alias display, fuzzy search, empty state, row-click drawer, and copy-click-doesn't-bubble.
- [x] 72/72 blocks tests green; 29/29 turbo tasks green.
- [x] Storybook stories for `All`, `SysOnly`, `RefBlue`, `SortedPerceptually` with render assertions.
- [ ] Manual verification: open the ColorTable story, confirm hover reveals copy buttons, clicking any of them writes to the clipboard without opening the drawer.