### PR TITLE
fix(blocks,switcher): add :focus-visible indicators to interactive UI

### DIFF
--- a/.changeset/focus-visible-interactive-ui.md
+++ b/.changeset/focus-visible-interactive-ui.md
@@ -1,0 +1,12 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+---
+
+Fix: keyboard users now get a visible focus indicator on three interactive surfaces that previously had `tabIndex=0` + key handlers but no `:focus-visible` styling. Adds 2px solid outlines (using `var(--swatchbook-accent-bg, #1d4ed8)`) on:
+
+- `<TokenNavigator>` group-row + leaf-row.
+- `<TokenTable>` row.
+- `<ThemeSwitcher>` pill (was explicitly `outline: none` with no replacement).
+
+Mouse interaction stays focus-ring-free; only keyboard navigation paints the outline. Pre-1.0 a11y blocker per the dossier audit.

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -163,3 +163,52 @@ export const OnSelectFires = meta.story({
     expect(overlay).toBeNull();
   },
 });
+
+/**
+ * Pre-1.0 a11y blocker (#696). Group-row + leaf-row have `role="button"` +
+ * `tabIndex={0}` + `onKeyDown`; verify the `:focus-visible` rule paints a
+ * non-zero outline. Chromatic skips this one — the focus state is asserted
+ * via computed style, not pixels.
+ */
+export const FocusVisibleRow = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const group = canvasElement.querySelector('[data-testid="token-navigator-group"]');
+      if (!group) throw new Error('navigator did not render any group rows');
+    });
+    // Tab until a treeitem (group-row or leaf-row) receives keyboard focus.
+    for (let i = 0; i < 30; i += 1) {
+      await userEvent.tab();
+      const focused = document.activeElement;
+      if (
+        focused instanceof HTMLElement &&
+        canvasElement.contains(focused) &&
+        (focused.classList.contains('sb-token-navigator__group-row') ||
+          focused.classList.contains('sb-token-navigator__leaf-row'))
+      ) {
+        break;
+      }
+    }
+    const focused = document.activeElement;
+    if (
+      !(focused instanceof HTMLElement) ||
+      !(
+        focused.classList.contains('sb-token-navigator__group-row') ||
+        focused.classList.contains('sb-token-navigator__leaf-row')
+      )
+    ) {
+      throw new Error(
+        `expected a navigator row to receive keyboard focus; got ${focused?.tagName}`,
+      );
+    }
+    const computed = getComputedStyle(focused);
+    expect(computed.outlineStyle, 'focus-visible row outline must be solid (not none)').toBe(
+      'solid',
+    );
+    expect(
+      Number.parseFloat(computed.outlineWidth),
+      'focus-visible row outline-width must be > 0',
+    ).toBeGreaterThan(0);
+  },
+});

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -177,19 +177,21 @@ export const FocusVisibleRow = meta.story({
       const group = canvasElement.querySelector('[data-testid="token-navigator-group"]');
       if (!group) throw new Error('navigator did not render any group rows');
     });
-    // Tab until a treeitem (group-row or leaf-row) receives keyboard focus.
-    for (let i = 0; i < 30; i += 1) {
+    const isFocusedTreeitem = (): boolean => {
+      const el = document.activeElement;
+      return (
+        el instanceof HTMLElement &&
+        canvasElement.contains(el) &&
+        (el.classList.contains('sb-token-navigator__group-row') ||
+          el.classList.contains('sb-token-navigator__leaf-row'))
+      );
+    };
+    const tabUntilTreeitem = async (remaining: number): Promise<void> => {
+      if (isFocusedTreeitem() || remaining <= 0) return;
       await userEvent.tab();
-      const focused = document.activeElement;
-      if (
-        focused instanceof HTMLElement &&
-        canvasElement.contains(focused) &&
-        (focused.classList.contains('sb-token-navigator__group-row') ||
-          focused.classList.contains('sb-token-navigator__leaf-row'))
-      ) {
-        break;
-      }
-    }
+      await tabUntilTreeitem(remaining - 1);
+    };
+    await tabUntilTreeitem(30);
     const focused = document.activeElement;
     if (
       !(focused instanceof HTMLElement) ||

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -65,13 +65,16 @@ export const FocusVisibleRow = meta.story({
   parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvasElement }) => {
     await assertTableRenders(canvasElement);
-    // Tab from the document root until a tbody row receives focus —
-    // keyboard-driven focus is what activates :focus-visible.
-    for (let i = 0; i < 20; i += 1) {
+    const isFocusedRow = (): boolean => {
+      const el = document.activeElement;
+      return el?.tagName === 'TR' && el !== null && canvasElement.contains(el);
+    };
+    const tabUntilRow = async (remaining: number): Promise<void> => {
+      if (isFocusedRow() || remaining <= 0) return;
       await userEvent.tab();
-      const focused = document.activeElement;
-      if (focused?.tagName === 'TR' && canvasElement.contains(focused)) break;
-    }
+      await tabUntilRow(remaining - 1);
+    };
+    await tabUntilRow(20);
     const focused = document.activeElement;
     if (!(focused instanceof HTMLElement) || focused.tagName !== 'TR') {
       throw new Error(`expected a tbody row to receive keyboard focus; got ${focused?.tagName}`);

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -1,5 +1,5 @@
 import { TokenTable } from '@unpunnyfuns/swatchbook-blocks';
-import { expect, waitFor } from 'storybook/test';
+import { expect, userEvent, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -53,4 +53,36 @@ export const SysTypography = meta.story({ args: { filter: 'typography.*' } });
 export const DimensionsOnly = meta.story({
   args: { type: 'dimension' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});
+
+/**
+ * Pre-1.0 a11y blocker (#696). Rows have `tabIndex={0}` + click handler;
+ * verify the `:focus-visible` rule paints a non-zero outline so keyboard
+ * users get an "I am here" indicator. Chromatic skips this one — the
+ * focus state is asserted via computed style, not pixels.
+ */
+export const FocusVisibleRow = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvasElement }) => {
+    await assertTableRenders(canvasElement);
+    // Tab from the document root until a tbody row receives focus —
+    // keyboard-driven focus is what activates :focus-visible.
+    for (let i = 0; i < 20; i += 1) {
+      await userEvent.tab();
+      const focused = document.activeElement;
+      if (focused?.tagName === 'TR' && canvasElement.contains(focused)) break;
+    }
+    const focused = document.activeElement;
+    if (!(focused instanceof HTMLElement) || focused.tagName !== 'TR') {
+      throw new Error(`expected a tbody row to receive keyboard focus; got ${focused?.tagName}`);
+    }
+    const computed = getComputedStyle(focused);
+    expect(computed.outlineStyle, 'focus-visible row outline must be solid (not none)').toBe(
+      'solid',
+    );
+    expect(
+      Number.parseFloat(computed.outlineWidth),
+      'focus-visible row outline-width must be > 0',
+    ).toBeGreaterThan(0);
+  },
 });

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -51,6 +51,12 @@
   font-size: 12px;
 }
 
