### PR TITLE
fix(addon): add compatibility entrypoints for legacy addon resolvers

### DIFF
--- a/.changeset/addon-compat-entrypoints.md
+++ b/.changeset/addon-compat-entrypoints.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Ship root-level `manager.js`, `preset.js`, `preview.js` shims alongside the existing `package.json#exports` subpath entries. Tools that resolve addon entrypoints by joining filenames onto the package directory — bypassing `exports` — now find the entry files without ceremony. Storybook 10.x, which resolves via `exports`, is unaffected.

--- a/packages/addon/manager.js
+++ b/packages/addon/manager.js
@@ -1,0 +1,1 @@
+export * from './dist/manager.mjs';

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -54,7 +54,10 @@
     "#/*": "./src/*"
   },
   "files": [
-    "dist"
+    "dist",
+    "manager.js",
+    "preset.js",
+    "preview.js"
   ],
   "sideEffects": [
     "./dist/preview.mjs"

--- a/packages/addon/preset.js
+++ b/packages/addon/preset.js
@@ -1,0 +1,1 @@
+export * from './dist/preset.mjs';

--- a/packages/addon/preview.js
+++ b/packages/addon/preview.js
@@ -1,0 +1,1 @@
+export * from './dist/preview.mjs';


### PR DESCRIPTION
## Summary

Add compatibility storybook addon entrypoints

## Full description

The Storybooks addon loaders look, under certain conditions, for manager, preset and preview entrypoint files that are adjacent to the addon's package.json.
