### PR TITLE
chore(core): declare @terrazzo/parser + plugin-css as peer deps

### DIFF
--- a/.changeset/chore-terrazzo-peer-deps.md
+++ b/.changeset/chore-terrazzo-peer-deps.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Declare `@terrazzo/parser` and `@terrazzo/plugin-css` as peer dependencies on swatchbook-core (still listed under `dependencies` too). Terrazzo's ecosystem plugins — `@terrazzo/plugin-swift`, `-android`, `-sass`, `-js`, etc. — all peer-depend on `@terrazzo/parser`. Without the peer declaration on our side, a user installing `plugin-swift@3.x` next to our `parser@2.x` would hit silent API-shape mismatches (parser 3 and plugin 3 talk one protocol; parser 2 talks another). Now pnpm can hoist to a single shared parser instance and surface version mismatches at install time instead of at render time.
+
+No runtime behavior change; installs that already satisfy the range see no difference.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,6 +64,10 @@
     "@terrazzo/plugin-token-listing": "0.1.0-alpha.1",
     "@terrazzo/token-tools": "^2.0.3"
   },
+  "peerDependencies": {
+    "@terrazzo/parser": "^2.0.3",
+    "@terrazzo/plugin-css": "^2.0.3"
+  },
   "devDependencies": {
     "@terrazzo/plugin-css-in-js": "^2.0.3",
     "@types/node": "^25.6.0",


### PR DESCRIPTION
## Summary

- Declare \`@terrazzo/parser\` and \`@terrazzo/plugin-css\` as peer dependencies on \`@unpunnyfuns/swatchbook-core\` (both remain under \`dependencies\` too for self-contained installs).
- Communicates the version contract for user-provided plugins injected via \`config.terrazzoPlugins\`: a \`@terrazzo/plugin-swift@3.x\` installed next to our \`parser@2.x\` now surfaces as a peer-dep warning at install time, and pnpm hoists to a single shared parser instance across our core and the user's plugins.
- No runtime behavior change for installs that already match the range.

Milestone: Maintenance
Closes #621
Plan impact: none (hygiene).

## Test plan

- [x] \`pnpm install\` — clean, lockfile unchanged.
- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 green.
- [ ] After merge: verify a downstream install with a deliberately-mismatched plugin surfaces the peer-dep warning as expected.