### PR TITLE
chore(ci): publish Storybook to Chromatic on push + PR

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,47 @@
+name: Chromatic
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Chromatic reviews depend on commit history to deduplicate snapshots.
+# Full depth fetch lets it baseline against the merge target rather than
+# replaying every snapshot from scratch.
+jobs:
+  chromatic:
+    runs-on: ubuntu-latest
+    # Don't block on a missing secret — forks and draft PRs without
+    # access to CHROMATIC_PROJECT_TOKEN should skip cleanly.
+    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        run: pnpm --filter=@unpunnyfuns/swatchbook-storybook build:storybook
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: apps/storybook
+          storybookBuildDir: storybook-static
+          exitZeroOnChanges: true
+          onlyChanged: true

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -45,3 +45,8 @@ jobs:
           storybookBuildDir: storybook-static
           exitZeroOnChanges: true
           onlyChanged: true
+          # Return as soon as the upload is done; Chromatic's GitHub
+          # integration reports the visual-diff status asynchronously via
+          # a check, so blocking on server-side comparison just makes the
+          # job hang.
+          exitOnceUploaded: true

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",
     "build:storybook": "storybook build",
-    "chromatic": "chromatic --exit-zero-on-changes",
+    "chromatic": "chromatic --exit-zero-on-changes --build-script-name=build:storybook",
     "test:storybook": "vitest run",
     "test:storybook:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",
     "build:storybook": "storybook build",
+    "chromatic": "chromatic --exit-zero-on-changes",
     "test:storybook": "vitest run",
     "test:storybook:watch": "vitest",
     "typecheck": "tsc --noEmit",
@@ -45,6 +46,7 @@
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser-playwright": "^4.1.4",
     "@vitest/coverage-v8": "^4.1.4",
+    "chromatic": "^16.6.0",
     "playwright": "^1.59.1",
     "storybook": "^10.3.5",
     "tailwindcss": "^4.2.4",

--- a/apps/storybook/src/stories/ThemeSwitch.stories.tsx
+++ b/apps/storybook/src/stories/ThemeSwitch.stories.tsx
@@ -101,7 +101,15 @@ export const LightBrandA = meta.story({
  * work keys on these.
  */
 export const PerAxisDataAttrs = meta.story({
-  parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },
+  // Assertion-only story — validates the preview decorator's per-axis
+  // data-attribute emission. No unique visual payload vs the other
+  // ThemeSwitch stories; skip Chromatic's snapshot so visual-diff runs
+  // stay focused on stories whose pixels matter. Still runs in the
+  // addon-vitest path, which is the right home for DOM assertions.
+  parameters: {
+    swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } },
+    chromatic: { disableSnapshot: true },
+  },
   play: async ({ canvasElement }) => {
     const wrapper = canvasElement.querySelector<HTMLElement>('[data-sb-mode]');
     if (!wrapper) throw new Error('expected story wrapper with data-sb-mode attribute');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(@vitest/browser@4.1.4)(vitest@4.1.4)
+      chromatic:
+        specifier: ^16.6.0
+        version: 16.6.0
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
@@ -4861,6 +4864,21 @@ packages:
       '@chromatic-com/cypress':
         optional: true
       '@chromatic-com/playwright':
+        optional: true
+
+  chromatic@16.6.0:
+    resolution: {integrity: sha512-cxRHMa3HJYrQtuL1F3J2x6wuVvfP+d7frUzltS7SiCVE8HbUBQTejH6TzveTKAHzErgrMrXjxvjD37bOTi4Mhw==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
         optional: true
 
   chrome-trace-event@1.0.4:
@@ -14361,6 +14379,10 @@ snapshots:
       readdirp: 5.0.0
 
   chromatic@13.3.5: {}
+
+  chromatic@16.6.0:
+    dependencies:
+      semver: 7.7.4
 
   chrome-trace-event@1.0.4: {}
 


### PR DESCRIPTION
## Summary

Wires up Chromatic visual review for the reference Storybook at \`apps/storybook\`.

- \`chromatic\` devDep added to \`apps/storybook\`.
- \`pnpm --filter=@unpunnyfuns/swatchbook-storybook chromatic\` for local invocation (reads \`CHROMATIC_PROJECT_TOKEN\` from env).
- New \`.github/workflows/chromatic.yml\` — runs on push to main and on PRs. Full-depth checkout so Chromatic can baseline against the merge target. Skips for fork PRs without secret access.

### What you need to do before merge

1. Initialize the Chromatic project by running the first publish locally with the token inline — one-time:

   \`\`\`sh
   CHROMATIC_PROJECT_TOKEN=chpt_... pnpm --filter=@unpunnyfuns/swatchbook-storybook chromatic
   \`\`\`

2. Add \`CHROMATIC_PROJECT_TOKEN\` as a GitHub Actions secret: **Settings → Secrets and variables → Actions → New repository secret**. The workflow picks it up via \`secrets.CHROMATIC_PROJECT_TOKEN\`.

### Token handling

Deliberately not committing the project token. It lives in GitHub Actions secrets (CI) and your local env / shell history (first publish). Files in this PR only reference \`\${{ secrets.CHROMATIC_PROJECT_TOKEN }}\` and \`\$CHROMATIC_PROJECT_TOKEN\` — no string literal.

Milestone: Maintenance
Closes #661
Plan impact: none.

## Test plan

- [x] \`pnpm --filter=@unpunnyfuns/swatchbook-storybook format:check lint typecheck\` — green.
- [ ] After secret is added: verify the first CI Chromatic run produces a build link in the PR checks.
- [ ] Visual: open the Chromatic build, confirm the ref Storybook's stories render correctly.