### PR TITLE
docs(addon): rewrite readme intro for standalone npm reading

### DIFF
--- a/.changeset/addon-readme-intro.md
+++ b/.changeset/addon-readme-intro.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+Docs: rewrite the addon README intro so it reads standalone on the npm page. Drops the "Storybook 10 side of swatchbook" framing (which assumed reader-side context) for a self-contained category statement, names the toolbar / re-render mechanism in plain terms, and spells out the re-export relationship with `swatchbook-blocks` + `swatchbook-switcher` so consumers don't go install those separately.

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -1,10 +1,10 @@
 # swatchbook-addon
 
-The Storybook 10 side of [swatchbook](https://github.com/unpunnyfuns/swatchbook).
+Storybook 10 addon for documenting DTCG design tokens.
 
-Loads your DTCG tokens at config time, exposes the resolved graph to the preview through a virtual module, and renders a toolbar popover with one dropdown per modifier axis (`mode`, `brand`, …), preset pills, and a color-format picker. Ships a typed `useToken()` hook for stories that need a resolved value at runtime.
+Loads your token files, resolves the alias graph, and adds a toolbar that flips the active theme tuple (`mode × brand × contrast × …`). Every story and MDX doc block re-renders against the new tuple without per-story wiring — component stories and the token reference share one source of truth.
 
-One install pulls the whole React surface — toolbar, preview decorator, every MDX doc block, `ThemeSwitcher`, `useToken()`. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` works without a second install line because the addon re-exports the full blocks + switcher API.
+Bundles MDX doc blocks (`<TokenTable />`, `<ColorPalette />`, `<TokenDetail />`, …), a standalone `<ThemeSwitcher>` for non-Storybook surfaces, and a typed `useToken()` hook for stories that need a resolved value at runtime. Re-exports [`@unpunnyfuns/swatchbook-blocks`](../blocks) and [`@unpunnyfuns/swatchbook-switcher`](../switcher) — a single install covers the whole React surface.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Rewrites the opening of `packages/addon/README.md` so it reads on its own on the [npm page](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-addon) — which is the most likely first contact for a prospective consumer.

- Drops `The Storybook 10 side of [swatchbook]` (comparator-frame that presumes reader-side context).
- Replaces the plumbing-vocabulary feature dump (`virtual module`, `config time`, `modifier axis`, `preset pills`, `color-format picker`) with a one-breath description of the toolbar + re-render mechanism.
- Spells out the re-export relationship with `swatchbook-blocks` + `swatchbook-switcher` plainly, instead of embedding an import example in the intro.

Three paragraphs, ~3 sentences each — same shape as the sibling `core` / `blocks` READMEs, but the opener no longer leans on the reader knowing what swatchbook is.

Patch changeset on `@unpunnyfuns/swatchbook-addon` so the next release picks up the README on the npm page.

Milestone: Maintenance
Closes #687
Plan impact: none