### PR TITLE
docs: refresh CLAUDE.md for v0.20-era state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,75 +1,76 @@
 # Swatchbook — Claude orientation
 
-Storybook addon + doc blocks for DTCG design tokens. Monorepo under `@unpunnyfuns`.
+Storybook addon + doc blocks for DTCG design tokens, built on [Terrazzo](https://terrazzo.app/)'s parser. Monorepo under `@unpunnyfuns`.
+
+## Scope framing — preview host, not token transformer
+
+**Critical to keep straight.** Swatchbook is the preview side of a Terrazzo pipeline: parses DTCG, displays tokens inside Storybook, reacts to the toolbar's axis flips. It does **not** transform tokens for production platforms — that's the consumer's `@terrazzo/cli` build. We accept user-provided `Plugin` objects via `config.terrazzoPlugins` (same relationship Vite has to Rollup plugins) and display what those plugins emit; we don't ship a transform-customisation API of our own.
+
+When a proposal frames swatchbook as owning transform logic, custom naming schemes, our own plugin protocol, or "competing" with Style Dictionary / Terrazzo CLI, push back. The right answer is almost always "point the user at their existing tool and read its output via the listing."
 
 ## Current state
 
-`v0.4.0 shipped` — three fixed-group packages (core / addon / blocks) published via Changesets + trusted publishing. Documentation site live at https://unpunnyfuns.github.io/swatchbook/ with multi-version support (`/next/` for main, `/` for the latest release, older minors browsable via the version dropdown).
+`v0.20.1 shipped`. Six published packages in a fixed-version Changesets group — `core`, `addon`, `blocks`, `switcher`, `integrations`, `mcp` — plus private workspaces (`tokens`, `apps/docs`, `apps/storybook`). Documentation site at https://unpunnyfuns.github.io/swatchbook/ with Docusaurus 3.10 + Faster (Rspack); single versioned snapshot per minor under `apps/docs/versioned_docs/`. Pre-1.0; routine breaking changes take a **minor** bump.
 
-Post-0.4.0 landscape:
+Architectural pillars settled this era:
 
-- **Block chrome config** (PR #388): blocks read ten chrome variables in a fixed `--swatchbook-*` namespace independent of `cssVarPrefix`; `DEFAULT_CHROME_MAP` holds hard-coded literals using `light-dark()` so zero-config chrome auto-flips with Storybook/OS color-scheme. `config.chrome = { surfaceDefault: 'color.brand.bg.primary', … }` wires individual roles to consumer tokens. The old `chromeAliases()` + prefix-rewiring inline style on every block wrapper is retired.
-- **Blocks styling migration** (PRs #384, #391, #393, #395, #397, #399): every block under `packages/blocks/src/` (Diagnostics, type-preview, scale, font+color, navigator+table, TokenDetail+subtree) moved from inline `const styles = {...}` objects to colocated `.css` files with BEM-ish `sb-<block>__<part>--<modifier>` class names and `clsx` for composition. `.sb-unstyled` scoping replaces the earlier `block-reset.ts` workaround. See issue #375 for the umbrella.
+- **Token Listing adoption.** `@terrazzo/plugin-token-listing` runs in core's in-memory build and produces `Project.listing[path]` — per-token `names.<platform>`, `previewValue`, `source.loc`, alias-resolved `originalValue`. Blocks read authoritative CSS var names from `listing[path].names.css` via `resolveCssVar()` (single source of truth, no parallel kebab-casing). Composite preview values come from the same listing — `<TokenTable>`, `<TokenDetail>`, `<ColorTable>` show what the consumer's plugin-css produces, not a parallel stringification. Format is `0.1.0-alpha.1` upstream — coupled to its output JSON; insulated by `computeTokenListing` which can swap to direct `getTransforms` consumption if the format churns.
+- **Terrazzo alignment surface** on `Config`: `cssOptions`, `listingOptions`, `terrazzoPlugins`. Forward into the internal Terrazzo build so a single shared options module keeps consumer's production CLI and our preview build in lockstep. `cssOptions` strips `variableName` / `permutations` / `filename` / `skipBuild` (load-bearing); `swatchbook/css-options` warn diagnostic for the soft-inert `baseSelector` / `baseScheme` / `modeSelectors` trio. `@terrazzo/parser` and `@terrazzo/plugin-css` are declared as peer deps on core to enforce single-shared-instance via pnpm hoist.
+- **Chromatic CI.** `.github/workflows/chromatic.yml` publishes the reference Storybook on push + PR. `parameters.chromatic.pauseAnimationAtEnd: true` globally; MotionSample detects Chromatic's user-agent inside `usePrefersReducedMotion` and renders its static fallback so setInterval-driven loops don't snap-to-different-frames each run. Heavy-DOM stories (TokenNavigator, TokenTable) carry a `chromatic.delay: 400` on their meta. Build runs through turbo so `^build` builds workspace-package deps first. Don't add the global `chromatic.prefersReducedMotion: true` parameter — it broke Chromatic's verification parser in our setup (rolled back in commit 893331f).
+- **Block-chrome config** stays accurate: blocks read ten roles from a fixed `--swatchbook-*` namespace independent of `cssVarPrefix`; `DEFAULT_CHROME_MAP` uses `light-dark()` literals so zero-config chrome auto-flips with Storybook/OS color-scheme. `config.chrome = { surfaceDefault: 'color.brand.bg.primary', … }` wires individual roles to consumer tokens.
 
-Post-0.3.0 landscape (still accurate):
-
-- **Panel → docblock migration** complete. The addon's in-manager Design Tokens panel was removed in v0.3.0 (PR #350). Consumers compose `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />` on an MDX page via the [token-dashboard guide](https://unpunnyfuns.github.io/swatchbook/guides/token-dashboard).
-- **TokenTable redesign** in v0.3.0 (PR #359): compact two-column layout with click-to-open `<TokenDetail>` drawer, shared with `<TokenNavigator>`'s drawer via `internal/DetailOverlay.tsx`.
-- **sortBy/sortDir + default-filter fix** (PR #349): every list-style block takes `sortBy`/`sortDir` props and the broken `filter = '$type'` defaults were removed.
-- **`formatTokenValue`** (PR #346): single entry point for per-`$type` value stringification across every block, honoring the color-format dropdown for color sub-values of composites (shadow, border, gradient).
-
-Update this section when the state genuinely shifts. See the matching GitHub milestones for per-issue state.
+Update this section when state genuinely shifts. See GitHub milestones for per-issue state.
 
 ### Milestone taxonomy
 
-GitHub milestones are scope buckets, not a sequence. Currently active:
-
-- **Maintenance** — hygiene, refactors, CI polish, cleanup. The default home for most post-v0.3.0 work.
-- **Release** — Changesets versioning, publish workflow, cutting tags. Dormant between releases; active when a minor/major is queued.
-- **Feature milestones** — named scope areas. Spun up per-effort when a coherent push lands (e.g. *Block value display + chrome consistency*, *Panel → docblock migration* — both closed as of v0.3.0). No implied ordering.
-
-When filing an issue: feature work → the relevant scope milestone if one's active. Repo hygiene → *Maintenance*. Release plumbing → *Release*.
+- **Maintenance** — hygiene, refactors, CI polish, cleanup. Default home for most ongoing work.
+- **Release** — Changesets versioning, publish workflow, cutting tags. Active when a minor is queued.
+- **Feature milestones** — named scope areas. Spun up per-effort when a coherent push lands.
 
 ## Project conventions
 
-- **Latest deps policy:** always pin the latest stable major/minor of every third-party dependency unless a concrete blocker is documented in `docs/decisions.md`. When adding a dep, check `npm view <pkg> version` and use that. Default to eager upgrades — we'd rather hit new-version friction early than accumulate a drift debt.
-- **ESM only.** Every package is `"type": "module"`. No CJS builds, no dual-format outputs, no `require()`-compatible fallbacks. Package builds emit ESM only (`tsdown --format esm`). If a downstream consumer still needs CJS, that's their problem to solve with a bundler.
-- **Bundler:** `tsdown` (rolldown-powered). Never add `tsup` — it's deprecated.
-- **Source layout:** every package keeps its code under `./src/`. Package root holds config only (`package.json`, `tsconfig.json`, `README.md`). Build output goes to `./dist/`.
-- **Import specifiers: explicit extensions, always.** Relative and subpath imports both carry the extension that's on disk — `.ts`, `.tsx`, `.css`, `.json`, `.svg`, whatever. `allowImportingTsExtensions + noEmit` in the base tsconfig makes TS happy; Vite, Vitest, tsdown, Node strip-types all resolve `.ts` / `.tsx` specifiers natively. The rule is *what you see is what's imported* — no extension inference, no "fake `.js`".
-- **Internal aliasing: `package.json#imports` with `#/` prefix + extension-agnostic target.** The map is just `"#/*": "./src/*"`; the extension lives on the specifier. One entry handles every filetype.
+- **Latest deps policy:** always pin the latest stable major/minor of every third-party dep unless a concrete blocker is documented. `npm view <pkg> version` when adding. Eager upgrades; we'd rather hit new-version friction early than accumulate a drift debt.
+- **ESM only.** Every package is `"type": "module"`. No CJS, no dual-format outputs, no `require()` fallbacks. tsdown emits ESM only (`--format esm`).
+- **Bundler:** `tsdown` (rolldown-powered). Never add `tsup` — deprecated.
+- **Source layout:** code under `./src/`. Package root holds config only. Build output to `./dist/`.
+- **Import specifiers: explicit extensions, always.** `.ts`, `.tsx`, `.css`, `.json`, `.svg`. `allowImportingTsExtensions + noEmit` in base tsconfig keeps TS happy; Vite, Vitest, tsdown, Node strip-types all resolve `.ts` / `.tsx` natively.
+- **Internal aliasing:** `package.json#imports` with `#/` prefix, extension-agnostic target.
   ```json
   { "imports": { "#/*": "./src/*" } }
   ```
   ```ts
-  import { emitCss } from '#/css.ts';          // ✅
-  import { Button }  from '#/components/Button.tsx'; // ✅
-  import tokens     from '#/tokens/color.json';  // ✅
-  import logo       from '#/assets/logo.svg';        // ✅
-  import './styles.css';                             // ✅
-  import { foo }    from '#/foo';                    // ❌ no extension
-  import { bar }    from '../bar';                   // ❌ no extension
+  import { emitCss } from '#/css.ts';                    // ✅
+  import { Button }  from '#/components/Button.tsx';     // ✅
+  import tokens     from '#/tokens/color.json';          // ✅
+  import logo       from '#/assets/logo.svg';            // ✅
+  import './styles.css';                                 // ✅
+  import { foo }    from '#/foo';                        // ❌ no extension
+  import { bar }    from '../bar';                       // ❌ no extension
   ```
-  The leading slash in `#/` lands cleanly because Node 24.14+ supports `#/`-prefixed subpaths. TypeScript (5.4+), Vite, and Vitest all honor `package.json#imports` natively — no `tsconfig#paths`, no `resolve.alias`. Don't add them.
-- **Node baseline:** always the **latest LTS** everywhere — dev, CI matrix, published `engines.node`. Today that's Node 24. When a new LTS lands (typically October of even years), bump engines + CI in a same-day PR. Don't add lower-version compat paths, polyfills, or matrix entries for older Node.
-- **CI Playwright image:** CI runs inside a GHCR mirror of the Playwright image, pinned in `.github/workflows/ci.yml` as `ghcr.io/<repo>/playwright:vX.Y.Z-noble`. Chromium + system deps come pre-installed; GHCR pulls are ~3-5s on GHA runners vs ~27s from MCR. The mirror is maintained by `.github/workflows/mirror-playwright.yml` (manual dispatch). **On Playwright upgrade:** (1) bump `playwright` in `apps/storybook/package.json`; (2) dispatch the Mirror Playwright workflow with the new tag; (3) verify the new tag under repo Packages; (4) update the `container.image` tag in `ci.yml` + this bullet in the same PR.
-- **Package manager:** pnpm@10.33.0 (workspaces); orchestration via Turborepo.
+  Node 24.14+ supports `#/`-prefixed subpaths. TypeScript 5.4+, Vite, Vitest honor `package.json#imports` natively — no `tsconfig#paths`, no `resolve.alias`.
+- **Node baseline:** latest LTS everywhere — dev, CI matrix, published `engines.node`. Today: Node 24. Bump engines + CI in a same-day PR when the next LTS lands.
+- **CI Playwright image:** GHCR mirror pinned in `.github/workflows/ci.yml` as `ghcr.io/<repo>/playwright:vX.Y.Z-noble`. Mirror maintained by `.github/workflows/mirror-playwright.yml` (manual dispatch). On Playwright upgrade: bump `playwright` in `apps/storybook/package.json`, dispatch the mirror workflow with the new tag, verify the new tag under repo Packages, update `container.image` in `ci.yml` + this bullet in the same PR.
+- **Package manager:** pnpm@10.33.0 (workspaces); Turborepo orchestration. `uuid` pinned to `^14` via root pnpm overrides (transitively from `webpack-dev-server → sockjs`; clears GHSA-w5hq-g745-h8pq).
 - **Code style:** functional, avoid classes/singletons. No CSS-in-JS. No inline end-of-line comments.
 - **Lint/format:** `oxlint` + `oxfmt`. Never `npx biome`.
 - **Tests:** Vitest everywhere. Storybook Test (via `@storybook/addon-vitest`) for interaction tests in `apps/storybook`.
-- **Test structure: flat.** Each `it` reads top-to-bottom without scrolling up — per Kent C. Dodds's [Avoid Nesting When You're Testing](https://kentcdodds.com/blog/avoid-nesting-when-youre-testing).
-  - **No nested `describe`.** One `describe` per file at most, as a file-level grouping. If you feel the urge to nest, split files instead.
-  - **No `beforeEach`** for cosmetic shared setup. Write an inline `setup()` helper and have each test call it; duplicating a line or two beats the "what is `user` here?" hunt.
-  - **`beforeAll` is a perf escape hatch**, not a grouping tool. Acceptable only when the shared setup is genuinely expensive (e.g. `loadProject` takes ~1s so running it per-test would blow the timeout) and the alternative would be a meaningful regression. Annotate the reason inline.
-  - Prose over jargon in test names: `` it('resolves alias chains (role → primitive)') `` beats `` it('resolves') `` inside nested describes.
-- **Pre-commit checks (always, no exceptions):** before running `git commit`, run
+- **Test structure: flat.** Each `it` reads top-to-bottom without scrolling up.
+  - **No nested `describe`.** One `describe` per file at most. Split files instead of nesting.
+  - **No `beforeEach`** for cosmetic shared setup. Inline `setup()` helper per test.
+  - **`beforeAll` is a perf escape hatch**, not a grouping tool. Acceptable only when shared setup is genuinely expensive (`loadProject` ~1s) and the alternative would meaningfully regress runtime. Annotate the reason inline.
+  - Prose over jargon in test names.
+- **Pre-commit checks (always, no exceptions):** before `git commit`, run
   ```
-  pnpm -r format && pnpm turbo run lint typecheck test
+  pnpm -r format && pnpm turbo run format:check lint typecheck test
   ```
-  Format changes to already-staged files land as noisy follow-up commits; CI fails on lint/typecheck/test regressions. Running all four locally catches every class before the push. If something is too slow, scope with `--filter=<pkg>` — don't skip.
-- **Design tokens:** flat paths organized per DTCG `$type`, following [Terrazzo's style guide](https://terrazzo.app/docs/guides/styleguide/). Primitives (color, dimension, duration, fontFamily, fontWeight, cubicBezier, number, strokeStyle) and composites (shadow, border, transition, gradient, typography) coexist under their type root — `color.palette.blue.500` alongside `color.surface.default`, `size.100` alongside `space.md`, `duration.fast` alongside `transition.enter`. No tier prefix in paths. Variation across `mode`, `brand`, `contrast` lives in resolver modifiers.
+  Format-only changes to staged files land as noisy follow-up commits; CI fails on regressions. Scope with `--filter=<pkg>` if something's slow — don't skip.
+- **Design tokens:** flat paths organised per DTCG `$type`, following [Terrazzo's style guide](https://terrazzo.app/docs/guides/styleguide/). Primitives and composites coexist under their type root — `color.palette.blue.500` alongside `color.surface.default`, `space.md` alongside `radius.sm`. No tier prefix in paths. Variation across `mode`, `brand`, `contrast` lives in resolver modifiers.
 - **TypeScript:** strict, `exactOptionalPropertyTypes`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax` on.
-- **READMEs:** module name + one-liner; structure table; TypeScript examples with imports; ✅/❌ for do's/don'ts.
+- **READMEs:** terse human-register opening (one short sentence on what the package IS, then a sentence on how it fits the bigger picture). Detailed reference (API tables, config fields, block catalogues) lives on the docs site, not in the README. Each README links to the docs site prominently.
+
+## Docs site structure
+
+Three navbar pills: Guides / Reference / Developers. Reference sidebar groups three categories (Packages / Blocks / Model) so the index reads as an index, not a flat list. Integrations live under `guides/integrations/` (one index + one page per integration). No separate Concepts section — model pages live under `reference/`. Markdown links between docs **must include the `.mdx` extension** so Docusaurus rewrites them at build time; without the extension, the SPA router resolves them against the current page on click and 404s. Index pages with non-default IDs link as `./folder/index.mdx`, not `./folder/`.
 
 ## DTCG skill
 
@@ -77,15 +78,15 @@ When filing an issue: feature work → the relevant scope milestone if one's act
 
 ## Storybook addon gotchas
 
-- **Manager bundle**: use `React.createElement` (or a local `h` alias), **not JSX**. Storybook's manager page runs React 18 and doesn't expose `react/jsx-runtime`'s React-19 dispatcher — JSX in manager code crashes with *"Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')"*. Preview code is fine with JSX (runs on the consumer's React).
-- **Register tools via element-returning function**: `render: () => h(ThemeToolbar)` — passing the component function directly (`render: ThemeToolbar`) invokes hooks outside React's render cycle.
-- **Preview ↔ manager comms**: use Storybook's channel (`addons.getChannel()` + `emit`/`on`). The manager can't import preview-side Vite virtual modules.
+- **Manager bundle**: use `React.createElement` (or local `h` alias), **not JSX**. The manager runs React 18 and doesn't expose `react/jsx-runtime`'s React-19 dispatcher — JSX in manager code crashes with *"Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')"*. Preview code is fine with JSX.
+- **Register tools via element-returning function**: `render: () => h(ThemeToolbar)` — passing the component function directly invokes hooks outside React's render cycle.
+- **Preview ↔ manager comms**: Storybook's channel (`addons.getChannel()` + `emit`/`on`). Manager can't import preview-side Vite virtual modules.
 - **CSF Next addons**: default-export a factory that returns `definePreviewAddon(previewExports)` (from `storybook/internal/csf`). Consumers opt in via `definePreview({ addons: [swatchbookAddon()] })`.
-- **MDX doc blocks can't use story hooks**: `useGlobals` / `useArgs` / `useChannel` / `useParameter` from `storybook/preview-api` all require the preview HooksContext, which only exists while a story is rendering. Called from an MDX doc block they throw *"Storybook preview hooks can only be called inside decorators and story functions."* For cross-story reactivity in MDX, subscribe to `addons.getChannel()` directly (`globalsUpdated` is the event) and manage state with plain React hooks.
+- **MDX doc blocks can't use story hooks**: `useGlobals` / `useArgs` / `useChannel` / `useParameter` from `storybook/preview-api` require the preview HooksContext, which only exists while a story is rendering. From an MDX doc block they throw. Subscribe to `addons.getChannel()` directly and manage state with plain React hooks.
 
 ## Storybook MCP
 
-`apps/storybook` runs an MCP server via `@storybook/addon-mcp` at `http://localhost:6006/mcp`. The MCP endpoint only exists while Storybook is running — start it in one terminal before using MCP tools in another.
+`apps/storybook` runs an MCP server via `@storybook/addon-mcp` at `http://localhost:6006/mcp`. The endpoint only exists while Storybook is running.
 
 ```
 # Terminal 1
@@ -96,16 +97,18 @@ claude
 
 ## Releases
 
-- **Versioning:** [Changesets](https://github.com/changesets/changesets). Config in `.changeset/config.json`. The three published packages — `@unpunnyfuns/swatchbook-core`, `@unpunnyfuns/swatchbook-addon`, `@unpunnyfuns/swatchbook-blocks` — are grouped as `fixed`: they always carry the same version and release together. Private workspaces (root, `apps/storybook`, `tokens-reference`, `tokens-starter`) are listed under `ignore` so they never appear in bump prompts or get published.
-- **Writing a changeset:** any PR with a user-visible change to the fixed-group packages runs `pnpm changeset` locally, picks the bump type (`patch` / `minor` / `major`), and commits the generated `.changeset/*.md` alongside the change. Purely internal refactors can skip it. **Docs-only PRs add a `patch` changeset** — the snapshot script rebuilds the current minor's snapshot on every release, so docs fixes only reach `/` (the versioned default) via a release cycle. Without a changeset the fix just sits on `/next/`.
-- **Publishing flow:** on `main`, Changesets' GitHub Action opens a "Version Packages" PR that consumes queued `.changeset/*.md` entries, bumps `package.json` versions, and regenerates `CHANGELOG.md`. Merging that PR runs `pnpm release` (builds + `changeset publish`) which pushes tags to GitHub and publishes to npm via trusted publishing (GitHub OIDC → short-lived npm token; no `NPM_TOKEN` secret, provenance attestation on). See `.github/workflows/release.yml`.
-- **Docs versioning:** `scripts/snapshot-docs-version.mjs` snapshots `apps/docs/docs/` into `apps/docs/versioned_docs/version-<minor>/` and updates `versions.json` + `versioned_sidebars/`. Run it when cutting a new minor (the current `docs/` tree becomes the new released version; `main`'s `docs/` keeps serving at `/next/`). Turbo's `build` task includes `versioned_docs/**`, `versioned_sidebars/**`, `versions.json` in its input hash so the remote cache invalidates when a snapshot lands (PR #362 — without this, a fresh minor silently serves the previous minor's HTML).
+- **Versioning:** [Changesets](https://github.com/changesets/changesets). Six published packages — `core` / `addon` / `blocks` / `switcher` / `integrations` / `mcp` — grouped as `fixed`: same version, released together. Private workspaces (`tokens`, root, `apps/*`) are listed under `ignore`.
+- **Pre-1.0 semver:** routine breaking changes take a `minor` bump. No `!` in PR titles. Each major is a deliberate stability commitment, not "this PR happens to break something."
+- **Writing a changeset:** PRs with user-visible changes run `pnpm changeset` locally and commit the generated `.changeset/*.md`. Internal-only refactors can skip it. **Docs-only PRs add a `patch` changeset** so the snapshot script rebuilds the current minor's snapshot on release — without it, the docs fix only reaches `/next/`, not `/`.
+- **Publishing flow:** Changesets' GitHub Action opens a "Version Packages" PR on `main` that consumes queued `.changeset/*.md` entries and bumps versions. Merging runs `pnpm release` → `changeset publish` via trusted publishing (GitHub OIDC → short-lived npm token; provenance attestation on). See `.github/workflows/release.yml`.
+- **Docs versioning:** `scripts/snapshot-docs-version.mjs` snapshots `apps/docs/docs/` into `apps/docs/versioned_docs/version-<minor>/` and updates `versions.json` + `versioned_sidebars/`. Runs as part of the release. Turbo's `build` task includes the snapshot dirs in its input hash so the cache invalidates when a snapshot lands.
 
 ## Plan governance
 
 - Plan body edits → same PR as the change they reflect.
 - Tactical choices that don't change design intent → append to `docs/decisions.md`.
-- PR template (`.github/pull_request_template.md`) requires `Milestone:`, `Closes:`, and `Plan impact:` lines — don't remove them.
-- Every PR links an existing GitHub issue. File one first if needed: `gh issue create --milestone "Mx — …" --title "…"`. Merging the PR auto-closes the issue; milestones close automatically when the last issue is done.
-- **PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)**: `<type>(<scope>): <description>`. Types: `feat` / `fix` / `chore` / `docs` / `test` / `ci` / `refactor` / `perf` / `build` / `revert`. Scope is a package slug (`core`, `addon`, `blocks`, `tokens-reference`, `tokens-starter`, `storybook`, `docs`, `ci`) or omitted. Milestone goes in the PR body, never the title — squash-merge lands the title on `main`.
-- **Issue vs PR references in prose:** GitHub shares a numeric namespace between issues and pull requests, and both render as `#N`. When referencing either in prose (status updates, CLAUDE.md, commit bodies, chat), **prefix with `issue` or `PR` — e.g. "issue #77", "PR #83"**. Inside PR bodies and issue comments the bare `#N` is fine because GitHub renders the linked page with an unmistakable type header; prose lacks that cue and ambiguity stings when you go looking weeks later.
+- PR template (`.github/pull_request_template.md`) requires `Milestone:`, `Closes:`, and `Plan impact:` lines.
+- **`Closes #N` must be plain text, one per line.** GitHub's auto-close parser ignores `**Closes:** #N` (bold-wrapped) and `Closes: #N1, #N2` (comma-separated past the first). The template was the original source of the bolded form — it's been corrected; don't re-introduce it.
+- Every PR links an existing GitHub issue. File one first if needed: `gh issue create --milestone "Maintenance" --title "…"`. Merging the PR auto-closes the issue.
+- **PR titles follow [Conventional Commits](https://www.conventionalcommits.org/)**: `<type>(<scope>): <description>`. Types: `feat` / `fix` / `chore` / `docs` / `test` / `ci` / `refactor` / `perf` / `build` / `revert`. Scope is a package slug (`core`, `addon`, `blocks`, `switcher`, `integrations`, `mcp`, `tokens`, `storybook`, `docs`, `ci`) or omitted. Milestone goes in the PR body, never the title. Verb-first lowercase subject (lowercase even for proper nouns).
+- **Issue vs PR references in prose:** GitHub shares a numeric namespace; `#N` could be either. In prose (status updates, CLAUDE.md, commit bodies, chat), prefix with `issue` or `PR` — "issue #77", "PR #83". Inside PR bodies and issue comments the bare `#N` is fine because GitHub renders the linked page with a type header.


### PR DESCRIPTION
## Summary

\`CLAUDE.md\` had drifted significantly. Refreshed for the v0.20 reality.

### Replaced

- **Current state**: \`v0.4.0\` → \`v0.20.1\`. Published-package list 3 → 6 (added switcher, integrations, mcp). Post-0.4.0 / post-0.3.0 landscape sections (stale) replaced with four architectural pillars covering Token Listing adoption, Terrazzo alignment surface, Chromatic CI, and block chrome.
- **Conventional Commits scope list**: added \`switcher\`, \`integrations\`, \`mcp\`, \`tokens\`; removed retired \`tokens-reference\` / \`tokens-starter\`.
- **\`Closes #N\` rule**: documents both the no-bolding rule (the template was the original source) and the existing one-per-line rule.
- Dropped the deleted token-dashboard guide reference.

### Added

- **\"Scope framing — preview host, not token transformer\"** section right after the title. Captures the host-not-emulator positioning that emerged this session — pushes back on proposals that frame swatchbook as owning transform logic.
- **Token Listing adoption** mechanics: how \`Project.listing[path]\` flows into blocks via \`resolveCssVar()\`; alpha-format coupling caveat.
- **Terrazzo alignment surface**: cssOptions / listingOptions / terrazzoPlugins.
- **Chromatic CI gotchas**: pauseAnimationAtEnd + the per-component reduced-motion detection in MotionSample; the chromatic.prefersReducedMotion-param-broke-the-parser trap; delay-400 on heavy-DOM stories; turbo for build deps.
- **\"Docs site structure\"** section with the .mdx-extension requirement on internal markdown links.
- **Pre-1.0 semver** convention in Releases.
- **pnpm uuid override** mention.

No behavior changes — orientation file only.

Milestone: Maintenance
Closes #673
Plan impact: none.

## Test plan

- [x] Diff reads cleanly. No claims left over from earlier eras.
- [x] All cross-references (PRs, commit SHAs, file paths) verified against current repo state.