### PR TITLE
docs(mcp): drop client-specific wiring instructions

### DIFF
--- a/.changeset/mcp-client-wiring-wording.md
+++ b/.changeset/mcp-client-wiring-wording.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-mcp": patch
+---
+
+Make the MCP-client wiring instructions client-agnostic across the README and the docs site (`reference/mcp`, `intro`, `developers/architecture`). Previous wording singled out one client by name and embedded a single platform-specific config path; the `mcpServers` JSON shape is the same across MCP hosts, so the wording now lets each host's own docs cover where its server-config file lives.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -173,7 +173,7 @@ npx @unpunnyfuns/swatchbook-mcp --config swatchbook.config.ts
    ↓
  createServer(project)              ← packages/mcp/src/server.ts
    ↓
- StdioServerTransport → MCP client (Claude Desktop, Claude Code, …)
+ StdioServerTransport → MCP client
 ```
 
 Fourteen tools, all stateless reads against the in-memory `Project`:

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -40,7 +40,7 @@ The addon publishes tokens to the preview through a Vite virtual module, recompu
 
 ## For AI agents
 
-The optional [`@unpunnyfuns/swatchbook-mcp`](./reference/mcp.mdx) package ships a stdio [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes the token graph — paths, axes, alias chains, diagnostics, per-theme resolved values — to AI assistants like Claude Desktop or Claude Code. Fourteen read-only tools; live-reloads on token edits.
+The optional [`@unpunnyfuns/swatchbook-mcp`](./reference/mcp.mdx) package ships a stdio [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes the token graph — paths, axes, alias chains, diagnostics, per-theme resolved values — to any MCP-capable AI assistant. Fourteen read-only tools; live-reloads on token edits.
 
 ## See it live
 

--- a/apps/docs/docs/reference/mcp.mdx
+++ b/apps/docs/docs/reference/mcp.mdx
@@ -41,7 +41,7 @@ CLI flags:
 
 ## Wire into an MCP client
 
-Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+Add an entry to the client's MCP server config:
 
 ```json
 {
@@ -59,7 +59,7 @@ Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json
 }
 ```
 
-Restart the client and ask it about your tokens — it'll call `describe_project` first, then drill into whatever you asked about.
+The `mcpServers` shape is the same across MCP hosts; consult the host's docs for where its config file lives. Restart the client and ask it about your tokens — it'll call `describe_project` first, then drill into whatever you asked about.
 
 ## Tools
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -12,7 +12,7 @@ Point it at a swatchbook config (or a bare DTCG `resolver.json`) and it parses t
 npx @unpunnyfuns/swatchbook-mcp --config swatchbook.config.ts
 ```
 
-Or wire it into an MCP client. Claude Desktop (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+Or wire it into an MCP client by adding an entry to its server config:
 
 ```json
 {


### PR DESCRIPTION
## Summary

- README + docs site (`reference/mcp`, `intro`, `developers/architecture`) no longer single out Claude Desktop or its macOS config path; the `mcpServers` JSON shape is portable across MCP hosts.
- Wiring instructions now read as "add an entry to the client's MCP server config" with a one-liner that the shape is the same across hosts and to consult the host's own docs for where the file lives.
- Patch changeset (`@unpunnyfuns/swatchbook-mcp`) so the next release rebuilds the `version-0.20` snapshot and the wording fix lands at `/`, not just `/next/`.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck --filter=@unpunnyfuns/swatchbook-mcp --filter=@unpunnyfuns/swatchbook-docs`

Milestone: Maintenance

Closes #677

Plan impact: none.