### PR TITLE
refactor(blocks): formatTokenValue prefers listing.previewValue when available

### DIFF
--- a/.changeset/refactor-format-token-value-listing.md
+++ b/.changeset/refactor-format-token-value-listing.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Thread the Token Listing entry through `formatTokenValue` so composite display strings (shadow / border / gradient / typography / transition) prefer `listing[path].previewValue` when available. Before this PR, value stringification for composite types was still stitched locally — listing's authoritative plugin-css-computed string was ignored. The gate: non-color types always prefer listing; color tokens prefer listing only when the active color format is `'hex'` (other formats stay as colorjs.io inspection output). Closes the last drift surface from the Token Listing adoption.
+
+Callers updated: `TokenTable`, `TokenDetail`, `TokenNavigator`, `DimensionScale`, `StrokeStyleSample`. `AxisVariance` deliberately keeps local formatting because it renders per-theme resolved values and listing entries carry one canonical representation.

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -81,7 +81,7 @@ export function DimensionScale({
       return {
         path,
         cssVar: resolveCssVar(path, project),
-        displayValue: formatTokenValue(token.$value, token.$type, 'raw'),
+        displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
         pxValue,
         capped: Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX,
       };

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -64,7 +64,7 @@ export function StrokeStyleSample({
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,
       cssVar: resolveCssVar(path, project),
-      displayValue: formatTokenValue(token.$value, token.$type, 'raw'),
+      displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
       cssStyle: extractCssStyle(token.$value),
     }));
   }, [resolved, filter, project, sortBy, sortDir]);

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -5,6 +5,7 @@ import { formatColor } from '#/format-color.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { useProject } from '#/internal/use-project.ts';
 import { AliasChain } from '#/token-detail/AliasChain.tsx';
 import { AliasedBy } from '#/token-detail/AliasedBy.tsx';
 import { AxisVariance } from '#/token-detail/AxisVariance.tsx';
@@ -38,9 +39,10 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
     );
   }
 
+  const { listing } = useProject();
   const isColor = token.$type === 'color';
   const gamut = isColor ? formatColor(token.$value, colorFormat) : null;
-  const value = formatTokenValue(token.$value, token.$type, colorFormat);
+  const value = formatTokenValue(token.$value, token.$type, colorFormat, listing[path]);
   const outOfGamut = gamut?.outOfGamut ?? false;
 
   return (

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -415,7 +415,7 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
     return (
       <span className="sb-token-navigator__preview-box">
         <span className="sb-token-navigator__value">
-          {formatTokenValue(token.$value, type, colorFormat)}
+          {formatTokenValue(token.$value, type, colorFormat, project.listing[path])}
         </span>
         <span
           className="sb-token-navigator__color-swatch"
@@ -429,7 +429,7 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
     return (
       <span className="sb-token-navigator__preview-box">
         <span className="sb-token-navigator__value">
-          {formatTokenValue(token.$value, type, colorFormat)}
+          {formatTokenValue(token.$value, type, colorFormat, project.listing[path])}
         </span>
         <span className="sb-token-navigator__preview-dimension">
           <DimensionBar path={path} kind="length" />
@@ -468,7 +468,7 @@ function LeafPreview({ path, token }: LeafPreviewProps): ReactElement {
   return (
     <span className="sb-token-navigator__preview-box">
       <span className="sb-token-navigator__value">
-        {formatTokenValue(token.$value, type, colorFormat)}
+        {formatTokenValue(token.$value, type, colorFormat, project.listing[path])}
       </span>
     </span>
   );

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -78,7 +78,7 @@ export function TokenTable({
       return {
         path,
         type: token.$type ?? '',
-        value: formatTokenValue(token.$value, token.$type, colorFormat),
+        value: formatTokenValue(token.$value, token.$type, colorFormat, project.listing[path]),
         outOfGamut: color?.outOfGamut ?? false,
         cssVar: resolveCssVar(path, project),
         isColor,

--- a/packages/blocks/src/internal/format-token-value.ts
+++ b/packages/blocks/src/internal/format-token-value.ts
@@ -1,3 +1,4 @@
+import type { VirtualTokenListingShape } from '#/contexts.ts';
 import { type ColorFormat, formatColor } from '#/format-color.ts';
 
 /**
@@ -24,10 +25,24 @@ export function formatTokenValue(
   value: unknown,
   $type: string | undefined,
   colorFormat: ColorFormat,
+  listingEntry?: VirtualTokenListingShape,
 ): string {
   if (value == null) return '';
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
     return String(value);
+  }
+
+  // Prefer plugin-css's authoritative `previewValue` when available. For
+  // non-color types that's always authoritative (`"16px"`, `"1px solid
+  // #e2e8f0"`, `"cubic-bezier(…)"`). For color tokens we only take it when
+  // the active toolbar format matches plugin-css's output (hex) — other
+  // formats (rgb / hsl / oklch / raw) are the user's inspection choice
+  // and fall through to local colorjs.io conversion.
+  const preview = listingEntry?.previewValue;
+  if (preview !== undefined) {
+    const previewStr = typeof preview === 'string' ? preview : String(preview);
+    if ($type !== 'color') return previewStr;
+    if (colorFormat === 'hex') return previewStr;
   }
 
   switch ($type) {


### PR DESCRIPTION
## Summary

- Thread an optional \`listingEntry\` param through \`formatTokenValue\` in \`packages/blocks/src/internal/format-token-value.ts\`.
- When the listing carries a \`previewValue\`: prefer it for non-color types always; for colors only when \`colorFormat === 'hex'\`.
- Update callers that have \`project\` handy: \`TokenTable\`, \`TokenDetail\`, \`TokenNavigator\`, \`DimensionScale\`, \`StrokeStyleSample\`. \`AxisVariance\` stays local on purpose.

## Full description

The #604 commit explicitly called out composite-type stringification as \"the last drift surface\" — shadow / border / gradient / typography / transition were still being stitched by local helpers. Plugin-css / plugin-token-listing produce canonical strings (\`\"1px solid #e2e8f0\"\`, \`\"cubic-bezier(0.2, 0, 0, 1)\"\`, \`\"inset 0 1px 2px rgba(0,0,0,0.1)\"\`) that match what the consumer's production pipeline emits. Threading the listing entry and preferring \`previewValue\` eliminates the divergence.

Gate logic:

\`\`\`ts
const preview = listingEntry?.previewValue;
if (preview !== undefined) {
  const previewStr = typeof preview === 'string' ? preview : String(preview);
  if ($type !== 'color') return previewStr;           // always prefer for non-colors
  if (colorFormat === 'hex') return previewStr;       // prefer for colors only when format matches plugin-css's output
  // else fall through to local colorjs.io conversion (inspection mode)
}
\`\`\`

**Why AxisVariance stays local:** it renders the same token across multiple themes to show how the value varies. A single \`listing[path]\` entry carries one canonical value per token — using it would collapse every theme cell to the same string and hide the variance.

**Milestone:** Maintenance
**Closes:** #610
**Plan impact:** None — signature change is additive (optional 4th param).

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37 / 37 green.
- [x] All 82 existing blocks tests pass without modification.
- [ ] Manual verification in Storybook: check \`TokenTable\` / \`TokenDetail\` / \`TokenNavigator\` render the same displayed values as before for colors in hex mode, and distinguishing values in oklch mode (listing takes over in hex, colorjs.io in oklch).