+.sb-token-navigator__group-row:focus-visible,
+.sb-token-navigator__leaf-row:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: 1px;
+}
+
 .sb-token-navigator__leaf-row {
   display: flex;
   align-items: center;

--- a/packages/blocks/src/TokenTable.css
+++ b/packages/blocks/src/TokenTable.css
@@ -62,6 +62,11 @@
   cursor: pointer;
 }
 
+.sb-token-table__row:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: -2px;
+}
+
 .sb-token-table__td {
   padding: 8px 12px;
   border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));

--- a/packages/switcher/src/ThemeSwitcher.css
+++ b/packages/switcher/src/ThemeSwitcher.css
@@ -59,6 +59,11 @@
   box-shadow: none;
 }
 
+.sb-switcher__pill:focus-visible {
+  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline-offset: 1px;
+}
+
 .sb-switcher__pill--active {
   font-weight: 600;
   background: rgba(0, 122, 255, 0.12);


### PR DESCRIPTION
## Summary

From sub-issue #696 (pre-1.0 dossier — three a11y blockers, one PR).

Three interactive surfaces had `tabIndex=0` + keyboard handlers but no `:focus-visible` styling. Keyboard users got no "I am here" indicator. Adds 2px solid outlines using `var(--swatchbook-accent-bg, #1d4ed8)` — same pattern `ColorTable.css` already uses on the variant-pill.

### Sites

- **`packages/blocks/src/TokenNavigator.css`** — shared `:focus-visible` rule for `.sb-token-navigator__group-row` + `.sb-token-navigator__leaf-row`.
- **`packages/blocks/src/TokenTable.css`** — `:focus-visible` on `.sb-token-table__row`. Uses `outline-offset: -2px` so the ring sits inside the row's own border (rows have implicit cell borders that would otherwise visually extend the indicator).
- **`packages/switcher/src/ThemeSwitcher.css`** — replaces the explicit `outline: none` on `.sb-switcher__pill` with a `:focus-visible` rule. The deliberate `onMouseDown preventDefault` that prevents mouse-focus stickiness stays intact, so mouse interactions still don't paint a ring.

### Chrome role decision

Reusing `--swatchbook-accent-bg` (with the existing `#1d4ed8` fallback) instead of adding a dedicated `borderFocus` chrome role. Three reasons:
1. Matches the precedent set by `ColorTable.css:130` for `.sb-color-table__variant-pill:focus-visible`.
2. Adds zero new chrome surface — no `DEFAULT_CHROME_MAP` change, no new `core.ChromeRole` member to consider for v1.0 stability.
3. Accent is the color users have already mapped to a meaningful project-specific value via `chrome: { accentBg: 'color.accent.bg' }`. Focus rings paint in the same color the user has chosen for their accent — visually coherent.

If a future audit wants a distinct focus role, that's a non-breaking addition for any post-1.0 release.

## Tests

Two new play stories (Chromatic-skipped — focus state is asserted via computed style, not pixels):

- `TokenTable.stories.tsx` → **`FocusVisibleRow`**: tabs from document root until a `<tr>` receives focus, asserts `outlineStyle === 'solid'` and `outlineWidth > 0`.
- `TokenNavigator.stories.tsx` → **`FocusVisibleRow`**: tabs into the navigator until a group-row or leaf-row is focused, asserts the same.

ThemeSwitcher pill has no top-level Storybook story (only mounted via the addon toolbar + docs-site navbar). Visual review on the upcoming Chromatic baseline covers it.

## Test plan

- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test --filter=swatchbook-blocks --filter=swatchbook-switcher` — 9/9 tasks green.
- [x] `pnpm turbo run test:storybook` — 143/143 tests pass, including the two new FocusVisibleRow stories.

Patch changeset on `@unpunnyfuns/swatchbook-blocks` + `@unpunnyfuns/swatchbook-switcher`.

Milestone: Maintenance
Closes #696
Plan impact: none