### PR TITLE
feat(core): expose cssOptions, listingOptions, terrazzoPlugins on config

### DIFF
--- a/.changeset/feat-config-terrazzo-options.md
+++ b/.changeset/feat-config-terrazzo-options.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+New config props on `defineSwatchbookConfig` for sharing Terrazzo plugin options with the internal build pipeline: `cssOptions`, `listingOptions`, and `terrazzoPlugins`. Consumers who run their own Terrazzo CLI in production can now align swatchbook's docs-side emission with whatever their production build produces — no more drift between the hex values / CSS variable names / per-platform identifiers the docs show and what actually ships.
+
+- `cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>` forwards to the internal `plugin-css` instance. `legacyHex`, `colorDepth`, `transform`, and everything else plugin-css accepts flow through; `variableName` and `permutations` stay managed because swatchbook's axis composition depends on them.
+- `listingOptions?: Omit<TokenListingPluginOptions, 'filename'>` forwards to the internal `plugin-token-listing`. Register platforms beyond `css` (swift, android, figma, custom name functions) and `listing[path].names.<platform>` populates for block consumption.
+- `terrazzoPlugins?: readonly Plugin[]` adds extra Terrazzo plugins alongside swatchbook's internal two. Required when `listingOptions.platforms` references anything outside the built-in `css` entry — the referenced plugin has to be loaded in the build.
+
+Consumers who don't run a separate Terrazzo build leave all three unset and nothing changes. The idiomatic share-across-configs pattern is a single file that exports the shared options and imports into both `terrazzo.config.ts` and `swatchbook.config.ts`.

