### PR TITLE
fix: override uuid to ^14 to clear GHSA-w5hq-g745-h8pq

### DIFF
--- a/.changeset/docs-readme-rework.md
+++ b/.changeset/docs-readme-rework.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+---
+
+Rework every package README to match the docs intro's register: human-register opening sentence, line breaks for pacing, detail-dense reference material (API tables, config fields, block catalogues, CLI flag tables, MCP tool tables) pushed out to the docs site where it belongs. Each README now answers "what is this and how do I install it" in ~50 lines instead of ~120, with clear links for readers who want more. Total README line count across all packages dropped from ~700 to ~370.

--- a/README.md
+++ b/README.md
@@ -1,24 +1,13 @@
 # swatchbook
 
-A Storybook addon and MDX blocks for documenting [DTCG](https://www.designtokens.org/) design tokens.
+A Storybook addon and MDX doc blocks for visualising [DTCG design tokens](https://www.designtokens.org/TR/2025.10/).
 
-Two things in one:
+Built on [Terrazzo](https://terrazzo.app/)'s parser. Your production build runs Terrazzo's CLI against the same DTCG source; swatchbook reads it too, inside Storybook.
 
-- **Doc blocks** — `TokenNavigator`, `TokenTable`, `ColorPalette`, `TypographyScale`, `TokenDetail`, and per-type previews for motion, shadow, border, and gradient. React components for MDX.
-- **A multi-axis theme switcher** — flip dark mode, brand, contrast, density, whatever dimensions your design system has, from one toolbar button. Each dimension is a DTCG resolver modifier; each becomes a dropdown inside a single popover. (See [*why axes, not themes*](https://unpunnyfuns.github.io/swatchbook/concepts/axes-vs-themes).)
+If your stories already style with CSS variables, they pick up the toolbar's axis flips automatically. That's mostly what the tool does.
 
-**Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) · **Live Storybook:** [/storybook](https://unpunnyfuns.github.io/swatchbook/storybook/)
-
-## Packages
-
-| Package | Purpose |
-| --- | --- |
-| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Toolbar, preview decorator, `useToken()`. Re-exports the full blocks + switcher React surface so consumers can install just this one. |
-| [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. Emits CSS variables and TypeScript types. |
-| [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks. Color swatches, dimension bars, typography samples, composite previews, per-token detail. |
-| [`@unpunnyfuns/swatchbook-switcher`](./packages/switcher) | Framework-agnostic axis / preset popover UI. Used by the addon toolbar and by the docs-site navbar. |
-| [`@unpunnyfuns/swatchbook-integrations`](./packages/integrations) | Display-side integrations plugging DTCG tokens into third-party tooling inside Storybook. Subpaths for Tailwind v4 (`/tailwind`) and CSS-in-JS consumers like emotion / styled-components (`/css-in-js`). |
-| [`@unpunnyfuns/swatchbook-mcp`](./packages/mcp) | Model Context Protocol server exposing a DTCG project's tokens, axes, and diagnostics to AI agents. Runs without Storybook. |
+**Documentation** · [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/)
+**Live Storybook** · [/storybook](https://unpunnyfuns.github.io/swatchbook/storybook/)
 
 ## Install
 
@@ -26,105 +15,34 @@ Two things in one:
 npm install -D @unpunnyfuns/swatchbook-addon
 ```
 
-One package pulls the whole React surface — toolbar, preview decorator, MDX doc blocks, `ThemeSwitcher`, `useToken()`. The sibling packages (`-core`, `-blocks`, `-switcher`) come along transitively and stay independently installable for slice-only consumers (e.g. a Docusaurus site that only renders the switcher).
+One package pulls the whole React surface — toolbar, preview decorator, MDX doc blocks, `ThemeSwitcher`, `useToken()`. See the [Quickstart](https://unpunnyfuns.github.io/swatchbook/quickstart) for configuration.
 
-Register the addon in `.storybook/main.ts`:
+## Packages
 
-```ts
-import { defineMain } from '@storybook/react-vite/node';
+| Package | Purpose |
+| --- | --- |
+| [`@unpunnyfuns/swatchbook-addon`](./packages/addon) | Storybook 10 addon. Re-exports the blocks + switcher React surface. |
+| [`@unpunnyfuns/swatchbook-core`](./packages/core) | Framework-free DTCG loader. |
+| [`@unpunnyfuns/swatchbook-blocks`](./packages/blocks) | MDX doc blocks. |
+| [`@unpunnyfuns/swatchbook-switcher`](./packages/switcher) | Framework-agnostic axis / preset popover UI. |
+| [`@unpunnyfuns/swatchbook-integrations`](./packages/integrations) | Tailwind v4 and CSS-in-JS adapters for the addon. |
+| [`@unpunnyfuns/swatchbook-mcp`](./packages/mcp) | Model Context Protocol server for AI agents. |
 
-export default defineMain({
-  stories: ['../src/**/*.stories.@(ts|tsx)', '../src/**/*.mdx'],
-  framework: '@storybook/react-vite',
-  addons: [
-    {
-      name: '@unpunnyfuns/swatchbook-addon',
-      options: {
-        config: {
-          resolver: 'tokens/resolver.json',
-          cssVarPrefix: 'ds',
-        },
-      },
-    },
-  ],
-});
-```
-
-Opt the preview into the addon's annotations:
-
-```ts
-import { definePreview } from '@storybook/react-vite';
-import swatchbookAddon from '@unpunnyfuns/swatchbook-addon';
-
-export default definePreview({
-  addons: [swatchbookAddon()],
-});
-```
-
-## First doc page
-
-Create an MDX file under your stories glob. Everything below re-renders against whichever tuple the toolbar has active:
-
-```mdx
-import { Meta } from '@storybook/addon-docs/blocks';
-import {
-  ColorPalette,
-  Diagnostics,
-  TokenDetail,
-  TokenNavigator,
-  TokenTable,
-} from '@unpunnyfuns/swatchbook-addon';
-
-<Meta title="Docs/Tokens" />
-
-# Tokens
-
-<Diagnostics />
-
-## Palette
-<ColorPalette filter="color.palette.*" />
-
-## Semantic roles
-<ColorPalette filter="color.*" />
-
-## Everything
-<TokenNavigator initiallyExpanded={0} />
-
-## Inspect a single token
-<TokenDetail path="color.accent.bg" />
-```
-
-Each block takes filter / scoping props — `filter` (path glob), `type` (DTCG `$type`), `root` (subtree). Type-specific blocks (`<TypographyScale>`, `<DimensionScale>`, `<FontFamilySample>`, `<FontWeightScale>`, `<BorderPreview>`, `<ShadowPreview>`, `<GradientPalette>`, `<MotionPreview>`, `<StrokeStyleSample>`) ship alongside the cross-type ones and render with built-in samples. See the [blocks reference](https://unpunnyfuns.github.io/swatchbook/reference/blocks) for the full prop list per block.
-
-## Integrations
-
-Wire your DTCG tokens into third-party tooling inside Storybook via `@unpunnyfuns/swatchbook-integrations`:
-
-- **Tailwind v4** — `/tailwind` subpath contributes a virtual `@theme` block aliasing Tailwind utility scales to your `--<prefix>-*` vars. `bg-<prefix>-surface-default`, `p-<prefix>-md`, etc.
-- **CSS-in-JS** — `/css-in-js` subpath serves a typed JS accessor for emotion, styled-components, or any ThemeProvider consuming a JS theme object.
-
-See the [integrations docs](https://unpunnyfuns.github.io/swatchbook/integrations) for wiring recipes and the "write your own integration" story.
-
-## Documentation
-
-See the [documentation](https://unpunnyfuns.github.io/swatchbook/) for concepts, guides, chrome theming, and the full API reference.
-
-## Credits
-
-Parses DTCG tokens through [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) — its parser, resolver evaluation, and alias resolution are the foundation this project builds on.
+Most consumers only install the addon; the rest travel transitively. Each sub-package is publishable on its own for slice-only use (e.g. the switcher in a Docusaurus navbar).
 
 ## Development
 
-pnpm workspaces + Turborepo. Node 24. ESM. `tsdown` for package builds.
+pnpm workspaces + Turborepo. Node 24. ESM.
 
 ```sh
 pnpm install
 pnpm dev                           # apps/storybook on :6006
 pnpm turbo run lint typecheck test build
-pnpm turbo run test:storybook
 ```
 
-We use pnpm internally for workspace orchestration; consumers can install with any package manager.
+## Credits
+
+Parses DTCG tokens through [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) — its parser, resolver evaluation, and alias resolution are the foundation.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "pnpm": {
     "overrides": {
-      "webpackbar": "7.0.0"
+      "webpackbar": "7.0.0",
+      "uuid": "^14.0.0"
     },
     "patchedDependencies": {
       "@terrazzo/plugin-css-in-js@2.0.3": "patches/@terrazzo__plugin-css-in-js@2.0.3.patch"

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,8 +1,10 @@
 # swatchbook-addon
 
-Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design tokens. Loads your tokens at config time (via `@unpunnyfuns/swatchbook-core`), exposes the resolved graph to the preview through a virtual module, renders a toolbar popover with one dropdown per modifier axis (`mode`, `brand`, and so on) alongside preset pills and a color-format picker, and ships a `useToken()` hook with typed paths. Re-exports the full blocks + switcher React surface so `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` works without a second install.
+The Storybook 10 side of [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
+Loads your DTCG tokens at config time, exposes the resolved graph to the preview through a virtual module, and renders a toolbar popover with one dropdown per modifier axis (`mode`, `brand`, …), preset pills, and a color-format picker. Ships a typed `useToken()` hook for stories that need a resolved value at runtime.
+
+One install pulls the whole React surface — toolbar, preview decorator, every MDX doc block, `ThemeSwitcher`, `useToken()`. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` works without a second install line because the addon re-exports the full blocks + switcher API.
 
 ## Install
 
@@ -10,106 +12,48 @@ Published as `@unpunnyfuns/swatchbook-addon`. Storybook 10 addon for DTCG design
 npm install -D @unpunnyfuns/swatchbook-addon
 ```
 
-One package pulls the whole React surface — toolbar, preview decorator, `useToken()`, every MDX doc block (`TokenTable`, `ColorPalette`, `TokenDetail`, `SwatchbookProvider`, block-side hooks), and the standalone `ThemeSwitcher`. `swatchbook-core`, `-blocks`, and `-switcher` come along transitively; each is still independently installable for slice-only consumers.
-
 Peer requirements: `storybook@^10.3`, `react` / `react-dom` 18+.
 
-## Register
+## Usage
 
-`.storybook/main.ts` — CSF Next. Inline config is the recommended path; the separate `swatchbook.config.ts` file is an escape hatch for sharing config with other tooling (see below).
+The [Quickstart](https://unpunnyfuns.github.io/swatchbook/quickstart) walks through `.storybook/main.ts` + `.storybook/preview.ts` setup end to end. The short version:
 
-```ts
-import { defineMain } from '@storybook/react-vite/node';
-
-export default defineMain({
-  stories: ['../src/**/*.stories.@(ts|tsx)', '../src/**/*.mdx'],
-  framework: '@storybook/react-vite',
-  addons: [
-    {
-      name: '@unpunnyfuns/swatchbook-addon',
-      options: {
-        config: {
-          resolver: 'tokens/resolver.json',
-          default: { mode: 'Light' },
-          cssVarPrefix: 'ds',
-        },
+```ts title=".storybook/main.ts"
+addons: [
+  {
+    name: '@unpunnyfuns/swatchbook-addon',
+    options: {
+      config: {
+        resolver: 'tokens/resolver.json',
+        cssVarPrefix: 'ds',
       },
     },
-  ],
-});
+  },
+],
 ```
 
-`.storybook/preview.ts` — opt the preview into the addon's annotations (decorator, globalTypes, initialGlobals):
-
-```ts
-import { definePreview } from '@storybook/react-vite';
+```ts title=".storybook/preview.ts"
 import swatchbookAddon from '@unpunnyfuns/swatchbook-addon';
-
-export default definePreview({
-  addons: [swatchbookAddon()],
-});
+export default definePreview({ addons: [swatchbookAddon()] });
 ```
-
-## Options
-
-| Option       | Type     | What                                                              |
-| ------------ | -------- | ----------------------------------------------------------------- |
-| `config`     | `Config` | Inline swatchbook config. Recommended for most projects. Mutually exclusive with `configPath`. |
-| `configPath` | `string` | Path to a config module relative to `.storybook/`. Loaded via jiti so `.ts` / `.mts` / `.js` / `.mjs` all work. Use when the same config is consumed by other tooling (a CLI, CI lint, external build script). |
 
 ## `useToken`
 
-```ts
+```tsx
 import { useToken } from '@unpunnyfuns/swatchbook-addon';
 
 function Card() {
   const bg = useToken('color.surface.default');
-  const radius = useToken('radius.lg');
-  return (
-    <div style={{ background: bg.cssVar, borderRadius: radius.cssVar }}>
-      {bg.description}
-    </div>
-  );
+  return <div style={{ background: bg.cssVar }}>{bg.description}</div>;
 }
 ```
 
-Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across themes; `value` flips with the active theme. Paths autocomplete from the generated `.swatchbook/tokens.d.ts` once the addon has run against your project.
+Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across themes; `value` flips with the active tuple. Paths autocomplete from the generated `.swatchbook/tokens.d.ts`.
 
-## Toolbar pills (presets)
+## Credits
 
-Add `presets` to your `swatchbook.config.ts` to surface quick-select pills next to the axis dropdowns:
+Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
 
-```ts
-export default defineSwatchbookConfig({
-  tokens: ['tokens/**/*.json'],
-  resolver: 'tokens/resolver.json',
-  presets: [
-    { name: 'Default Light', axes: { mode: 'Light', brand: 'Default' } },
-    { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' }, description: 'Dark + violet accent.' },
-  ],
-});
-```
+## Documentation
 
-Clicking a pill writes the full tuple — partial presets fill in omitted axes from each axis's default. The active pill is highlighted when the current tuple matches; if you tweak an axis dropdown after applying a preset, the pill shows a small "modified" dot so you can see that the current tuple has drifted from the named preset. Presets come from config only — there is no in-session "save as".
-
-## Per-story overrides
-
-```ts
-export const DarkBrandA = meta.story({
-  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },
-});
-```
-
-`axes` is a tuple of `{ axisName: contextName }` entries. Any axis left out falls back to its default; unknown keys or contexts are silently ignored. The legacy `theme: 'Composed Name'` form is still accepted for single-axis overrides.
-
-## Do / don't
-
-- ✅ Use `useToken` for typed lookups when you need the resolved value at runtime (aria labels, conditional rendering, …).
-- ✅ Prefer `var(--…)` in CSS; `useToken().cssVar` gives you the right string programmatically.
-
-## See also
-
-- [`@unpunnyfuns/swatchbook-core`](../core) — the loader this addon wraps. Consume directly if you need DTCG processing outside Storybook.
-- [`@unpunnyfuns/swatchbook-blocks`](../blocks) — MDX doc blocks that build on this addon's virtual module.
-- [Project README](../../README.md) — install and wiring flow for the whole toolchain.
-- [Documentation](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -1,107 +1,53 @@
 # swatchbook-blocks
 
-Published as `@unpunnyfuns/swatchbook-blocks`. Storybook MDX doc blocks for DTCG design tokens. React components for rendering token documentation inside `.mdx` pages or regular stories. Self-mount the addon's CSS and react to axis changes from the toolbar; work inside the docs container even though story decorators don't.
+React MDX doc blocks for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
+Render your DTCG tokens in `.mdx` stories — swatch grids, type-specific previews, per-token inspectors. The blocks react to the toolbar's axis flips without any wiring in your story code.
+
+Most consumers pick this up transitively via [`@unpunnyfuns/swatchbook-addon`](../addon); `import { TokenTable } from '@unpunnyfuns/swatchbook-addon'` works out of the box. Install this package directly when you want blocks *without* the Storybook addon — unit tests, a standalone React app wrapping tokens in a custom surface.
 
 ## Install
-
-Most consumers pick this up transitively via `@unpunnyfuns/swatchbook-addon` — the addon re-exports the full blocks API, so `import { TokenTable } from '@unpunnyfuns/swatchbook-addon'` works and you don't need a second install line. Reach for this package directly when you want blocks *without* the Storybook addon (unit tests, a standalone React app wrapping tokens in a custom surface):
 
 ```sh
 npm install @unpunnyfuns/swatchbook-blocks
 ```
 
-Blocks read the token graph from a `SwatchbookProvider`. Inside Storybook, the addon's preview decorator mounts the provider automatically. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly (see [Outside Storybook](#outside-storybook) below).
-
-## Blocks
-
-| Block               | What                                                                                |
-| ------------------- | ----------------------------------------------------------------------------------- |
-| `TokenTable`        | Searchable table of tokens, filterable by path glob and `$type`.                    |
-| `TokenNavigator`    | Expandable tree view of the token graph keyed on dot-path segments, with inline per-type previews. |
-| `ColorPalette`      | Swatch grid grouped by sub-path. Auto-groups from the filter; `groupBy` overrides.  |
-| `TypographyScale`   | Each typography composite token rendered as a sample line using its own value.      |
-| `FontFamilySample`  | Pangram rendered per `fontFamily` primitive.                                        |
-| `FontWeightScale`   | Same sample text rendered at each `fontWeight` primitive, sorted ascending.         |
-| `StrokeStyleSample` | Border rendered per `strokeStyle` primitive.                                        |
-| `GradientPalette`   | Wide swatch per `gradient` token with stop breakdown (linear-gradient default).      |
-| `MotionSample`      | Animated ball + track for one `transition` / `duration` / `cubicBezier` token. Accepts `speed` / `runKey`. |
-| `ShadowSample`      | Surface rectangle with one `shadow` token applied as `box-shadow`.                  |
-| `BorderSample`      | Surface rectangle with one `border` token applied as `border`.                      |
-| `DimensionBar`      | Width-driven bar (or square / radius sample, via `kind`) for one `dimension` token. |
-| `TokenDetail`       | Single-token inspector — composition of the subcomponents below. |
-| `TokenHeader`       | Heading + `$type` pill + cssVar + `$description`, or a missing-token empty state. |
-| `CompositePreview`  | Type-dispatched live preview (typography, shadow, border, transition, dimension, duration, cubicBezier, fontFamily, fontWeight, strokeStyle, gradient, color). |
-| `CompositeBreakdown`| Labelled sub-value grid for composite types (typography / border / transition / shadow / gradient). |
-| `AliasChain`        | Forward alias chain (`path → alias → …`). Renders nothing for non-aliases. |
-| `AliasedBy`         | Aliased-by tree (backward). Truncates at depth 6. |
-| `AxisVariance`      | Per-axis value table — constant, one-axis, or two-axis matrix view. |
-| `TokenUsageSnippet` | Copy-ready `color: var(--…);` snippet. |
-
-Shared: every block accepts a `caption` override and renders against the addon's `var(--<prefix>-…)` output.
-
 ## Usage
 
-### Inside Storybook
-
-The addon's preview decorator wraps every story in a `SwatchbookProvider` for you, so MDX and story authors drop blocks in directly:
+Inside Storybook the addon mounts a `SwatchbookProvider` for you:
 
 ```mdx
-import { TokenTable, ColorPalette, TokenDetail } from '@unpunnyfuns/swatchbook-addon';
-
-# Color tokens
+import { ColorPalette, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-addon';
 
 <ColorPalette filter="color.*" />
-
-## Every color token
-
 <TokenTable filter="color.*" type="color" />
-
-## Inspect one
-
 <TokenDetail path="color.accent.bg" />
 ```
 
-### Outside Storybook
-
-Blocks are pure presentation — given a `ProjectSnapshot` they render without any Storybook or Vite plugin. Mount a `SwatchbookProvider` at the top of your tree:
+Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot`:
 
 ```tsx
 import { SwatchbookProvider, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 import snapshot from './tokens-snapshot.json';
 
-export function TokenDocs() {
-  return (
-    <SwatchbookProvider value={snapshot}>
-      <TokenTable filter='color.*' />
-    </SwatchbookProvider>
-  );
-}
+<SwatchbookProvider value={snapshot}>
+  <TokenTable filter='color.*' />
+</SwatchbookProvider>
 ```
 
-`SwatchbookProvider` is the canonical integration point. The `virtual:swatchbook/tokens` module is the Storybook addon's internal wiring, not a public API.
+Block catalogue, props, and composition patterns live in the [blocks reference](https://unpunnyfuns.github.io/swatchbook/reference/blocks) and the [authoring guide](https://unpunnyfuns.github.io/swatchbook/guides/authoring-doc-stories).
 
-## Props
+## Boundaries
 
-```ts
-<TokenTable filter="color.*" type="color" />
-<ColorPalette filter="color.*" />
-<TypographyScale filter="typography" sample="The quick brown fox" />
-<TokenDetail path="color.accent.bg" />
-```
+- ✅ Compose multiple blocks per page — each mounts independently.
+- ✅ Render outside Storybook with a hand-built or loaded `ProjectSnapshot`.
+- ❌ Don't import from `virtual:swatchbook/tokens` — it's the addon's internal wiring, not a public API. Use `SwatchbookProvider`.
+- ❌ Don't use `useGlobals` / `useArgs` from `storybook/preview-api` inside custom blocks — those hooks throw in docs context.
 
-## Do / don't
+## Credits
 
-- ✅ React to the active swatchbook theme — switching in the toolbar updates resolved values live, even on MDX docs pages.
-- ✅ Compose multiple blocks per MDX page — each mounts independently.
-- ✅ Render blocks outside Storybook by wrapping them in `SwatchbookProvider` with a hand-built or loaded `ProjectSnapshot`.
-- ❌ Don't import from `virtual:swatchbook/tokens` directly — it's the addon's internal wiring, not a public API. Use `SwatchbookProvider` instead.
-- ❌ Don't use `useGlobals` / `useArgs` from `storybook/preview-api` inside custom blocks you write — those are story-only hooks and throw in docs context. Subscribe to `addons.getChannel()` directly for globals reactivity.
+Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
 
-## See also
+## Documentation
 
-- [`@unpunnyfuns/swatchbook-addon`](../addon) — required peer. Registers the virtual module and the toolbar.
-- [`@unpunnyfuns/swatchbook-core`](../core) — underlying loader.
-- [Project README](../../README.md) — install and wiring flow for the whole toolchain.
-- [Documentation](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,8 +1,10 @@
 # swatchbook-core
 
-Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses token files via [Terrazzo](https://terrazzo.app/), resolves aliases, and composes themes through a DTCG 2025.10 resolver or authored layered axes.
+The framework-free loader at the heart of [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/).
+Parses DTCG token files via [Terrazzo](https://terrazzo.app/), resolves aliases, composes themes through a DTCG 2025.10 resolver or authored layered axes. No DOM, no React — just a `Project` object you can consume from any Node-side tool.
+
+Storybook consumers get this transitively via [`@unpunnyfuns/swatchbook-addon`](../addon). Install directly when you're running `loadProject` outside Storybook: build scripts, CLIs, docs-site generators, custom tooling.
 
 ## Install
 
@@ -10,137 +12,33 @@ Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses 
 npm install @unpunnyfuns/swatchbook-core
 ```
 
-Install directly when you're using `loadProject` outside Storybook — build scripts, CLIs, docs-site generators, your own tooling that needs the axis-composed token graph. Storybook consumers get core transitively via `@unpunnyfuns/swatchbook-addon` and don't need a separate install.
-
-For production asset emission (CSS variables, JS theme objects, Tailwind config, Swift constants, …), run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources. This package's job ends at the composed `Project`; downstream targets are Terrazzo's ecosystem.
-
-## Public API
-
-| Export | Purpose |
-| --- | --- |
-| `defineSwatchbookConfig(config)` | Identity helper for a typed `swatchbook.config.ts`. |
-| `loadProject(config, cwd?)` | Parse + resolve — returns `Project { axes, themes, themesResolved, graph, diagnostics, … }`. |
-| `resolveTheme(project, name)` | Pick a single composed theme out of a project. |
-| `permutationID(input)` | Stringify a tuple (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`) to the form used as `Theme.name` and CSS data-attribute values. |
-| Types | `Axis`, `AxisConfig`, `Config`, `Preset`, `Theme`, `Project`, `ResolvedTheme`, `TokenMap`, `Diagnostic`, `DiagnosticSeverity`, `SwatchbookIntegration`. |
-
-## Minimal config
+## Usage
 
 ```ts
-import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
+import { loadProject, defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 
-export default defineSwatchbookConfig({
+const config = defineSwatchbookConfig({
   resolver: 'tokens/resolver.json',
-  default: { mode: 'Light', brand: 'Default' },
   cssVarPrefix: 'sb',
 });
-```
-
-The resolver file is the spec-defined document describing how token sets compose into named themes — see [the DTCG 2025.10 resolver draft](https://www.designtokens.org/TR/2025.10/resolver/). Every token file the resolver references via `$ref` is loaded automatically; the addon's Vite plugin derives HMR watch paths from that set, so no separate `tokens` glob is needed for resolver-backed projects.
-
-If you want HMR to watch a directory broader than the resolver references directly — say, to pick up a new token file the moment it's added — supply `tokens: ['tokens/**/*.json']` alongside `resolver` and the plugin will union the two.
-
-Projects without a resolver (plain-parse or layered-axes) still need `tokens` — the loader has nothing to start from otherwise.
-
-`default` is a partial tuple keyed by axis name. Any axis you omit falls back to that axis's own `default`; unknown keys and invalid context values produce `warn` diagnostics and are sanitized out. Omit `default` entirely to start the project in the all-axis-defaults tuple.
-
-### Layered axes (resolver-less)
-
-Projects that don't want to author a DTCG resolver can declare axes inline. Each context names an ordered list of overlay files that layer on top of `tokens` for that context; for every combination of axis contexts, Swatchbook parses `[...base, ...overlaysInAxisOrder]` with alias resolution — last write wins on duplicate token paths:
-
-```ts
-import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
-
-export default defineSwatchbookConfig({
-  tokens: ['tokens/base/**/*.json'],
-  axes: [
-    {
-      name: 'mode',
-      contexts: {
-        Light: [],
-        Dark: ['tokens/modes/dark.json'],
-      },
-      default: 'Light',
-    },
-    {
-      name: 'brand',
-      contexts: {
-        Default: [],
-        'Brand A': ['tokens/brands/brand-a.json'],
-      },
-      default: 'Default',
-    },
-  ],
-});
-```
-
-- ✅ Empty context arrays are legal — they mean "no override" (common for a `Default` context).
-- ❌ Setting both `resolver` and `axes` is an error. Pick one.
-- ❌ Setting neither falls back to a single synthetic `theme` axis (unchanged behavior).
-
-## Load
-
-```ts
-import { loadProject } from '@unpunnyfuns/swatchbook-core';
 
 const project = await loadProject(config, process.cwd());
 // project.themesResolved[themeName] — ready to read, no further I/O.
 ```
 
-`project.diagnostics` is always populated — severity is `'error' | 'warn' | 'info'`. The addon surfaces these in its Design Tokens panel; your own pipeline can inspect / `throw` on `severity === 'error'` as fits.
+The [config reference](https://unpunnyfuns.github.io/swatchbook/reference/config) covers every field; the [core reference](https://unpunnyfuns.github.io/swatchbook/reference/core) covers the `Project` shape and exported helpers (`resolveTheme`, `permutationID`, typed `Axis` / `Theme` / `Diagnostic`).
 
-## Axes and theme naming
+## Boundaries
 
-`Project.axes` surfaces the theming modifiers as first-class — one `Axis` per resolver modifier (`source: 'resolver'`) or per authored layered axis (`source: 'layered'`), each with its `contexts`, `default`, and `description`. Projects loaded with neither a resolver nor `axes` fall back to a single synthetic axis named `theme` (`source: 'synthetic'`).
-
-Theme names are derived from the axis tuple via `permutationID(input)`: single-axis tuples stringify to the context value alone (`{ theme: 'Light' }` → `"Light"`); multi-axis tuples join context values with ` · ` (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`). Pick sensible context names — what you write is what the toolbar shows. Consuming code should prefer `axes` + `themes[].input` over matching names by string.
-
-## Presets
-
-`config.presets` lets you name tuple combinations authors want quick access to — the addon renders them as toolbar pills, and downstream consumers can read them from `Project.presets`.
-
-```ts
-export default defineSwatchbookConfig({
-  tokens: ['tokens/**/*.json'],
-  resolver: 'tokens/resolver.json',
-  presets: [
-    { name: 'Default Light', axes: { mode: 'Light', brand: 'Default' } },
-    { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' }, description: 'Dark + violet accent.' },
-  ],
-});
-```
-
-Each preset names a partial tuple; any axis the preset omits resolves to that axis's `default` when applied. `loadProject` validates presets: unknown axis keys and invalid context values surface as `warn` diagnostics and are sanitized out, but the preset stays in `Project.presets` (an empty preset is still a valid tuple).
-
-## Disabling axes
-
-`config.disabledAxes` suppresses declared axes from the toolbar, CSS emission, and theme enumeration — each listed axis is pinned to its `default` context and drops out of `Project.axes`. Useful when the resolver declares a work-in-progress modifier you don't want surfaced yet, without editing the resolver document.
-
-```ts
-export default defineSwatchbookConfig({
-  resolver: 'tokens/resolver.json',
-  disabledAxes: ['contrast'],
-});
-```
-
-- Disabled names land on `Project.disabledAxes` so panels and blocks can still indicate the axis exists but is pinned.
-- Unknown axis names produce `warn` diagnostics (group `swatchbook/disabled-axes`) and are ignored.
-- Config-level only — there's no runtime toggle.
-
-## Do / don't
-
-- ✅ Use this package at build time — Node, scripts, SSR, storybook presets. It has no DOM or React dependency.
-- ✅ Use Terrazzo's CLI for production artifact emission against the same DTCG sources.
-- ❌ Don't import from `@terrazzo/parser` directly unless you need features core doesn't expose. Stay on the core surface so upgrades don't churn your code.
-- ❌ Don't ship the `Project` object to the browser — it's node-parsed and carries full raw-AST references. Use `themesResolved` projections instead.
+- ✅ Build-time use — Node, scripts, SSR, Storybook presets.
+- ✅ Pair with [Terrazzo](https://terrazzo.app/)'s CLI for production artifact emission (CSS / JS / Tailwind / Swift / Sass / …).
+- ❌ Don't ship the `Project` object to the browser — it carries full raw-AST references. Use `themesResolved` projections instead.
+- ❌ Don't reach into `@terrazzo/parser` directly. Stay on the core surface so upgrades don't churn your code.
 
 ## Credits
 
-Token parsing, alias resolution, and DTCG resolver evaluation are provided by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp). This package wraps those APIs into a Swatchbook-shaped project.
+Token parsing, alias resolution, and DTCG resolver evaluation are provided by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp). This package wraps those APIs into a swatchbook-shaped project.
 
-## See also
+## Documentation
 
-- [`@unpunnyfuns/swatchbook-addon`](../addon) — the Storybook wrapper. Uses `loadProject` at startup, exposes results over a virtual module.
-- [`@unpunnyfuns/swatchbook-blocks`](../blocks) — React doc blocks consumed from MDX.
-- [Project README](../../README.md) — install + wiring flow for the whole toolchain.
-- [Documentation](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,15 +1,8 @@
 # swatchbook-integrations
 
-Published as `@unpunnyfuns/swatchbook-integrations`. Display-side integrations for the swatchbook Storybook addon. Each subpath ships a factory that plugs into the addon's `integrations[]` option as a `SwatchbookIntegration`.
+Preview-side adapters that let your Storybook stories use [Tailwind v4](./src/tailwind.ts) or a [CSS-in-JS library](./src/css-in-js.ts) against [swatchbook](https://github.com/unpunnyfuns/swatchbook)'s tokens.
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook/integrations](https://unpunnyfuns.github.io/swatchbook/integrations). The addon stays tool-agnostic — integrations own their library-specific logic.
-
-## Available subpaths
-
-| Subpath | Covers | Consumer usage |
-| --- | --- | --- |
-| `./tailwind` | Tailwind v4 | Plug in; the addon auto-applies the generated `@theme` block. Write `bg-<prefix>-surface-default` / `p-<prefix>-md` utilities anywhere. |
-| `./css-in-js` | emotion, styled-components, any ThemeProvider consuming a JS theme object | Plug in, then `import { theme, color, space } from 'virtual:swatchbook/theme'` where needed. Named exports, explicit import site. |
+Not a replacement for your production build. Integrations are preview-only — they let `bg-sb-surface-default` or `theme.color.accent.bg` resolve correctly inside Storybook; for production artifacts, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources.
 
 ## Install
 
@@ -17,16 +10,15 @@ Published as `@unpunnyfuns/swatchbook-integrations`. Display-side integrations f
 npm install -D @unpunnyfuns/swatchbook-integrations
 ```
 
-Tailwind's Vite plugin is an additional dep for the `/tailwind` subpath:
+The `/tailwind` subpath wants Tailwind's Vite plugin too:
 
 ```sh
 npm install -D tailwindcss @tailwindcss/vite
 ```
 
-## Wiring
+## Usage
 
 ```ts title=".storybook/main.ts"
-import { defineMain } from '@storybook/react-vite/node';
 import tailwindIntegration from '@unpunnyfuns/swatchbook-integrations/tailwind';
 import cssInJsIntegration from '@unpunnyfuns/swatchbook-integrations/css-in-js';
 
@@ -43,19 +35,13 @@ export default defineMain({
 });
 ```
 
-The [per-subpath docs](https://unpunnyfuns.github.io/swatchbook/integrations) cover the consumer-facing usage for each one.
+Per-integration wiring details live in the [Integrations guide](https://unpunnyfuns.github.io/swatchbook/guides/integrations/) — Tailwind's Vite plugin setup, the CSS-in-JS `virtual:swatchbook/theme` import, role-map overrides, and how to write your own integration against the `SwatchbookIntegration` contract.
 
-## Writing your own integration
+## Boundaries
 
-The mechanism is sketched in the [architecture doc](https://unpunnyfuns.github.io/swatchbook/developers/architecture). In short: implement the `SwatchbookIntegration` contract from `@unpunnyfuns/swatchbook-core`, export a factory from your package, drop the factory's result into `integrations[]`.
+- ✅ Preview-side use inside Storybook. Stories that style with utility classes or theme accessors pick up the swatchbook toolbar's axis flips via CSS cascade.
+- ❌ No MUI / Vuetify / Bootstrap SCSS factories. Those need resolved values per named theme — run Terrazzo's CLI with `@terrazzo/plugin-js` for that case.
 
-## What this package does not do
+## Documentation
 
-- **Does not write artifacts to disk.** The integrations feed the Storybook preview only. For your application's production build, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources.
-- **Does not cover MUI / Vuetify / Bootstrap SCSS factories.** Those need resolved values per named theme, not `var()` references. Run Terrazzo's CLI with `@terrazzo/plugin-js` for that case; display-side integrations are out of scope.
-
-## See also
-
-- [`@unpunnyfuns/swatchbook-core`](../core) — `SwatchbookIntegration` type, `Project` shape, the loader your integrations' `render(project)` consumes.
-- [`@unpunnyfuns/swatchbook-addon`](../addon) — Storybook addon consuming `integrations[]`.
-- [Integrations docs](https://unpunnyfuns.github.io/swatchbook/integrations) — per-subpath recipes.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,12 +1,10 @@
 # swatchbook-mcp
 
-Published as `@unpunnyfuns/swatchbook-mcp`. Model Context Protocol server for swatchbook — exposes a DTCG project's tokens, axes, and diagnostics to AI agents without running Storybook.
+A [Model Context Protocol](https://modelcontextprotocol.io/) server for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) via `@unpunnyfuns/swatchbook-core`.
+Exposes a DTCG project's tokens, axes, alias chains, and diagnostics to AI agents without running Storybook. Useful for agents doing figma-to-token round-trips, alias-chain navigation, CI lint hooks, AI-assisted token authoring.
 
-## What it's for
-
-Agents that need to reason about your design tokens — figma-to-token round-trips, alias-chain navigation, CI lint hooks, AI-assisted authoring — without spinning up a Storybook iframe. Point it at a `swatchbook.config.{ts,mts,js,mjs}` or a bare DTCG `resolver.json` and it parses the project on startup, then answers MCP tool calls against the resolved graph.
+Point it at a swatchbook config (or a bare DTCG `resolver.json`) and it parses the project on startup, then answers MCP tool calls against the resolved graph.
 
 ## Install & run
 
@@ -14,7 +12,7 @@ Agents that need to reason about your design tokens — figma-to-token round-tri
 npx @unpunnyfuns/swatchbook-mcp --config swatchbook.config.ts
 ```
 
-Or wire it into an MCP client's config. Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+Or wire it into an MCP client. Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
 
 ```json
 {
@@ -27,39 +25,11 @@ Or wire it into an MCP client's config. Claude Desktop (`~/Library/Application S
 }
 ```
 
-CLI flags:
-
-| Flag             | What                                                                                                                             |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `--config <path>` | Required. Either a `swatchbook.config.{ts,mts,js,mjs}` (full config) or a DTCG `resolver.json` (bare — other options at defaults). |
-| `--cwd <path>`    | Override the working directory for resolving relative `resolver` / `tokens` paths.                                                |
-| `--no-watch`      | Disable live-reload. By default the server watches the config + resolved source files and swaps in fresh data on edits.            |
-| `--help`          | Print usage and exit.                                                                                                            |
-
-## Tools
-
-| Tool                  | Inputs                                                   | Returns                                                                                                       |
-| --------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `describe_project`    | (none)                                                    | High-level overview — token counts, axes, themes, presets, diagnostic counts, `$type`s present.                |
-| `list_tokens`         | `filter?` path glob, `type?` DTCG `$type`, `theme?` name | Array of `{ path, type?, value }` from the named theme (or default). Use first to discover paths.             |
-| `search_tokens`       | `query`, `theme?`, `limit?`                               | Case-insensitive substring search across paths, descriptions, and values. Returns matches + `matchedIn` hint. |
-| `resolve_theme`       | `tuple`, `filter?`, `type?`                               | Resolved token map for an axis tuple (`{ mode: "Dark", brand: "…" }`). Fills omitted axes from defaults.      |
-| `get_token`           | `path`                                                    | Full detail: per-theme value, alias chain, aliased-by list, CSS var reference.                                |
-| `get_alias_chain`     | `path`                                                    | Forward alias chain per theme (`path → ... → primitive`). Empty when the token is a primitive.                |
-| `get_aliased_by`      | `path`, `maxDepth?`                                       | Backward alias tree — every token that resolves through this path. Breadth-first with cycle protection; default max depth 6. |
-| `get_consumer_output` | `path`, `tuple?`                                          | CSS var, resolved value, compound `[data-…]` selector + HTML attrs needed to pin the tuple on `<html>`.        |
-| `get_color_formats`   | `path`, `theme?`                                          | Color token rendered in `hex` / `rgb` / `hsl` / `oklch` / `raw`, each with an `outOfGamut` flag.                |
-| `get_color_contrast`  | `foreground`, `background`, `theme?`, `algorithm?`        | Pair-wise contrast between two color tokens. `wcag21` returns the 1–21 ratio + AA/AAA pass flags (normal + large text); `apca` returns the signed Lc + body / large-text / non-text pass flags. |
-| `get_axis_variance`   | `path`                                                    | Classify how the token's resolved value depends on each axis. Returns `kind` (`constant` / `single` / `multi`), varying vs constant axes, and a per-axis breakdown with the value seen in each context. |
-| `list_axes`           | (none)                                                    | Axes + contexts + themes + presets from the project config.                                                   |
-| `get_diagnostics`     | `severity?` `'error' \| 'warn' \| 'info'`                 | Parser / resolver / validation diagnostics.                                                                   |
-| `emit_css`            | (none)                                                    | Full project stylesheet — `:root` default + per-tuple compound-selector blocks. |
-
-Path globs accept `*` (one segment), `**` (any number of segments trailing or mid-path), or exact dot-paths.
+Live-reload is on by default — the server watches the config and resolved source files, swapping in fresh data on edits. Pass `--no-watch` to disable.
 
 ## Programmatic use
 
-You can also construct the server in-process — useful if you're embedding the MCP handler in a larger toolchain:
+For embedding the MCP handler in a larger toolchain:
 
 ```ts
 import { createServer, loadFromConfig } from '@unpunnyfuns/swatchbook-mcp';
@@ -70,8 +40,14 @@ const server = createServer(project);
 await server.connect(new StdioServerTransport());
 ```
 
-## See also
+## Tools
 
-- [`@unpunnyfuns/swatchbook-core`](../core) — the loader this server wraps.
-- [Project README](../../README.md) — install and wiring flow for the whole toolchain.
-- [Model Context Protocol](https://modelcontextprotocol.io/) — the upstream spec.
+Fourteen read-only tools covering token listing, search, theme resolution, alias chains, color formats + contrast, axis variance, and diagnostics. Full catalogue in the [MCP reference](https://unpunnyfuns.github.io/swatchbook/reference/mcp).
+
+## Credits
+
+Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
+
+## Documentation
+
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/switcher/README.md
+++ b/packages/switcher/README.md
@@ -1,12 +1,12 @@
 # swatchbook-switcher
 
-Published as `@unpunnyfuns/swatchbook-switcher`. Framework-agnostic theme-switcher UI for swatchbook — axis pills, preset pills, color-format selector. Consumed by the Storybook addon toolbar and by any React host that knows how to set `data-*` attributes on the document to drive per-theme CSS.
+The framework-agnostic theme-switcher UI for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-> **Documentation:** [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/). Token parsing powered by [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
+A React component: axis dropdowns, preset pills, color-format selector. The Storybook addon's toolbar uses it; so does the docs-site navbar. Reach for this package directly when you want the switcher on a non-Storybook site — a docs navbar, a standalone React app consuming swatchbook tokens.
+
+Most consumers pick it up transitively via [`@unpunnyfuns/swatchbook-addon`](../addon); `import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` works out of the box.
 
 ## Install
-
-Most consumers pick this up transitively via `@unpunnyfuns/swatchbook-addon` — the addon re-exports the full switcher API, so `import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` works and you don't need a second install line. Reach for this package directly when you want the switcher *without* the Storybook addon (a docs-site navbar, a standalone React app using swatchbook tokens):
 
 ```sh
 npm install @unpunnyfuns/swatchbook-switcher
@@ -17,44 +17,29 @@ npm install @unpunnyfuns/swatchbook-switcher
 ```tsx
 import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-switcher';
 
-function SiteHeader({ axes, presets, themes }) {
-  return (
-    <ThemeSwitcher
-      axes={axes}
-      presets={presets}
-      themes={themes}
-      activeAxes={{ mode: 'Dark' }}
-      colorFormat="oklch"
-      onAxisChange={(axis, context) => {
-        document.documentElement.setAttribute(`data-sb-${axis}`, context);
-      }}
-      onColorFormatChange={(format) => {
-        document.documentElement.setAttribute('data-sb-color-format', format);
-      }}
-    />
-  );
-}
+<ThemeSwitcher
+  axes={axes}
+  presets={presets}
+  themes={themes}
+  activeAxes={{ mode: 'Dark' }}
+  colorFormat="oklch"
+  onAxisChange={(axis, context) => {
+    document.documentElement.setAttribute(`data-sb-${axis}`, context);
+  }}
+  onColorFormatChange={(format) => {
+    document.documentElement.setAttribute('data-sb-color-format', format);
+  }}
+/>;
 ```
 
 The component is pure — it doesn't read or write to storage, and it doesn't bake in any particular way of applying the active tuple. The caller decides how to translate `onAxisChange` into DOM updates, routing changes, or global state.
 
-## Exports
+`SwitcherAxis` / `SwitcherPreset` / `SwitcherTheme` are the accepted shapes and are cross-compatible with `Project.axes` / `.presets` / `.themes` from `@unpunnyfuns/swatchbook-core` — pass them through directly.
 
-| Name | Shape |
-| --- | --- |
-| `ThemeSwitcher` | The popover component. |
-| `ThemeSwitcherProps` | Prop types — axes, presets, themes, active axis tuple, color format, change callbacks, optional `className`. |
-| `SwitcherAxis` / `SwitcherPreset` / `SwitcherTheme` | JSON-friendly shapes the component accepts. Cross-compatible with `@unpunnyfuns/swatchbook-core`'s `Project.axes` / `.presets` / `.themes` — pass them through directly. |
+## Credits
 
-## Where it's used inside this repo
+Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
 
-- The Storybook addon's toolbar popover (`packages/addon/src/manager/toolbar.ts`).
-- The docs site's navbar (`apps/docs/src/theme/Navbar/SwatchbookSwitcher/index.tsx`).
+## Documentation
 
-Both cases feed `ThemeSwitcher` a snapshot of the active `Project` and wire the callbacks to `document.documentElement.setAttribute` calls. If you're rendering swatchbook tokens on a site that isn't Storybook, mirror that pattern.
-
-## See also
-
-- [`@unpunnyfuns/swatchbook-addon`](../addon) — Storybook addon. Re-exports `ThemeSwitcher` along with the full blocks surface.
-- [`@unpunnyfuns/swatchbook-blocks`](../blocks) — MDX doc blocks that the switcher-driven axis changes propagate to.
-- [`@unpunnyfuns/swatchbook-core`](../core) — the DTCG loader whose output feeds this component.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -1,10 +1,14 @@
 # swatchbook-tokens
 
-Internal workspace package (`@unpunnyfuns/swatchbook-tokens`). Exhaustive DTCG 2025.10 fixture used as swatchbook's internal test bed and as a reference for consumers structuring their own token projects. Private — not published.
+The reference DTCG fixture for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-## Theming compositions
+An exhaustive DTCG 2025.10 token project — palette primitives, semantic roles, typography composites, motion, shadow, border, gradient, stroke — used as swatchbook's own internal test bed and as a worked example for projects structuring their own token trees.
 
-`tokens/resolver.json` — a DTCG 2025.10 native resolver (`sets` + `modifiers` + `resolutionOrder`). Three independent modifiers compose into named themes: every combination of `mode` (Light/Dark), `brand` (Default/Brand A), and `contrast` (Normal/High).
+Private workspace package. Not published.
+
+## Composition
+
+`tokens/resolver.json` is a DTCG 2025.10 native resolver (`sets` + `modifiers` + `resolutionOrder`). Three independent modifiers compose into named themes: every combination of `mode` (Light/Dark), `brand` (Default/Brand A), and `contrast` (Normal/High).
 
 ## Consumption
 
@@ -12,5 +16,5 @@ Internal workspace package (`@unpunnyfuns/swatchbook-tokens`). Exhaustive DTCG 2
 import { tokensDir, resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 ```
 
-✅ Use the exported path helpers — they're `import.meta`-resolved and survive `node_modules` hoisting.
-❌ Don't hard-code `node_modules/@unpunnyfuns/swatchbook-tokens/tokens/...` in consuming code.
+- ✅ Use the exported path helpers — `import.meta`-resolved, survives `node_modules` hoisting.
+- ❌ Don't hard-code `node_modules/@unpunnyfuns/swatchbook-tokens/tokens/...` paths.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   webpackbar: 7.0.0
+  uuid: ^14.0.0
 
 patchedDependencies:
   '@terrazzo/plugin-css-in-js@2.0.3':
@@ -8711,8 +8712,8 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
-  uuid@8.3.2:
-    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -18273,7 +18274,7 @@ snapshots:
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
-      uuid: 8.3.2
+      uuid: 14.0.0
       websocket-driver: 0.7.4
 
   sort-css-media-queries@2.2.0: {}
@@ -18810,7 +18811,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@8.3.2: {}
+  uuid@14.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Summary

Dependabot alert #3 — [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq), medium severity, \"Missing buffer bounds check in v3/v5/v6 when buf is provided.\" Vulnerable range: \`uuid < 14.0.0\`.

### How it reaches us

\`webpack-dev-server@5.2.3\` → \`sockjs@0.3.24\` → \`uuid@8.3.2\`. Docs-site dev/build toolchain only; no runtime impact for any published package.

### Is the actual code path vulnerable?

No. sockjs calls \`require('uuid').v4()\` with no args — the modern post-v7 API, different code path. The vulnerable function is v3/v5/v6 called with a \`buf\` argument, which sockjs never does. Pinning to ^14 clears the alert and keeps us on a supported major regardless.

### Fix

pnpm override on \`uuid\` at repo root (\`package.json#pnpm.overrides\`). All uuid entries in the lockfile now land on 14.0.0.

Milestone: Maintenance
Closes #655
Plan impact: none.

## Test plan

- [x] \`pnpm install\` clean.
- [x] \`pnpm turbo run format:check lint typecheck test build\` — 39/39 green.
- [x] \`pnpm --filter=@unpunnyfuns/swatchbook-docs build\` — clean (the dev-server path that actually uses sockjs+uuid).
- [ ] Post-merge: Dependabot alert auto-closes once main picks up the override.