### PR TITLE
fix(tokens): keep muted text legible under dark + high contrast

### DIFF
--- a/packages/tokens/tokens/themes/contrast-high.json
+++ b/packages/tokens/tokens/themes/contrast-high.json
@@ -1,15 +1,15 @@
 {
   "color": {
     "$type": "color",
-    "$description": "High-contrast overlay — strengthens borders and focus rings, escalates the accent to AAA contrast via each mode's `color.accessible.accent.*` slot (alias indirection keeps this file mode-agnostic; Light picks up a deep-blue button, Dark an inverted light-blue-with-dark-text button). Typography shifts to a Comic-family stack for irregular-letterform legibility.",
+    "$description": "High-contrast overlay — strengthens borders and focus rings, escalates the accent to AAA contrast and lifts muted/subtle text toward each mode's `color.accessible.*` slot (alias indirection keeps this file mode-agnostic; Light picks up a deep-blue button with darker muted text on light surfaces, Dark an inverted light-blue-with-dark-text button paired with lighter muted text on dark surfaces). Typography shifts to a Comic-family stack for irregular-letterform legibility.",
     "border": {
       "default": { "$value": "{color.palette.neutral.700}" },
       "strong":  { "$value": "{color.palette.neutral.900}" },
       "focus":   { "$value": "{color.palette.yellow.500}" }
     },
     "text": {
-      "muted":  { "$value": "{color.palette.neutral.700}" },
-      "subtle": { "$value": "{color.palette.neutral.600}" }
+      "muted":  { "$value": "{color.accessible.text.muted}" },
+      "subtle": { "$value": "{color.accessible.text.subtle}" }
     },
     "accent": {
       "bg":       { "$value": "{color.accessible.accent.bg}" },

--- a/packages/tokens/tokens/themes/dark.json
+++ b/packages/tokens/tokens/themes/dark.json
@@ -26,11 +26,15 @@
       "fg":       { "$value": "{color.palette.neutral.900}" }
     },
     "accessible": {
-      "$description": "AAA-contrast accent alternates for Dark mode. Inverted pattern — light-blue button background carries dark text. The contrast-high overlay aliases role tokens to this namespace so each mode owns its own AAA values without contrast-high branching per mode.",
+      "$description": "AAA-contrast accent and text alternates for Dark mode. Inverted pattern — light-blue button background carries dark text; muted/subtle text lifts toward the top of the neutral ramp so it stays legible on dark muted/subtle surfaces. The contrast-high overlay aliases role tokens to this namespace so each mode owns its own AAA values without contrast-high branching per mode.",
       "accent": {
         "bg":       { "$value": "{color.palette.blue.100}" },
         "bg-hover": { "$value": "{color.palette.blue.50}" },
         "fg":       { "$value": "{color.palette.neutral.900}" }
+      },
+      "text": {
+        "muted":  { "$value": "{color.palette.neutral.200}" },
+        "subtle": { "$value": "{color.palette.neutral.300}" }
       }
     }
   }

--- a/packages/tokens/tokens/themes/light.json
+++ b/packages/tokens/tokens/themes/light.json
@@ -16,11 +16,15 @@
       "inverse": { "$value": "{color.palette.neutral.0}" }
     },
     "accessible": {
-      "$description": "AAA-contrast accent alternates for Light mode. Deep blue button background retains white text at AAA-normal contrast. The contrast-high overlay aliases role tokens to this namespace so each mode owns its own AAA values without contrast-high branching per mode.",
+      "$description": "AAA-contrast accent and text alternates for Light mode. Deep blue button background retains white text at AAA-normal contrast; muted/subtle text deepen against the light neutral ramp. The contrast-high overlay aliases role tokens to this namespace so each mode owns its own AAA values without contrast-high branching per mode.",
       "accent": {
         "bg":       { "$value": "{color.palette.blue.900}" },
         "bg-hover": { "$value": "{color.palette.blue.900}" },
         "fg":       { "$value": "{color.palette.neutral.0}" }
+      },
+      "text": {
+        "muted":  { "$value": "{color.palette.neutral.700}" },
+        "subtle": { "$value": "{color.palette.neutral.600}" }
       }
     }
   }


### PR DESCRIPTION
## Summary

- `themes/contrast-high.json` overrode `color.text.muted` to `{color.palette.neutral.700}` mode-blind — fine on light surfaces, dark-slate-on-dark-slate under `mode=Dark, contrast=High`.
- Extended the existing `color.accessible.*` per-mode pattern (already used for `accent.*`): `light.json` and `dark.json` each own `accessible.text.{muted,subtle}`; `contrast-high.json` re-aliases the role tokens through that slot.
- Light + High unchanged (`neutral.700` / `neutral.600`); Dark + High lifts to `neutral.200` / `neutral.300`, restoring legibility on `surface.muted` (`neutral.800`) and `surface.default` (`neutral.900`).
- Private fixture only — no published-package contents change, so no changeset.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck --filter=@unpunnyfuns/swatchbook-tokens`
- [x] `pnpm turbo run test --filter=@unpunnyfuns/swatchbook-core --filter=@unpunnyfuns/swatchbook-blocks` (regression check)
- [ ] Visual check in Storybook on `Docs/Colors` under each `mode × contrast` combination — variant pills readable on every tuple.

Milestone: Maintenance

Closes #678

Plan impact: none.