### PR TITLE
ci: enable TurboSnap by emitting preview-stats.json

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -50,14 +50,12 @@ jobs:
           workingDir: apps/storybook
           storybookBuildDir: storybook-static
           exitZeroOnChanges: true
-          # `onlyChanged: true` (TurboSnap) wants a preview-stats.json
-          # from the Storybook build that our build:storybook script
-          # doesn't produce — Chromatic disables itself with "missing
-          # stats file" error and fails the job. Re-enable once we've
-          # added `--stats-json` to the build (or sorted out the
-          # Rspack-builder stats path); capturing every story every run
-          # is fine at our scale.
-          onlyChanged: false
+          # TurboSnap: only snapshot stories whose dependency graph
+          # touched the diff. `--stats-json` in apps/storybook's
+          # build:storybook script emits the preview-stats.json
+          # Chromatic uses to compute the dependency graph; without it,
+          # Chromatic falls back to capturing every story every run.
+          onlyChanged: true
           # Return as soon as the upload is done; Chromatic's GitHub
           # integration reports the visual-diff status asynchronously via
           # a check, so blocking on server-side comparison just makes the

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -12,7 +12,7 @@
   },
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",
-    "build:storybook": "storybook build",
+    "build:storybook": "storybook build --stats-json",
     "chromatic": "chromatic --exit-zero-on-changes --build-script-name=build:storybook",
     "test:storybook": "vitest run",
     "test:storybook:watch": "vitest",


### PR DESCRIPTION
## Summary

Closes #712.

Two-line change to flip Chromatic's TurboSnap on:

- `apps/storybook/package.json` → `build:storybook` adds `--stats-json`. Storybook writes `storybook-static/preview-stats.json` alongside the build output.
- `.github/workflows/chromatic.yml` → `onlyChanged: true`. The chromatic action reads `preview-stats.json` to compute the dependency graph and skip stories whose modules weren't touched.

After this lands, a PR that doesn't change UI files (e.g. a docs-only PR or a `package.json` metadata tweak) snapshots ~zero stories. A PR that touches one block snapshots only that block's stories. Big change candidates per PR drop from "every story" to "what your diff actually affected."

## Test plan

- [x] Local `pnpm build:storybook --stats-json` writes `storybook-static/preview-stats.json` (verified).
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck --filter=swatchbook-storybook` — 8/8 tasks green.
- After merge: confirm the next push-to-main Chromatic run reports a TurboSnap-enabled build, then watch the next PR for "skipped X stories" in the Chromatic action log.

No changeset — workspace tooling change, not a published-package change.

Milestone: Maintenance
Closes #712
Plan impact: none