### PR TITLE
feat(blocks): add ColorTable groups variants + expands inline

### DIFF
--- a/.changeset/feat-color-table-grouping.md
+++ b/.changeset/feat-color-table-grouping.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`ColorTable` now collapses sibling variants into a single row with a pill selector — clicking a pill swaps the displayed HEX / HSL / OKLCH / CSS var to that variant's values. Given `variants={{ hover: 'hover', disabled: 'disabled' }}`, the tokens `color.bg.hi`, `color.bg.hi.disabled`, and `color.bg.hi.hover` emit one row with three pills (`base` / `disabled` / `hover`). Backmarket-style hyphen tails (`color.bg.hi-h` with `variants={{ hover: 'h' }}`) group identically.
+
+Row click now expands the row inline instead of opening a drawer. The detail panel surfaces `$description`, the token's alias chain, and — for multi-variant groups — a compact sub-table comparing every variant's values at once. `onSelect` still acts as the escape hatch: when set, it replaces both the expansion and any drawer behavior with consumer-owned follow-up.
+
+Single-member groups (no matching variants, or a lone variant with no siblings) render as plain rows with no pill selector. Passing no `variants` map disables grouping entirely — back-compat.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -69,7 +69,20 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 <ColorTable filter="color.*" />
 ```
 
-Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, HEX, HSL, OKLCH, CSS var, and alias-target columns side-by-side — independent of the global color-format toggle, because this block's reason for existing is density. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + any format value; row click opens the same `<TokenDetail>` drawer `TokenTable` uses.
+Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, HEX, HSL, OKLCH, CSS var, and alias-target columns side-by-side — independent of the global color-format toggle, because this block's reason for existing is density. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + any format value.
+
+Clicking a row expands it inline — the detail panel surfaces `$description`, the token's alias chain, and (for grouped variants) a sub-table comparing every variant's values. No separate drawer.
+
+**Variant grouping** — pass a `variants` map to collapse sibling tokens that share a base path into a single row with a pill selector. Clicking a pill swaps the displayed values to that variant:
+
+```tsx
+<ColorTable
+  filter="color.bg.*"
+  variants={{ hover: 'hover', disabled: 'disabled' }}
+/>
+```
+
+Given tokens like `color.bg.hi` / `color.bg.hi.hover` / `color.bg.hi.disabled`, the table emits one row for `color.bg.hi` with three pills (`base`, `hover`, `disabled`). The same map also handles Backmarket-style hyphen tails — `color.bg.hi-h` with `variants={{ hover: 'h' }}` groups identically. Suffix matching is longest-wins and requires a real segment boundary, so `variants={{ zero: '0' }}` will not spuriously hit `neutral-900`.
 
 Props:
 
@@ -78,8 +91,8 @@ Props:
 - `sortBy?: 'path' | 'value' | 'none'` — default `'path'`. `'value'` orders perceptually (oklch L → C → H).
 - `sortDir?: 'asc' | 'desc'` — default `'asc'`.
 - `searchable?: boolean` — render a fuzzy-search input above the table. Defaults to `true`.
-- `onSelect?(path: string): void` — suppress the built-in drawer.
-- `variants?: Record<string, string>` — map from display label to trailing-segment suffix. Rows whose leaf ends in `-<suffix>` (hyphen tail) or whose last dot-segment equals `<suffix>` (DTCG-idiomatic) render the label as a pill after the name. Longest-suffix-wins, leading hyphen required for tails (`0` won't hit `neutral-900`). Example: `variants={{ hover: 'hover', disabled: 'disabled' }}` tags `color.bg.hi.disabled` and `color.bg.hi-disabled` identically.
+- `onSelect?(path: string): void` — replaces the expand-in-place default with a consumer-driven callback, invoked with the currently-selected variant's path.
+- `variants?: Record<string, string>` — label-to-suffix map for grouping. Accepts both DTCG dot-segment (`hi.disabled`) and Backmarket hyphen-tail (`hi-d`) conventions. Single-member groups render as plain rows; empty / omitted map disables grouping entirely.
 
 ### TypographyScale
 

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -69,9 +69,9 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 <ColorTable filter="color.*" />
 ```
 
-Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, HEX, HSL, OKLCH, CSS var, and alias-target columns side-by-side — independent of the global color-format toggle, because this block's reason for existing is density. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + any format value.
+Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
 
-Clicking a row expands it inline — the detail panel surfaces `$description`, the token's alias chain, and (for grouped variants) a sub-table comparing every variant's values. No separate drawer.
+Clicking a row expands it inline — the detail panel surfaces `$description`, the token's alias chain, and (for grouped variants) a sub-table comparing every variant's HEX / HSL / OKLCH at once. That side-by-side comparison is the one place per-format density earns its weight; the collapsed row only shows the format the user already picked.
 
 **Variant grouping** — pass a `variants` map to collapse sibling tokens that share a base path into a single row with a pill selector. Clicking a pill swaps the displayed values to that variant:
 

