### PR TITLE
chore: pre-adopt pnpm 11 supply-chain defaults

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "apps/*"
   - "packages/*"
+
+minimumReleaseAge: 1440
+blockExoticSubdeps: true


### PR DESCRIPTION
## Summary

Pre-adopts two pnpm 11 supply-chain defaults that are already supported on pnpm 10.33 so we get the safety benefit a release early — and so the eventual pnpm 11 upgrade itself is a no-op for these settings.

```yaml
minimumReleaseAge: 1440      # available since 10.16; default in v11
blockExoticSubdeps: true     # available since 10.26; default in v11
```

- **`minimumReleaseAge: 1440`** — refuses to install versions younger than 24 hours. Defends against the chalk / debug / nx class of attacks where a maintainer's npm account is compromised, a poisoned version is published, and registry security pulls it within ~1–6 hours. A 24h delay catches the entire observed detection window with 24× margin.
- **`blockExoticSubdeps: true`** — refuses transitive deps resolved from git / tarball / file sources. The lockfile currently has **zero** such resolutions, so this is a forward-fence rather than a fix. It earns its keep on future upgrades, where an attacker-injected intermediate package could try to pull a poisoned blob via a non-registry source.

## Deferred until the actual pnpm 11 upgrade

- `minimumReleaseAgeStrict` and `minimumReleaseAgeIgnoreMissingTime` — both v11-only
- `allowBuilds` consolidation (v11 replaces `onlyBuiltDependencies` etc.)
- `devEngines.packageManager` migration from the `packageManager` field

## Tradeoff against the latest-deps policy

CLAUDE.md says "always pin the latest stable major/minor … we'd rather hit new-version friction early." The 24h delay does not conflict: that policy is about *drift avoidance* (don't lag months); the delay is about *adoption tempo* (don't install something published 30 minutes ago). Realistic upgrade cadence (Dependabot batches, manual `npm view` + test + ship) is already day(s)-scale.

If we ever need a same-day security fix, `minimumReleaseAgeExclude: ['<pkg>']` lets us bypass per-package.

## Test plan

- [x] `pnpm install --frozen-lockfile` — clean, no resolution churn
- [x] `pnpm turbo run format:check lint typecheck test` — 37/37 green
- [x] Verified lockfile has 0 exotic resolutions, so `blockExoticSubdeps: true` regresses nothing

Milestone: Maintenance
Closes #729
Plan impact: none