### PR TITLE
feat(core): tighten cssOptions + expand Terrazzo-alignment guide

### DIFF
--- a/.changeset/docs-aligning-with-your-build.md
+++ b/.changeset/docs-aligning-with-your-build.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Expand the "Aligning with your token build" guide (`guides/sharing-terrazzo-options`) from a short shared-options recipe into a full primer: per-knob notes for `cssOptions` / `listingOptions` / `terrazzoPlugins`, what swatchbook owns vs what passes through, the soft-inert `baseSelector` / `baseScheme` / `modeSelectors` trio, per-platform identifier display via `terrazzoPlugins` + `listingOptions.platforms`, monorepo layout guidance, a Style Dictionary section covering DTCG-source alignment and the "don't try to match names" counterpoint, and a common-pitfalls section. Guide now appears in the sidebar; cross-linked from `concepts/token-pipeline` and `integrations/`.

--- a/.changeset/feat-css-options-tightening.md
+++ b/.changeset/feat-css-options-tightening.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+Tighten `Config.cssOptions`: `filename` and `skipBuild` are now stripped from the allowed type in addition to `variableName` and `permutations`. Neither was ever honored end-to-end — `filename` is overridden to the in-memory capture name, and `skipBuild: true` would silently null out the listing's `previewValue`. Removing them from the type turns a silent no-op into a compile-time signal.
+
+Deprecated plugin-css knobs (`baseSelector`, `baseScheme`, `modeSelectors`) are still type-accepted because they sit on `CSSPluginOptions`, but are runtime-inert under swatchbook's permutation-based emission. Setting any of them now produces a `swatchbook/css-options` warn diagnostic that lists the offending keys and points at the replacement, matching the validation pattern already used for `default` / `presets` / `chrome` / `disabledAxes`.
+
+Breaking (pre-1.0, minor): configs that were setting `filename` or `skipBuild` on `cssOptions` — which had no effect in practice — will now fail to typecheck. Delete the field.

--- a/apps/docs/docs/concepts/token-pipeline.mdx
+++ b/apps/docs/docs/concepts/token-pipeline.mdx
@@ -56,7 +56,7 @@ The virtual module lives inside Vite's module graph. Vite builds your Storybook 
 
 For **Storybook**, the virtual module is the tokens' runtime home: the preview reads CSS from it, the MDX doc blocks read the resolved graph from it, the toolbar reads the axes from it. No compile step needed.
 
-For **production**, you want CSS variables baked into your framework's asset pipeline the normal way. Run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources — swatchbook is built on Terrazzo's parser, and Terrazzo's ecosystem of platform plugins (`plugin-css`, `plugin-js`, `plugin-tailwind`, `plugin-swift`, `plugin-sass`, …) covers every downstream target.
+For **production**, you want CSS variables baked into your framework's asset pipeline the normal way. Run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources — swatchbook is built on Terrazzo's parser, and Terrazzo's ecosystem of platform plugins (`plugin-css`, `plugin-js`, `plugin-tailwind`, `plugin-swift`, `plugin-sass`, …) covers every downstream target. When both pipelines run, [align their options](../guides/sharing-terrazzo-options) so the values swatchbook shows match the values your apps ship.
 
 ## Where the same no-compile-step property holds
 

--- a/apps/docs/docs/guides/sharing-terrazzo-options.mdx
+++ b/apps/docs/docs/guides/sharing-terrazzo-options.mdx
@@ -1,47 +1,104 @@
 ---
 id: sharing-terrazzo-options
-title: Sharing Terrazzo options
+title: Aligning with your token build
 sidebar_position: 5
 ---
 
-# Sharing Terrazzo options with a production build
+# Aligning swatchbook with your production token build
 
-If you run `@terrazzo/cli` in production alongside swatchbook's Storybook-time rendering, you want both pipelines to agree on the `plugin-css` options they consume — otherwise the hex values / CSS variable names / per-platform identifiers the docs show can drift from what actually ships.
+Swatchbook renders tokens inside Storybook by running `@terrazzo/parser` against the same DTCG source your production pipeline consumes. If that production pipeline is also Terrazzo (or, with some caveats, Style Dictionary), you can wire the two so they agree on hex formatting, CSS variable names, per-platform identifiers, and everything else downstream of the raw token graph. When they agree, the swatches, values, and usage snippets swatchbook shows match exactly what your apps ship.
 
