### PR TITLE
feat(integrations): derive /tailwind roles from the project

### DIFF
--- a/.changeset/feat-tailwind-dynamic-roles.md
+++ b/.changeset/feat-tailwind-dynamic-roles.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-integrations': minor
+---
+
+Replace `/tailwind`'s hardcoded `DEFAULT_ROLES` map with a dynamic role derivation that walks the project's default-theme token graph at render time and classifies each token into a Tailwind scale by `$type` + path. Color tokens → `color`, `space.*` / `spacing.*` dimensions → `spacing`, `radius.*` / `borderRadius.*` / `border-radius.*` dimensions → `radius`, shadows → `shadow`, font families → `font`. Font-size-ish dimensions (`font.size.*`, `text.*`) are intentionally skipped because Tailwind's `--text-*` entries want size + line-height pairs that this preview integration doesn't synthesize.
+
+Result: zero-config now works for every DTCG project shape, not just the one that matches the reference fixture. A project using `color.background.*` / `spacing.small` / `borderRadius.round` gets usable Tailwind utilities out of the box; previously it got a `@theme` block of `var(--undefined-…)` references.
+
+The `roles` option still wins — pass your own map to pin a curated subset, rename scales, or emit into Tailwind scales the derivation doesn't cover.
+
+Breaking (pre-1.0, minor): projects relying on the reference-fixture shape will now additionally emit `--color-<prefix>-palette-*` utilities etc. for every palette token. This is extra utility surface, not a removal; existing class names keep working.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,4 @@
 ## Full description
 <!-- What changes and why. -->
 
-**Closes:** <!-- Closes #N / Refs #N — every code PR links an issue. Open one first if it doesn't exist -->
+Closes #<!-- issue number — every code PR links an issue. Open one first if it doesn't exist. One `Closes #N` per line, plain text (not **Closes:** — GitHub's linker ignores markdown-formatted labels and the issue won't auto-close). Use `Refs #N` for related-but-not-closing references. -->

--- a/apps/docs/docs/integrations/tailwind.mdx
+++ b/apps/docs/docs/integrations/tailwind.mdx
@@ -81,9 +81,36 @@ Every entry in the `@theme` block is nested under your project's `cssVarPrefix`.
 
 This matters because Tailwind v4's `max-w-<name>` / `w-<name>` / `size-<name>` utilities read from the `--spacing-*` namespace. Without the prefix, a swatchbook entry named `--spacing-sm` would shadow Tailwind's default `--container-sm`, making `max-w-sm` tiny. The double-prefix (`--spacing-sb-sm`) sidesteps that collision entirely.
 
-## Customising the role map
+## How the role map is built
 
-The integration ships a curated default role map covering the semantic DTCG roles — surface / text / accent / border / status colours, a 9-stop spacing scale, radii, shadows. If your project has different paths, pass your own map:
+With zero configuration, the integration walks your project's default-theme token graph at render time and classifies every token into a Tailwind scale based on its `$type` + path:
+
+| DTCG `$type` | Path shape | Tailwind scale | Role name |
+| --- | --- | --- | --- |
+| `color` | any | `color` | path minus `color.` prefix |
+| `dimension` | `space.*` / `spacing.*` | `spacing` | path minus that prefix |
+| `dimension` | `radius.*` / `borderRadius.*` / `border-radius.*` | `radius` | path minus that prefix |
+| `dimension` | anything else | `spacing` | full path dot→dash |
+| `shadow` | any | `shadow` | path minus `shadow.` prefix |
+| `fontFamily` | any | `font` | path minus `font.` / `font.family.` / `fontFamily.` prefix |
+
+Font-size-ish dimensions (`font.size.*`, `text.*`) are intentionally skipped — Tailwind's `--text-*` entries want size+line-height pairs and this preview integration doesn't synthesize those.
+
+The result:
+
+- Every color token the project has becomes a `bg-<prefix>-*` / `text-<prefix>-*` / etc. utility.
+- Every spacing dimension becomes a `p-<prefix>-*` / `m-<prefix>-*` / etc. utility.
+- Same for radius, shadow, and font-family.
+
+So a project whose paths are `color.surface.default`, `space.md`, `radius.pill` gets the same `--color-sb-surface-default`, `--spacing-sb-md`, `--radius-sb-pill` output as before. A project using `color.background.subtle`, `spacing.small`, `borderRadius.round` gets `--color-sb-background-subtle`, `--spacing-sb-small`, `--radius-sb-round`. No hand-maintained map either way.
+
+### Overriding the derivation
+
+Pass a `roles` map to replace the derivation outright. Useful when:
+
+- You want to restrict the emitted utilities to a curated subset (faster compile, tidier Intellisense in Storybook).
+- Your paths don't fit the classification rules above and you want to name them explicitly.
+- You want to emit into a Tailwind scale the derivation doesn't cover (e.g. `--animate-*`).
 
 ```ts
 tailwindIntegration({
@@ -101,7 +128,7 @@ tailwindIntegration({
 });
 ```
 
