### PR TITLE
chore(blocks,addon): drop dead exports + standardize import specifiers

### DIFF
--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -1,5 +1,5 @@
 import { definePreviewAddon } from 'storybook/internal/csf';
-import * as previewExports from './preview.tsx';
+import * as previewExports from '#/preview.tsx';
 
 export {
   ADDON_ID,

--- a/packages/blocks/src/internal/styles.tsx
+++ b/packages/blocks/src/internal/styles.tsx
@@ -8,8 +8,6 @@ import type { CSSProperties, ReactElement, ReactNode } from 'react';
  * empty-state — lives in `styles.css` and is applied via class names.
  */
 
-export const MONO_STACK = 'ui-monospace, SFMono-Regular, Menlo, monospace';
-
 export const TEXT_DEFAULT = 'var(--swatchbook-text-default, CanvasText)';
 export const TEXT_MUTED = 'var(--swatchbook-text-muted, CanvasText)';
 
@@ -21,8 +19,6 @@ export const BORDER_DEFAULT = `1px solid var(--swatchbook-border-default, rgba(1
 export const BORDER_FAINT = `1px solid var(--swatchbook-border-default, rgba(128,128,128,0.15))`;
 export const BORDER_STRONG = `1px solid var(--swatchbook-border-default, rgba(128,128,128,0.3))`;
 
-export const SIZE_LABEL = 11;
-export const SIZE_META = 12;
 export const SIZE_PILL = 10;
 
 export const typePillStyle = {


### PR DESCRIPTION
## Summary

Two small internal cleanups from sub-issue #700 (pre-1.0 dossier):

- **`packages/blocks/src/internal/styles.tsx`** — remove `MONO_STACK`, `SIZE_LABEL`, `SIZE_META`. All three exported, zero references across the workspace, not re-exported from blocks' public `index.ts`.
- **`packages/addon/src/index.ts:2`** — change `import * as previewExports from './preview.tsx'` to `'#/preview.tsx'`. The relative import was the only non-`#/` cross-file reference in the addon source.

No user-visible API change. No changeset.

## Noticed during cleanup, not fixed here

`packages/blocks/src/internal/styles.tsx` has more externally-unused exports (`TEXT_DEFAULT`, `SURFACE_DEFAULT`, `BORDER_DEFAULT`, `SIZE_PILL` outside its own helper, `typePillStyle`). Kept this PR scoped to the three the dossier called out. Worth a follow-up sweep — happy to file a separate issue if useful.

## Test plan

- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test --filter=swatchbook-blocks --filter=swatchbook-addon` — 11/11 tasks green.
- [x] No public API surface change (verified `packages/blocks/src/index.ts` doesn't re-export the three removed symbols).

Milestone: Maintenance
Closes #700
Plan impact: none