--- a/apps/storybook/src/stories/ColorTable.stories.tsx
+++ b/apps/storybook/src/stories/ColorTable.stories.tsx
@@ -43,10 +43,10 @@ export const SortedPerceptually = meta.story({
   args: { sortBy: 'value' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });
-export const WithVariantPills = meta.story({
+export const GroupedVariants = meta.story({
   args: {
     filter: 'color.*',
-    variants: { hover: 'h', disabled: 'd', active: 'a' },
+    variants: { hover: 'hover' },
   },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -52,6 +52,10 @@
   min-width: 200px;
 }
 
+.sb-color-table__th--expand {
+  width: 28px;
+}
+
 .sb-color-table__row {
   cursor: pointer;
 }
@@ -61,10 +65,18 @@
   outline-offset: -2px;
 }
 
+.sb-color-table__row--expanded {
+  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.06));
+}
+
 .sb-color-table__td {
   padding: 8px 12px;
   border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
   vertical-align: middle;
+}
+
+.sb-color-table__row--expanded > .sb-color-table__td {
+  border-bottom: 0;
 }
 
 .sb-color-table__path {
@@ -78,18 +90,49 @@
   vertical-align: middle;
 }
 
+.sb-color-table__variant-pills {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 8px;
+  vertical-align: middle;
+}
+
 .sb-color-table__variant-pill {
   display: inline-block;
-  margin-left: 6px;
   padding: 1px 6px;
+  margin: 0;
   border-radius: 4px;
+  border: 0;
   font-family: inherit;
   font-size: 10px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
   background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
   color: var(--swatchbook-text-muted, CanvasText);
-  vertical-align: middle;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
+}
+
+.sb-color-table__variant-pill:hover {
+  background: var(--swatchbook-surface-raised, rgba(128, 128, 128, 0.25));
+  color: var(--swatchbook-text-default, CanvasText);
+}
+
+.sb-color-table__variant-pill:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: 1px;
+}
+
+.sb-color-table__variant-pill--active {
+  background: var(--swatchbook-accent-bg, #1d4ed8);
+  color: var(--swatchbook-accent-fg, white);
+}
+
+.sb-color-table__variant-pill--active:hover {
+  background: var(--swatchbook-accent-bg, #1d4ed8);
+  color: var(--swatchbook-accent-fg, white);
 }
 
 .sb-color-table__swatch-cell {
@@ -155,6 +198,113 @@
 
 .sb-color-table__alias-empty {
   opacity: 0.4;
+}
+
+.sb-color-table__expand-cell {
+  width: 28px;
+  text-align: center;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-color-table__chevron {
+  display: inline-block;
+  transition: transform 120ms ease;
+}
+
+.sb-color-table__chevron--expanded {
+  transform: rotate(90deg);
+}
+
+.sb-color-table__detail-row {
+  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.06));
+}
+
+.sb-color-table__detail-cell {
+  padding: 12px 16px 20px;
+}
+
+.sb-color-table__detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--swatchbook-text-default, CanvasText);
+}
+
+.sb-color-table__description {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.sb-color-table__chain {
+  margin: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-color-table__detail-label {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-size: 10px;
+  font-family: inherit;
+  margin-right: 4px;
+}
+
+.sb-color-table__detail-empty {
+  margin: 0;
+  color: var(--swatchbook-text-muted, CanvasText);
+  font-style: italic;
+}
+
+.sb-color-table__variant-grid {
+  margin-top: 4px;
+}
+
+.sb-color-table__variant-grid-header {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-size: 10px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  margin-bottom: 6px;
+}
+
+.sb-color-table__subtable {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+}
+
+.sb-color-table__subth {
+  text-align: left;
+  padding: 4px 8px;
+  font-family: inherit;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--swatchbook-text-muted, CanvasText);
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+}
+
+.sb-color-table__subtd {
+  padding: 4px 8px;
+  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.1));
+  vertical-align: middle;
+}
+
+.sb-color-table__subtd--path {
+  color: var(--swatchbook-text-muted, CanvasText);
+}
+
+.sb-color-table__subrow--active {
+  background: var(--swatchbook-surface-raised, rgba(128, 128, 128, 0.12));
+}
+
+.sb-color-table__subrow--active > .sb-color-table__subtd {
+  font-weight: 600;
+  color: var(--swatchbook-text-default, CanvasText);
 }
 
 .sb-color-table__sr-only {

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,14 +1,16 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 import './ColorTable.css';
 import { formatColor, type NormalizedColor } from '#/format-color.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
-import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
+
+const BASE_LABEL = 'base';
+const COLUMN_COUNT = 8;
 
 export interface ColorTableProps {
   /**
@@ -29,46 +31,56 @@ export interface ColorTableProps {
   /** `'asc'` (default) or `'desc'`. */
   sortDir?: SortDir;
   /**
-   * Render a fuzzy-search input above the table (case-insensitive,
-   * single-char typo tolerance, out-of-order terms, matches across path +
-   * any format value). Defaults to `true`.
+   * Render a fuzzy-search input above the table. Defaults to `true`.
    */
   searchable?: boolean;
   /**
-   * Called with the clicked row's dot-path. When set, the built-in
-   * `<TokenDetail>` drawer is suppressed — the consumer owns follow-up UI.
+   * Called with the *currently-selected* variant's dot-path on row click.
+   * When set, the built-in expand-in-place behavior is suppressed — the
+   * consumer owns follow-up UI.
    */
   onSelect?(path: string): void;
   /**
    * Map from a display label to a suffix matched against each token's
-   * trailing path segment. A row whose leaf matches one of the suffixes
-   * gets the corresponding label rendered as a pill after the token name.
+   * trailing path segment. Tokens whose leaves match a suffix are grouped
+   * under a shared "base" path (the path with the suffix stripped), and
+   * the group renders as a single row with a pill selector — clicking a
+   * pill swaps the displayed values to that variant. Sibling tokens
+   * without a suffix that share the group's base path are labeled `base`.
    *
-   * Accepts both DTCG-idiomatic and Backmarket-style conventions:
-   * - **Dot segment** (`color.bg.hi.disabled`): the last dot-segment equals
-   *   the suffix exactly (`suffix === 'disabled'`).
-   * - **Hyphen tail** (`color.bg.hi-d`): the last dot-segment ends in
-   *   `-<suffix>` (`suffix === 'd'`).
+   * Matches both DTCG-idiomatic and Backmarket-style conventions:
+   * - **Dot segment** (`color.bg.hi.disabled`): last dot-segment equals
+   *   the suffix (`disabled`). Base path = drop the last segment.
+   * - **Hyphen tail** (`color.bg.hi-d`): last dot-segment ends in
+   *   `-<suffix>` (`d`). Base path = trim the `-<suffix>` from the leaf.
    *
-   * Longest-suffix-wins: `{ hover: 'h', hoverDark: 'h-dark' }` picks
-   * `hoverDark` for a path ending in `-h-dark`. The hyphen-tail form
-   * requires an actual hyphen boundary — suffix `0` does not match
-   * `neutral-900`. Tokens that don't match any suffix render with no pill.
+   * Longest-suffix-wins. Hyphen-tail form requires an actual hyphen
+   * boundary — suffix `0` does not match `neutral-900`.
    *
-   * Empty map (default) → no pills; the block behaves exactly as before.
+   * Single-member groups render as plain rows (no pill selector). Empty
+   * map (default) disables grouping entirely; each token renders as its
+   * own row, identical to the pre-grouping behavior.
    */
   variants?: Record<string, string>;
 }
 
-interface Row {
+interface Variant {
+  label: string;
   path: string;
   cssVar: string;
   hex: string;
   hsl: string;
   oklch: string;
   hexOutOfGamut: boolean;
+  description?: string;
   aliasOf?: string;
-  variant?: string;
+  aliasChain?: readonly string[];
+}
+
+interface Group {
+  base: string;
+  variants: Variant[];
+  searchText: string;
 }
 
 export function ColorTable({
@@ -81,58 +93,84 @@ export function ColorTable({
   variants,
 }: ColorTableProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const [selectedByBase, setSelectedByBase] = useState<Record<string, string>>({});
+  const [expandedByBase, setExpandedByBase] = useState<ReadonlySet<string>>(() => new Set());
 
-  const variantIndex = useMemo(() => buildVariantIndex(variants), [variants]);
+  const defs = useMemo(() => buildVariantDefs(variants), [variants]);
 
-  const rows = useMemo<Row[]>(() => {
+  const groups = useMemo<Group[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'color') return false;
       return globMatch(path, filter);
     });
-    const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
-    return entries.map(([path, token]) => {
+    const sorted = sortTokens(filtered, { by: sortBy, dir: sortDir });
+
+    const groupMap = new Map<string, { base: string; variants: Variant[] }>();
+    for (const [path, token] of sorted) {
       const raw = token.$value as NormalizedColor;
       const hex = formatColor(raw, 'hex');
       const hsl = formatColor(raw, 'hsl');
       const oklch = formatColor(raw, 'oklch');
-      const variant = matchVariant(path, variantIndex);
-      return {
+      const match = matchVariant(path, defs.matchOrder);
+      const variant: Variant = {
+        label: match?.label ?? BASE_LABEL,
         path,
         cssVar: makeCssVar(path, cssVarPrefix),
         hex: hex.value,
         hsl: hsl.value,
         oklch: oklch.value,
         hexOutOfGamut: hex.outOfGamut,
+        ...(token.$description !== undefined && { description: token.$description }),
         ...(token.aliasOf !== undefined && { aliasOf: token.aliasOf }),
-        ...(variant !== undefined && { variant }),
+        ...(token.aliasChain !== undefined && { aliasChain: token.aliasChain }),
       };
+      const basePath = match?.basePath ?? path;
+      const existing = groupMap.get(basePath);
+      if (existing) existing.variants.push(variant);
+      else groupMap.set(basePath, { base: basePath, variants: [variant] });
+    }
+
+    const out: Group[] = [];
+    for (const { base, variants: vs } of groupMap.values()) {
+      vs.sort((a, b) => orderIndex(a.label, defs) - orderIndex(b.label, defs));
+      const searchText = vs.map((v) => `${v.path} ${v.hex} ${v.hsl} ${v.oklch}`).join(' ');
+      out.push({ base, variants: vs, searchText });
+    }
+    return out;
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir, defs]);
+
+  const visibleGroups = useMemo(() => {
+    if (!searchable || query.trim() === '') return groups;
+    return fuzzyFilter(groups, query, (g) => g.searchText);
+  }, [groups, query, searchable]);
+
+  const totalTokens = useMemo(() => groups.reduce((n, g) => n + g.variants.length, 0), [groups]);
+
+  const toggleExpand = useCallback((base: string) => {
+    setExpandedByBase((prev) => {
+      const next = new Set(prev);
+      if (next.has(base)) next.delete(base);
+      else next.add(base);
+      return next;
     });
-  }, [resolved, filter, cssVarPrefix, sortBy, sortDir, variantIndex]);
+  }, []);
 
-  const visibleRows = useMemo(() => {
-    if (!searchable || query.trim() === '') return rows;
-    return fuzzyFilter(rows, query, (r) => `${r.path} ${r.hex} ${r.hsl} ${r.oklch}`);
-  }, [rows, query, searchable]);
-
-  const handleRowClick = useCallback(
-    (path: string) => {
-      if (onSelect) onSelect(path);
-      else setSelectedPath(path);
-    },
-    [onSelect],
-  );
+  const selectVariant = useCallback((base: string, label: string) => {
+    setSelectedByBase((prev) => ({ ...prev, [base]: label }));
+  }, []);
 
   const matchSuffix =
-    searchable && query.trim() !== '' ? ` · ${visibleRows.length} matching "${query.trim()}"` : '';
+    searchable && query.trim() !== ''
+      ? ` · ${visibleGroups.length} matching "${query.trim()}"`
+      : '';
   const captionText =
     caption ??
-    `${rows.length} color${rows.length === 1 ? '' : 's'}${
-      filter ? ` matching \`${filter}\`` : ''
-    }${matchSuffix} · ${activeTheme}`;
+    `${totalTokens} color${totalTokens === 1 ? '' : 's'} across ${groups.length} group${
+      groups.length === 1 ? '' : 's'
+    }${filter ? ` matching \`${filter}\`` : ''}${matchSuffix} · ${activeTheme}`;
 
-  if (rows.length === 0) {
+  if (groups.length === 0) {
     return (
       <div {...themeAttrs(cssVarPrefix, activeTheme)}>
         <div className="sb-block__empty">No color tokens match this filter.</div>
@@ -168,85 +206,217 @@ export function ColorTable({
             <th className="sb-color-table__th">OKLCH</th>
             <th className="sb-color-table__th">CSS var</th>
             <th className="sb-color-table__th">Alias</th>
+            <th className="sb-color-table__th sb-color-table__th--expand">
+              <span className="sb-color-table__sr-only">Expand</span>
+            </th>
           </tr>
         </thead>
         <tbody>
-          {visibleRows.length === 0 && (
+          {visibleGroups.length === 0 && (
             <tr>
-              <td colSpan={7} className="sb-color-table__td sb-color-table__empty-row">
+              <td colSpan={COLUMN_COUNT} className="sb-color-table__td sb-color-table__empty-row">
                 No colors match "{query.trim()}".
               </td>
             </tr>
           )}
-          {visibleRows.map((row) => (
-            <tr
-              key={row.path}
-              className="sb-color-table__row"
-              onClick={() => handleRowClick(row.path)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleRowClick(row.path);
-                }
-              }}
-              tabIndex={0}
-              aria-label={`Inspect ${row.path}`}
-              data-testid="color-table-row"
-              data-path={row.path}
-            >
-              <td className="sb-color-table__td sb-color-table__swatch-cell">
-                <span
-                  className="sb-color-table__swatch"
-                  style={{ background: row.cssVar }}
-                  aria-hidden
-                />
-              </td>
-              <td className={cx('sb-color-table__td', 'sb-color-table__path')}>
-                <span className="sb-color-table__path-text">{row.path}</span>
-                {row.variant !== undefined && (
-                  <span
-                    className="sb-color-table__variant-pill"
-                    data-variant={row.variant}
-                    data-testid="color-table-variant"
-                  >
-                    {row.variant}
-                  </span>
-                )}
-              </td>
-              <ValueCell value={row.hex} label={`Copy HEX ${row.hex}`}>
-                {row.hexOutOfGamut && (
-                  <span
-                    title="Out of sRGB gamut"
-                    aria-label="out of gamut"
-                    className="sb-color-table__gamut-warn"
-                  >
-                    ⚠
-                  </span>
-                )}
-              </ValueCell>
-              <ValueCell value={row.hsl} label={`Copy HSL ${row.hsl}`} />
-              <ValueCell value={row.oklch} label={`Copy OKLCH ${row.oklch}`} />
-              <ValueCell value={row.cssVar} label={`Copy CSS var ${row.cssVar}`} />
-              <td className="sb-color-table__td sb-color-table__alias">
-                {row.aliasOf ? (
-                  <span className="sb-color-table__alias-text">{row.aliasOf}</span>
-                ) : (
-                  <span className="sb-color-table__alias-empty" aria-hidden>
-                    —
-                  </span>
-                )}
-              </td>
-            </tr>
+          {visibleGroups.map((group) => (
+            <GroupRow
+              key={group.base}
+              group={group}
+              selectedLabel={selectedByBase[group.base]}
+              expanded={expandedByBase.has(group.base)}
+              onToggleExpand={toggleExpand}
+              onSelectVariant={selectVariant}
+              {...(onSelect !== undefined && { onSelect })}
+            />
           ))}
         </tbody>
       </table>
+    </div>
+  );
+}
 
-      {selectedPath !== null && (
-        <DetailOverlay
-          path={selectedPath}
-          onClose={() => setSelectedPath(null)}
-          testId="color-table-overlay"
-        />
+function GroupRow({
+  group,
+  selectedLabel,
+  expanded,
+  onToggleExpand,
+  onSelectVariant,
+  onSelect,
+}: {
+  group: Group;
+  selectedLabel: string | undefined;
+  expanded: boolean;
+  onToggleExpand(base: string): void;
+  onSelectVariant(base: string, label: string): void;
+  onSelect?(path: string): void;
+}): ReactElement {
+  const multi = group.variants.length > 1;
+  const active =
+    group.variants.find((v) => v.label === selectedLabel) ?? (group.variants[0] as Variant);
+  const nameText = multi ? group.base : active.path;
+
+  const handleRowActivate = (): void => {
+    if (onSelect) onSelect(active.path);
+    else onToggleExpand(group.base);
+  };
+
+  return (
+    <Fragment>
+      <tr
+        className={cx('sb-color-table__row', {
+          'sb-color-table__row--expanded': expanded,
+        })}
+        onClick={handleRowActivate}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleRowActivate();
+          }
+        }}
+        tabIndex={0}
+        aria-label={
+          onSelect
+            ? `Inspect ${active.path}`
+            : expanded
+              ? `Collapse ${group.base}`
+              : `Expand ${group.base}`
+        }
+        aria-expanded={onSelect ? undefined : expanded}
+        data-testid="color-table-row"
+        data-path={active.path}
+        data-base={group.base}
+      >
+        <td className="sb-color-table__td sb-color-table__swatch-cell">
+          <span
+            className="sb-color-table__swatch"
+            style={{ background: active.cssVar }}
+            aria-hidden
+          />
+        </td>
+        <td className={cx('sb-color-table__td', 'sb-color-table__path')}>
+          <span className="sb-color-table__path-text">{nameText}</span>
+          {multi && (
+            <span
+              className="sb-color-table__variant-pills"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+              role="presentation"
+            >
+              {group.variants.map((v) => (
+                <button
+                  key={v.label}
+                  type="button"
+                  className={cx('sb-color-table__variant-pill', {
+                    'sb-color-table__variant-pill--active': v.label === active.label,
+                  })}
+                  onClick={() => onSelectVariant(group.base, v.label)}
+                  aria-pressed={v.label === active.label}
+                  data-testid="color-table-variant"
+                  data-variant={v.label}
+                >
+                  {v.label}
+                </button>
+              ))}
+            </span>
+          )}
+        </td>
+        <ValueCell value={active.hex} label={`Copy HEX ${active.hex}`}>
+          {active.hexOutOfGamut && (
+            <span
+              title="Out of sRGB gamut"
+              aria-label="out of gamut"
+              className="sb-color-table__gamut-warn"
+            >
+              ⚠
+            </span>
+          )}
+        </ValueCell>
+        <ValueCell value={active.hsl} label={`Copy HSL ${active.hsl}`} />
+        <ValueCell value={active.oklch} label={`Copy OKLCH ${active.oklch}`} />
+        <ValueCell value={active.cssVar} label={`Copy CSS var ${active.cssVar}`} />
+        <td className="sb-color-table__td sb-color-table__alias">
+          {active.aliasOf ? (
+            <span className="sb-color-table__alias-text">{active.aliasOf}</span>
+          ) : (
+            <span className="sb-color-table__alias-empty" aria-hidden>
+              —
+            </span>
+          )}
+        </td>
+        <td className="sb-color-table__td sb-color-table__expand-cell">
+          {!onSelect && (
+            <span
+              className={cx('sb-color-table__chevron', {
+                'sb-color-table__chevron--expanded': expanded,
+              })}
+              aria-hidden
+            >
+              ▸
+            </span>
+          )}
+        </td>
+      </tr>
+      {expanded && !onSelect && (
+        <tr className="sb-color-table__detail-row" data-testid="color-table-detail">
+          <td colSpan={COLUMN_COUNT} className="sb-color-table__td sb-color-table__detail-cell">
+            <ExpandedDetail group={group} active={active} />
+          </td>
+        </tr>
+      )}
+    </Fragment>
+  );
+}
+
+function ExpandedDetail({ group, active }: { group: Group; active: Variant }): ReactElement {
+  const hasDescription = active.description !== undefined && active.description.length > 0;
+  const chain = active.aliasChain && active.aliasChain.length > 0 ? active.aliasChain : undefined;
+  const multi = group.variants.length > 1;
+
+  return (
+    <div className="sb-color-table__detail">
+      {hasDescription && <p className="sb-color-table__description">{active.description}</p>}
+      {chain && (
+        <p className="sb-color-table__chain">
+          <span className="sb-color-table__detail-label">Alias chain:</span> {chain.join(' → ')}
+        </p>
+      )}
+      {multi && (
+        <div className="sb-color-table__variant-grid">
+          <div className="sb-color-table__variant-grid-header">All variants</div>
+          <table className="sb-color-table__subtable">
+            <thead>
+              <tr>
+                <th className="sb-color-table__subth">Variant</th>
+                <th className="sb-color-table__subth">Path</th>
+                <th className="sb-color-table__subth">HEX</th>
+                <th className="sb-color-table__subth">HSL</th>
+                <th className="sb-color-table__subth">OKLCH</th>
+              </tr>
+            </thead>
+            <tbody>
+              {group.variants.map((v) => (
+                <tr
+                  key={v.label}
+                  className={cx({
+                    'sb-color-table__subrow--active': v.label === active.label,
+                  })}
+                >
+                  <td className="sb-color-table__subtd">{v.label}</td>
+                  <td className="sb-color-table__subtd sb-color-table__subtd--path">{v.path}</td>
+                  <td className="sb-color-table__subtd">{v.hex}</td>
+                  <td className="sb-color-table__subtd">{v.hsl}</td>
+                  <td className="sb-color-table__subtd">{v.oklch}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      {!hasDescription && !chain && !multi && (
+        <p className="sb-color-table__detail-empty">
+          No description or alias chain authored for this token.
+        </p>
       )}
     </div>
   );
@@ -284,37 +454,72 @@ interface VariantEntry {
   suffix: string;
 }
 
-/**
- * Pre-sort the variants map by descending suffix length so the first
- * `endsWith` hit during matching is always the longest. Empty suffixes are
- * dropped — they'd match every path and make the feature meaningless.
- */
-function buildVariantIndex(variants: Record<string, string> | undefined): readonly VariantEntry[] {
-  if (!variants) return [];
+interface VariantDefs {
+  /** Match iteration order — longest suffix first. */
+  matchOrder: readonly VariantEntry[];
+  /** Display iteration order — preserves the caller's declared order. */
+  displayOrder: readonly string[];
+}
+
+function buildVariantDefs(variants: Record<string, string> | undefined): VariantDefs {
+  if (!variants) return { matchOrder: [], displayOrder: [] };
   const entries: VariantEntry[] = [];
+  const displayOrder: string[] = [];
   for (const [label, suffix] of Object.entries(variants)) {
     if (suffix.length === 0) continue;
     entries.push({ label, suffix });
+    displayOrder.push(label);
   }
-  entries.sort((a, b) => b.suffix.length - a.suffix.length);
-  return entries;
+  const matchOrder = entries.toSorted((a, b) => b.suffix.length - a.suffix.length);
+  return { matchOrder, displayOrder };
 }
 
 /**
- * Resolve the variant label for a token path, if any. The leaf (last
- * dot-segment) must either equal the suffix outright (`hi.disabled`
- * matches suffix `disabled`) or end in `-<suffix>` (`hi-d` matches `d`).
- * The leading hyphen is required for the tail form, so suffix `h` matches
- * `hi-h` but not `highlight` or `neutral-900` — the whole trailing token
- * has to be the suffix, not a character within it. Entries are tried
- * longest-first, so `h-dark` wins over `dark` when both are configured
- * and the path ends in `-h-dark`.
+ * Position of a label within a group — the `base` entry always sorts first,
+ * then declared labels in the order the caller wrote them in the `variants`
+ * prop. Unknown labels (shouldn't happen in practice) fall to the end.
  */
-function matchVariant(path: string, variantIndex: readonly VariantEntry[]): string | undefined {
-  if (variantIndex.length === 0) return undefined;
-  const leaf = path.split('.').at(-1) ?? path;
-  for (const entry of variantIndex) {
-    if (leaf === entry.suffix || leaf.endsWith(`-${entry.suffix}`)) return entry.label;
+function orderIndex(label: string, defs: VariantDefs): number {
+  if (label === BASE_LABEL) return -1;
+  const idx = defs.displayOrder.indexOf(label);
+  return idx >= 0 ? idx : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Resolve the variant label + base path for a token, if any. The leaf
+ * (last dot-segment) must either equal the suffix outright (dot-segment
+ * form: `hi.disabled` matches suffix `disabled`) or end in `-<suffix>`
+ * (hyphen-tail form: `hi-d` matches `d`). The leading hyphen is required
+ * for the tail form so suffix `0` can't hit `neutral-900` by character.
+ *
+ * Returned `basePath` is what gets used as the grouping key:
+ * - Dot-segment match → parent path (drop the last dot-segment)
+ * - Hyphen-tail match → same dot-depth, leaf with `-<suffix>` stripped
+ *
+ * Entries in `matchOrder` are pre-sorted longest-first, so `h-dark` wins
+ * over `dark` for a path ending in `-h-dark`.
+ */
+function matchVariant(
+  path: string,
+  matchOrder: readonly VariantEntry[],
+): { label: string; basePath: string } | undefined {
+  if (matchOrder.length === 0) return undefined;
+  const segments = path.split('.');
+  const leaf = segments.at(-1) ?? path;
+  for (const entry of matchOrder) {
+    if (leaf === entry.suffix) {
+      const parent = segments.slice(0, -1).join('.');
+      if (parent.length === 0) continue;
+      return { label: entry.label, basePath: parent };
+    }
+    const tailMarker = `-${entry.suffix}`;
+    if (leaf.endsWith(tailMarker)) {
+      const trimmed = leaf.slice(0, -tailMarker.length);
+      if (trimmed.length === 0) continue;
+      const copy = segments.slice(0, -1);
+      copy.push(trimmed);
+      return { label: entry.label, basePath: copy.join('.') };
+    }
   }
   return undefined;
 }

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -287,7 +287,6 @@ function GroupRow({
               ? `Collapse ${group.base}`
               : `Expand ${group.base}`
         }
-        aria-expanded={onSelect ? undefined : expanded}
         data-testid="color-table-row"
         data-path={active.path}
         data-base={group.base}

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -3,14 +3,15 @@ import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { Fragment, useCallback, useMemo, useState } from 'react';
 import './ColorTable.css';
-import { formatColor, type NormalizedColor } from '#/format-color.ts';
+import { useColorFormat } from '#/contexts.ts';
+import { type ColorFormat, formatColor, type NormalizedColor } from '#/format-color.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, makeCssVar, useProject } from '#/internal/use-project.ts';
 
 const BASE_LABEL = 'base';
-const COLUMN_COUNT = 8;
+const COLUMN_COUNT = 6;
 
 export interface ColorTableProps {
   /**
@@ -68,10 +69,13 @@ interface Variant {
   label: string;
   path: string;
   cssVar: string;
+  /** The display value in the currently-active color format. */
+  value: string;
+  outOfGamut: boolean;
+  /** Hex / HSL / OKLCH breakdown — retained for the expanded sub-table. */
   hex: string;
   hsl: string;
   oklch: string;
-  hexOutOfGamut: boolean;
   description?: string;
   aliasOf?: string;
   aliasChain?: readonly string[];
@@ -93,6 +97,7 @@ export function ColorTable({
   variants,
 }: ColorTableProps): ReactElement {
   const { resolved, activeTheme, cssVarPrefix } = useProject();
+  const colorFormat = useColorFormat();
   const [query, setQuery] = useState('');
   const [selectedByBase, setSelectedByBase] = useState<Record<string, string>>({});
   const [expandedByBase, setExpandedByBase] = useState<ReadonlySet<string>>(() => new Set());
@@ -112,15 +117,17 @@ export function ColorTable({
       const hex = formatColor(raw, 'hex');
       const hsl = formatColor(raw, 'hsl');
       const oklch = formatColor(raw, 'oklch');
+      const active = pickActiveFormat(raw, colorFormat, hex, hsl, oklch);
       const match = matchVariant(path, defs.matchOrder);
       const variant: Variant = {
         label: match?.label ?? BASE_LABEL,
         path,
         cssVar: makeCssVar(path, cssVarPrefix),
+        value: active.value,
+        outOfGamut: active.outOfGamut,
         hex: hex.value,
         hsl: hsl.value,
         oklch: oklch.value,
-        hexOutOfGamut: hex.outOfGamut,
         ...(token.$description !== undefined && { description: token.$description }),
         ...(token.aliasOf !== undefined && { aliasOf: token.aliasOf }),
         ...(token.aliasChain !== undefined && { aliasChain: token.aliasChain }),
@@ -134,11 +141,11 @@ export function ColorTable({
     const out: Group[] = [];
     for (const { base, variants: vs } of groupMap.values()) {
       vs.sort((a, b) => orderIndex(a.label, defs) - orderIndex(b.label, defs));
-      const searchText = vs.map((v) => `${v.path} ${v.hex} ${v.hsl} ${v.oklch}`).join(' ');
+      const searchText = vs.map((v) => `${v.path} ${v.value}`).join(' ');
       out.push({ base, variants: vs, searchText });
     }
     return out;
-  }, [resolved, filter, cssVarPrefix, sortBy, sortDir, defs]);
+  }, [resolved, filter, cssVarPrefix, sortBy, sortDir, defs, colorFormat]);
 
   const visibleGroups = useMemo(() => {
     if (!searchable || query.trim() === '') return groups;
@@ -201,9 +208,7 @@ export function ColorTable({
               <span className="sb-color-table__sr-only">Swatch</span>
             </th>
             <th className="sb-color-table__th sb-color-table__th--path">Name</th>
-            <th className="sb-color-table__th">HEX</th>
-            <th className="sb-color-table__th">HSL</th>
-            <th className="sb-color-table__th">OKLCH</th>
+            <th className="sb-color-table__th">Value</th>
             <th className="sb-color-table__th">CSS var</th>
             <th className="sb-color-table__th">Alias</th>
             <th className="sb-color-table__th sb-color-table__th--expand">
@@ -321,10 +326,10 @@ function GroupRow({
             </span>
           )}
         </td>
-        <ValueCell value={active.hex} label={`Copy HEX ${active.hex}`}>
-          {active.hexOutOfGamut && (
+        <ValueCell value={active.value} label={`Copy value ${active.value}`}>
+          {active.outOfGamut && (
             <span
-              title="Out of sRGB gamut"
+              title="Out of sRGB gamut for this format"
               aria-label="out of gamut"
               className="sb-color-table__gamut-warn"
             >
@@ -332,8 +337,6 @@ function GroupRow({
             </span>
           )}
         </ValueCell>
-        <ValueCell value={active.hsl} label={`Copy HSL ${active.hsl}`} />
-        <ValueCell value={active.oklch} label={`Copy OKLCH ${active.oklch}`} />
         <ValueCell value={active.cssVar} label={`Copy CSS var ${active.cssVar}`} />
         <td className="sb-color-table__td sb-color-table__alias">
           {active.aliasOf ? (
@@ -447,6 +450,36 @@ function ValueCell({
       </span>
     </td>
   );
+}
+
+type FormatColorResult = ReturnType<typeof formatColor>;
+
+/**
+ * Pick the value + gamut flag to display in the single Value column based
+ * on the active color-format context. We pre-compute hex/hsl/oklch for the
+ * expanded sub-table regardless; the extras (`rgb`, `raw`) take a fresh
+ * `formatColor` pass. Keeps the hot path fast while staying honest about
+ * out-of-gamut warnings per-format.
+ */
+function pickActiveFormat(
+  raw: NormalizedColor,
+  colorFormat: ColorFormat,
+  hex: FormatColorResult,
+  hsl: FormatColorResult,
+  oklch: FormatColorResult,
+): { value: string; outOfGamut: boolean } {
+  switch (colorFormat) {
+    case 'hex':
+      return { value: hex.value, outOfGamut: hex.outOfGamut };
+    case 'hsl':
+      return { value: hsl.value, outOfGamut: hsl.outOfGamut };
+    case 'oklch':
+      return { value: oklch.value, outOfGamut: oklch.outOfGamut };
+    default: {
+      const extra = formatColor(raw, colorFormat);
+      return { value: extra.value, outOfGamut: extra.outOfGamut };
+    }
+  }
 }
 
 interface VariantEntry {

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { ColorTable, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
 
@@ -17,7 +17,9 @@ function makeSnapshot(): ProjectSnapshot {
         'color.text.default': {
           $type: 'color',
           $value: { hex: '#111111' },
+          $description: 'Primary text on default surfaces.',
           aliasOf: 'color.palette.neutral.900',
+          aliasChain: ['color.palette.neutral.900'],
         },
         'color.palette.neutral.900': {
           $type: 'color',
@@ -37,7 +39,7 @@ function makeSnapshot(): ProjectSnapshot {
   };
 }
 
-describe('ColorTable', () => {
+describe('ColorTable — base rendering', () => {
   afterEach(() => {
     cleanup();
   });
@@ -69,11 +71,8 @@ describe('ColorTable', () => {
     expect(within(row).getByText('#111111')).toBeDefined();
     expect(within(row).getByText(/var\(--sb-color-text-default\)/)).toBeDefined();
     expect(within(row).getByText('color.palette.neutral.900')).toBeDefined();
-    // HSL + OKLCH are stringified by formatColor; just assert their copy buttons exist.
-    const hslCopy = within(row).queryByLabelText(/Copy HSL/);
-    const oklchCopy = within(row).queryByLabelText(/Copy OKLCH/);
-    expect(hslCopy).not.toBeNull();
-    expect(oklchCopy).not.toBeNull();
+    expect(within(row).queryByLabelText(/Copy HSL/)).not.toBeNull();
+    expect(within(row).queryByLabelText(/Copy OKLCH/)).not.toBeNull();
   });
 
   it('renders an em-dash in the alias column for non-aliased tokens', () => {
@@ -87,7 +86,7 @@ describe('ColorTable', () => {
     expect(alias?.textContent?.trim()).toBe('—');
   });
 
-  it('fuzzy search narrows rows and survives out-of-order terms', () => {
+  it('fuzzy search narrows rows with out-of-order terms', () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>
         <ColorTable />
@@ -112,87 +111,7 @@ describe('ColorTable', () => {
     expect(screen.getByText('No color tokens match this filter.')).toBeDefined();
   });
 
-  it('clicking a row opens the DetailOverlay by default', async () => {
-    const { findByTestId } = render(
-      <SwatchbookProvider value={makeSnapshot()}>
-        <ColorTable />
-      </SwatchbookProvider>,
-    );
-    const rows = screen.getAllByTestId('color-table-row');
-    rows[0]?.click();
-    expect(await findByTestId('color-table-overlay')).toBeDefined();
-  });
-
-  it('renders variant pills from the variants map (longest suffix wins)', () => {
-    const snapshot = makeSnapshot();
-    snapshot.themesResolved['Light'] = {
-      ...snapshot.themesResolved['Light'],
-      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
-      'color.bg.hi-h': { $type: 'color', $value: { hex: '#222222' } },
-      'color.bg.hi-d': { $type: 'color', $value: { hex: '#333333' } },
-      'color.bg.hi-h-dark': { $type: 'color', $value: { hex: '#444444' } },
-    };
-
-    render(
-      <SwatchbookProvider value={snapshot}>
-        <ColorTable
-          filter="color.bg.*"
-          variants={{ hover: 'h', disabled: 'd', hoverDark: 'h-dark' }}
-        />
-      </SwatchbookProvider>,
-    );
-
-    const byPath = new Map<string, string | null>();
-    for (const row of screen.getAllByTestId('color-table-row')) {
-      const path = row.getAttribute('data-path') ?? '';
-      const pill = row.querySelector('[data-testid="color-table-variant"]');
-      byPath.set(path, pill?.textContent ?? null);
-    }
-
-    expect(byPath.get('color.bg.hi')).toBeNull();
-    expect(byPath.get('color.bg.hi-h')).toBe('hover');
-    expect(byPath.get('color.bg.hi-d')).toBe('disabled');
-    expect(byPath.get('color.bg.hi-h-dark')).toBe('hoverDark');
-  });
-
-  it('matches DTCG-idiomatic dot-segment variants (hi.disabled)', () => {
-    const snapshot = makeSnapshot();
-    snapshot.themesResolved['Light'] = {
-      ...snapshot.themesResolved['Light'],
-      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
-      'color.bg.hi.disabled': { $type: 'color', $value: { hex: '#222222' } },
-      'color.bg.hi.hover': { $type: 'color', $value: { hex: '#333333' } },
-    };
-
-    render(
-      <SwatchbookProvider value={snapshot}>
-        <ColorTable filter="color.bg.*" variants={{ hover: 'hover', disabled: 'disabled' }} />
-      </SwatchbookProvider>,
-    );
-
-    const byPath = new Map<string, string | null>();
-    for (const row of screen.getAllByTestId('color-table-row')) {
-      const path = row.getAttribute('data-path') ?? '';
-      const pill = row.querySelector('[data-testid="color-table-variant"]');
-      byPath.set(path, pill?.textContent ?? null);
-    }
-
-    expect(byPath.get('color.bg.hi')).toBeNull();
-    expect(byPath.get('color.bg.hi.disabled')).toBe('disabled');
-    expect(byPath.get('color.bg.hi.hover')).toBe('hover');
-  });
-
-  it('ignores variants that would match characters inside a segment (neutral-900 ≠ suffix 0)', () => {
-    render(
-      <SwatchbookProvider value={makeSnapshot()}>
-        <ColorTable filter="color.palette.*" variants={{ zero: '0' }} />
-      </SwatchbookProvider>,
-    );
-    const pills = screen.queryAllByTestId('color-table-variant');
-    expect(pills.length).toBe(0);
-  });
-
-  it('renders no pills when the variants prop is omitted', () => {
+  it('renders no variant pills when the variants prop is omitted', () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>
         <ColorTable />
@@ -211,5 +130,217 @@ describe('ColorTable', () => {
     const copy = screen.getAllByLabelText(/Copy HEX/)[0];
     copy?.click();
     expect(picks.length).toBe(0);
+  });
+});
+
+describe('ColorTable — grouping', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function makeVariantSnapshot(): ProjectSnapshot {
+    const base = makeSnapshot();
+    base.themesResolved['Light'] = {
+      ...base.themesResolved['Light'],
+      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
+      'color.bg.hi-h': { $type: 'color', $value: { hex: '#222222' } },
+      'color.bg.hi-d': { $type: 'color', $value: { hex: '#333333' } },
+    };
+    return base;
+  }
+
+  it('collapses sibling variants into one row with a pill per variant', () => {
+    render(
+      <SwatchbookProvider value={makeVariantSnapshot()}>
+        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+      </SwatchbookProvider>,
+    );
+
+    const rows = screen.getAllByTestId('color-table-row');
+    const bases = rows.map((r) => r.getAttribute('data-base'));
+    expect(bases).toContain('color.bg.hi');
+    expect(bases.filter((b) => b === 'color.bg.hi').length).toBe(1);
+
+    const hiRow = rows.find((r) => r.getAttribute('data-base') === 'color.bg.hi');
+    if (!hiRow) throw new Error('group row not found');
+    const pills = within(hiRow).getAllByTestId('color-table-variant');
+    const labels = pills.map((p) => p.textContent);
+    expect(labels).toEqual(['base', 'hover', 'disabled']);
+  });
+
+  it('defaults to the "base" variant when one is present', () => {
+    render(
+      <SwatchbookProvider value={makeVariantSnapshot()}>
+        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+      </SwatchbookProvider>,
+    );
+
+    const hiRow = screen
+      .getAllByTestId('color-table-row')
+      .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
+    if (!hiRow) throw new Error('group row not found');
+    expect(hiRow.getAttribute('data-path')).toBe('color.bg.hi');
+    expect(within(hiRow).getByText('#111111')).toBeDefined();
+  });
+
+  it('clicking a pill swaps the active variant and the displayed values', () => {
+    render(
+      <SwatchbookProvider value={makeVariantSnapshot()}>
+        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+      </SwatchbookProvider>,
+    );
+
+    const hiRowInitial = screen
+      .getAllByTestId('color-table-row')
+      .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
+    if (!hiRowInitial) throw new Error('group row not found');
+    const disabledPill = within(hiRowInitial)
+      .getAllByTestId('color-table-variant')
+      .find((p) => p.textContent === 'disabled');
+    if (!disabledPill) throw new Error('disabled pill not found');
+    act(() => {
+      fireEvent.click(disabledPill);
+    });
+
+    const hiRow = screen
+      .getAllByTestId('color-table-row')
+      .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
+    if (!hiRow) throw new Error('group row after click not found');
+    expect(hiRow.getAttribute('data-path')).toBe('color.bg.hi-d');
+    expect(within(hiRow).getByText('#333333')).toBeDefined();
+  });
+
+  it('renders DTCG dot-segment variants (hi.disabled) the same as hyphen tails', () => {
+    const snap = makeSnapshot();
+    snap.themesResolved['Light'] = {
+      ...snap.themesResolved['Light'],
+      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
+      'color.bg.hi.disabled': { $type: 'color', $value: { hex: '#222222' } },
+      'color.bg.hi.hover': { $type: 'color', $value: { hex: '#333333' } },
+    };
+    render(
+      <SwatchbookProvider value={snap}>
+        <ColorTable filter="color.bg.*" variants={{ hover: 'hover', disabled: 'disabled' }} />
+      </SwatchbookProvider>,
+    );
+
+    const rows = screen.getAllByTestId('color-table-row');
+    expect(rows.length).toBe(1);
+    const pills = within(rows[0] as HTMLElement).getAllByTestId('color-table-variant');
+    expect(pills.map((p) => p.textContent)).toEqual(['base', 'hover', 'disabled']);
+  });
+
+  it('ignores variants that would match characters inside a segment (neutral-900 ≠ suffix 0)', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="color.palette.*" variants={{ zero: '0' }} />
+      </SwatchbookProvider>,
+    );
+    expect(screen.queryAllByTestId('color-table-variant').length).toBe(0);
+  });
+});
+
+describe('ColorTable — expansion', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('row click toggles inline expansion (no drawer)', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="color.text.default" />
+      </SwatchbookProvider>,
+    );
+    expect(screen.queryByTestId('color-table-detail')).toBeNull();
+
+    const row = screen.getByTestId('color-table-row');
+    act(() => {
+      fireEvent.click(row);
+    });
+    expect(screen.getByTestId('color-table-detail')).toBeDefined();
+    expect(row.getAttribute('aria-expanded')).toBe('true');
+
+    act(() => {
+      fireEvent.click(row);
+    });
+    expect(screen.queryByTestId('color-table-detail')).toBeNull();
+  });
+
+  it('expansion surfaces $description and alias chain from the active variant', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="color.text.default" />
+      </SwatchbookProvider>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByTestId('color-table-row'));
+    });
+    const detail = screen.getByTestId('color-table-detail');
+    expect(within(detail).getByText('Primary text on default surfaces.')).toBeDefined();
+    expect(detail.textContent).toContain('color.palette.neutral.900');
+  });
+
+  it('multi-variant expansion lists all variants in a sub-table', () => {
+    const snap = makeSnapshot();
+    snap.themesResolved['Light'] = {
+      ...snap.themesResolved['Light'],
+      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
+      'color.bg.hi-h': { $type: 'color', $value: { hex: '#222222' } },
+      'color.bg.hi-d': { $type: 'color', $value: { hex: '#333333' } },
+    };
+    render(
+      <SwatchbookProvider value={snap}>
+        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+      </SwatchbookProvider>,
+    );
+    const row = screen
+      .getAllByTestId('color-table-row')
+      .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
+    if (!row) throw new Error('group row not found');
+    act(() => {
+      fireEvent.click(row);
+    });
+    const detail = screen.getByTestId('color-table-detail');
+    expect(detail.textContent).toContain('#111111');
+    expect(detail.textContent).toContain('#222222');
+    expect(detail.textContent).toContain('#333333');
+  });
+
+  it('onSelect suppresses expansion and hands the active path to the consumer', () => {
+    const picks: string[] = [];
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ColorTable filter="color.text.default" onSelect={(p) => picks.push(p)} />
+      </SwatchbookProvider>,
+    );
+    const row = screen.getByTestId('color-table-row');
+    row.click();
+    expect(picks).toEqual(['color.text.default']);
+    expect(screen.queryByTestId('color-table-detail')).toBeNull();
+  });
+
+  it('clicking a pill does not toggle the row expansion', () => {
+    const snap = makeSnapshot();
+    snap.themesResolved['Light'] = {
+      ...snap.themesResolved['Light'],
+      'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
+      'color.bg.hi-h': { $type: 'color', $value: { hex: '#222222' } },
+    };
+    render(
+      <SwatchbookProvider value={snap}>
+        <ColorTable filter="color.bg.*" variants={{ hover: 'h' }} />
+      </SwatchbookProvider>,
+    );
+    const row = screen
+      .getAllByTestId('color-table-row')
+      .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
+    if (!row) throw new Error('group row not found');
+    const hoverPill = within(row)
+      .getAllByTestId('color-table-variant')
+      .find((p) => p.textContent === 'hover');
+    if (!hoverPill) throw new Error('hover pill not found');
+    hoverPill.click();
+
+    expect(screen.queryByTestId('color-table-detail')).toBeNull();
   });
 });

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -260,7 +260,7 @@ describe('ColorTable — expansion', () => {
       fireEvent.click(row);
     });
     expect(screen.getByTestId('color-table-detail')).toBeDefined();
-    expect(row.getAttribute('aria-expanded')).toBe('true');
+    expect(row.getAttribute('aria-label')).toBe('Collapse color.text.default');
 
     act(() => {
       fireEvent.click(row);

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -60,7 +60,7 @@ describe('ColorTable — base rendering', () => {
     ]);
   });
 
-  it('shows HEX, HSL, OKLCH, CSS var, and alias columns per row', () => {
+  it('shows the active-format value, CSS var, and alias columns per row', () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>
         <ColorTable filter="color.text.default" />
@@ -68,11 +68,13 @@ describe('ColorTable — base rendering', () => {
     );
 
     const row = screen.getByTestId('color-table-row');
+    // Default color-format context is 'hex' — so the single value column is the hex.
     expect(within(row).getByText('#111111')).toBeDefined();
     expect(within(row).getByText(/var\(--sb-color-text-default\)/)).toBeDefined();
     expect(within(row).getByText('color.palette.neutral.900')).toBeDefined();
-    expect(within(row).queryByLabelText(/Copy HSL/)).not.toBeNull();
-    expect(within(row).queryByLabelText(/Copy OKLCH/)).not.toBeNull();
+    // Per-format HSL / OKLCH copy buttons shouldn't exist on the collapsed row.
+    expect(within(row).queryByLabelText(/Copy HSL/)).toBeNull();
+    expect(within(row).queryByLabelText(/Copy OKLCH/)).toBeNull();
   });
 
   it('renders an em-dash in the alias column for non-aliased tokens', () => {
@@ -127,7 +129,7 @@ describe('ColorTable — base rendering', () => {
         <ColorTable onSelect={(p) => picks.push(p)} filter="color.surface.*" />
       </SwatchbookProvider>,
     );
-    const copy = screen.getAllByLabelText(/Copy HEX/)[0];
+    const copy = screen.getAllByLabelText(/Copy value/)[0];
     copy?.click();
     expect(picks.length).toBe(0);
   });


### PR DESCRIPTION
## Summary

- ColorTable's \`variants\` prop now collapses sibling tokens into one row with a pill selector. Clicking a pill swaps the displayed values to that variant.
- Row click expands the row inline. Detail panel surfaces \`\$description\`, alias chain, and — for multi-variant groups — a sub-table comparing every variant's values at once.
- Replaces PR #592's inline-pill rendering; the earlier version was a stepping stone.

## Full description

Backmarket's semantic colors page was the reference — one row per base token, pills for siblings, click-to-expand. The inline-pill v1 answered "which states does this token serve?" but didn't save vertical space. This version does.

### Grouping

\`\`\`tsx
<ColorTable
  filter="color.bg.*"
  variants={{ hover: 'hover', disabled: 'disabled' }}
/>
\`\`\`

Given tokens \`color.bg.hi\`, \`color.bg.hi.hover\`, \`color.bg.hi.disabled\` → one row for \`color.bg.hi\` with pills \`base\` / \`hover\` / \`disabled\`. Same map also matches Backmarket-style \`color.bg.hi-h\` hyphen tails (\`variants={{ hover: 'h' }}\`). Longest-suffix-wins; leading hyphen required for tail form so suffix \`0\` can't hit \`neutral-900\`. Single-member groups render as plain rows, so partial coverage works.

### Inline expansion

Row click toggles expansion instead of opening the old \`DetailOverlay\` drawer. Detail shows:
- \`\$description\` when authored
- Alias chain (\`aliasChain\`) joined with \` → \`
- For multi-variant groups: a \"All variants\" sub-table with one row per variant (path + HEX + HSL + OKLCH) so you can compare without clicking pills. Active variant is highlighted.

\`onSelect\` stays as the escape hatch — when set, replaces expansion and fires with the currently-selected variant's path.

### Verification

Verified end-to-end via Playwright against the running Storybook fixtures (the reference tokens happen to use \`-hover\` suffix on \`color.accent.bg\` / \`color.accessible.accent.bg\`):

- 59 tokens → 57 groups (2 pairs collapsed)
- Pill click: \`color.accent.bg\` (#1d4ed8) → \`color.accent.bg-hover\` (#1e3a8a); active pill state flips
- Row expansion renders alias chain (\`color.palette.blue.900\`) + variant-comparison sub-table

**Milestone:** Maintenance
**Closes:** #596
**Plan impact:** None — slots into the existing \`variants\` prop surface from 0.16.

## Test plan

- [x] 17 unit tests in \`packages/blocks/test/color-table.test.tsx\` (82 total in blocks): grouping of both conventions, default variant selection, pill-click value swap, inline expansion toggle, description + alias chain surfacing, multi-variant sub-table content, \`onSelect\` escape hatch, copy-click-doesn't-bubble.
- [x] \`pnpm turbo run lint typecheck test\` — 29 / 29 green.
- [x] Playwright verification on running Storybook confirms grouping, pill swap, inline expansion work end-to-end.
- [ ] Manual a11y sweep: aria-pressed on pills, aria-expanded on row, keyboard navigation through pills + row toggle.