--- a/packages/core/src/emit-via-terrazzo.ts
+++ b/packages/core/src/emit-via-terrazzo.ts
@@ -92,11 +92,18 @@ export async function emitViaTerrazzo(
   const prefix = project.config.cssVarPrefix ?? '';
   const selection = resolveSelection(project, options.selection ?? 'themes');
 
+  // Merge per-call options over the project-wide config. Per-call wins
+  // because integrations (Tailwind, css-in-js) may want to override the
+  // consumer's global plugin-css shape for their specific emission.
+  const mergedCssOptions = { ...project.config.cssOptions, ...options.cssOptions };
+  const projectPlugins = project.config.terrazzoPlugins ?? [];
+  const extraPlugins = options.plugins ?? [];
+
   const config = defineConfig(
     {
       plugins: [
         cssPlugin({
-          ...options.cssOptions,
+          ...mergedCssOptions,
           variableName: (token) =>
             prefix ? makeCSSVar(String(token.id), { prefix }) : makeCSSVar(String(token.id)),
           permutations: selection.map((entry) => ({
@@ -105,7 +112,8 @@ export async function emitViaTerrazzo(
               `${compoundSelector(entry.input, project.axes, prefix)} {\n${css}\n}\n`,
           })),
         }),
-        ...(options.plugins ?? []),
+        ...projectPlugins,
+        ...extraPlugins,
       ],
     },
     { logger, cwd: cwdURL },

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -89,6 +89,11 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
           normalized.parserInput,
           cwd,
           configWithDefaults.cssVarPrefix ?? '',
+          {
+            ...(config.cssOptions !== undefined && { cssOptions: config.cssOptions }),
+            ...(config.listingOptions !== undefined && { listingOptions: config.listingOptions }),
+            ...(config.terrazzoPlugins !== undefined && { extraPlugins: config.terrazzoPlugins }),
+          },
         )
       : {};
 

--- a/packages/core/src/token-listing.ts
+++ b/packages/core/src/token-listing.ts
@@ -1,7 +1,10 @@
 import { pathToFileURL } from 'node:url';
-import { build, defineConfig, Logger } from '@terrazzo/parser';
-import cssPlugin from '@terrazzo/plugin-css';
-import tokenListingPlugin, { type ListedToken } from '@terrazzo/plugin-token-listing';
+import { build, defineConfig, Logger, type Plugin } from '@terrazzo/parser';
+import cssPlugin, { type CSSPluginOptions } from '@terrazzo/plugin-css';
+import tokenListingPlugin, {
+  type ListedToken,
+  type TokenListingPluginOptions,
+} from '@terrazzo/plugin-token-listing';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
 import type { ParserInput } from '#/types.ts';
 
@@ -31,29 +34,47 @@ export type TokenListingByPath = Record<string, ListedToken>;
  * error, plugin crash). The caller treats listing data as optional
  * enrichment; losing it shouldn't block `loadProject`.
  */
+export interface ComputeTokenListingOptions {
+  /** Extra options forwarded to the internal `plugin-css` instance. */
+  cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>;
+  /** Extra options forwarded to the internal `plugin-token-listing` instance. */
+  listingOptions?: Omit<TokenListingPluginOptions, 'filename'>;
+  /** Extra plugins loaded into the build — referenced by `listingOptions.platforms`. */
+  extraPlugins?: readonly Plugin[];
+}
+
 export async function computeTokenListing(
   parserInput: ParserInput,
   cwd: string,
   prefix: string,
+  options: ComputeTokenListingOptions = {},
 ): Promise<TokenListingByPath> {
   try {
     const { tokens, sources, resolver } = parserInput;
     const logger = new Logger({ level: 'warn' });
     const cwdURL = pathToFileURL(`${cwd}/`);
 
+    // User-supplied `platforms` overrides the default CSS entry when
+    // present — otherwise the built-in `css` platform is the only one
+    // registered, matching the earlier default behavior.
+    const platforms = options.listingOptions?.platforms ?? {
+      css: { name: '@terrazzo/plugin-css', description: 'CSS custom properties' },
+    };
+
     const config = defineConfig(
       {
         plugins: [
           cssPlugin({
+            ...options.cssOptions,
             filename: 'tokens.css',
             variableName: (token) =>
               prefix ? makeCSSVar(String(token.id), { prefix }) : makeCSSVar(String(token.id)),
           }),
+          ...(options.extraPlugins ?? []),
           tokenListingPlugin({
+            ...options.listingOptions,
             filename: 'tokens.listing.json',
-            platforms: {
-              css: { name: '@terrazzo/plugin-css', description: 'CSS custom properties' },
-            },
+            platforms,
           }),
         ],
       },

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,5 +1,7 @@
 import type { InputSourceWithDocument } from '@terrazzo/json-schema-tools';
-import type { Resolver, TokenNormalized } from '@terrazzo/parser';
+import type { Plugin, Resolver, TokenNormalized } from '@terrazzo/parser';
+import type { CSSPluginOptions } from '@terrazzo/plugin-css';
+import type { TokenListingPluginOptions } from '@terrazzo/plugin-token-listing';
 import type { TokenListingByPath } from '#/token-listing.ts';
 
 export type TokenMap = Record<string, TokenNormalized>;
@@ -109,6 +111,40 @@ export interface Config {
    * fall back to the `Canvas` / `CanvasText` system colors.
    */
   chrome?: Record<string, string>;
+  /**
+   * Options forwarded to the `@terrazzo/plugin-css` instance swatchbook
+   * runs internally (for the stylesheet it emits and for the Token
+   * Listing's `names.css` derivation). Line this up with the consumer's
+   * own `plugin-css` options — `legacyHex`, `transform`, `colorDepth`,
+   * and similar — so docs-side names and values match what the
+   * consumer's production build emits.
+   *
+   * The `variableName` and `permutations` fields are managed internally
+   * and cannot be overridden — swatchbook's axis composition depends on
+   * them. Everything else is passed through.
+   */
+  cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>;
+  /**
+   * Options forwarded to `@terrazzo/plugin-token-listing`. Use
+   * `platforms` to register additional platforms beyond `css` (e.g.
+   * `swift`, `android`, `figma`) — each entry's `name` is a reference
+   * to a loaded plugin. For the reference to resolve, that plugin has
+   * to be loaded into the build, which is what `terrazzoPlugins` below
+   * is for.
+   *
+   * `filename` is managed internally (the listing is captured in
+   * memory, not written to disk).
+   */
+  listingOptions?: Omit<TokenListingPluginOptions, 'filename'>;
+  /**
+   * Additional Terrazzo plugins to load alongside swatchbook's own
+   * `plugin-css` + `plugin-token-listing`. The listing can reference
+   * any of these by name in its `platforms` map to derive per-platform
+   * identifiers. Plugins whose outputs swatchbook doesn't consume are
+   * simply ignored — they run, their files land in the in-memory
+   * output set, nothing else happens.
+   */
+  terrazzoPlugins?: readonly Plugin[];
 }
 
 export type DiagnosticSeverity = 'error' | 'warn' | 'info';

--- a/packages/core/test/config-terrazzo-options.test.ts
+++ b/packages/core/test/config-terrazzo-options.test.ts
@@ -1,0 +1,74 @@
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
+import { dirname } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { loadProject } from '#/load.ts';
+
+const fixtureCwd = dirname(tokensDir);
+
+describe('Config terrazzo options plumbing', () => {
+  it('forwards cssOptions to the internal plugin-css instance', async () => {
+    // legacyHex flips oklch/p3-ish colors to sRGB hex fallbacks.
+    const project = await loadProject(
+      {
+        resolver: resolverPath,
+        default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+        cssVarPrefix: 'sb',
+        cssOptions: { legacyHex: true },
+      },
+      fixtureCwd,
+    );
+    // Smoke test: listing populates, names still correct, no crash from the
+    // extra plugin option surface. Behavioral effect of legacyHex is a
+    // plugin-css concern we don't re-verify here.
+    const entry = project.listing['color.accent.bg'];
+    expect(entry?.$extensions['app.terrazzo.listing'].names['css']).toBe('--sb-color-accent-bg');
+  });
+
+  it('forwards listingOptions.platforms to plugin-token-listing', async () => {
+    // Register an extra platform whose naming function just tags paths with
+    // a marker — no real plugin needed, function is the whole platform.
+    const project = await loadProject(
+      {
+        resolver: resolverPath,
+        default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+        cssVarPrefix: 'sb',
+        listingOptions: {
+          platforms: {
+            css: { name: '@terrazzo/plugin-css' },
+            figma: { name: ({ token }) => `figma/${token.id.replaceAll('.', '/')}` },
+          },
+        },
+      },
+      fixtureCwd,
+    );
+    const entry = project.listing['color.accent.bg'];
+    const names = entry?.$extensions['app.terrazzo.listing'].names;
+    expect(names?.['css']).toBe('--sb-color-accent-bg');
+    expect(names?.['figma']).toBe('figma/color/accent/bg');
+  });
+
+  it('runs terrazzoPlugins alongside the internal plugin-css', async () => {
+    // Give a tiny passthrough plugin that records being called. Its
+    // presence in the build is what matters — listing shouldn't crash.
+    const calls: string[] = [];
+    const project = await loadProject(
+      {
+        resolver: resolverPath,
+        default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+        cssVarPrefix: 'sb',
+        terrazzoPlugins: [
+          {
+            name: 'test/passthrough',
+            transform() {
+              calls.push('transform');
+            },
+          },
+        ],
+      },
+      fixtureCwd,
+    );
+    expect(calls.length).toBeGreaterThan(0);
+    const entry = project.listing['color.accent.bg'];
+    expect(entry).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

Three new optional props on \`defineSwatchbookConfig\` so consumers can align swatchbook's internal Terrazzo build with the one they run in production — closing the last class of drift Sidnioulz flagged (consumers using \`plugin-css\` with non-default options, or registering Swift / Android / other platform plugins).

- \`cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>\` — forwards to internal plugin-css.
- \`listingOptions?: Omit<TokenListingPluginOptions, 'filename'>\` — forwards to internal plugin-token-listing. Enables extra platforms.
- \`terrazzoPlugins?: readonly Plugin[]\` — extra plugins loaded into the build. Required when \`listingOptions.platforms\` references anything beyond the built-in \`css\`.

## Full description

The idiomatic pattern for a consumer who runs their own Terrazzo CLI:

\`\`\`ts
// shared-terrazzo-options.ts
import cssPlugin from '@terrazzo/plugin-css';
import swiftPlugin from '@terrazzo/plugin-swift';

export const sharedCss = { legacyHex: true, colorDepth: 24 } as const;
export const sharedPlugins = [swiftPlugin({ /* ... */ })];

// terrazzo.config.ts
export default defineConfig({
  plugins: [cssPlugin(sharedCss), ...sharedPlugins, tokenListingPlugin({ platforms: { css, swift } })],
});

// swatchbook.config.ts
export default defineSwatchbookConfig({
  cssOptions: sharedCss,
  terrazzoPlugins: sharedPlugins,
  listingOptions: {
    platforms: {
      css: { name: '@terrazzo/plugin-css' },
      swift: { name: '@terrazzo/plugin-swift', description: 'UIColor' },
    },
  },
});
\`\`\`

Both pipelines consume the same plugin-css options and same extra plugins. The listing's \`names.css\` / \`names.swift\` match what the consumer's production emits. Block-side \`resolveCssVar\` and \`resolveColorValue\` consume the listing — zero drift.

Consumers who don't run a separate Terrazzo build leave all three unset and nothing changes.

### Why not 'point at my terrazzo.config.ts'?

Terrazzo's \`cssPlugin(options)\` captures its options in a closure — the returned Plugin object has no options accessor. So we can't take a user-constructed config, extract their plugin-css options, and merge in our managed \`permutations\`. We could load the file and layer our own plugin-css on top, but that produces two plugin-css instances and the listing picks an ambiguous one. The inline-options approach is the honest bound of what's possible without a Terrazzo-side enhancement that attaches raw options to returned plugins.

**Milestone:** Maintenance
**Closes:** #606
**Plan impact:** None — extends \`Config\` with three optional fields. Back-compat preserved.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37 / 37 green.
- [x] 3 new unit tests in \`packages/core/test/config-terrazzo-options.test.ts\`: \`cssOptions\` forwards (legacyHex smoke test), \`listingOptions.platforms\` forwards (extra platform appears in \`names\`), \`terrazzoPlugins\` run (transform hook fires).
- [x] 117 / 117 core tests.