### PR TITLE
refactor(blocks): route makeCssVar through Terrazzo's makeCSSVar

### DIFF
--- a/.changeset/refactor-blocks-makecssvar.md
+++ b/.changeset/refactor-blocks-makecssvar.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Route the block-side `makeCssVar` through Terrazzo's `makeCSSVar` from `@terrazzo/token-tools/css` — same function `packages/core/src/css.ts` already uses when emitting the stylesheet. Removes a parallel kebab-casing implementation that would have drifted from Terrazzo's own naming rules over time. No behavior change for current inputs; future naming-policy shifts in Terrazzo now propagate to both emission and block display in one step.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -74,6 +74,7 @@
     "vitest": "^4.1.4"
   },
   "dependencies": {
+    "@terrazzo/token-tools": "^2.0.3",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
     "clsx": "^2.1.1",
     "colorjs.io": "0.6.1"

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,3 +1,4 @@
+import { makeCSSVar } from '@terrazzo/token-tools/css';
 import { useEffect } from 'react';
 import { useActiveAxes, useActiveTheme, useOptionalSwatchbookData } from '#/contexts.ts';
 import { useChannelGlobals } from '#/internal/channel-globals.ts';
@@ -145,16 +146,14 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
   };
 }
 
+/**
+ * Thin wrapper around Terrazzo's `makeCSSVar` so the block-display surface
+ * and `packages/core/src/css.ts`'s emitter share one implementation. Any
+ * future naming-policy shift in Terrazzo (casing, unicode, prefix handling)
+ * reaches both surfaces at once instead of needing a parallel update here.
+ */
 export function makeCssVar(path: string, prefix: string): string {
-  // Match Terrazzo's emitter: split on `.`, kebab-case each segment (so
-  // camelCase segments like `cubicBezier` become `cubic-bezier`), then join
-  // with `-`. Without this the block-side reference drifts from the
-  // emitted CSS var name whenever a segment carries capitals.
-  const tail = path
-    .split('.')
-    .map((segment) => segment.replaceAll(/([a-z\d])([A-Z])/g, '$1-$2').toLowerCase())
-    .join('-');
-  return prefix ? `var(--${prefix}-${tail})` : `var(--${tail})`;
+  return prefix ? makeCSSVar(path, { prefix, wrapVar: true }) : makeCSSVar(path, { wrapVar: true });
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -223,6 +223,9 @@ importers:
 
   packages/blocks:
     dependencies:
+      '@terrazzo/token-tools':
+        specifier: ^2.0.3
+        version: 2.0.3
       '@unpunnyfuns/swatchbook-core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

- Add \`@terrazzo/token-tools\` as a direct dep on \`@unpunnyfuns/swatchbook-blocks\`.
- Replace the local kebab-casing regex in \`makeCssVar\` with a thin wrapper around Terrazzo's \`makeCSSVar\`.
- Same source of truth as \`packages/core/src/css.ts\` uses when emitting the stylesheet.

## Full description

\`packages/blocks/src/internal/use-project.ts\` had its own kebab-casing implementation with a comment literally reading "Match Terrazzo's emitter." It worked, but the coupling was by convention, not contract — any future Terrazzo change to casing rules, unicode handling, or prefix policy would silently drift. Since \`@unpunnyfuns/swatchbook-core\` already imports \`makeCSSVar\` from \`@terrazzo/token-tools/css\` for emission, pulling the same function onto the block-display side closes the drift without changing any behavior today.

Call-site API is unchanged (\`makeCssVar(path, prefix)\` still returns \`var(--<prefix>-<path>)\`), so blocks don't need edits beyond the internal helper.

**Milestone:** Maintenance
**Closes:** #601
**Plan impact:** None. First of three staged steps toward reducing bespoke Terrazzo-parallel logic in the block-display layer; step 2 (color value conversion) and step 3 (\`plugin-token-listing\` adoption) are tracked separately.

## Test plan

- [x] \`pnpm turbo run lint typecheck test\` — 29 / 29 green.
- [x] 82 blocks unit tests green (no behavior change for current inputs).
- [ ] Manual verification in Storybook: token paths with camelCase segments (\`typography.headingLarge\`, \`duration.cubicBezier\`) still render the expected \`--cubic-bezier\` / \`--heading-large\` var names.