-The map replaces the default entirely — what you list is what you get. Tailwind scale names (`color`, `spacing`, `radius`, `shadow`) are keys; each entry is `[tailwindEntryName, dtcgPath]`.
+The map replaces the derivation entirely — what you list is what you get. Tailwind scale names are keys; each entry is `[tailwindEntryName, dtcgPath]`.
 
 ## HMR
 

--- a/packages/integrations/src/tailwind.ts
+++ b/packages/integrations/src/tailwind.ts
@@ -8,14 +8,23 @@ export interface TailwindIntegrationOptions {
    */
   virtualId?: string;
   /**
-   * Override or extend the default role map. Keys are Tailwind scale
-   * names (`color`, `spacing`, `radius`, `shadow`); values are ordered
-   * `[tailwindEntryName, dtcgPath]` pairs. Supplied map **replaces**
-   * the default — pass your own to customise which roles land in
-   * `@theme`. Omit to use the curated default.
+   * Override the auto-derived role map. Keys are Tailwind scale names
+   * (`color`, `spacing`, `radius`, `shadow`, `font`); values are ordered
+   * `[tailwindEntryName, dtcgPath]` pairs. Supplied map **replaces** the
+   * derived one — pass your own to pin exact entries, restrict the
+   * universe of emitted utilities, or name scales the derivation doesn't
+   * cover.
+   *
+   * Omit to let the integration derive a role map from the project at
+   * render time: every `color` token lands under the `color` scale,
+   * every `dimension` token under `spacing` / `radius` based on its
+   * path prefix, every `shadow` under `shadow`, every `fontFamily` under
+   * `font`. Works for any DTCG project without a configuration step.
    */
   roles?: Readonly<Record<string, readonly (readonly [string, string])[]>>;
 }
