### PR TITLE
chore(docs): flip fasterByDefault — switch to Rspack

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -26,7 +26,7 @@ const config: Config = {
   future: {
     v4: {
       siteStorageNamespacing: true,
-      fasterByDefault: false,
+      fasterByDefault: true,
       mdx1CompatDisabledByDefault: true,
       useCssCascadeLayers: true,
       removeLegacyPostBuildHeadAttribute: true,


### PR DESCRIPTION
## Summary

Flip \`future.v4.fasterByDefault: true\` in \`apps/docs/docusaurus.config.ts\`. Docusaurus now builds the docs site through Rspack + SWC JS loader + SWC minimizers + LightningCSS + SSG worker threads instead of webpack + Terser + cssnano. Four of five \`future.v4\` flags are now enabled — this was the remaining build-system swap, and it matches what v4 will do by default.

### What this doesn't fix

The sockjs + uuid@8 transitive chain stays in the lockfile even with Rspack on — Docusaurus keeps webpack as an optional dep. PR #656's uuid override is still needed until the chain is actually pruned upstream.

Milestone: Maintenance
Closes #658
Plan impact: none.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test build\` — 39/39 green.
- [x] Docs build produces the same route tree (47 HTML files).
- [ ] Post-merge: watch the docs deploy for any Rspack-specific runtime surprises not caught at build time.