### PR TITLE
feat(blocks): surface per-platform names in ConsumerOutput

### DIFF
--- a/.changeset/feat-consumer-output-platform-names.md
+++ b/.changeset/feat-consumer-output-platform-names.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`<ConsumerOutput>` (and therefore `<TokenDetail>`, which composes it) now renders one extra row per non-CSS platform that appears in the Token Listing. Loading `@terrazzo/plugin-swift` / `-android` / `-sass` / `-js` through `config.terrazzoPlugins` and naming it in `config.listingOptions.platforms` is all it takes — rows with labels like "Swift", "Android", "Sass", "Js" appear automatically with each plugin's authoritative identifier, copy-to-clipboard included.
+
+Cashes in the per-platform half of the Token Listing migration. The data was already flowing through the addon → blocks plumbing; this change surfaces it.
+
+Exports `VirtualTokenListingShape` from `@unpunnyfuns/swatchbook-blocks` for consumers building custom per-platform blocks.

--- a/.changeset/feat-tailwind-dynamic-roles.md
+++ b/.changeset/feat-tailwind-dynamic-roles.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-integrations': minor
+---
+
+Replace `/tailwind`'s hardcoded `DEFAULT_ROLES` map with a dynamic role derivation that walks the project's default-theme token graph at render time and classifies each token into a Tailwind scale by `$type` + path. Color tokens → `color`, `space.*` / `spacing.*` dimensions → `spacing`, `radius.*` / `borderRadius.*` / `border-radius.*` dimensions → `radius`, shadows → `shadow`, font families → `font`. Font-size-ish dimensions (`font.size.*`, `text.*`) are intentionally skipped because Tailwind's `--text-*` entries want size + line-height pairs that this preview integration doesn't synthesize.
+
+Result: zero-config now works for every DTCG project shape, not just the one that matches the reference fixture. A project using `color.background.*` / `spacing.small` / `borderRadius.round` gets usable Tailwind utilities out of the box; previously it got a `@theme` block of `var(--undefined-…)` references.
+
+The `roles` option still wins — pass your own map to pin a curated subset, rename scales, or emit into Tailwind scales the derivation doesn't cover.
+
+Breaking (pre-1.0, minor): projects relying on the reference-fixture shape will now additionally emit `--color-<prefix>-palette-*` utilities etc. for every palette token. This is extra utility surface, not a removal; existing class names keep working.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,4 +3,4 @@
 ## Full description
 <!-- What changes and why. -->
 
-**Closes:** <!-- Closes #N / Refs #N — every code PR links an issue. Open one first if it doesn't exist -->
+Closes #<!-- issue number — every code PR links an issue. Open one first if it doesn't exist. One `Closes #N` per line, plain text (not **Closes:** — GitHub's linker ignores markdown-formatted labels and the issue won't auto-close). Use `Refs #N` for related-but-not-closing references. -->

--- a/apps/docs/docs/guides/sharing-terrazzo-options.mdx
+++ b/apps/docs/docs/guides/sharing-terrazzo-options.mdx
@@ -168,7 +168,9 @@ If the shared module imports from other workspace packages, make sure your bundl
 
 The Token Listing records `names.<platform>` for every platform registered in `listingOptions.platforms`, using the named plugin's own identifier-naming logic. Blocks read these without duplicating any rules.
 
