### PR TITLE
docs: cover the Terrazzo-alignment work from 0.15 to 0.17

### DIFF
--- a/.changeset/docs-terrazzo-options-and-listing.md
+++ b/.changeset/docs-terrazzo-options-and-listing.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Document the Terrazzo-alignment work that landed in 0.15–0.17: the three new `defineSwatchbookConfig` props (`cssOptions`, `listingOptions`, `terrazzoPlugins`) in the config reference, the `Project.listing` + `ProjectSnapshot.listing` surface in the core and hooks references, and a new guide page on the `shared-terrazzo-options.ts` pattern for consumers who run `@terrazzo/cli` alongside swatchbook.

--- a/apps/docs/docs/guides/sharing-terrazzo-options.mdx
+++ b/apps/docs/docs/guides/sharing-terrazzo-options.mdx
@@ -1,0 +1,96 @@
+---
+id: sharing-terrazzo-options
+title: Sharing Terrazzo options
+sidebar_position: 5
+---
+
+# Sharing Terrazzo options with a production build
+
+If you run `@terrazzo/cli` in production alongside swatchbook's Storybook-time rendering, you want both pipelines to agree on the `plugin-css` options they consume — otherwise the hex values / CSS variable names / per-platform identifiers the docs show can drift from what actually ships.
+
+Swatchbook exposes three config props that forward into its internal Terrazzo build: [`cssOptions`](../reference/config#cssoptions-omitcsspluginoptions-variablename--permutations), [`listingOptions`](../reference/config#listingoptions-omittokenlistingpluginoptions-filename), and [`terrazzoPlugins`](../reference/config#terrazzoplugins-readonly-plugin). The idiomatic way to consume them is a single shared options module that both your `terrazzo.config.ts` and `swatchbook.config.ts` import.
+
+## The pattern
+
+```ts title="shared-terrazzo-options.ts"
+import cssPlugin from '@terrazzo/plugin-css';
+import swiftPlugin from '@terrazzo/plugin-swift';
+import type { CSSPluginOptions, TokenListingPluginOptions } from '@terrazzo/plugin-css';
+import type { Plugin } from '@terrazzo/parser';
+
+export const sharedCssOptions: CSSPluginOptions = {
+  legacyHex: true,
+  colorDepth: 24,
+  // transform: ..., etc.
+};
+
+export const sharedPlugins: readonly Plugin[] = [
+  swiftPlugin({ /* swift plugin options */ }),
+];
+
+export const sharedListingOptions: TokenListingPluginOptions = {
+  platforms: {
+    css:   { name: '@terrazzo/plugin-css' },
+    swift: { name: '@terrazzo/plugin-swift', description: 'UIColor' },
+  },
+};
+
+// Re-exported so terrazzo.config.ts can build plugin-css + plugin-swift with
+// the same option objects swatchbook.config.ts hands to swatchbook.
+export { cssPlugin, swiftPlugin };
+```
+
+```ts title="terrazzo.config.ts"
+import { defineConfig } from '@terrazzo/parser';
+import tokenListingPlugin from '@terrazzo/plugin-token-listing';
+import {
+  cssPlugin,
+  sharedCssOptions,
+  sharedListingOptions,
+  sharedPlugins,
+} from './shared-terrazzo-options';
+
+export default defineConfig({
+  tokens: 'tokens/**/*.json',
+  outDir: 'dist',
+  plugins: [
+    cssPlugin(sharedCssOptions),
+    ...sharedPlugins,
+    tokenListingPlugin(sharedListingOptions),
+  ],
+});
+```
+
+```ts title="swatchbook.config.ts"
+import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
+import {
+  sharedCssOptions,
+  sharedListingOptions,
+  sharedPlugins,
+} from './shared-terrazzo-options';
+
+export default defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  cssVarPrefix: 'ds',
+  cssOptions: sharedCssOptions,
+  listingOptions: sharedListingOptions,
+  terrazzoPlugins: sharedPlugins,
+});
+```
+
+Both configs now consume the same objects. Any change to `sharedCssOptions` (a new transform, a `colorDepth` flip, a `legacyHex` toggle) reaches the production CLI and the Storybook-time build together.
+
+## What alignment buys you
+
+- **CSS variable names.** `plugin-css`'s `variableName` policy is one source of truth. `listing[path].names.css` matches the variable name your production CSS emits — the swatches in `<TokenTable>` / `<ColorTable>` / `<TokenDetail>` reference the same var your consumers import.
+- **Preview values.** `listing[path].previewValue` is a plugin-css-computed CSS string — hex form honors `legacyHex`, channel precision honors `colorDepth`. Blocks that display values pick this up verbatim instead of running a parallel conversion.
+- **Per-platform identifiers.** `listing[path].names.swift` / `names.android` / etc. come from the plugin you loaded. A future column in `<ColorTable>` (or a block you write yourself) can render them directly — no duplication of the naming rule.
+
+## When you don't need this
+
+If you don't run `@terrazzo/cli` separately, leave all three props unset. Swatchbook loads `plugin-css` with defaults and `plugin-token-listing` with a single `css` platform — the rest of the block-display pipeline continues to work exactly as before. Drift isn't a concern when there's only one pipeline.
+
+## See also
+
+- [Config reference: `cssOptions` / `listingOptions` / `terrazzoPlugins`](../reference/config) — the prop-by-prop contract.
+- [`@terrazzo/plugin-token-listing` source](https://github.com/terrazzoapp/terrazzo/tree/main/packages/plugin-token-listing) — the listing format swatchbook consumes.

--- a/apps/docs/docs/reference/blocks/hooks.mdx
+++ b/apps/docs/docs/reference/blocks/hooks.mdx
@@ -12,7 +12,9 @@ Outside Storybook, wrap the tree in `SwatchbookProvider` and pass a `ProjectSnap
 
 ## `useSwatchbookData()`
 
-Returns the full `ProjectSnapshot` the provider is holding (themes, axes, presets, tokens, diagnostics, …). Useful for custom blocks that need graph-level information the canned blocks don't expose.
+Returns the full `ProjectSnapshot` the provider is holding (themes, axes, presets, tokens, diagnostics, listing, …). Useful for custom blocks that need graph-level information the canned blocks don't expose.
+
+The snapshot's `listing?: Readonly<Record<string, VirtualTokenListingShape>>` field carries per-token metadata from `@terrazzo/plugin-token-listing` — authoritative CSS variable names (`names.css`), preview values, source file + line references. Empty for layered / plain-parse projects; read-it-when-present, fall back gracefully. Blocks that need a token's CSS var reference should call `resolveCssVar(path, project)` (also re-exported) rather than constructing the var string themselves — it reads the listing first and falls back to `makeCssVar` when a listing entry is missing.
 
 ## `useActiveTheme()`
 

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -208,8 +208,55 @@ Produces a single `:root` chrome block with all ten roles declared — overrides
 
 Unknown role keys (outside the ten above) and target paths that don't resolve to any token or composite sub-field in any theme produce `warn` diagnostics (group `swatchbook/chrome`) and are dropped — the corresponding chrome slot falls back to its hard-coded literal default. The validated entries land on `Project.chrome` for downstream tooling.
 
+### `cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>`
+
+Options forwarded to the `@terrazzo/plugin-css` instance swatchbook runs internally — for the stylesheet it emits for the Storybook preview and for the Token Listing's `names.css` derivation. Use this when your production Terrazzo build passes non-default options to `plugin-css` (`legacyHex`, `colorDepth`, a custom `transform`, etc.) and you want the docs-side output to match.
+
+`variableName` and `permutations` are managed internally — swatchbook's axis-aware multi-theme emission depends on them — and are stripped from the option type. Everything else passes through.
+
+```ts
+defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  cssVarPrefix: 'ds',
+  cssOptions: { legacyHex: true, colorDepth: 24 },
+});
+```
+
+### `listingOptions?: Omit<TokenListingPluginOptions, 'filename'>`
+
+Options forwarded to `@terrazzo/plugin-token-listing`. The listing is how swatchbook surfaces authoritative per-token metadata (plugin-css-computed CSS variable names, preview values, alias chains, source file + line references) into `Project.listing` and the block-side `ProjectSnapshot.listing`. Use `listingOptions.platforms` to register additional platforms beyond the built-in `css` entry:
+
+```ts
+import swiftPlugin from '@terrazzo/plugin-swift';
+
+defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  cssVarPrefix: 'ds',
+  listingOptions: {
+    platforms: {
+      css:   { name: '@terrazzo/plugin-css' },
+      swift: { name: '@terrazzo/plugin-swift', description: 'UIColor' },
+    },
+  },
+  terrazzoPlugins: [swiftPlugin({ /* swift plugin options */ })],
+});
+```
+
+Each `platforms` entry names a Terrazzo plugin whose identifier-naming logic derives the token's identifier on that platform. The plugin has to be loaded in the build for the reference to resolve — see `terrazzoPlugins` below.
+
+`filename` is managed internally (the listing is captured in memory, not written to disk) and is stripped from the option type.
+
+### `terrazzoPlugins?: readonly Plugin[]`
+
+Additional Terrazzo plugins loaded alongside swatchbook's internal `plugin-css` + `plugin-token-listing`. Required when `listingOptions.platforms` references anything beyond the built-in `css` — the referenced plugin has to actually run in the same build for the listing to resolve its naming. Plugins whose output swatchbook doesn't consume are harmless — they run, their output files land in the in-memory output set, nothing else happens.
+
+Common use: load `@terrazzo/plugin-swift` / `-android` / `-js` / `-sass` alongside so their naming logic populates `listing[path].names.<platform>` for block consumption.
+
+See [Sharing Terrazzo options](../guides/sharing-terrazzo-options) for the pattern of sharing one options file between `terrazzo.config.ts` and `swatchbook.config.ts`.
+
 ## See also
 
 - [Theming inputs](../concepts/theming-inputs) — when to pick resolver vs layered.
 - [Axes](../concepts/axes) — the runtime model for selection.
 - [Reference: core](./core) — the loader APIs this config drives.
+- [Sharing Terrazzo options](../guides/sharing-terrazzo-options) — keep the swatchbook build aligned with a production Terrazzo CLI.

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -133,9 +133,28 @@ interface Project {
   sourceFiles: string[];
   /** Loader cwd — what all config-relative paths resolved against. */
   cwd: string;
+  /**
+   * Path-indexed Token Listing data from `@terrazzo/plugin-token-listing`.
+   * Each entry carries authoritative plugin-css-emitted CSS variable names,
+   * a CSS-ready `previewValue`, `originalValue` (pre-resolution), and
+   * `source.loc` pointing back to the authoring file + line. Populated for
+   * resolver-backed projects; empty `{}` for layered / plain-parse paths.
+   * Downstream blocks prefer this over re-deriving values locally.
+   */
+  listing: TokenListingByPath;
   diagnostics: Diagnostic[];
 }
 ```
