### PR TITLE
docs(quickstart): mention Tailwind + CSS-in-JS integrations inline

### DIFF
--- a/.changeset/docs-quickstart-integrations.md
+++ b/.changeset/docs-quickstart-integrations.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Add a short "If your stories use Tailwind or a CSS-in-JS library" section to the Quickstart. Stories already using CSS variables pick up toolbar flips via cascade with no extra work; the two common library cases get a one-bullet each pointing at the respective integration guide. Surfaces the integration story earlier so first-time users discover it alongside the addon install, not only after digging through Guides.

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -67,6 +67,15 @@ export default definePreview({
 
 Inline `config` is the primary path. If you'd rather keep the config in its own file (useful when the same config is consumed by a CLI or CI lint outside Storybook), write a `swatchbook.config.ts` and point at it with `options.configPath: '../swatchbook.config.ts'` — see [config reference](./reference/config) for details.
 
+### If your stories use Tailwind or a CSS-in-JS library
+
+Stories that already use CSS variables need no extra wiring — the swatchbook toolbar flips `--<prefix>-*` vars via cascade and the stories repaint automatically. Two library-specific shortcuts for everything else:
+
+- **Tailwind v4.** Add [`@unpunnyfuns/swatchbook-integrations/tailwind`](./guides/integrations/tailwind) to the addon's `integrations[]` and `@tailwindcss/vite` to Storybook's Vite plugins. Utility classes like `bg-<prefix>-surface-default` / `p-<prefix>-md` resolve through swatchbook's tokens automatically.
+- **emotion / styled-components / any `ThemeProvider`.** Add [`@unpunnyfuns/swatchbook-integrations/css-in-js`](./guides/integrations/css-in-js) to `integrations[]`. Stories `import { theme } from 'virtual:swatchbook/theme'` and hand it to their provider.
+
+Both integrations are preview-only — they let utility classes and theme accessors resolve correctly inside Storybook, nothing else. See the [Integrations guide](./guides/integrations) for the full picture.
+
 Start Storybook:
 
 ```bash


### PR DESCRIPTION
## Summary

Add a short \"If your stories use Tailwind or a CSS-in-JS library\" section to the Quickstart, right after Configure.

- CSS-variable stories need no extra wiring — the toolbar flips \`--<prefix>-*\` vars via cascade and stories repaint automatically.
- Tailwind v4: one bullet for the \`/tailwind\` integration + \`@tailwindcss/vite\` plug-in.
- emotion / styled-components / any \`ThemeProvider\`: one bullet for the \`/css-in-js\` integration + \`virtual:swatchbook/theme\`.

Links out to the [Integrations guide](./guides/integrations/) and per-library pages for the full picture. Keeps the quickstart short — three lines and two links — while surfacing the integration story to first-time readers who'd otherwise miss it until they poked around Guides.

Milestone: Maintenance
Closes #637
Plan impact: none.

## Test plan

- [x] \`pnpm --filter=@unpunnyfuns/swatchbook-docs build\` — clean build, no broken links.