### PR TITLE
docs: register tsx/typescript with Prism so code blocks highlight

### DIFF
--- a/.changeset/docs-prism-languages.md
+++ b/.changeset/docs-prism-languages.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Docs: register `tsx` + `typescript` with Prism so `.tsx` and `.ts` fenced code blocks across the docs site (quickstart, authoring-doc-stories guide, switcher reference, etc.) render with syntax highlighting instead of plaintext. The four `mdx` fences in the source switch to `tsx` since their content is JSX-import-heavy and tsx covers it cleanly; native `mdx` highlighting isn't bundled with `prism-react-renderer`.

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -20,7 +20,7 @@ The blocks read the active token graph from a `SwatchbookProvider`. The addon's 
 
 ## A minimal docs page
 
-```mdx title="src/docs/colors.mdx"
+```tsx title="src/docs/colors.mdx"
 import { Meta } from '@storybook/addon-docs/blocks';
 import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 
@@ -47,7 +47,7 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 One page with diagnostics, tree, and table gives a top-to-bottom view — project health, browsable hierarchy, searchable lookup:
 
-```mdx title="src/docs/tokens.mdx"
+```tsx title="src/docs/tokens.mdx"
 import { Meta } from '@storybook/addon-docs/blocks';
 import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 
@@ -104,7 +104,7 @@ function Badge({ level }: { level: 'info' | 'warn' }) {
 
 Force a specific tuple on a single doc page:
 
-```mdx
+```tsx
 <Meta title="Docs/Colors (Dark)" parameters={{ swatchbook: { axes: { mode: 'Dark' } } }} />
 ```
 

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -90,7 +90,7 @@ pnpm storybook
 
 Create an MDX file under your stories glob. The addon's blocks render against whichever tuple the toolbar has active, so everything below re-renders live as you flip modifiers:
 
-```mdx title="src/docs/Tokens.mdx"
+```tsx title="src/docs/Tokens.mdx"
 import { Meta } from '@storybook/addon-docs/blocks';
 import {
   ColorPalette,

--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -133,7 +133,7 @@ const config: Config = {
     prism: {
       theme: prismThemes.github,
       darkTheme: prismThemes.dracula,
-      additionalLanguages: ['bash', 'json'],
+      additionalLanguages: ['bash', 'json', 'typescript', 'tsx'],
     },
   } satisfies Preset.ThemeConfig,
 };


### PR DESCRIPTION
## Summary

The docs site's `prism.additionalLanguages` only listed `bash` and `json`. Every fence using `ts`, `tsx`, or `mdx` (quickstart, authoring-doc-stories, switcher reference, MCP, sharing-terrazzo-options, etc.) fell back to plaintext.

- Add `typescript` + `tsx` to `additionalLanguages`.
- Rename the four `mdx` fences in source to `tsx` — `prism-react-renderer` doesn't bundle `mdx` (build fails with `Cannot find module './prism-mdx'` when listed). The fence content is JSX-import-heavy and `tsx` highlights it cleanly.

Patch changeset on `@unpunnyfuns/swatchbook-core` so the snapshot script rebuilds the current minor's docs.

## Test plan

- [x] `pnpm turbo run build --filter=swatchbook-docs` — succeeds.
- [x] Verified locally that `tsx`, `ts`, and (formerly-mdx, now-tsx) blocks on [authoring-doc-stories](https://unpunnyfuns.github.io/swatchbook/guides/authoring-doc-stories) render with proper highlighting.

Milestone: Maintenance
Closes #727
Plan impact: none