### PR TITLE
chore: clear ip-address GHSA-v2v4-37r5-5v8g via override

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "pnpm": {
     "overrides": {
       "webpackbar": "7.0.0",
-      "uuid": "^14.0.0"
+      "uuid": "^14.0.0",
+      "ip-address": "^10.1.1"
     },
     "patchedDependencies": {
       "@terrazzo/plugin-css-in-js@2.0.3": "patches/@terrazzo__plugin-css-in-js@2.0.3.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   webpackbar: 7.0.0
   uuid: ^14.0.0
+  ip-address: ^10.1.1
 
 patchedDependencies:
   '@terrazzo/plugin-css-in-js@2.0.3':
@@ -6097,8 +6098,8 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
-  ip-address@10.1.0:
-    resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
@@ -15094,7 +15095,7 @@ snapshots:
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
       express: 5.2.1
-      ip-address: 10.1.0
+      ip-address: 10.2.0
 
   express@4.22.1:
     dependencies:
@@ -15735,7 +15736,7 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
-  ip-address@10.1.0: {}
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 


### PR DESCRIPTION
## Summary

- Adds `ip-address: ^10.1.1` to root `pnpm.overrides` (slots in alongside the existing `uuid` / `webpackbar` overrides — same pattern that clears GHSA-w5hq-g745-h8pq).
- Lockfile re-resolves: `ip-address@10.1.0` → `10.2.0` (latest 10.x). Single version still — no duplication.
- Diff scope: `package.json` (one line) + `pnpm-lock.yaml` (three resolution updates).

## Background

Dependabot alert [#4](https://github.com/unpunnyfuns/swatchbook/security/dependabot/4) — [GHSA-v2v4-37r5-5v8g](https://github.com/advisories/GHSA-v2v4-37r5-5v8g), medium severity, XSS in `Address6` HTML-emitting methods. `pnpm why -r ip-address` finds two chains, both rooted in `swatchbook-mcp`:

- runtime: `@modelcontextprotocol/sdk` → `express-rate-limit@8.3.2` → `ip-address`
- dev: `@modelcontextprotocol/inspector-server@0.21.2` → `express-rate-limit@8.3.2` → `ip-address`

`express-rate-limit` uses `ip-address` for IP normalization / range comparison only, not the HTML-emitting methods the advisory targets, so practical exposure to the sink is essentially zero. The override is just to clear the alert.

No changeset — workspace-internal lockfile change; no published `dependencies` field changes.

## Test plan

- [x] `pnpm install` — lockfile resolves cleanly, single `ip-address@10.2.0`.
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 tasks green.
- [x] `pnpm why -r ip-address` confirms only one version remains.

Milestone: Maintenance
Closes #690
Plan impact: none