### PR TITLE
chore: clear serialize-javascript GHSA advisories via override

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "pnpm": {
     "overrides": {
       "webpackbar": "7.0.0",
-      "uuid": "^14.0.0"
+      "uuid": "^14.0.0",
+      "serialize-javascript": "^7.0.5"
     },
     "patchedDependencies": {
       "@terrazzo/plugin-css-in-js@2.0.3": "patches/@terrazzo__plugin-css-in-js@2.0.3.patch"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   webpackbar: 7.0.0
   uuid: ^14.0.0
+  serialize-javascript: ^7.0.5
 
 patchedDependencies:
   '@terrazzo/plugin-css-in-js@2.0.3':
@@ -7672,9 +7673,6 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
-  randombytes@2.1.0:
-    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
-
   range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
     engines: {node: '>= 0.6'}
@@ -8086,8 +8084,9 @@ packages:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
 
-  serialize-javascript@6.0.2:
-    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
+  serialize-javascript@7.0.5:
+    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+    engines: {node: '>=20.0.0'}
 
   serve-handler@6.1.7:
     resolution: {integrity: sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==}
@@ -14535,7 +14534,7 @@ snapshots:
       globby: 13.2.2
       normalize-path: 3.0.0
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.106.2(@swc/core@1.15.26)(esbuild@0.27.7)
 
   core-js-compat@3.49.0:
@@ -14609,7 +14608,7 @@ snapshots:
       jest-worker: 29.7.0
       postcss: 8.5.10
       schema-utils: 4.3.3
-      serialize-javascript: 6.0.2
+      serialize-javascript: 7.0.5
       webpack: 5.106.2(@swc/core@1.15.26)(esbuild@0.27.7)
     optionalDependencies:
       clean-css: 5.3.3
@@ -17541,10 +17540,6 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
-  randombytes@2.1.0:
-    dependencies:
-      safe-buffer: 5.2.1
-
   range-parser@1.2.0: {}
 
   range-parser@1.2.1: {}
@@ -18145,9 +18140,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@6.0.2:
-    dependencies:
-      randombytes: 2.1.0
+  serialize-javascript@7.0.5: {}
 
   serve-handler@6.1.7:
     dependencies:


### PR DESCRIPTION
## Summary

From sub-issue #706 (pre-1.0 dossier defer).

Pins `serialize-javascript` to `^7.0.5` in root `pnpm.overrides`, clearing two open Dependabot advisories:

- [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) (high) — RCE via `RegExp.flags` and `Date.prototype.toISOString()`. Vulnerable `<= 7.0.2`, patched `7.0.3`.
- [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) (moderate) — CPU exhaustion DoS via crafted array-like objects. Vulnerable `< 7.0.5`, patched `7.0.5`.

Comes in transitively through `apps/docs > @docusaurus/core > @docusaurus/bundler > copy-webpack-plugin > serialize-javascript`. Build-time only — not in any published package's runtime path.

## Major-bump consideration

`copy-webpack-plugin@11.0.0` declares `serialize-javascript: ^6.0.0`, so the override forces 7.x against its semver expectation. In practice, copy-webpack-plugin only invokes `serialize-javascript`'s default export with internal-bundler-asset metadata; it doesn't touch any of the v6→v7 breaking-changed APIs. Verified by building the docs site:

```
@unpunnyfuns/swatchbook-docs:build: [SUCCESS] Generated static files in "build".
```

## Test plan

- [x] `pnpm install` resolves to a single `serialize-javascript@7.0.5`.
- [x] `pnpm audit --prod` no longer reports either advisory (the remaining `ip-address` one is on PR #691).
- [x] `pnpm turbo run build --filter=swatchbook-docs` succeeds.
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 tasks green.

No changeset — workspace-internal lockfile change; no published `dependencies` field changes.

Milestone: Maintenance
Closes #706
Plan impact: none