### PR TITLE
fix(core): emit listing-build failures as diagnostics instead of silent {}

### DIFF
--- a/.changeset/listing-diagnostic.md
+++ b/.changeset/listing-diagnostic.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Fix: emit a `swatchbook/listing` warn diagnostic when the Token Listing build fails (plugin crash inside a user-supplied `terrazzoPlugins` entry, missing listing output, malformed JSON). Previously those failures returned an empty listing silently, leaving `<TokenTable>` / `<ColorTable>` / `<TokenDetail>` previews falling back to raw values with no signal as to why. The `<Diagnostics />` block already auto-opens when warnings are non-zero, so authors see the failure immediately.

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -1,4 +1,3 @@
-import jsPlugin from '@terrazzo/plugin-js';
 import sassPlugin from '@terrazzo/plugin-sass';
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
@@ -36,17 +35,18 @@ export default defineSwatchbookConfig({
     bodyFontFamily: 'typography.body.font-family',
     bodyFontSize: 'typography.body.font-size',
   },
-  // Load Sass + JS plugins so the Token Listing's `names.<platform>`
-  // columns populate beyond CSS. Purely for preview — these plugins
-  // don't emit files through swatchbook; they contribute their
-  // identifier-naming logic so `<TokenDetail>`'s Consumer Output rows
-  // show `Sass` / `Js` identifiers alongside the CSS var.
-  terrazzoPlugins: [sassPlugin({ filename: 'tokens.scss' }), jsPlugin({ filename: 'tokens.js' })],
+  // Load plugin-sass so the Token Listing's `names.sass` column populates
+  // beyond CSS. Purely for preview — the plugin doesn't emit files through
+  // swatchbook; it contributes its identifier-naming logic so
+  // `<TokenDetail>`'s Consumer Output renders the Sass identifier alongside
+  // the CSS var. plugin-js is intentionally absent: it doesn't register
+  // transforms via `getTransforms`, so plugin-token-listing can't look up
+  // a `js` format and the listing build fails outright.
+  terrazzoPlugins: [sassPlugin({ filename: 'tokens.scss' })],
   listingOptions: {
     platforms: {
       css: { name: '@terrazzo/plugin-css', description: 'CSS custom properties' },
       sass: { name: '@terrazzo/plugin-sass', description: 'Sass variables' },
-      js: { name: '@terrazzo/plugin-js', description: 'JS accessors' },
     },
   },
   presets: [

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -86,7 +86,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     });
   }
 
-  const listing =
+  const { listing, diagnostics: listingDiagnostics } =
     normalized.parserInput !== undefined
       ? await computeTokenListing(
           normalized.parserInput,
@@ -98,7 +98,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
             ...(config.terrazzoPlugins !== undefined && { extraPlugins: config.terrazzoPlugins }),
           },
         )
-      : {};
+      : { listing: {}, diagnostics: [] };
 
   return {
     config: configWithDefaults,
@@ -121,6 +121,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
       ...presetDiagnostics,
       ...chromeDiagnostics,
       ...cssOptionsDiagnostics,
+      ...listingDiagnostics,
       ...projectDiagnostics,
     ],
   };

--- a/packages/core/src/token-listing.ts
+++ b/packages/core/src/token-listing.ts
@@ -6,7 +6,7 @@ import tokenListingPlugin, {
   type TokenListingPluginOptions,
 } from '@terrazzo/plugin-token-listing';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
-import type { ParserInput } from '#/types.ts';
+import type { Diagnostic, ParserInput } from '#/types.ts';
 
 export type { ListedToken } from '@terrazzo/plugin-token-listing';
 
@@ -30,9 +30,11 @@ export type TokenListingByPath = Record<string, ListedToken>;
  * so the `names.css` field in every entry matches exactly what emission
  * would produce — by construction, no parallel logic to drift.
  *