+
+type RoleMap = Readonly<Record<string, readonly (readonly [string, string])[]>>;
 
 /**
  * Preview-only Tailwind v4 integration for the swatchbook Storybook
@@ -56,13 +65,13 @@ export default function tailwindIntegration(
   options: TailwindIntegrationOptions = {},
 ): SwatchbookIntegration {
   const virtualId = options.virtualId ?? 'virtual:swatchbook/tailwind.css';
-  const roles = options.roles ?? DEFAULT_ROLES;
+  const userRoles = options.roles;
 
   return {
     name: 'tailwind',
     virtualModule: {
       virtualId,
-      render: (project) => renderTailwindTheme(project, roles),
+      render: (project) => renderTailwindTheme(project, userRoles ?? deriveRoles(project)),
       // Tailwind's `@theme` block is a global stylesheet — exactly the
       // kind of payload the addon should auto-inject into the preview,
       // so consumers don't hand-write a second `import` line after
@@ -72,16 +81,14 @@ export default function tailwindIntegration(
   };
 }
 
-function renderTailwindTheme(
-  project: Project,
-  roles: Readonly<Record<string, readonly (readonly [string, string])[]>>,
-): string {
+function renderTailwindTheme(project: Project, roles: RoleMap): string {
   const prefix = project.config.cssVarPrefix ?? '';
   const sourcePrefix = prefix ? `${prefix}-` : '';
   const scopePrefix = prefix ? `${prefix}-` : '';
 
   const entries: string[] = [];
   for (const [scale, names] of Object.entries(roles)) {
+    if (names.length === 0) continue;
     entries.push(`  /* ${scale} */`);
     for (const [themeKey, sourcePath] of names) {
       const sourceVar = `--${sourcePrefix}${sourcePath.replaceAll('.', '-')}`;
@@ -105,58 +112,91 @@ function renderTailwindTheme(
 }
 
 /**
- * Example role map derived from the reference fixture's semantic paths.
- * Consumers with divergent paths pass their own map through
- * `tailwindIntegration({ roles })`. The default is not a general-purpose
- * schema — it's the concrete shape that makes the addon's own Storybook
- * run usefully, and a convenient starting point to copy and edit.
+ * Walk the project's default-theme token graph and classify each entry
+ * into a Tailwind scale based on its `$type` + path. Returns a role map
+ * shaped the same as a user-supplied `roles` option.
+ *
+ * Scale assignment:
+ * - `$type: 'color'`     → `color`, role = path minus `color.` prefix
+ * - `$type: 'dimension'` → `spacing` (default), `radius` (if path starts with
+ *   `radius.`, `borderRadius.`, or `border-radius.`), or nothing (skipped)
+ *   for dimensions that look like font sizes (`font.size.*`, `text.*`), since
+ *   Tailwind's `--text-*` scale needs size + line-height pairs this preview
+ *   integration doesn't synthesize
+ * - `$type: 'shadow'`      → `shadow`, role = path minus `shadow.` prefix
+ * - `$type: 'fontFamily'`  → `font`, role = path minus `font.` / `font.family.` / `fontFamily.` prefix
+ *
+ * Other `$type`s are skipped — they don't have a natural single-value
+ * Tailwind utility and would produce broken output.
  */
-const DEFAULT_ROLES: Readonly<Record<string, readonly (readonly [string, string])[]>> = {
-  color: [
-    ['surface-default', 'color.surface.default'],
-    ['surface-muted', 'color.surface.muted'],
-    ['surface-raised', 'color.surface.raised'],
-    ['surface-subtle', 'color.surface.subtle'],
-    ['surface-inverse', 'color.surface.inverse'],
-    ['text-default', 'color.text.default'],
-    ['text-muted', 'color.text.muted'],
-    ['text-subtle', 'color.text.subtle'],
-    ['text-inverse', 'color.text.inverse'],
-    ['text-accent', 'color.text.accent'],
-    ['accent-bg', 'color.accent.bg'],
-    ['accent-bg-hover', 'color.accent.bg-hover'],
-    ['accent-fg', 'color.accent.fg'],
-    ['border-default', 'color.border.default'],
-    ['border-strong', 'color.border.strong'],
-    ['border-focus', 'color.border.focus'],
-    ['status-danger-bg', 'color.status.danger-bg'],
-    ['status-danger-fg', 'color.status.danger-fg'],
-    ['status-success-bg', 'color.status.success-bg'],
-    ['status-success-fg', 'color.status.success-fg'],
-    ['status-warning-bg', 'color.status.warning-bg'],
-    ['status-warning-fg', 'color.status.warning-fg'],
-  ],
-  spacing: [
-    ['none', 'space.none'],
-    ['2xs', 'space.2xs'],
-    ['xs', 'space.xs'],
-    ['sm', 'space.sm'],
-    ['md', 'space.md'],
-    ['lg', 'space.lg'],
-    ['xl', 'space.xl'],
-    ['2xl', 'space.2xl'],
-    ['3xl', 'space.3xl'],
-  ],
-  radius: [
-    ['sm', 'radius.sm'],
-    ['md', 'radius.md'],
-    ['lg', 'radius.lg'],
-    ['xl', 'radius.xl'],
-    ['pill', 'radius.pill'],
-  ],
-  shadow: [
-    ['sm', 'shadow.sm'],
-    ['md', 'shadow.md'],
-    ['lg', 'shadow.lg'],
-  ],
-};
+function deriveRoles(project: Project): RoleMap {
+  const scales: Record<string, [string, string][]> = {
+    color: [],
+    spacing: [],
+    radius: [],
+    shadow: [],
+    font: [],
+  };
+
+  for (const [path, token] of Object.entries(project.graph)) {
+    const classification = classify(path, token.$type);
+    if (!classification) continue;
+    const { scale, role } = classification;
+    if (!role) continue;
+    scales[scale]?.push([role, path]);
+  }
+
+  const out: Record<string, readonly (readonly [string, string])[]> = {};
+  for (const [scale, entries] of Object.entries(scales)) {
+    if (entries.length === 0) continue;
+    entries.sort(([a], [b]) => a.localeCompare(b, 'en'));
+    out[scale] = entries;
+  }
+  return out;
+}
+
+const SPACING_ROOTS = ['space', 'spacing'] as const;
+const RADIUS_ROOTS = ['radius', 'borderRadius', 'border-radius'] as const;
+const FONT_PREFIXES = ['font.family.', 'fontFamily.', 'font.'] as const;
+
+function classify(path: string, type: string | undefined): { scale: string; role: string } | null {
+  switch (type) {
+    case 'color':
+      return { scale: 'color', role: stripPrefix(path, 'color.') };
+    case 'shadow':
+      return { scale: 'shadow', role: stripPrefix(path, 'shadow.') };
+    case 'fontFamily': {
+      for (const prefix of FONT_PREFIXES) {
+        if (path.startsWith(prefix)) {
+          return { scale: 'font', role: pathToRole(path.slice(prefix.length)) };
+        }
+      }
+      return { scale: 'font', role: pathToRole(path) };
+    }
+    case 'dimension': {
+      const head = path.split('.', 1)[0] ?? '';
+      if ((RADIUS_ROOTS as readonly string[]).includes(head)) {
+        return { scale: 'radius', role: pathToRole(path.slice(head.length + 1)) };
+      }
+      if ((SPACING_ROOTS as readonly string[]).includes(head)) {
+        return { scale: 'spacing', role: pathToRole(path.slice(head.length + 1)) };
+      }
+      // Font-size-ish dimensions are skipped — Tailwind's `--text-*` entries
+      // expect a size+line-height pair that this integration doesn't build.
+      if (head === 'font' && /size|text/i.test(path)) return null;
+      if (head === 'text') return null;
+      // Default-bucket any other dimension under spacing — safer than guessing.
+      return { scale: 'spacing', role: pathToRole(path) };
+    }
+    default:
+      return null;
+  }
+}
+
+function stripPrefix(path: string, prefix: string): string {
+  return pathToRole(path.startsWith(prefix) ? path.slice(prefix.length) : path);
+}
+
+function pathToRole(remainder: string): string {
+  return remainder.replaceAll('.', '-');
+}

--- a/packages/integrations/test/tailwind.test.ts
+++ b/packages/integrations/test/tailwind.test.ts
@@ -47,11 +47,35 @@ it('drops the dash when cssVarPrefix is empty', async () => {
   expect(css).not.toContain('--sb-');
 });
 
-it('accepts a custom role map replacing the default', () => {
+it('accepts a custom role map replacing the derived default', () => {
   const css = render(project, {
     roles: { color: [['only-accent', 'color.accent.bg']] },
   });
   expect(css).toContain('--color-sb-only-accent: var(--sb-color-accent-bg);');
   expect(css).not.toContain('--color-sb-surface-default:');
   expect(css).not.toContain('--spacing-sb-md:');
+});
+
+it('derives color entries from every `$type: color` token in the project', () => {
+  const css = render(project);
+  // Semantic colors (authored under color.surface.*)
+  expect(css).toContain('--color-sb-surface-default: var(--sb-color-surface-default);');
+  // Palette tokens land in the derivation too — consumers get the raw scale by default.
+  expect(css).toMatch(/--color-sb-palette-neutral-\d+: var\(--sb-color-palette-neutral-\d+\);/);
+});
+
+it('routes `$type: dimension` tokens under spacing or radius by path root', () => {
+  const css = render(project);
+  // `space.md` → spacing scale
+  expect(css).toContain('--spacing-sb-md: var(--sb-space-md);');
+  // `radius.pill` → radius scale (not spacing)
+  expect(css).toContain('--radius-sb-pill: var(--sb-radius-pill);');
+  expect(css).not.toContain('--spacing-sb-pill: var(--sb-radius-pill);');
+});
+
+it('derived scales are sorted deterministically', () => {
+  const css = render(project);
+  const spacingMatches = [...css.matchAll(/--spacing-sb-([\w-]+): /g)].map((m) => m[1]!);
+  const sorted = spacingMatches.toSorted((a, b) => a.localeCompare(b, 'en'));
+  expect(spacingMatches).toEqual(sorted);
 });


### PR DESCRIPTION
## Summary

- Replace `/tailwind`'s hardcoded 45-entry `DEFAULT_ROLES` map (modeled on the reference fixture's paths) with a dynamic role derivation that walks the default-theme token graph at render time and classifies each token into a Tailwind scale by `\$type` + path prefix.
- Scale table: `color` → `color`; `dimension` with `space.`/`spacing.` prefix → `spacing`; `dimension` with `radius.`/`borderRadius.`/`border-radius.` prefix → `radius`; `shadow` → `shadow`; `fontFamily` → `font`. Font-size-ish dimensions (`font.size.*`, `text.*`) are intentionally skipped — Tailwind's `--text-*` entries want size+line-height pairs this preview integration doesn't synthesize.
- Zero-config now works for any DTCG project shape, not just the one matching the reference fixture. A project using `color.background.subtle` / `spacing.small` / `borderRadius.round` gets usable Tailwind utilities out of the box; previously it got a `@theme` block of `var(--undefined-…)` references.
- The `roles` option still wins — pass your own map to pin a curated subset, rename scales, or emit into scales the derivation doesn't cover.
- Piggyback: fix the PR template's `Closes:` line so GitHub's linker actually fires. Bolded `**Closes:**` is silently ignored by the auto-close parser, which has repeatedly left merged PRs' issues open (most recently #615).

Milestone: Maintenance
Closes #614
Plan impact: none.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test` — 37/37 green.
- [x] New tests cover dynamic derivation: every color token emitted, palette tokens land in `color`, `space.*` goes to spacing and `radius.*` to radius, scales sort deterministically.
- [x] Existing fixture-based tests (`surface-default`, `space.md`, `radius.lg`, `shadow.md`) keep passing — derivation is a superset.
- [x] Custom `roles` override still overrides derivation outright.
- [ ] Auto-close sanity: merge should close #614 without manual cleanup (validating the template fix on its own PR).