### PR TITLE
fix(blocks): keep colortable inside its container on wide rows

### DIFF
--- a/.changeset/blocks-colortable-overflow.md
+++ b/.changeset/blocks-colortable-overflow.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+`<ColorTable>` now wraps its `<table>` in a `.sb-color-table__scroll` div with `overflow-x: auto; max-width: 100%`. Previously, wide rows (long alias paths or multiple variant pills on `nowrap` cells) could push the surrounding container horizontally — most noticeable on docs pages with several `<ColorTable>` instances stacked. The wrapper contains the worst case to the table's own region; `max-width: 240px` truncation on the value cell keeps typical rows from needing to scroll at all.

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -1,3 +1,9 @@
+.sb-color-table__scroll {
+  width: 100%;
+  max-width: 100%;
+  overflow-x: auto;
+}
+
 .sb-color-table__table {
   width: 100%;
   border-collapse: collapse;

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -201,43 +201,45 @@ export function ColorTable({
           />
         </div>
       )}
-      <table className="sb-color-table__table">
-        <caption className="sb-color-table__caption">{captionText}</caption>
-        <thead>
-          <tr>
-            <th className="sb-color-table__th sb-color-table__th--swatch">
-              <span className="sb-color-table__sr-only">Swatch</span>
-            </th>
-            <th className="sb-color-table__th sb-color-table__th--path">Name</th>
-            <th className="sb-color-table__th">Value</th>
-            <th className="sb-color-table__th">CSS var</th>
-            <th className="sb-color-table__th">Alias</th>
-            <th className="sb-color-table__th sb-color-table__th--expand">
-              <span className="sb-color-table__sr-only">Expand</span>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {visibleGroups.length === 0 && (
+      <div className="sb-color-table__scroll">
+        <table className="sb-color-table__table">
+          <caption className="sb-color-table__caption">{captionText}</caption>
+          <thead>
             <tr>
-              <td colSpan={COLUMN_COUNT} className="sb-color-table__td sb-color-table__empty-row">
-                No colors match "{query.trim()}".
-              </td>
+              <th className="sb-color-table__th sb-color-table__th--swatch">
+                <span className="sb-color-table__sr-only">Swatch</span>
+              </th>
+              <th className="sb-color-table__th sb-color-table__th--path">Name</th>
+              <th className="sb-color-table__th">Value</th>
+              <th className="sb-color-table__th">CSS var</th>
+              <th className="sb-color-table__th">Alias</th>
+              <th className="sb-color-table__th sb-color-table__th--expand">
+                <span className="sb-color-table__sr-only">Expand</span>
+              </th>
             </tr>
-          )}
-          {visibleGroups.map((group) => (
-            <GroupRow
-              key={group.base}
-              group={group}
-              selectedLabel={selectedByBase[group.base]}
-              expanded={expandedByBase.has(group.base)}
-              onToggleExpand={toggleExpand}
-              onSelectVariant={selectVariant}
-              {...(onSelect !== undefined && { onSelect })}
-            />
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {visibleGroups.length === 0 && (
+              <tr>
+                <td colSpan={COLUMN_COUNT} className="sb-color-table__td sb-color-table__empty-row">
+                  No colors match "{query.trim()}".
+                </td>
+              </tr>
+            )}
+            {visibleGroups.map((group) => (
+              <GroupRow
+                key={group.base}
+                group={group}
+                selectedLabel={selectedByBase[group.base]}
+                expanded={expandedByBase.has(group.base)}
+                onToggleExpand={toggleExpand}
+                onSelectVariant={selectVariant}
+                {...(onSelect !== undefined && { onSelect })}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- `<ColorTable>` now wraps its `<table>` in a `.sb-color-table__scroll` div with `overflow-x: auto; max-width: 100%`.
- Previously the table sat directly inside the theme-attrs wrapper with `white-space: nowrap` on path / value / CSS-var / alias cells, so long alias paths or stacked variant pills could push the page horizontally — most visible on the docs `Docs/Colors` page with several `<ColorTable>` instances stacked.
- Patch changeset on `@unpunnyfuns/swatchbook-blocks`.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter=@unpunnyfuns/swatchbook-blocks` — all 86 tests pass.
- [ ] Visual check on `Docs/Colors` in Storybook: wide rows now scroll inside the table region; the docs page no longer scrolls horizontally.

Milestone: Maintenance

Closes #679

Plan impact: none.