- * Returns an empty map on any failure (missing listing output, parse
- * error, plugin crash). The caller treats listing data as optional
- * enrichment; losing it shouldn't block `loadProject`.
+ * Returns `{ listing, diagnostics }`. On any failure (missing listing
+ * output, parse error, plugin crash inside a user-supplied
+ * `terrazzoPlugins` entry) returns an empty map plus a `swatchbook/listing`
+ * warn diagnostic so the caller surfaces the failure instead of silently
+ * degrading `<TokenTable>` / `<ColorTable>` previews.
  */
 export interface ComputeTokenListingOptions {
   /** Extra options forwarded to the internal `plugin-css` instance. */
@@ -43,12 +45,17 @@ export interface ComputeTokenListingOptions {
   extraPlugins?: readonly Plugin[];
 }
 
+export interface ComputeTokenListingResult {
+  listing: TokenListingByPath;
+  diagnostics: Diagnostic[];
+}
+
 export async function computeTokenListing(
   parserInput: ParserInput,
   cwd: string,
   prefix: string,
   options: ComputeTokenListingOptions = {},
-): Promise<TokenListingByPath> {
+): Promise<ComputeTokenListingResult> {
   try {
     const { tokens, sources, resolver } = parserInput;
     const logger = new Logger({ level: 'warn' });
@@ -83,21 +90,50 @@ export async function computeTokenListing(
 
     const result = await build(tokens, { config, resolver, sources, logger });
     const listingFile = result.outputFiles.find((f) => f.filename === 'tokens.listing.json');
-    if (!listingFile) return {};
+    if (!listingFile) {
+      return { listing: {}, diagnostics: [missingListingDiagnostic()] };
+    }
 
     const raw =
       typeof listingFile.contents === 'string'
         ? listingFile.contents
         : new TextDecoder().decode(listingFile.contents);
     const parsed = JSON.parse(raw) as { data?: ListedToken[] };
-    if (!Array.isArray(parsed.data)) return {};
+    if (!Array.isArray(parsed.data)) {
+      return { listing: {}, diagnostics: [malformedListingDiagnostic()] };
+    }
 
     const byPath: TokenListingByPath = {};
     for (const entry of parsed.data) {
       byPath[entry.$name] = entry;
     }
-    return byPath;
-  } catch {
-    return {};
+    return { listing: byPath, diagnostics: [] };
+  } catch (err) {
+    return { listing: {}, diagnostics: [crashedListingDiagnostic(err)] };
   }
+}
+
+function crashedListingDiagnostic(err: unknown): Diagnostic {
+  const detail = err instanceof Error ? err.message : String(err);
+  return {
+    severity: 'warn',
+    group: 'swatchbook/listing',
+    message: `Token listing build failed: ${detail}. <TokenTable> / <ColorTable> previews will fall back to raw values.`,
+  };
+}
+
+function missingListingDiagnostic(): Diagnostic {
+  return {
+    severity: 'warn',
+    group: 'swatchbook/listing',
+    message: `Token listing build emitted no \`tokens.listing.json\` output. <TokenTable> / <ColorTable> previews will fall back to raw values.`,
+  };
+}
+
+function malformedListingDiagnostic(): Diagnostic {
+  return {
+    severity: 'warn',
+    group: 'swatchbook/listing',
+    message: `Token listing JSON had no \`data\` array. <TokenTable> / <ColorTable> previews will fall back to raw values.`,
+  };
 }

--- a/packages/core/test/token-listing.test.ts
+++ b/packages/core/test/token-listing.test.ts
@@ -1,5 +1,7 @@
+import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 import { describe, expect, it } from 'vitest';
-import { loadWithPrefix } from './_helpers';
+import { loadProject } from '#/load';
+import { fixtureCwd, loadWithPrefix } from './_helpers';
 
 describe('Token Listing integration', () => {
   it('populates project.listing for resolver-backed projects', async () => {
@@ -36,5 +38,31 @@ describe('Token Listing integration', () => {
     const preview = entry?.$extensions['app.terrazzo.listing'].previewValue;
     expect(typeof preview).toBe('string');
     expect(preview).toMatch(/^#[0-9a-fA-F]{6,8}$/);
+  });
+
+  it('surfaces a swatchbook/listing warn diagnostic when a terrazzoPlugin throws', async () => {
+    const project = await loadProject(
+      {
+        resolver: resolverPath,
+        default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+        cssVarPrefix: 'sb',
+        terrazzoPlugins: [
+          {
+            name: 'test/throws',
+            transform() {
+              throw new Error('plugin asplode');
+            },
+          },
+        ],
+      },
+      fixtureCwd,
+    );
+    expect(Object.keys(project.listing)).toHaveLength(0);
+    const listingDiagnostics = project.diagnostics.filter(
+      (d) => d.group === 'swatchbook/listing',
+    );
+    expect(listingDiagnostics).toHaveLength(1);
+    expect(listingDiagnostics[0]?.severity).toBe('warn');
+    expect(listingDiagnostics[0]?.message).toContain('plugin asplode');
   });
 });


### PR DESCRIPTION
## Summary

From sub-issue #694 (pre-1.0 dossier blocker).

`computeTokenListing` previously returned `{}` on any failure inside the listing build — including bugs in user-supplied `terrazzoPlugins` — with no diagnostic. Result: `<TokenTable>` / `<ColorTable>` / `<TokenDetail>` previews silently fell back to raw values and the consumer had no signal as to why.

This PR changes the function's return type from `Promise<TokenListingByPath>` to `Promise<{ listing, diagnostics }>` and pushes a `swatchbook/listing` warn diagnostic in three failure paths:

- Plugin crash inside the build (catch block).
- Build emitted no `tokens.listing.json` output file.
- Listing JSON had no `data` array.

`load.ts` merges those diagnostics into the project's `diagnostics` array. The `<Diagnostics />` block already auto-opens when warnings are non-zero, so authors see the failure immediately.

`computeTokenListing` is not part of the public API (only the type aliases `ListedToken` and `TokenListingByPath` are exported via `core/index.ts`), so the return-shape change has no consumer impact.

## Test plan

- [x] Added `surfaces a swatchbook/listing warn diagnostic when a terrazzoPlugin throws` to `packages/core/test/token-listing.test.ts`. Asserts `loadProject` completes, `project.listing` is empty, exactly one `swatchbook/listing` warn diagnostic is present, and the diagnostic message contains the plugin's error text.
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test --filter=swatchbook-core` — 4/4 tasks green; 123/123 tests passing (was 122).
- [x] Existing passing path unchanged: success returns `diagnostics: []` so the existing `populates project.listing` test asserts no diagnostics get added.

Patch changeset on `@unpunnyfuns/swatchbook-core`.

Milestone: Maintenance
Closes #694
Plan impact: none