### PR TITLE
fix(core): resolve config.resolver bare package specifiers via node_modules

### DIFF
--- a/.changeset/resolver-bare-specifier.md
+++ b/.changeset/resolver-bare-specifier.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+`config.resolver` now accepts bare package specifiers (e.g. `@my/tokens/resolver.json`). Resolution prefers `cwd`-relative paths when the file is on disk — preserving every existing config form — and falls back to `node_modules` resolution from `cwd` otherwise, so token packages can ship a resolver that consumers reference directly without copying it into their tree.

--- a/packages/core/src/permutations/resolver.ts
+++ b/packages/core/src/permutations/resolver.ts
@@ -1,4 +1,6 @@
+import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
 import { isAbsolute, resolve as resolvePath } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { defineConfig as defineTerrazzoConfig, loadResolver, parse } from '@terrazzo/parser';
@@ -26,6 +28,40 @@ export interface ResolverLoadResult {
   /** Retained Terrazzo parse output for downstream plugin emission. */
   parserInput?: ParserInput;
   diagnostics: Diagnostic[];
+}
+
+/**
+ * Resolve a `config.resolver` value to an absolute file path.
+ *
+ * Resolution order:
+ *
+ * 1. Absolute paths pass through unchanged.
+ * 2. Explicit relative paths (`./resolver.json`, `../config/resolver.json`)
+ *    resolve against `cwd`.
+ * 3. Anything else first tries `cwd`-relative on disk — preserves the
+ *    legacy "`resolver.json` in the project root" form — and falls back
+ *    to `node_modules` resolution when that file isn't present. Token
+ *    packages can ship a resolver that consumers reference directly
+ *    (`@scope/pkg/resolver.json`) without copying it into their tree.
+ *
+ * The `createRequire` anchor doesn't need to exist on disk — it only
+ * fixes the starting point for the `node_modules` walk.
+ */
+function resolveResolverInput(resolverPath: string, cwd: string): string {
+  if (isAbsolute(resolverPath)) return resolverPath;
+  if (resolverPath.startsWith('.')) return resolvePath(cwd, resolverPath);
+
+  const cwdRelative = resolvePath(cwd, resolverPath);
+  if (existsSync(cwdRelative)) return cwdRelative;
+
+  const require = createRequire(resolvePath(cwd, '__swatchbook_resolver__'));
+  try {
+    return require.resolve(resolverPath);
+  } catch {
+    throw new Error(
+      `swatchbook: could not resolve config.resolver "${resolverPath}". Tried "${cwdRelative}" on disk and node_modules under "${cwd}".`,
+    );
+  }
 }
 
 /**
@@ -62,7 +98,7 @@ export async function loadResolverPermutations(
   let loaded: Awaited<ReturnType<typeof loadResolver>> | undefined;
   let resolverAbsolute: string | undefined;
   if (resolverPath) {
-    resolverAbsolute = isAbsolute(resolverPath) ? resolverPath : resolvePath(cwd, resolverPath);
+    resolverAbsolute = resolveResolverInput(resolverPath, cwd);
     // `loadResolver` expects the resolver file alone as input and fetches
     // referenced token files via `req`. Passing tokens up front triggers
     // "Resolver must be the only input" errors.

--- a/packages/core/test/resolver-edge-cases.test.ts
+++ b/packages/core/test/resolver-edge-cases.test.ts
@@ -96,6 +96,37 @@ it('records sourceFiles for every file pulled through $ref', async () => {
   expect(resolverPath).toBeDefined();
 });
 
+it('resolves a `config.resolver` bare package specifier through the consumer cwd node_modules', async () => {
+  // Stage a fake token package at node_modules/@swatchbook-test/tokens/.
+  // No `exports` field: Node falls back to legacy subpath resolution so
+  // `@swatchbook-test/tokens/resolver.json` maps to the file on disk.
+  writeJSON('node_modules/@swatchbook-test/tokens/package.json', {
+    name: '@swatchbook-test/tokens',
+    version: '0.0.0',
+  });
+  writeJSON('node_modules/@swatchbook-test/tokens/tokens.json', {
+    color: { red: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } } },
+  });
+  writeJSON('node_modules/@swatchbook-test/tokens/resolver.json', {
+    $schema: 'https://www.designtokens.org/TR/2025.10/resolver/',
+    version: '2025.10',
+    sets: { main: { sources: [{ $ref: './tokens.json' }] } },
+    resolutionOrder: [{ $ref: '#/sets/main' }],
+  });
+  const project = await loadProject(
+    { resolver: '@swatchbook-test/tokens/resolver.json', default: {} },
+    workspace,
+  );
+  expect(project.permutations.length).toBeGreaterThan(0);
+  expect(project.diagnostics.some((d) => d.severity === 'error')).toBe(false);
+});
+
+it('surfaces a clear error when a bare-specifier resolver is not installed', async () => {
+  await expect(
+    loadProject({ resolver: '@nope/not-installed/resolver.json', default: {} }, workspace),
+  ).rejects.toThrow(/not-installed|Cannot find/);
+});
+
 it('surfaces a warn diagnostic when a modifier has no default and no contexts', async () => {
   writeJSON('tokens.json', {
     color: { red: { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 0, 0] } } },


### PR DESCRIPTION
## Summary

Before, every non-absolute `config.resolver` value was passed through `path.resolve(cwd, value)`, so a bare package specifier like `resolver: "@my/tokens/resolver.json"` became `<cwd>/@my/tokens/resolver.json` and couldn't reach a token package installed in `node_modules` (#736).

New resolution order in `packages/core/src/permutations/resolver.ts`:

1. Absolute paths pass through.
2. Explicit relative paths (`./`, `../`) resolve against `cwd` — unchanged.
3. Anything else tries `cwd`-relative on disk first, then falls back to `node_modules` resolution from `cwd` (`createRequire(<cwd>/sentinel).resolve(spec)`) when no file is there. The on-disk preference preserves the legacy `resolver: "resolver.json"` form every existing config uses.

Test coverage in `packages/core/test/resolver-edge-cases.test.ts` exercises both the success path (a staged `node_modules/@swatchbook-test/tokens/` package resolves correctly) and the error path (an uninstalled bare specifier surfaces a clear message naming both candidates).

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-core test` — 129/129 pass, including the two new cases.
- [x] `pnpm turbo run format:check lint typecheck` on core — green.
- [ ] Verify against mrginglymus's reproducer in `apps/storybook` (token package layout).

Milestone: Maintenance
Closes #736
Plan impact: none.