+
+### `TokenListingByPath`
+
+Path-indexed alias over `@terrazzo/plugin-token-listing`'s `ListedToken` shape. Blocks read authoritative CSS variable names from `listing[path].$extensions['app.terrazzo.listing'].names.css` and preview strings from `.previewValue`. The full entry carries `originalValue` (pre-resolution, aliases preserved) and `source.loc` (file + line range pointing at the authoring source).
+
+```ts
+type TokenListingByPath = Record<string, ListedToken>;
+```
+
+See [Sharing Terrazzo options](../guides/sharing-terrazzo-options) for registering extra platforms (swift, android, …) so additional `names.<platform>` entries populate.
 
 ### `SwatchbookIntegration`
 


### PR DESCRIPTION
## Summary

- \`reference/config.mdx\`: three new prop sections — \`cssOptions\`, \`listingOptions\`, \`terrazzoPlugins\`.
- \`reference/core.mdx\`: \`Project.listing\` field + \`TokenListingByPath\` type note.
- \`reference/blocks/hooks.mdx\`: \`ProjectSnapshot.listing\` mention, \`resolveCssVar\` guidance for custom blocks.
- New \`guides/sharing-terrazzo-options.mdx\` — end-to-end \`shared-terrazzo-options.ts\` pattern.

## Full description

PRs #602, #604, #607 landed a meaningful user-facing surface without any docs coverage. Reference pages stopped at \`chrome\`; the \`listing\` field on \`Project\` / \`ProjectSnapshot\` wasn't mentioned anywhere; there was no guide on the share-one-options-file pattern that makes the new config props useful in practice.

Docusaurus build is clean locally; patch changeset so the doc snapshot rebuilds on the next release and the fix reaches the versioned default, not just \`/next/\`.

**Milestone:** Maintenance
**Closes:** #608
**Plan impact:** None — docs-only.

## Test plan

- [x] \`pnpm turbo run build --filter=@unpunnyfuns/swatchbook-docs\` — no broken link warnings, new guide + reference additions render.
- [x] \`pnpm turbo run format:check lint typecheck test\` — 37 / 37 green.