### PR TITLE
docs(storybook): group color roles into single rows

### DIFF
--- a/apps/storybook/src/docs/Colors.mdx
+++ b/apps/storybook/src/docs/Colors.mdx
@@ -28,11 +28,41 @@ in the toolbar to see every swatch repaint.
 
 ## Semantic roles (variant-grouped)
 
-Same tokens, but suffix variants (`-hover`, `-disabled`) collapse onto
-their base row with a pill selector. Click a row to expand every
-variant side-by-side.
+One row per role, with the leaf segments (`default` / `muted` / `raised`
+/ …) as pills under each base. Click a row to expand every variant
+side-by-side. The `status` row bundles its `-bg` / `-fg` hyphen pairs
+under each status name.
 
-<ColorTable filter="color.*" />
+<ColorTable
+  filter="color.surface.*"
+  variants={{
+    default: 'default',
+    muted: 'muted',
+    raised: 'raised',
+    subtle: 'subtle',
+    inverse: 'inverse',
+  }}
+/>
+
+<ColorTable
+  filter="color.text.*"
+  variants={{
+    default: 'default',
+    muted: 'muted',
+    subtle: 'subtle',
+    inverse: 'inverse',
+    accent: 'accent',
+  }}
+/>
+
+<ColorTable filter="color.accent.*" variants={{ bg: 'bg', fg: 'fg', hover: '-hover' }} />
+
+<ColorTable
+  filter="color.border.*"
+  variants={{ default: 'default', strong: 'strong', focus: 'focus' }}
+/>
+
+<ColorTable filter="color.status.*" variants={{ bg: '-bg', fg: '-fg' }} />
 
 ## Palette
 


### PR DESCRIPTION
## Summary

The Colors page rendered \`color.surface.*\` as five separate rows (one per leaf) because the \`ColorTable\` had no \`variants\` prop passed — default behavior disables grouping. Split the one catch-all \`<ColorTable filter=\"color.*\" />\` into five role-scoped tables with explicit variants maps:

- \`color.surface.*\` → base row \`color.surface\`, pills { default, muted, raised, subtle, inverse }.
- \`color.text.*\` → { default, muted, subtle, inverse, accent }.
- \`color.accent.*\` → { bg, fg, hover } (hover is the \`-hover\` hyphen-tail variant of \`bg\`).
- \`color.border.*\` → { default, strong, focus }.
- \`color.status.*\` → { bg: '-bg', fg: '-fg' } — one row per status name with the hyphen pair as pills.

Each role is one row; click to expand every variant side-by-side.

Milestone: Maintenance
Closes #663
Plan impact: none.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck --filter=@unpunnyfuns/swatchbook-storybook\` — green.
- [ ] Visual: open \`pnpm dev\`, navigate to Docs / Colors, confirm each role renders as a single row with pills.