-Load the plugin in `terrazzoPlugins`, name it in `listingOptions.platforms`, and `listing[path].names.swift` (or `.android`, `.js`, `.sass`, …) populates automatically. Writing a per-platform column in a custom block becomes a one-liner:
+Load the plugin in `terrazzoPlugins`, name it in `listingOptions.platforms`, and `listing[path].names.swift` (or `.android`, `.js`, `.sass`, …) populates automatically. `<TokenDetail>` / `<ConsumerOutput>` pick up the extra platforms and render one row per platform in the Consumer Output section — no block-writing required for the common display case.
+
+For custom blocks, the data is on the project snapshot:
 
 ```tsx
 const swiftName = project.listing?.[path]?.names?.swift;

--- a/apps/docs/docs/integrations/tailwind.mdx
+++ b/apps/docs/docs/integrations/tailwind.mdx
@@ -81,9 +81,36 @@ Every entry in the `@theme` block is nested under your project's `cssVarPrefix`.
 
 This matters because Tailwind v4's `max-w-<name>` / `w-<name>` / `size-<name>` utilities read from the `--spacing-*` namespace. Without the prefix, a swatchbook entry named `--spacing-sm` would shadow Tailwind's default `--container-sm`, making `max-w-sm` tiny. The double-prefix (`--spacing-sb-sm`) sidesteps that collision entirely.
 
-## Customising the role map
+## How the role map is built
 
-The integration ships a curated default role map covering the semantic DTCG roles — surface / text / accent / border / status colours, a 9-stop spacing scale, radii, shadows. If your project has different paths, pass your own map:
+With zero configuration, the integration walks your project's default-theme token graph at render time and classifies every token into a Tailwind scale based on its `$type` + path:
+
+| DTCG `$type` | Path shape | Tailwind scale | Role name |
+| --- | --- | --- | --- |
+| `color` | any | `color` | path minus `color.` prefix |
+| `dimension` | `space.*` / `spacing.*` | `spacing` | path minus that prefix |
+| `dimension` | `radius.*` / `borderRadius.*` / `border-radius.*` | `radius` | path minus that prefix |
+| `dimension` | anything else | `spacing` | full path dot→dash |
+| `shadow` | any | `shadow` | path minus `shadow.` prefix |
+| `fontFamily` | any | `font` | path minus `font.` / `font.family.` / `fontFamily.` prefix |
+
+Font-size-ish dimensions (`font.size.*`, `text.*`) are intentionally skipped — Tailwind's `--text-*` entries want size+line-height pairs and this preview integration doesn't synthesize those.
+
+The result:
+
+- Every color token the project has becomes a `bg-<prefix>-*` / `text-<prefix>-*` / etc. utility.
+- Every spacing dimension becomes a `p-<prefix>-*` / `m-<prefix>-*` / etc. utility.
+- Same for radius, shadow, and font-family.
+
+So a project whose paths are `color.surface.default`, `space.md`, `radius.pill` gets the same `--color-sb-surface-default`, `--spacing-sb-md`, `--radius-sb-pill` output as before. A project using `color.background.subtle`, `spacing.small`, `borderRadius.round` gets `--color-sb-background-subtle`, `--spacing-sb-small`, `--radius-sb-round`. No hand-maintained map either way.
+
+### Overriding the derivation
+
+Pass a `roles` map to replace the derivation outright. Useful when:
+
+- You want to restrict the emitted utilities to a curated subset (faster compile, tidier Intellisense in Storybook).
+- Your paths don't fit the classification rules above and you want to name them explicitly.
+- You want to emit into a Tailwind scale the derivation doesn't cover (e.g. `--animate-*`).
 
 ```ts
 tailwindIntegration({
@@ -101,7 +128,7 @@ tailwindIntegration({
 });
 ```
 
-The map replaces the default entirely — what you list is what you get. Tailwind scale names (`color`, `spacing`, `radius`, `shadow`) are keys; each entry is `[tailwindEntryName, dtcgPath]`.
+The map replaces the derivation entirely — what you list is what you get. Tailwind scale names are keys; each entry is `[tailwindEntryName, dtcgPath]`.
 
 ## HMR
 

--- a/apps/docs/docs/reference/blocks/inspector.mdx
+++ b/apps/docs/docs/reference/blocks/inspector.mdx
@@ -80,4 +80,6 @@ Copy-ready `color: var(--…);` reference snippet.
 <ConsumerOutput path="color.accent.bg" />
 ```
 
-Two-row summary of the token's **Path** and **CSS var** with copy-to-clipboard on each. Shows the active axis tuple above the rows when more than one axis is in play.
+Summary rows for the token's **Path** and **CSS var** with copy-to-clipboard on each. Shows the active axis tuple above the rows when more than one axis is in play.
+
+When the project's Terrazzo build loads additional plugins (`@terrazzo/plugin-swift`, `-android`, `-sass`, `-js`, …) alongside the default `plugin-css` — wired via `config.terrazzoPlugins` and named in `config.listingOptions.platforms` — one extra row appears per platform, carrying that plugin's authoritative identifier for the token (`Color.accentBg`, `@color/accent_bg`, `$accent-bg`, …). See [Aligning with your token build](../../guides/sharing-terrazzo-options) for the setup pattern.

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -32,6 +32,8 @@
     "@storybook/addon-vitest": "^10.3.5",
     "@storybook/react-vite": "^10.3.5",
     "@tailwindcss/vite": "^4.2.4",
+    "@terrazzo/plugin-js": "2.0.3",
+    "@terrazzo/plugin-sass": "2.0.3",
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -1,3 +1,5 @@
+import jsPlugin from '@terrazzo/plugin-js';
+import sassPlugin from '@terrazzo/plugin-sass';
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 
@@ -33,6 +35,19 @@ export default defineSwatchbookConfig({
     accentFg: 'color.accent.fg',
     bodyFontFamily: 'typography.body.font-family',
     bodyFontSize: 'typography.body.font-size',
+  },
+  // Load Sass + JS plugins so the Token Listing's `names.<platform>`
+  // columns populate beyond CSS. Purely for preview — these plugins
+  // don't emit files through swatchbook; they contribute their
+  // identifier-naming logic so `<TokenDetail>`'s Consumer Output rows
+  // show `Sass` / `Js` identifiers alongside the CSS var.
+  terrazzoPlugins: [sassPlugin({ filename: 'tokens.scss' }), jsPlugin({ filename: 'tokens.js' })],
+  listingOptions: {
+    platforms: {
+      css: { name: '@terrazzo/plugin-css', description: 'CSS custom properties' },
+      sass: { name: '@terrazzo/plugin-sass', description: 'Sass variables' },
+      js: { name: '@terrazzo/plugin-js', description: 'JS accessors' },
+    },
   },
   presets: [
     {

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -31,6 +31,7 @@ export {
   type VirtualDiagnosticShape,
   type VirtualPresetShape,
   type VirtualThemeShape,
+  type VirtualTokenListingShape,
   type VirtualTokenShape,
 } from '#/contexts.ts';
 export {

--- a/packages/blocks/src/token-detail/ConsumerOutput.tsx
+++ b/packages/blocks/src/token-detail/ConsumerOutput.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from 'react';
 import { useState } from 'react';
+import { useProject } from '#/internal/use-project.ts';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
 
 export interface ConsumerOutputProps {
@@ -9,12 +10,23 @@ export interface ConsumerOutputProps {
 
 export function ConsumerOutput({ path }: ConsumerOutputProps): ReactElement | null {
   const { token, cssVar, activeAxes } = useTokenDetailData(path);
+  const { listing } = useProject();
 
   if (!token) return null;
 
   const tupleLabel = Object.entries(activeAxes)
     .map(([k, v]) => `${k}=${v}`)
     .join(', ');
+
+  // Platforms beyond `css`. Populated only when the consumer has loaded
+  // extra plugins (`@terrazzo/plugin-swift`, `-android`, `-sass`, …) via
+  // `config.terrazzoPlugins` + `config.listingOptions.platforms`. Always
+  // empty otherwise — the row set falls back to Path + CSS exactly like
+  // before listing adoption.
+  const names = listing[path]?.names ?? {};
+  const extraPlatforms = Object.keys(names)
+    .filter((platform) => platform !== 'css' && names[platform])
+    .toSorted();
 
   return (
     <>
@@ -26,8 +38,21 @@ export function ConsumerOutput({ path }: ConsumerOutputProps): ReactElement | nu
       )}
       <OutputRow label="Path" value={path} testId="consumer-output-path" />
       <OutputRow label="CSS" value={cssVar} testId="consumer-output-css" />
+      {extraPlatforms.map((platform) => (
+        <OutputRow
+          key={platform}
+          label={formatPlatformLabel(platform)}
+          value={names[platform]!}
+          testId={`consumer-output-${platform}`}
+        />
+      ))}
     </>
   );
+}
+
+function formatPlatformLabel(platform: string): string {
+  if (platform.length === 0) return platform;
+  return platform[0]!.toUpperCase() + platform.slice(1);
 }
 
 interface OutputRowProps {

--- a/packages/blocks/test/consumer-output.test.tsx
+++ b/packages/blocks/test/consumer-output.test.tsx
@@ -1,0 +1,113 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  ConsumerOutput,
+  type ProjectSnapshot,
+  SwatchbookProvider,
+  type VirtualTokenListingShape,
+} from '#/index.ts';
+
+function makeSnapshot(
+  listing?: Readonly<Record<string, VirtualTokenListingShape>>,
+): ProjectSnapshot {
+  return {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    disabledAxes: [],
+    presets: [],
+    themes: [{ name: 'Light', input: { theme: 'Light' }, sources: [] }],
+    themesResolved: {
+      Light: {
+        'color.accent.bg': { $type: 'color', $value: { hex: '#3b82f6' } },
+      },
+    },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+    ...(listing !== undefined && { listing }),
+  };
+}
+
+describe('ConsumerOutput', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders Path + CSS rows when no listing is present', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <ConsumerOutput path="color.accent.bg" />
+      </SwatchbookProvider>,
+    );
+
+    expect(screen.getByTestId('consumer-output-path').textContent).toBe('color.accent.bg');
+    expect(screen.getByTestId('consumer-output-css').textContent).toBe('var(--sb-color-accent-bg)');
+    expect(screen.queryByTestId('consumer-output-swift')).toBeNull();
+  });
+
+  it('adds one row per non-css platform from the listing', () => {
+    const listing = {
+      'color.accent.bg': {
+        names: {
+          css: '--sb-color-accent-bg',
+          swift: 'Color.accentBg',
+          android: '@color/accent_bg',
+          sass: '$accent-bg',
+        },
+      },
+    } satisfies Record<string, VirtualTokenListingShape>;
+
+    render(
+      <SwatchbookProvider value={makeSnapshot(listing)}>
+        <ConsumerOutput path="color.accent.bg" />
+      </SwatchbookProvider>,
+    );
+
+    expect(screen.getByTestId('consumer-output-swift').textContent).toBe('Color.accentBg');
+    expect(screen.getByTestId('consumer-output-android').textContent).toBe('@color/accent_bg');
+    expect(screen.getByTestId('consumer-output-sass').textContent).toBe('$accent-bg');
+  });
+
+  it('sorts platform rows alphabetically for a stable order across renders', () => {
+    const listing = {
+      'color.accent.bg': {
+        names: {
+          css: '--sb-color-accent-bg',
+          swift: 'Color.accentBg',
+          android: '@color/accent_bg',
+          sass: '$accent-bg',
+          js: 'colorAccentBg',
+        },
+      },
+    } satisfies Record<string, VirtualTokenListingShape>;
+
+    render(
+      <SwatchbookProvider value={makeSnapshot(listing)}>
+        <ConsumerOutput path="color.accent.bg" />
+      </SwatchbookProvider>,
+    );
+
+    const labels = screen.getAllByText(/^(Android|Js|Sass|Swift)$/).map((el) => el.textContent);
+    expect(labels).toEqual(['Android', 'Js', 'Sass', 'Swift']);
+  });
+
+  it('skips platforms whose listing value is empty', () => {
+    const listing = {
+      'color.accent.bg': {
+        names: {
+          css: '--sb-color-accent-bg',
+          swift: '',
+        },
+      },
+    } satisfies Record<string, VirtualTokenListingShape>;
+
+    render(
+      <SwatchbookProvider value={makeSnapshot(listing)}>
+        <ConsumerOutput path="color.accent.bg" />
+      </SwatchbookProvider>,
+    );
+
+    expect(screen.queryByTestId('consumer-output-swift')).toBeNull();
+  });
+});

--- a/packages/integrations/src/tailwind.ts
+++ b/packages/integrations/src/tailwind.ts
@@ -8,14 +8,23 @@ export interface TailwindIntegrationOptions {
    */
   virtualId?: string;
   /**
-   * Override or extend the default role map. Keys are Tailwind scale
-   * names (`color`, `spacing`, `radius`, `shadow`); values are ordered
-   * `[tailwindEntryName, dtcgPath]` pairs. Supplied map **replaces**
-   * the default — pass your own to customise which roles land in
-   * `@theme`. Omit to use the curated default.
+   * Override the auto-derived role map. Keys are Tailwind scale names
+   * (`color`, `spacing`, `radius`, `shadow`, `font`); values are ordered
+   * `[tailwindEntryName, dtcgPath]` pairs. Supplied map **replaces** the
+   * derived one — pass your own to pin exact entries, restrict the
+   * universe of emitted utilities, or name scales the derivation doesn't
+   * cover.
+   *
+   * Omit to let the integration derive a role map from the project at
+   * render time: every `color` token lands under the `color` scale,
+   * every `dimension` token under `spacing` / `radius` based on its
+   * path prefix, every `shadow` under `shadow`, every `fontFamily` under
+   * `font`. Works for any DTCG project without a configuration step.
    */
   roles?: Readonly<Record<string, readonly (readonly [string, string])[]>>;
 }
+
+type RoleMap = Readonly<Record<string, readonly (readonly [string, string])[]>>;
 
 /**
  * Preview-only Tailwind v4 integration for the swatchbook Storybook
@@ -56,13 +65,13 @@ export default function tailwindIntegration(
   options: TailwindIntegrationOptions = {},
 ): SwatchbookIntegration {
   const virtualId = options.virtualId ?? 'virtual:swatchbook/tailwind.css';
-  const roles = options.roles ?? DEFAULT_ROLES;
+  const userRoles = options.roles;
 
   return {
     name: 'tailwind',
     virtualModule: {
       virtualId,
-      render: (project) => renderTailwindTheme(project, roles),
+      render: (project) => renderTailwindTheme(project, userRoles ?? deriveRoles(project)),
       // Tailwind's `@theme` block is a global stylesheet — exactly the
       // kind of payload the addon should auto-inject into the preview,
       // so consumers don't hand-write a second `import` line after
@@ -72,16 +81,14 @@ export default function tailwindIntegration(
   };
 }
 
-function renderTailwindTheme(
-  project: Project,
-  roles: Readonly<Record<string, readonly (readonly [string, string])[]>>,
-): string {
+function renderTailwindTheme(project: Project, roles: RoleMap): string {
   const prefix = project.config.cssVarPrefix ?? '';
   const sourcePrefix = prefix ? `${prefix}-` : '';
   const scopePrefix = prefix ? `${prefix}-` : '';
 
   const entries: string[] = [];
   for (const [scale, names] of Object.entries(roles)) {
+    if (names.length === 0) continue;
     entries.push(`  /* ${scale} */`);
     for (const [themeKey, sourcePath] of names) {
       const sourceVar = `--${sourcePrefix}${sourcePath.replaceAll('.', '-')}`;
@@ -105,58 +112,91 @@ function renderTailwindTheme(
 }
 
 /**
- * Example role map derived from the reference fixture's semantic paths.
- * Consumers with divergent paths pass their own map through
- * `tailwindIntegration({ roles })`. The default is not a general-purpose
- * schema — it's the concrete shape that makes the addon's own Storybook
- * run usefully, and a convenient starting point to copy and edit.
+ * Walk the project's default-theme token graph and classify each entry
+ * into a Tailwind scale based on its `$type` + path. Returns a role map
+ * shaped the same as a user-supplied `roles` option.
+ *
+ * Scale assignment:
+ * - `$type: 'color'`     → `color`, role = path minus `color.` prefix
+ * - `$type: 'dimension'` → `spacing` (default), `radius` (if path starts with
+ *   `radius.`, `borderRadius.`, or `border-radius.`), or nothing (skipped)
+ *   for dimensions that look like font sizes (`font.size.*`, `text.*`), since
+ *   Tailwind's `--text-*` scale needs size + line-height pairs this preview
+ *   integration doesn't synthesize
+ * - `$type: 'shadow'`      → `shadow`, role = path minus `shadow.` prefix
+ * - `$type: 'fontFamily'`  → `font`, role = path minus `font.` / `font.family.` / `fontFamily.` prefix
+ *
+ * Other `$type`s are skipped — they don't have a natural single-value
+ * Tailwind utility and would produce broken output.
  */
-const DEFAULT_ROLES: Readonly<Record<string, readonly (readonly [string, string])[]>> = {
-  color: [
-    ['surface-default', 'color.surface.default'],
-    ['surface-muted', 'color.surface.muted'],
-    ['surface-raised', 'color.surface.raised'],
-    ['surface-subtle', 'color.surface.subtle'],
-    ['surface-inverse', 'color.surface.inverse'],
-    ['text-default', 'color.text.default'],
-    ['text-muted', 'color.text.muted'],
-    ['text-subtle', 'color.text.subtle'],
-    ['text-inverse', 'color.text.inverse'],
-    ['text-accent', 'color.text.accent'],
-    ['accent-bg', 'color.accent.bg'],
-    ['accent-bg-hover', 'color.accent.bg-hover'],
-    ['accent-fg', 'color.accent.fg'],
-    ['border-default', 'color.border.default'],
-    ['border-strong', 'color.border.strong'],
-    ['border-focus', 'color.border.focus'],
-    ['status-danger-bg', 'color.status.danger-bg'],
-    ['status-danger-fg', 'color.status.danger-fg'],
-    ['status-success-bg', 'color.status.success-bg'],
-    ['status-success-fg', 'color.status.success-fg'],
-    ['status-warning-bg', 'color.status.warning-bg'],
-    ['status-warning-fg', 'color.status.warning-fg'],
-  ],
-  spacing: [
-    ['none', 'space.none'],
-    ['2xs', 'space.2xs'],
-    ['xs', 'space.xs'],
-    ['sm', 'space.sm'],
-    ['md', 'space.md'],
-    ['lg', 'space.lg'],
-    ['xl', 'space.xl'],
-    ['2xl', 'space.2xl'],
-    ['3xl', 'space.3xl'],
-  ],
-  radius: [
-    ['sm', 'radius.sm'],
-    ['md', 'radius.md'],
-    ['lg', 'radius.lg'],
-    ['xl', 'radius.xl'],
-    ['pill', 'radius.pill'],
-  ],
-  shadow: [
-    ['sm', 'shadow.sm'],
-    ['md', 'shadow.md'],
-    ['lg', 'shadow.lg'],
-  ],
-};
+function deriveRoles(project: Project): RoleMap {
+  const scales: Record<string, [string, string][]> = {
+    color: [],
+    spacing: [],
+    radius: [],
+    shadow: [],
+    font: [],
+  };
+
+  for (const [path, token] of Object.entries(project.graph)) {
+    const classification = classify(path, token.$type);
+    if (!classification) continue;
+    const { scale, role } = classification;
+    if (!role) continue;
+    scales[scale]?.push([role, path]);
+  }
+
+  const out: Record<string, readonly (readonly [string, string])[]> = {};
+  for (const [scale, entries] of Object.entries(scales)) {
+    if (entries.length === 0) continue;
+    entries.sort(([a], [b]) => a.localeCompare(b, 'en'));
+    out[scale] = entries;
+  }
+  return out;
+}
+
+const SPACING_ROOTS = ['space', 'spacing'] as const;
+const RADIUS_ROOTS = ['radius', 'borderRadius', 'border-radius'] as const;
+const FONT_PREFIXES = ['font.family.', 'fontFamily.', 'font.'] as const;
+
+function classify(path: string, type: string | undefined): { scale: string; role: string } | null {
+  switch (type) {
+    case 'color':
+      return { scale: 'color', role: stripPrefix(path, 'color.') };
+    case 'shadow':
+      return { scale: 'shadow', role: stripPrefix(path, 'shadow.') };
+    case 'fontFamily': {
+      for (const prefix of FONT_PREFIXES) {
+        if (path.startsWith(prefix)) {
+          return { scale: 'font', role: pathToRole(path.slice(prefix.length)) };
+        }
+      }
+      return { scale: 'font', role: pathToRole(path) };
+    }
+    case 'dimension': {
+      const head = path.split('.', 1)[0] ?? '';
+      if ((RADIUS_ROOTS as readonly string[]).includes(head)) {
+        return { scale: 'radius', role: pathToRole(path.slice(head.length + 1)) };
+      }
+      if ((SPACING_ROOTS as readonly string[]).includes(head)) {
+        return { scale: 'spacing', role: pathToRole(path.slice(head.length + 1)) };
+      }
+      // Font-size-ish dimensions are skipped — Tailwind's `--text-*` entries
+      // expect a size+line-height pair that this integration doesn't build.
+      if (head === 'font' && /size|text/i.test(path)) return null;
+      if (head === 'text') return null;
+      // Default-bucket any other dimension under spacing — safer than guessing.
+      return { scale: 'spacing', role: pathToRole(path) };
+    }
+    default:
+      return null;
+  }
+}
+
+function stripPrefix(path: string, prefix: string): string {
+  return pathToRole(path.startsWith(prefix) ? path.slice(prefix.length) : path);
+}
+
+function pathToRole(remainder: string): string {
+  return remainder.replaceAll('.', '-');
+}

--- a/packages/integrations/test/tailwind.test.ts
+++ b/packages/integrations/test/tailwind.test.ts
@@ -47,11 +47,35 @@ it('drops the dash when cssVarPrefix is empty', async () => {
   expect(css).not.toContain('--sb-');
 });
 
-it('accepts a custom role map replacing the default', () => {
+it('accepts a custom role map replacing the derived default', () => {
   const css = render(project, {
     roles: { color: [['only-accent', 'color.accent.bg']] },
   });
   expect(css).toContain('--color-sb-only-accent: var(--sb-color-accent-bg);');
   expect(css).not.toContain('--color-sb-surface-default:');
   expect(css).not.toContain('--spacing-sb-md:');
+});
+
+it('derives color entries from every `$type: color` token in the project', () => {
+  const css = render(project);
+  // Semantic colors (authored under color.surface.*)
+  expect(css).toContain('--color-sb-surface-default: var(--sb-color-surface-default);');
+  // Palette tokens land in the derivation too — consumers get the raw scale by default.
+  expect(css).toMatch(/--color-sb-palette-neutral-\d+: var\(--sb-color-palette-neutral-\d+\);/);
+});
+
+it('routes `$type: dimension` tokens under spacing or radius by path root', () => {
+  const css = render(project);
+  // `space.md` → spacing scale
+  expect(css).toContain('--spacing-sb-md: var(--sb-space-md);');
+  // `radius.pill` → radius scale (not spacing)
+  expect(css).toContain('--radius-sb-pill: var(--sb-radius-pill);');
+  expect(css).not.toContain('--spacing-sb-pill: var(--sb-radius-pill);');
+});
+
+it('derived scales are sorted deterministically', () => {
+  const css = render(project);
+  const spacingMatches = [...css.matchAll(/--spacing-sb-([\w-]+): /g)].map((m) => m[1]!);
+  const sorted = spacingMatches.toSorted((a, b) => a.localeCompare(b, 'en'));
+  expect(spacingMatches).toEqual(sorted);
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,12 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+      '@terrazzo/plugin-js':
+        specifier: 2.0.3
+        version: 2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9))
+      '@terrazzo/plugin-sass':
+        specifier: 2.0.3
+        version: 2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9))(@terrazzo/plugin-css@2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9)))
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -3967,6 +3973,19 @@ packages:
     peerDependencies:
       '@terrazzo/cli': ^2.0.3
       '@terrazzo/parser': ^2.0.3
+
+  '@terrazzo/plugin-js@2.0.3':
+    resolution: {integrity: sha512-uDVt6K7p9wZwenpWtSLYP06h2SoeyMraQWcITCKiiplIq4HpkEGg1IRMcdb7iYtg5MfnqU9lU12pnuGFXCLHYQ==}
+    peerDependencies:
+      '@terrazzo/cli': ^2.0.3
+      '@terrazzo/parser': ^2.0.3
+
+  '@terrazzo/plugin-sass@2.0.3':
+    resolution: {integrity: sha512-ITgGR1k8RwEuKdbm8+ZGgtEzvcOoWXLHCrr39rgGSIqL8ecDuNSUk4Y0ZDD71MuOVUMU0wBV67FcLH2xOjdOeQ==}
+    peerDependencies:
+      '@terrazzo/cli': ^2.0.3
+      '@terrazzo/parser': ^2.0.3
+      '@terrazzo/plugin-css': ^2.0.3
 
   '@terrazzo/plugin-token-listing@0.1.0-alpha.1':
     resolution: {integrity: sha512-hAL2mAGYBwMaHj+GeXbJinLqo1xYLazLBu8Dji8Us8OKWXHPhuJY71RZpT0oul70jOBXGRFii+pM7Tqe6T7Fuw==}
@@ -13336,6 +13355,19 @@ snapshots:
     dependencies:
       '@terrazzo/cli': 2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
       '@terrazzo/parser': 2.0.3(yaml-to-momoa@0.0.9)
+      '@terrazzo/token-tools': 2.0.3
+
+  '@terrazzo/plugin-js@2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9))':
+    dependencies:
+      '@terrazzo/cli': 2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+      '@terrazzo/parser': 2.0.3(yaml-to-momoa@0.0.9)
+      scule: 1.3.0
+
+  '@terrazzo/plugin-sass@2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9))(@terrazzo/plugin-css@2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9)))':
+    dependencies:
+      '@terrazzo/cli': 2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+      '@terrazzo/parser': 2.0.3(yaml-to-momoa@0.0.9)
+      '@terrazzo/plugin-css': 2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9))
       '@terrazzo/token-tools': 2.0.3
 
   '@terrazzo/plugin-token-listing@0.1.0-alpha.1(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.14)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))':


### PR DESCRIPTION
## Summary

- Extend \`<ConsumerOutput>\` (and therefore \`<TokenDetail>\`, which composes it) to render one row per non-CSS platform present in \`listing[path].names\`. Each row shows the platform's authoritative identifier — \`Color.accentBg\`, \`@color/accent_bg\`, \`\$accent-bg\`, \`colorAccentBg\` — with copy-to-clipboard.
- Zero config to opt in: if \`terrazzoPlugins\` loads the platform plugin and \`listingOptions.platforms\` names it, the rows appear. No block-writing required for the common display case.
- Export \`VirtualTokenListingShape\` from \`@unpunnyfuns/swatchbook-blocks\` for consumers building custom platform-aware blocks.
- Wire \`@terrazzo/plugin-sass\` + \`@terrazzo/plugin-js\` into \`apps/storybook\`'s \`swatchbook.config.ts\` so the feature is visible in the reference Storybook, not just in principle.
- Update the \`ConsumerOutput\` entry in \`reference/blocks/inspector.mdx\` and rewrite the per-platform section of \`guides/sharing-terrazzo-options\` — was framed as "future block columns could"; now describes the real behavior.

Cashes in the per-platform half of the Token Listing migration (\`listing[path].names.<platform>\` has been plumbed through addon → blocks since #604; this is the first block to surface it).

Milestone: Maintenance
Closes #619
Plan impact: none.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 green.
- [x] New unit tests: no-listing → Path + CSS only; with listing → one row per non-css platform; alphabetical order; empty-string values skipped.
- [ ] Manual: run \`pnpm dev\`, open a TokenDetail drawer, confirm Sass + Js rows appear with their respective identifiers, copy buttons work.