### PR TITLE
fix(ci): disable Chromatic TurboSnap until stats-json is wired

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -50,7 +50,14 @@ jobs:
           workingDir: apps/storybook
           storybookBuildDir: storybook-static
           exitZeroOnChanges: true
-          onlyChanged: true
+          # `onlyChanged: true` (TurboSnap) wants a preview-stats.json
+          # from the Storybook build that our build:storybook script
+          # doesn't produce — Chromatic disables itself with "missing
+          # stats file" error and fails the job. Re-enable once we've
+          # added `--stats-json` to the build (or sorted out the
+          # Rspack-builder stats path); capturing every story every run
+          # is fine at our scale.
+          onlyChanged: false
           # Return as soon as the upload is done; Chromatic's GitHub
           # integration reports the visual-diff status asynchronously via
           # a check, so blocking on server-side comparison just makes the


### PR DESCRIPTION
## Summary

Chromatic action errors with \`TurboSnap disabled due to missing stats file. Did not find preview-stats.json in your built Storybook.\` and exits non-zero, blocking every PR.

\`onlyChanged: true\` enables TurboSnap; TurboSnap wants \`preview-stats.json\`; \`build:storybook\` doesn't pass \`--stats-json\`. Set \`onlyChanged: false\` so Chromatic captures every story every run — slow but unblocks PRs.

Follow-up: add \`--stats-json\` to a Chromatic-specific build invocation (separate script, or a flag on \`build:storybook\` when CI=true) and flip \`onlyChanged\` back on. Tracked on the issue.

Milestone: Maintenance
Closes #675
Plan impact: none.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck\` — green (workflow-only change).
- [ ] CI Chromatic job runs to completion and uploads stories without the stats-file error.