### PR TITLE
fix(blocks): treat Chromatic as reduced-motion in MotionSample

### DIFF
--- a/.changeset/fix-chromatic-motion-stable.md
+++ b/.changeset/fix-chromatic-motion-stable.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+`MotionSample` (and by extension `<TokenNavigator>` when it renders `duration` / `transition` / `cubicBezier` tokens inline) now falls back to its static reduced-motion state when rendering inside Chromatic's snapshot runner. Detection via Chromatic's user-agent string. The setInterval-driven ball position was previously snapshotted at different positions run-to-run, flagging affected stories as unstable in Chromatic's diff review. Skipping the loop in Chromatic produces deterministic captures. Capture-only — local dev, addon-vitest, and the manual Storybook experience keep the animated version.

--- a/packages/blocks/src/internal/prefers-reduced-motion.ts
+++ b/packages/blocks/src/internal/prefers-reduced-motion.ts
@@ -1,13 +1,32 @@
 import { useEffect, useState } from 'react';
 
 /**
+ * True when rendering inside Chromatic's snapshot runner. Chromatic's
+ * browser ships a recognisable user-agent string; checked here so
+ * motion-looping components can fall back to their static state for
+ * deterministic snapshots without needing a global Chromatic parameter
+ * (globally forcing `prefersReducedMotion: true` broke Chromatic's
+ * verification parser in our setup — see commit 893331f).
+ */
+function isChromatic(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return navigator.userAgent.includes('Chromatic');
+}
+
+/**
  * Reactive `prefers-reduced-motion: reduce` detector. Returns the current
- * match and updates if the user toggles the OS-level preference.
+ * match and updates if the user toggles the OS-level preference. Also
+ * returns `true` under Chromatic to keep animated samples deterministic
+ * during visual regression capture.
  */
 export function usePrefersReducedMotion(): boolean {
   const [reduced, setReduced] = useState(false);
   useEffect(() => {
     if (typeof window === 'undefined') return;
+    if (isChromatic()) {
+      setReduced(true);
+      return;
+    }
     const query = window.matchMedia('(prefers-reduced-motion: reduce)');
     setReduced(query.matches);
     const onChange = (e: MediaQueryListEvent): void => setReduced(e.matches);


### PR DESCRIPTION
## Summary

Chromatic kept flagging TokenNavigator:Default and MotionPreview stories as unstable. Root cause: \`MotionSample\` drives a ball via \`setInterval\` — no animation 'end' for \`pauseAnimationAtEnd\` to hook, so each Chromatic run catches a different pixel position.

- Detect Chromatic's user-agent inside \`usePrefersReducedMotion\` and return \`true\`.
- MotionSample's existing reduced-motion branch renders the static 'Animation suppressed' fallback — deterministic snapshot, no component code changed.
- Dogfoods the contract we already expose to users who set their OS preference.
- Avoids the global \`chromatic.prefersReducedMotion\` parameter which broke Chromatic's verification parser in our setup (rolled back in commit 893331f).

Capture-only — local dev, addon-vitest, and the manual Storybook experience all still see the animated version.

Milestone: Maintenance
Closes #670
Plan impact: none.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test build test:storybook\` — 40/40 green.
- [ ] Post-merge: verify TokenNavigator:Default and MotionPreview stories go green in Chromatic (no more 'unstable' flag).