### PR TITLE
docs(intro): lead with the Terrazzo foundation

### DIFF
--- a/.changeset/docs-intro-terrazzo-lead.md
+++ b/.changeset/docs-intro-terrazzo-lead.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Lead the introduction with swatchbook's Terrazzo foundation: the first paragraph now states that swatchbook is built on Terrazzo's parser and that a production pipeline running Terrazzo's CLI against the same DTCG source shares the swatchbook-reads-it-too story. Readers previously had to scroll to "What it isn't" to learn swatchbook and Terrazzo are the same pipeline's preview and production halves. Trim the redundant re-explanation from "What it isn't" since the lead now carries it.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -7,7 +7,9 @@ sidebar_position: 1
 
 # swatchbook
 
-A Storybook addon and MDX doc blocks for visualising [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/). Two things in one package:
+A Storybook addon and MDX doc blocks for visualising [DTCG design tokens](https://design-tokens.org/tr/2025/drafts/), built on [Terrazzo](https://terrazzo.app/)'s parser. Your production build runs Terrazzo's CLI against the same DTCG source; swatchbook reads it too, inside Storybook, and keeps the two [aligned](./guides/sharing-terrazzo-options).
+
+Two things in one package:
 
 - **Doc blocks.** React components for MDX: `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, and per-type previews for motion, shadow, border, gradient, stroke style.
 - **A toolbar theme switcher.** One dropdown per modifier axis in your DTCG resolver. Flip mode, brand, contrast, density — whatever your system has — and tokens repaint live.
@@ -24,7 +26,7 @@ Design-system authors with DTCG tokens, especially systems with more than one in
 
 ## What it isn't
 
-Not a runtime theme-switcher for production apps, not a CSS-variable framework, not a token build tool. Swatchbook emits CSS variables and `data-<prefix>-*` attributes inside the Storybook preview so tokens repaint when an author flips an axis. For production theme switching, use your framework's theming tools. For production CSS / Swift / Android / etc. emission, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources — swatchbook is built on Terrazzo's parser and [aligns with its options](./guides/sharing-terrazzo-options) when both pipelines run.
+Not a runtime theme-switcher for production apps, not a CSS-variable framework, not a token build tool. Swatchbook emits CSS variables and `data-<prefix>-*` attributes inside the Storybook preview so tokens repaint when an author flips an axis. For production theme switching, use your framework's theming tools. For production CSS / Swift / Android / etc. emission, run Terrazzo's CLI against the same DTCG sources — swatchbook is the preview side of that pipeline, not a replacement for it.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

Move the Terrazzo fact to the intro's first paragraph. Readers used to have to scroll to \"What it isn't\" before learning swatchbook is built on Terrazzo's parser and that their production Terrazzo CLI run is the same pipeline's production half. The new lead sets the relationship upfront: swatchbook is the preview side, Terrazzo CLI is the production side, both read the same DTCG source.

Trim the now-redundant re-explanation from the \"What it isn't\" section.

Milestone: Maintenance
Closes #634
Plan impact: none.

## Test plan

- [x] \`pnpm --filter=@unpunnyfuns/swatchbook-docs build\` — clean, no broken links.