### PR TITLE
docs(blocks): add ColorTable reference + fuzzy-search refresh

### DIFF
--- a/.changeset/docs-color-table.md
+++ b/.changeset/docs-color-table.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Document `ColorTable` in the overview blocks reference, refresh `TokenNavigator` and `TokenTable` entries so their search primitive is described as fuzzy (not substring — swapped in 0.15), and note the copy-to-clipboard affordance on `TokenTable`'s value cell.

--- a/apps/docs/docs/reference/blocks/index.mdx
+++ b/apps/docs/docs/reference/blocks/index.mdx
@@ -23,9 +23,10 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ### Inside Storybook
 
 ```tsx
-import { ColorPalette, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
+import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
 <ColorPalette filter="color.*" />
+<ColorTable filter="color.*" />
 <TokenTable filter="size.*" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
@@ -55,7 +56,7 @@ export function TokenDocs() {
 
 Four groups by shape of use:
 
-- [**Overview blocks**](./overview) — survey many tokens at once. `TokenNavigator`, `TokenTable`, plus the per-type scales and palettes.
+- [**Overview blocks**](./overview) — survey many tokens at once. `TokenNavigator`, `TokenTable`, `ColorTable`, plus the per-type scales and palettes.
 - [**Inspector blocks**](./inspector) — single-token deep-dive. `TokenDetail` and its subparts.
 - [**Sample blocks**](./samples) — one-token visual atoms you can drop inline.
 - [**Utility blocks**](./utility) — `Diagnostics`.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -23,7 +23,7 @@ Most blocks in this group take:
 <TokenNavigator root="color" />
 ```
 
-Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A search input at the top filters by path substring — matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
+Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A fuzzy-search input at the top filters leaves by path — case-insensitive, out-of-order terms, single-character typo tolerance. Matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
 Props:
 
@@ -39,7 +39,7 @@ Props:
 <TokenTable type="color" />
 ```
 
-Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). A search input at the top narrows rows by path, type, or value substring. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
+Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). A fuzzy-search input at the top narrows rows by path, type, or value — case-insensitive, out-of-order terms, single-character typo tolerance. Each value cell has a hover-revealed copy-to-clipboard button. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
 
 Props:
 
@@ -62,6 +62,24 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
+
+### ColorTable
+
+```tsx
+<ColorTable filter="color.*" />
+```
+
+Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, HEX, HSL, OKLCH, CSS var, and alias-target columns side-by-side — independent of the global color-format toggle, because this block's reason for existing is density. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + any format value; row click opens the same `<TokenDetail>` drawer `TokenTable` uses.
+
+Props:
+
+- `filter?: string` — path glob. Defaults to every `$type: color` token.
+- `caption?: string` — override the caption.
+- `sortBy?: 'path' | 'value' | 'none'` — default `'path'`. `'value'` orders perceptually (oklch L → C → H).
+- `sortDir?: 'asc' | 'desc'` — default `'asc'`.
+- `searchable?: boolean` — render a fuzzy-search input above the table. Defaults to `true`.
+- `onSelect?(path: string): void` — suppress the built-in drawer.
+- `variants?: Record<string, string>` — map from display label to trailing-segment suffix. Rows whose leaf ends in `-<suffix>` (hyphen tail) or whose last dot-segment equals `<suffix>` (DTCG-idiomatic) render the label as a pill after the name. Longest-suffix-wins, leading hyphen required for tails (`0` won't hit `neutral-900`). Example: `variants={{ hover: 'hover', disabled: 'disabled' }}` tags `color.bg.hi.disabled` and `color.bg.hi-disabled` identically.
 
 ### TypographyScale
 


### PR DESCRIPTION
## Summary

- Document \`ColorTable\` in \`apps/docs/docs/reference/blocks/overview.mdx\` — columns, copy-buttons, fuzzy search, row-click drawer, variants prop with both hyphen-tail and DTCG dot-segment matching.
- Refresh \`TokenNavigator\` and \`TokenTable\` blurbs: their search is fuzzy (was "substring" in the prose — accurate before 0.15).
- Mention the copy-to-clipboard affordance on \`TokenTable\`'s value cell.
- Add \`ColorTable\` to the inline import example in \`blocks/index.mdx\`.

## Full description

PR #592 landed the ColorTable feature but the docs commit sat on a branch that didn't get merged with it. This is the follow-up. Patch changeset included so the doc snapshot rebuilds on the next release and the update reaches the versioned \`/\` default, not just \`/next/\`.

**Milestone:** Maintenance
**Closes:** #594
**Plan impact:** None — docs-only.

## Test plan

- [x] Docusaurus build locally: no broken links, new section renders.
- [x] No code changes; lint / typecheck / test unaffected.