-Swatchbook exposes three config props that forward into its internal Terrazzo build: [`cssOptions`](../reference/config#cssoptions-omitcsspluginoptions-variablename--permutations), [`listingOptions`](../reference/config#listingoptions-omittokenlistingpluginoptions-filename), and [`terrazzoPlugins`](../reference/config#terrazzoplugins-readonly-plugin). The idiomatic way to consume them is a single shared options module that both your `terrazzo.config.ts` and `swatchbook.config.ts` import.
+This guide covers:
 
-## The pattern
+- What "aligning" actually means — the surfaces where drift bites
+- The three config knobs swatchbook exposes for this (`cssOptions`, `listingOptions`, `terrazzoPlugins`)
+- What swatchbook controls internally and you can't override — with the reasoning
+- A shared-options module pattern for Terrazzo consumers
+- Per-platform identifier display (Swift, Android, SCSS, JS, …)
+- Practical notes for Style Dictionary users
+- Common pitfalls
+
+## Why alignment matters
+
+The symptom of misalignment is subtle: everything appears to work, but the values your docs show differ from the values your apps ship. Concretely:
+
+- A `<ColorTable>` cell shows `color(display-p3 0.24 0.56 0.89)` because swatchbook's default `plugin-css` produces the modern `color()` form. Your production CSS passes `legacyHex: true` and ships `#3d8fe4`. Your designers QA the docs, sign off on the modern form, and the rollout looks different than expected.
+- `<TokenUsageSnippet>` emits `var(--ds-colour-surface-default)` using a British-spelling `variableName` policy you configured in production — but swatchbook's default policy emits `--ds-color-surface-default`. Consumer-facing code reads fine; docs snippets are wrong.
+- A future per-platform column in a block you write renders `colorSurfaceDefault` for Swift, but production Swift ships `ColorSurfaceDefault` because `@terrazzo/plugin-swift` wasn't loaded in the swatchbook build.
+
+The three config knobs below close each gap.
+
+## The three knobs
+
+Swatchbook loads its own in-memory Terrazzo build at preview boot. That build contains `@terrazzo/plugin-css` (for the stylesheet injected into stories) and `@terrazzo/plugin-token-listing` (for the metadata blocks display). Three config fields forward options into that build:
+
+| Config field | Forwards to | Controls |
+| --- | --- | --- |
+| [`cssOptions`](../reference/config#cssoptions-omitcsspluginoptions-variablename--permutations) | `@terrazzo/plugin-css` | value formatting (hex vs `color()`), transforms, include/exclude globs, utility groups |
+| [`listingOptions`](../reference/config#listingoptions-omittokenlistingpluginoptions-filename) | `@terrazzo/plugin-token-listing` | per-platform naming, mode metadata, `previewValue` / `subtype` hooks |
+| [`terrazzoPlugins`](../reference/config#terrazzoplugins-readonly-plugin) | additional plugins in the build | which plugin naming logic is available to the listing |
+
+Set all three from a single shared module and your terrazzo.config.ts and swatchbook.config.ts stay in lockstep forever.
+
+## What swatchbook owns (and you can't override)
+
+Five fields are stripped at the type level. They're load-bearing for how swatchbook emits CSS and publishes the listing; letting consumers override them breaks the preview model.
+
+- **`cssOptions.variableName`** — swatchbook routes naming through `@terrazzo/token-tools`' `makeCSSVar` with your `cssVarPrefix`, so every variable carries the prefix and kebab-cases consistently with what the listing records under `names.css`. A custom policy would make the listing's `names.css` disagree with the emitted stylesheet, which is worse than the default.
+- **`cssOptions.permutations`** — swatchbook synthesizes one permutation per resolver theme (or per layered tuple) so the emitted stylesheet declares each permutation under a compound `data-<prefix>-<axis>` selector. Overriding this defeats axis-aware rendering.
+- **`cssOptions.filename`** — the internal stylesheet is captured in memory, never written to disk.
+- **`cssOptions.skipBuild`** — setting `true` nulls out the listing's `previewValue` derivation, breaking every block that displays a value.
+- **`listingOptions.filename`** — the listing is captured in memory; the `outputFile` handler finds the entry by filename, and swatchbook owns that handshake.
+
+Everything else passes through untouched.
+
+### Soft-inert knobs (type-accepted, runtime-ignored)
+
+Three older `plugin-css` options predate permutations and pre-`permutations`-era builds still expose them:
+
+- `baseSelector`
+- `baseScheme`
+- `modeSelectors`
+
+Setting any of these doesn't hit a type error because they're still part of `CSSPluginOptions`, but swatchbook always drives emission through permutations, so they do nothing in the preview. Load emits a `swatchbook/css-options` warn diagnostic listing the offending keys — visible in the preview's diagnostic overlay and on `Project.diagnostics` for programmatic consumers — so the "my setting isn't taking effect" failure mode turns into an explicit signal.
+
+## The shared-options module pattern
+
+Put everything both builds agree on in one file. Both configs import from it.
 
 ```ts title="shared-terrazzo-options.ts"
-import cssPlugin from '@terrazzo/plugin-css';
+import cssPlugin, { type CSSPluginOptions } from '@terrazzo/plugin-css';
 import swiftPlugin from '@terrazzo/plugin-swift';
-import type { CSSPluginOptions, TokenListingPluginOptions } from '@terrazzo/plugin-css';
+import androidPlugin from '@terrazzo/plugin-android';
 import type { Plugin } from '@terrazzo/parser';
+import type { TokenListingPluginOptions } from '@terrazzo/plugin-token-listing';
 
-export const sharedCssOptions: CSSPluginOptions = {
+/** Value-formatting policy — shared by production CSS and swatchbook's preview. */
+export const sharedCssOptions: Omit<CSSPluginOptions, 'variableName' | 'permutations'> = {
   legacyHex: true,
-  colorDepth: 24,
-  // transform: ..., etc.
+  include: ['color.*', 'space.*', 'radius.*', 'shadow.*', 'typography.*'],
 };
 
+/** Extra plugins whose naming rules we want reflected in `listing[path].names.*`. */
 export const sharedPlugins: readonly Plugin[] = [
-  swiftPlugin({ /* swift plugin options */ }),
+  swiftPlugin({ filename: 'tokens.swift' }),
+  androidPlugin({ filename: 'tokens.xml' }),
 ];
 
-export const sharedListingOptions: TokenListingPluginOptions = {
+/** Platforms the listing should enumerate per token. */
+export const sharedListingOptions: Omit<TokenListingPluginOptions, 'filename'> = {
   platforms: {
-    css:   { name: '@terrazzo/plugin-css' },
-    swift: { name: '@terrazzo/plugin-swift', description: 'UIColor' },
+    css:     { name: '@terrazzo/plugin-css',     description: 'CSS custom properties' },
+    swift:   { name: '@terrazzo/plugin-swift',   description: 'UIColor / SwiftUI Color' },
+    android: { name: '@terrazzo/plugin-android', description: 'colors.xml' },
   },
 };
 
-// Re-exported so terrazzo.config.ts can build plugin-css + plugin-swift with
-// the same option objects swatchbook.config.ts hands to swatchbook.
-export { cssPlugin, swiftPlugin };
+export { cssPlugin };
 ```
 
 ```ts title="terrazzo.config.ts"
-import { defineConfig } from '@terrazzo/parser';
+import { defineConfig } from '@terrazzo/cli';
 import tokenListingPlugin from '@terrazzo/plugin-token-listing';
 import {
   cssPlugin,
@@ -54,9 +111,15 @@ export default defineConfig({
   tokens: 'tokens/**/*.json',
   outDir: 'dist',
   plugins: [
-    cssPlugin(sharedCssOptions),
+    cssPlugin({
+      ...sharedCssOptions,
+      filename: 'tokens.css',
+    }),
     ...sharedPlugins,
-    tokenListingPlugin(sharedListingOptions),
+    tokenListingPlugin({
+      ...sharedListingOptions,
+      filename: 'tokens.listing.json',
+    }),
   ],
 });
 ```
@@ -78,19 +141,127 @@ export default defineSwatchbookConfig({
 });
 ```
 
-Both configs now consume the same objects. Any change to `sharedCssOptions` (a new transform, a `colorDepth` flip, a `legacyHex` toggle) reaches the production CLI and the Storybook-time build together.
+Now any change to `sharedCssOptions.legacyHex`, or a new plugin added to `sharedPlugins`, reaches both the production CLI and swatchbook's Storybook build with one edit.
 
-## What alignment buys you
+### Monorepo layouts
 
-- **CSS variable names.** `plugin-css`'s `variableName` policy is one source of truth. `listing[path].names.css` matches the variable name your production CSS emits — the swatches in `<TokenTable>` / `<ColorTable>` / `<TokenDetail>` reference the same var your consumers import.
-- **Preview values.** `listing[path].previewValue` is a plugin-css-computed CSS string — hex form honors `legacyHex`, channel precision honors `colorDepth`. Blocks that display values pick this up verbatim instead of running a parallel conversion.
-- **Per-platform identifiers.** `listing[path].names.swift` / `names.android` / etc. come from the plugin you loaded. A future column in `<ColorTable>` (or a block you write yourself) can render them directly — no duplication of the naming rule.
+In a monorepo the shared file usually lives where both the web app's production build and the design-system package's Storybook see it.
 
-## When you don't need this
+```
+packages/
+  tokens/
+    src/**/*.tokens.json
+    resolver.json
+    shared-terrazzo-options.ts   ← here
+    terrazzo.config.ts           ← imports ./shared-terrazzo-options
+  design-system/
+    swatchbook.config.ts         ← imports ../tokens/shared-terrazzo-options
+    .storybook/
+apps/
+  web/
+    … consumes the built tokens from packages/tokens/dist/
+```
 
-If you don't run `@terrazzo/cli` separately, leave all three props unset. Swatchbook loads `plugin-css` with defaults and `plugin-token-listing` with a single `css` platform — the rest of the block-display pipeline continues to work exactly as before. Drift isn't a concern when there's only one pipeline.
+If the shared module imports from other workspace packages, make sure your bundler (tsdown / rolldown / whatever `pnpm -r build` runs) resolves those imports in source form — or publish the shared module alongside the tokens package itself.
+
+## Per-platform identifier display
+
+The Token Listing records `names.<platform>` for every platform registered in `listingOptions.platforms`, using the named plugin's own identifier-naming logic. Blocks read these without duplicating any rules.
+
+Load the plugin in `terrazzoPlugins`, name it in `listingOptions.platforms`, and `listing[path].names.swift` (or `.android`, `.js`, `.sass`, …) populates automatically. Writing a per-platform column in a custom block becomes a one-liner:
+
+```tsx
+const swiftName = project.listing?.[path]?.names?.swift;
+// "SwiftKit.Color.surfaceDefault"
+```
+
+See [`ProjectSnapshot.listing`](../reference/blocks/hooks#project-snapshot-listing) for the full shape in the block context.
+
+The output files those plugins produce (`tokens.swift`, `tokens.xml`, …) land in the in-memory output set and are discarded. Swatchbook doesn't write them to disk — `terrazzoPlugins` runs plugins purely for their *naming contribution* to the listing, not for file emission.
+
+## Per-knob notes
+
+### `cssOptions.legacyHex`, `cssOptions.transform`
+
+Value-formatting changes flow both into the emitted stylesheet and into `listing[path].previewValue` (since `@terrazzo/plugin-token-listing` derives preview values by asking plugin-css for its CSS output). Setting `legacyHex: true` flips both simultaneously — the swatch CSS uses `#3d8fe4`, and every block that displays a value (`<TokenTable>`, `<TokenDetail>`, `<ColorTable>`) shows the same hex string.
+
+### `cssOptions.include` / `cssOptions.exclude`
+
+Glob-based filters on which tokens reach the emitted CSS. Useful when production ships only a subset (say, excluding brand-internal tokens). Swatchbook still parses all tokens — the listing still enumerates them, the blocks still display them — but the injected stylesheet carries only the filtered set. If a story uses a filtered-out token via CSS var, it'll read as unset.
+
+### `cssOptions.utility`
+
+Terrazzo's utility-CSS emission (classes like `.bg-color-accent-bg`). Production builds that ship utility classes can opt into the same emission in swatchbook's preview. Blocks don't consume utility output directly; this is purely "make sure the preview's behavior matches the final bundle's."
+
+### `listingOptions.previewValue`
+
+A hook that can override the auto-computed preview string per token. Useful if production formats values for a non-CSS target and you want docs to show that format. Return `undefined` to fall through to the automatic (plugin-css) value.
+
+### `listingOptions.subtype`
+
+A hook that classifies a token's intent (`bgColor`, `fgColor`, `borderColor`, `padding`, …). Reserved for future per-`subtype` block defaults — currently unused by blocks but worth setting so the metadata is in place.
+
+### `listingOptions.modes`
+
+Declares the resolver modes covered by the listing. Mostly redundant with swatchbook's own resolver reading, but can be set if you use resolver-free layered projects and want the listing to enumerate modes explicitly.
+
+## Style Dictionary
+
+[Style Dictionary](https://styledictionary.com) is the other common token build. Since 4.x it reads DTCG-shaped JSON natively, which opens alignment options.
+
+### If your source is DTCG
+
+Swatchbook reads DTCG from disk via `@terrazzo/parser`. Style Dictionary (4.x with `preprocessors: ['tokens-studio']` or straight DTCG) reads the same files. Point both at the same directory:
+
+```ts title="swatchbook.config.ts"
+defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  cssVarPrefix: 'ds',
+});
+```
+
+```js title="sd.config.js"
+export default {
+  source: ['tokens/**/*.tokens.json'],
+  platforms: {
+    css: { transformGroup: 'css', files: [{ destination: 'dist/tokens.css', format: 'css/variables' }] },
+    ios: { transformGroup: 'ios-swift', files: [{ destination: 'dist/Tokens.swift', format: 'ios-swift/class.swift' }] },
+  },
+};
+```
+
+The shared piece is the source tree. Alignment ends there — swatchbook computes its own CSS variable names using Terrazzo's naming rules, while Style Dictionary uses its own transform chain. Names *won't* match character-for-character unless you hand-tune both sides.
+
+For a preview-only tool that's usually fine. The swatchbook-rendered block shows what the tokens *are*; your apps ship what Style Dictionary emits. As long as both read the same DTCG input, token identity is preserved across pipelines even when naming differs.
+
+### If you need names to match exactly
+
+This is harder. Style Dictionary's `transforms` (`name/cti/kebab`, `name/cti/camel`, custom naming transforms) produce a naming scheme that doesn't round-trip through Terrazzo's `@terrazzo/token-tools/css.makeCSSVar`. Two routes:
+
+1. **Loosen the naming contract.** Treat DTCG dot-paths as the canonical identifier; display those in blocks via `<TokenDetail path="…">`; let each build name CSS variables however it wants. The `path` is always stable across pipelines.
+2. **Write a thin adapter.** Expose the CSS variable names Style Dictionary computes as a lookup map, read them through a custom block via `useProject()`, and render them next to Terrazzo's names. Requires block-writing work; the addon doesn't ship this.
+
+### When to use Style Dictionary *and* Terrazzo side-by-side
+
+Some teams use Terrazzo for CSS + JS targets (because `@terrazzo/plugin-css` integrates natively with swatchbook) and Style Dictionary for platform targets Terrazzo doesn't cover (some legacy XML formats, Flutter, specific design-tool round-trips). This works — both read the DTCG source tree, both emit to their own `dist/`. Swatchbook aligns with Terrazzo's side; Style Dictionary's side stays unaligned but also stays out of swatchbook's view.
+
+If you're weighing whether to add Terrazzo to an SD-only pipeline, the pragmatic answer is: if you want swatchbook's per-platform `names.*` columns populated with Swift/Android/etc. identifiers, add the Terrazzo plugin for that platform (`plugin-swift`, `plugin-android`) to the swatchbook build via `terrazzoPlugins`. The plugin runs in-memory only — nothing's written to disk, no parallel production artifact is produced — just the naming contribution to the listing.
+
+## Common pitfalls
+
+- **`cssVarPrefix` drift** — swatchbook's `cssVarPrefix` is independent of the prefix plugin-css would pick if you set `variableName` yourself. Since swatchbook owns `variableName`, setting `cssVarPrefix: 'sb'` is the only lever you need for prefix control on the swatchbook side. Production's prefix lives in its own plugin-css call (or in a `variableName` policy you ship). Both sides should pick the same prefix — the guide's "one shared module" pattern doesn't cover prefix because swatchbook takes it from a top-level field; double-check that `cssVarPrefix: 'ds'` in swatchbook matches whatever `--ds-*` your production stylesheet emits.
+- **Resolver vs `tokens` divergence** — if your production build reads a flat `tokens.json` but swatchbook reads a DTCG resolver, the two pipelines see different permutation sets. The listing will only reflect swatchbook's resolver view. Keep both on the same shape; if production needs flat output, emit it with Terrazzo's `plugin-js` or similar from the resolver's own permutations.
+- **Plugin loaded but not listed** — a plugin in `terrazzoPlugins` without a matching entry in `listingOptions.platforms` runs but doesn't contribute to `names.*`. Conversely, a platform entry in `listingOptions.platforms` whose plugin isn't in `terrazzoPlugins` will fail at listing time. Both sides or neither.
+- **Plugins that write to disk** — swatchbook captures `outputFile` calls in memory. A plugin that writes via `fs` directly (bypassing the Terrazzo build API) will try to write files relative to the Storybook preview's cwd during HMR. Prefer plugins that use the supported `outputFile` hook.
+- **`@terrazzo/cli` vs `@terrazzo/parser`'s `defineConfig`** — `@terrazzo/cli` is what a `tz build` consumer already has installed; `@terrazzo/parser` exports a lower-level `defineConfig` that takes a `cwd` option. Prefer the cli export in user-facing config files.
+
+## When you don't need any of this
+
+If you don't run a production token build alongside swatchbook — the tokens exist only for the docs site and Storybook — leave `cssOptions`, `listingOptions`, and `terrazzoPlugins` unset. Swatchbook loads `plugin-css` with defaults and `plugin-token-listing` with a single `css` platform. Drift isn't a concern when there's only one pipeline.
 
 ## See also
 
 - [Config reference: `cssOptions` / `listingOptions` / `terrazzoPlugins`](../reference/config) — the prop-by-prop contract.
+- [The token pipeline](../concepts/token-pipeline) — how swatchbook's virtual module differs from a file-emitting build.
 - [`@terrazzo/plugin-token-listing` source](https://github.com/terrazzoapp/terrazzo/tree/main/packages/plugin-token-listing) — the listing format swatchbook consumes.
+- [Style Dictionary docs](https://styledictionary.com/) — DTCG support landed in 4.0; alignment-friendly configurations start there.

--- a/apps/docs/docs/integrations/index.mdx
+++ b/apps/docs/docs/integrations/index.mdx
@@ -12,7 +12,7 @@ Display-side integrations that plug swatchbook's DTCG tokens into third-party to
 
 Swatchbook's purpose is **displaying DTCG tokens in Storybook**, not replacing downstream build pipelines. Integrations wire the token graph into whichever runtime library a story needs — Tailwind's `@theme` block, a JS theme accessor for CSS-in-JS, and so on — without requiring the addon itself to know anything about that library. Integration packages own the library-specific logic.
 
-Production artifacts (writing `tokens.js` / `tailwind.config.css` to disk for a consumer's own build) are not swatchbook's job — run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources if you need artifacts outside Storybook.
+Production artifacts (writing `tokens.js` / `tailwind.config.css` to disk for a consumer's own build) are not swatchbook's job — run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources if you need artifacts outside Storybook. Keep both pipelines in step with [shared Terrazzo options](../guides/sharing-terrazzo-options.mdx).
 
 ## Available integrations
 

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -208,19 +208,28 @@ Produces a single `:root` chrome block with all ten roles declared — overrides
 
 Unknown role keys (outside the ten above) and target paths that don't resolve to any token or composite sub-field in any theme produce `warn` diagnostics (group `swatchbook/chrome`) and are dropped — the corresponding chrome slot falls back to its hard-coded literal default. The validated entries land on `Project.chrome` for downstream tooling.
 
-### `cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>`
+### `cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations' | 'filename' | 'skipBuild'>`
 
-Options forwarded to the `@terrazzo/plugin-css` instance swatchbook runs internally — for the stylesheet it emits for the Storybook preview and for the Token Listing's `names.css` derivation. Use this when your production Terrazzo build passes non-default options to `plugin-css` (`legacyHex`, `colorDepth`, a custom `transform`, etc.) and you want the docs-side output to match.
+Options forwarded to the `@terrazzo/plugin-css` instance swatchbook runs internally — for the stylesheet it emits for the Storybook preview and for the Token Listing's `names.css` derivation. Use this when your production Terrazzo build passes non-default options to `plugin-css` (`legacyHex`, a custom `transform`, `include` / `exclude` globs, etc.) and you want the docs-side output to match.
 
-`variableName` and `permutations` are managed internally — swatchbook's axis-aware multi-theme emission depends on them — and are stripped from the option type. Everything else passes through.
+Four fields are managed internally and stripped from the allowed type:
+
+- `variableName` — swatchbook routes naming through `@terrazzo/token-tools/css.makeCSSVar` with your `cssVarPrefix`; overriding this would desync the listing's `names.css` from the emitted stylesheet.
+- `permutations` — synthesized one-per-theme so CSS emission is axis-aware; overriding breaks the preview's toolbar cascade.
+- `filename` — the internal stylesheet is captured in memory, never written to disk.
+- `skipBuild` — setting `true` would null out the listing's `previewValue` derivation, breaking every block that displays a value.
+
+Everything else passes through. Deprecated knobs (`baseSelector`, `baseScheme`, `modeSelectors`) still pass the type check but do nothing under swatchbook's permutation-based emission; setting any of them produces a `swatchbook/css-options` warn diagnostic with a pointer to what to use instead.
 
 ```ts
 defineSwatchbookConfig({
   resolver: 'tokens/resolver.json',
   cssVarPrefix: 'ds',
-  cssOptions: { legacyHex: true, colorDepth: 24 },
+  cssOptions: { legacyHex: true, include: ['color.*', 'space.*'] },
 });
 ```
+
+See [Aligning with your token build](../guides/sharing-terrazzo-options) for the end-to-end shared-options pattern.
 
 ### `listingOptions?: Omit<TokenListingPluginOptions, 'filename'>`
 

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -32,6 +32,7 @@ const sidebars: SidebarsConfig = {
     'guides/token-dashboard',
     'guides/multi-axis-walkthrough',
     'guides/consuming-the-active-theme',
+    'guides/sharing-terrazzo-options',
     'guides/migrating-from-addon-themes',
   ],
   integrations: [

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -2,6 +2,7 @@ import { validateChrome } from '#/chrome.ts';
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
 import { validateDisabledAxes } from '#/disabled-axes.ts';
 import { validatePresets } from '#/presets.ts';
+import { validateCssOptions } from '#/terrazzo-options.ts';
 import { resolveDefaultTuple } from '#/themes/default.ts';
 import { normalizeThemes } from '#/themes/normalize.ts';
 import { computeTokenListing } from '#/token-listing.ts';
@@ -69,6 +70,8 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     filteredResolved,
   );
 
+  const { diagnostics: cssOptionsDiagnostics } = validateCssOptions(config.cssOptions);
+
   // A misconfigured `disabledAxes` (e.g. pinning an axis whose default
   // context has no theme rows) can filter every theme out. We still return
   // an empty project so the addon can render diagnostics instead of
@@ -117,6 +120,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
       ...defaultDiagnostics,
       ...presetDiagnostics,
       ...chromeDiagnostics,
+      ...cssOptionsDiagnostics,
       ...projectDiagnostics,
     ],
   };

--- a/packages/core/src/terrazzo-options.ts
+++ b/packages/core/src/terrazzo-options.ts
@@ -1,0 +1,49 @@
+import type { CSSPluginOptions } from '@terrazzo/plugin-css';
+import type { Diagnostic } from '#/types.ts';
+
+/**
+ * CSS plugin options that swatchbook manages internally and strips from
+ * the allowed surface. `variableName` and `permutations` are load-bearing
+ * for axis-aware emission and prefix handling; `filename` and `skipBuild`
+ * would break the in-memory capture the listing pipeline relies on.
+ */
+export type StrippedCssOption = 'variableName' | 'permutations' | 'filename' | 'skipBuild';
+
+export type ForwardedCssOptions = Omit<CSSPluginOptions, StrippedCssOption>;
+
+/**
+ * Deprecated plugin-css knobs that are silently inert under swatchbook's
+ * permutation-based emission. Calling them out as `warn` diagnostics beats
+ * the alternative — authors wonder why their `modeSelectors` don't take
+ * effect and blame swatchbook.
+ */
+const INERT_DEPRECATED_KEYS = ['baseSelector', 'baseScheme', 'modeSelectors'] as const;
+
+/**
+ * Validate user-supplied `cssOptions`. The type system already prevents
+ * setting the stripped fields; this catches no-ops the type doesn't know
+ * about — plugin-css's deprecated mode selectors, superseded by the
+ * permutations swatchbook builds per theme.
+ */
+export function validateCssOptions(raw: ForwardedCssOptions | undefined): {
+  diagnostics: Diagnostic[];
+} {
+  if (!raw) return { diagnostics: [] };
+
+  const diagnostics: Diagnostic[] = [];
+  const present = INERT_DEPRECATED_KEYS.filter(
+    (key) => (raw as Record<string, unknown>)[key] !== undefined,
+  );
+  if (present.length > 0) {
+    diagnostics.push({
+      severity: 'warn',
+      group: 'swatchbook/css-options',
+      message: `\`cssOptions.${present.join('`, `cssOptions.')}\` ${
+        present.length === 1 ? 'is' : 'are'
+      } deprecated in @terrazzo/plugin-css and do not apply — swatchbook builds one permutation per resolver theme for axis-aware emission. Remove the setting${
+        present.length === 1 ? '' : 's'
+      } to silence this diagnostic.`,
+    });
+  }
+  return { diagnostics };
+}

--- a/packages/core/src/token-listing.ts
+++ b/packages/core/src/token-listing.ts
@@ -36,7 +36,7 @@ export type TokenListingByPath = Record<string, ListedToken>;
  */
 export interface ComputeTokenListingOptions {
   /** Extra options forwarded to the internal `plugin-css` instance. */
-  cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>;
+  cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations' | 'filename' | 'skipBuild'>;
   /** Extra options forwarded to the internal `plugin-token-listing` instance. */
   listingOptions?: Omit<TokenListingPluginOptions, 'filename'>;
   /** Extra plugins loaded into the build — referenced by `listingOptions.platforms`. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -115,15 +115,18 @@ export interface Config {
    * Options forwarded to the `@terrazzo/plugin-css` instance swatchbook
    * runs internally (for the stylesheet it emits and for the Token
    * Listing's `names.css` derivation). Line this up with the consumer's
-   * own `plugin-css` options — `legacyHex`, `transform`, `colorDepth`,
+   * own `plugin-css` options — `legacyHex`, `transform`, `include`,
    * and similar — so docs-side names and values match what the
    * consumer's production build emits.
    *
-   * The `variableName` and `permutations` fields are managed internally
-   * and cannot be overridden — swatchbook's axis composition depends on
-   * them. Everything else is passed through.
+   * `variableName` / `permutations` / `filename` / `skipBuild` are
+   * managed internally and cannot be overridden — swatchbook's
+   * axis-aware emission and in-memory listing capture depend on them.
+   * Passing deprecated knobs (`baseSelector`, `baseScheme`,
+   * `modeSelectors`) produces a `swatchbook/css-options` warn diagnostic
+   * because they're superseded by permutations in newer plugin-css.
    */
-  cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations'>;
+  cssOptions?: Omit<CSSPluginOptions, 'variableName' | 'permutations' | 'filename' | 'skipBuild'>;
   /**
    * Options forwarded to `@terrazzo/plugin-token-listing`. Use
    * `platforms` to register additional platforms beyond `css` (e.g.

--- a/packages/core/test/terrazzo-options.test.ts
+++ b/packages/core/test/terrazzo-options.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from 'vitest';
+import { validateCssOptions } from '#/terrazzo-options';
+
+it('validateCssOptions returns no diagnostics for an empty object', () => {
+  const { diagnostics } = validateCssOptions({});
+  expect(diagnostics).toEqual([]);
+});
+
+it('validateCssOptions returns no diagnostics when called without options', () => {
+  const { diagnostics } = validateCssOptions(undefined);
+  expect(diagnostics).toEqual([]);
+});
+
+it('validateCssOptions lets supported knobs pass without complaint', () => {
+  const { diagnostics } = validateCssOptions({ legacyHex: true, include: ['color.*'] });
+  expect(diagnostics).toEqual([]);
+});
+
+it('validateCssOptions warns when `baseSelector` is set — superseded by permutations', () => {
+  const { diagnostics } = validateCssOptions({ baseSelector: ':host' });
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.severity).toBe('warn');
+  expect(diagnostics[0]?.group).toBe('swatchbook/css-options');
+  expect(diagnostics[0]?.message).toMatch(/cssOptions\.baseSelector/);
+  expect(diagnostics[0]?.message).toMatch(/deprecated/);
+});
+
+it('validateCssOptions groups multiple inert knobs into one diagnostic', () => {
+  const { diagnostics } = validateCssOptions({
+    baseSelector: ':host',
+    baseScheme: 'light dark',
+    modeSelectors: [{ mode: 'dark', selectors: ['@media (prefers-color-scheme: dark)'] }],
+  });
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.message).toMatch(/baseSelector/);
+  expect(diagnostics[0]?.message).toMatch(/baseScheme/);
+  expect(diagnostics[0]?.message).toMatch(/modeSelectors/);
+});


### PR DESCRIPTION
## Summary

- Strip `filename` and `skipBuild` from the allowed `Config.cssOptions` type. Neither was ever honored end-to-end — `filename` gets overridden for the in-memory capture, and `skipBuild: true` would silently null out the listing's `previewValue`. Turn both silent no-ops into compile-time signals.
- Add a `swatchbook/css-options` warn diagnostic for the soft-inert deprecated trio (`baseSelector`, `baseScheme`, `modeSelectors`). They still pass the type check because they sit on `CSSPluginOptions`, but are runtime-inert under swatchbook's permutation-based emission. Matches the validation pattern used for `default` / `presets` / `chrome` / `disabledAxes`.
- Expand `guides/sharing-terrazzo-options` from a shared-options recipe into a proper primer: per-knob notes, what swatchbook owns vs what passes through, per-platform `names.*` display via `terrazzoPlugins` + `listingOptions.platforms`, monorepo layout guidance, a Style Dictionary section, and a common-pitfalls rundown. Add to sidebar; cross-link from `concepts/token-pipeline` and `integrations/`.

**Milestone:** Maintenance
**Closes:** #615
**Plan impact:** none (hygiene + docs).

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test` — 37/37 green.
- [x] `validateCssOptions` unit tests cover no-op, single-key, and multi-key cases.
- [ ] Visual: docs build renders the expanded guide + sidebar link; cross-links resolve.