### PR TITLE
build(blocks,switcher): add ./style.css to package exports map

### DIFF
--- a/.changeset/blocks-switcher-css-exports.md
+++ b/.changeset/blocks-switcher-css-exports.md
@@ -1,0 +1,6 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+---
+
+Add `./style.css` to each package's `exports` map. The CSS files were already shipped via internal side-effect imports, but consumers that wanted to deliberately link the stylesheet (extract, reorder cascade, ship as a separate `<link>`) couldn't reach it via the package map. Now `import '@unpunnyfuns/swatchbook-blocks/style.css'` and `import '@unpunnyfuns/swatchbook-switcher/style.css'` resolve explicitly. The existing side-effect import path is unchanged.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -32,6 +32,7 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs"
     },
+    "./style.css": "./dist/style.css",
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages/switcher/package.json
+++ b/packages/switcher/package.json
@@ -29,6 +29,7 @@
       "types": "./dist/index.d.mts",
       "import": "./dist/index.mjs"
     },
+    "./style.css": "./dist/style.css",
     "./package.json": "./package.json"
   },
   "imports": {


### PR DESCRIPTION
## Summary

From sub-issue #698 (pre-1.0 dossier).

`packages/blocks/dist/style.css` and `packages/switcher/dist/style.css` are emitted by tsdown but weren't listed in `package.json#exports`. Internal side-effect imports work (consumers get the CSS via the side-effect import in the JS entry), but consumers wanting to deliberately link the stylesheet — extract, reorder cascade, ship as a separate `<link>` — couldn't reach it through the package map.

Adds `"./style.css": "./dist/style.css"` to each package's `exports` map. Existing side-effect path unchanged.

## Test plan

- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test --filter=swatchbook-blocks --filter=swatchbook-switcher` — 9/9 tasks green.
- [x] Verified the existing `.` and `./package.json` entries are intact.
- Both packages get a `patch` changeset.

After merge:

- `import '@unpunnyfuns/swatchbook-blocks/style.css'` resolves explicitly.
- `import '@unpunnyfuns/swatchbook-switcher/style.css'` resolves explicitly.

Milestone: Maintenance
Closes #698
Plan impact: none