### PR TITLE
build(addon): correct sideEffects + promote vite/react-vite to peer deps

### DIFF
--- a/.changeset/addon-side-effects-peers.md
+++ b/.changeset/addon-side-effects-peers.md
@@ -1,0 +1,7 @@
+---
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+Build: `sideEffects` now lists `./dist/preview.mjs` instead of `false`. The previous declaration was technically wrong — `preview.tsx` does `import 'virtual:swatchbook/integration-side-effects'` purely for its effects. Bundlers honoring `sideEffects: false` could elide the import; in practice Storybook loads the preview entry whole, so this is a correctness tightening rather than a behavior change.
+
+Promote `@storybook/react-vite` and `vite` from `devDependencies` to `peerDependencies` (alongside the existing `react`, `react-dom`, `storybook` peers). Both are imported as types from the addon's source (`Decorator` / `Preview` from `@storybook/react-vite`, `InlineConfig` from `vite`), so consumer typecheck depends on them being resolvable. Previously they were carried transitively via `storybook`; declaring them explicitly makes the dependency contract honest.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -56,7 +56,9 @@
   "files": [
     "dist"
   ],
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/preview.mjs"
+  ],
   "publishConfig": {
     "access": "public"
   },
@@ -84,9 +86,11 @@
     "picomatch": "^4.0.4"
   },
   "peerDependencies": {
+    "@storybook/react-vite": "^10.3.5",
     "react": ">=18",
     "react-dom": ">=18",
-    "storybook": "^10.3.5"
+    "storybook": "^10.3.5",
+    "vite": ">=5"
   },
   "devDependencies": {
     "@storybook/react-vite": "^10.3.5",


### PR DESCRIPTION
## Summary

From sub-issue #699 (pre-1.0 dossier defer). Two correctness tightenings on `packages/addon/package.json`:

### `sideEffects`

Was `false`; now `["./dist/preview.mjs"]`.

`preview.tsx` does `import 'virtual:swatchbook/integration-side-effects'` purely for the effect (Tailwind integration's `@theme` block injection, etc.). The `false` declaration was technically wrong — bundlers honoring it could elide the import. In practice Storybook loads the preview entry whole, so this is a correctness tightening rather than a behavior change. The four other entries (`index`, `preset`, `manager`, `hooks/index`) remain side-effect-free, so tree-shaking on the consumer surface is preserved.

### Peer dependencies

Adds `@storybook/react-vite ^10.3.5` and `vite >=5` alongside the existing `storybook` / `react` / `react-dom` peers.

Both are imported as types from the addon's source:
- `import type { Decorator, Preview } from '@storybook/react-vite';` in `preview.tsx`
- `import type { InlineConfig } from 'vite';` in `preset.ts`

Consumer typecheck previously relied on these resolving transitively through Storybook. Declaring them explicitly makes the type contract honest. `vite >=5` covers Storybook 10's compatibility range; we test against `^8` locally (devDep stays for that reason).

## Test plan

- [x] `pnpm install` — lockfile resolves cleanly with the new peer declarations.
- [x] `pnpm turbo run format:check lint typecheck test build --filter=swatchbook-addon` — 8/8 tasks green.
- [x] Build emits the same five entrypoints (`index`, `preset`, `preview`, `manager`, `hooks/index`).

Patch changeset on `@unpunnyfuns/swatchbook-addon`.

Milestone: Maintenance
Closes #699
Plan impact: none