### PR TITLE
chore(core,addon): align public export surface with reference docs

### DIFF
--- a/.changeset/align-export-surface.md
+++ b/.changeset/align-export-surface.md
@@ -1,0 +1,19 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Align the public export surface with the reference docs ahead of v1.0.
+
+**Retracted from `@unpunnyfuns/swatchbook-core`** (no first-party consumers, removed from the package's public surface):
+
+- `emitTypes`, `emitCss`, `EmitCssOptions`
+- `emitViaTerrazzo`, `EmitViaTerrazzoOptions`, `EmitSelectionEntry`, `EmittedFile`
+- `dataAttr`
+
+`projectCss` stays public — it has real first-party consumers and is now documented in the [core reference](https://unpunnyfuns.github.io/swatchbook/reference/core). For production-platform emission, use Terrazzo's CLI directly.
+
+**Newly documented surface** (no API change, just docs that catch up to reality):
+
+- core: `projectCss`, `analyzeAxisVariance`, `CHROME_ROLES`, `DEFAULT_CHROME_MAP`, `ChromeRole`, `AxisVarianceResult`, `VarianceKind`, `ResolvedPermutation`, `TokenMap`, `ListedToken`, `DiagnosticSeverity`, `ParserInput`
+- addon: `AddonOptions` typed shape; phantom `GLOBAL_KEY` removed from the exported-constants example

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -114,13 +114,36 @@ The preview decorator mounts a `SwatchbookProvider` (from blocks) that populates
 import {
   ADDON_ID,
   AXES_GLOBAL_KEY,
-  GLOBAL_KEY,
   PARAM_KEY,
   VIRTUAL_MODULE_ID,
 } from '@unpunnyfuns/swatchbook-addon';
 ```
 
 Useful when wiring the addon into custom tooling or writing interaction tests that read the globals directly.
+
+## `AddonOptions`
+
+Typed shape of the `options` object passed to the Storybook `addons` entry — what the preset reads at preview start.
+
+```ts
+import type { AddonOptions } from '@unpunnyfuns/swatchbook-addon';
+
+interface AddonOptions {
+  /** Inline swatchbook config. Mutually exclusive with `configPath`. */
+  config?: Config;
+  /** Path to a config module, relative to the Storybook `configDir`. */
+  configPath?: string;
+  /**
+   * Display-side integrations plugged into the addon's Vite plugin.
+   * Each typically contributes a virtual module the preview imports
+   * (e.g. `virtual:swatchbook/tailwind.css`). The addon itself is
+   * tool-agnostic; integrations ship as separate packages.
+   */
+  integrations?: SwatchbookIntegration[];
+}
+```
+
+`Config` and `SwatchbookIntegration` come from [`@unpunnyfuns/swatchbook-core`](./core.mdx). See the [Registration](#registration) section above for a worked example, and the [Integrations guide](../guides/integrations/index.mdx) for `integrations` factories.
 
 ## Do / don't
 

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -60,6 +60,74 @@ permutationID({ mode: 'Dark', brand: 'Brand A' }); // → "Dark · Brand A"
 permutationID({ theme: 'Light' }); // → "Light"
 ```
 
+### `analyzeAxisVariance(path, axes, permutations, permutationsResolved)`
+
+Classify how a token's resolved value changes across each axis. Used by the `AxisVariance` block and the MCP server's `get_axis_variance` tool to drive consumer-facing previews.
+
+```ts
+import { analyzeAxisVariance } from '@unpunnyfuns/swatchbook-core';
+
+const result = analyzeAxisVariance(
+  'color.accent.bg',
+  project.axes,
+  project.permutations,
+  project.permutationsResolved,
+);
+// result.kind: 'constant' | 'single' | 'multi'
+// result.varyingAxes: axes whose contexts change this token
+// result.perAxis: per-axis contexts → stringified resolved values
+```
+
+Returns an [`AxisVarianceResult`](#axisvarianceresult). Available as a subpath import too: `import { analyzeAxisVariance } from '@unpunnyfuns/swatchbook-core/variance'` — useful for tree-shaking when only variance analysis is needed.
+
+### `projectCss(project)`
+
+Emit the project's resolved CSS as a string — the same output the addon publishes into `virtual:swatchbook/tokens` at preview time. Each permutation gets its own `[data-sb-<axis>="<context>"]` selector block; the default permutation's tokens are also written to `:root`.
+
+```ts
+import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+
+const project = await loadProject(config, process.cwd());
+const css = projectCss(project);
+// :root { --sb-color-accent-bg: …; … }
+// [data-sb-mode="Dark"] { --sb-color-accent-bg: …; }
+```
+
+For consumers building docs sites, the docs apps under `apps/docs/` use this same call to feed Docusaurus's Infima theme. For production builds, prefer Terrazzo's CLI — `projectCss` exists primarily for tooling that wants the same emission the addon does.
+
+## Constants
+
+### `CHROME_ROLES`
+
+Frozen list of the ten role names that block chrome reads from. Independent of `config.cssVarPrefix` — these always live under the `--swatchbook-*` namespace so blocks remain stylable regardless of consumer prefix.
+
+```ts
+import { CHROME_ROLES } from '@unpunnyfuns/swatchbook-core';
+
+CHROME_ROLES;
+// → ['borderDefault', 'surfaceDefault', 'surfaceMuted', 'surfaceRaised',
+//    'textDefault', 'textMuted', 'accentBg', 'accentFg',
+//    'bodyFontFamily', 'bodyFontSize']
+```
+
+### `DEFAULT_CHROME_MAP`
+
+Built-in chrome values used when `config.chrome` is empty or partial. Color roles use `light-dark()` so zero-config chrome auto-flips with the active `color-scheme` (which Storybook's preview iframe, MDX docs pages, and the OS preference all participate in).
+
+```ts
+import { DEFAULT_CHROME_MAP, type ChromeRole } from '@unpunnyfuns/swatchbook-core';
+
+DEFAULT_CHROME_MAP.surfaceDefault;   // 'light-dark(#ffffff, #0f172a)'
+DEFAULT_CHROME_MAP.accentBg;         // 'light-dark(#1d4ed8, #3b82f6)'
+```
+
+### `ChromeRole`
+
+```ts
+type ChromeRole = (typeof CHROME_ROLES)[number];
+// 'borderDefault' | 'surfaceDefault' | 'surfaceMuted' | …
+```
+
 ## Types
 
 ### `Config`
@@ -186,7 +254,7 @@ interface Permutation {
 
 ```ts
 interface Diagnostic {
-  severity: 'error' | 'warn' | 'info';
+  severity: DiagnosticSeverity;
   group: string;
   message: string;
   filename?: string;
@@ -194,6 +262,77 @@ interface Diagnostic {
   column?: number;
 }
 ```
+
+### `DiagnosticSeverity`
+
+```ts
+type DiagnosticSeverity = 'error' | 'warn' | 'info';
+```
+
+### `AxisVarianceResult`
+
+Returned by [`analyzeAxisVariance`](#analyzeaxisvariancepath-axes-permutations-permutationsresolved). `kind` classifies the overall variance shape; `perAxis` records the resolved value seen in each context with other axes held at their defaults.
+
+```ts
+interface AxisVarianceResult {
+  path: string;
+  kind: VarianceKind;
+  /** Axes whose contexts change this token's resolved value. */
+  varyingAxes: string[];
+  /** Axes whose contexts do not change the resolved value. */
+  constantAcrossAxes: string[];
+  perAxis: Record<
+    string,
+    {
+      varying: boolean;
+      contexts: Record<string, string>;
+    }
+  >;
+}
+```
+
+### `VarianceKind`
+
+```ts
+type VarianceKind = 'constant' | 'single' | 'multi';
+```
+
+### `ResolvedPermutation`
+
+Pair of `(name, tokens)` returned by [`resolvePermutation`](#resolvepermutationproject-name).
+
+```ts
+interface ResolvedPermutation {
+  name: string;
+  tokens: TokenMap;
+}
+```
+
+### `TokenMap`
+
+```ts
+type TokenMap = Record<string, TokenNormalized>;
+```
+
+`TokenNormalized` is Terrazzo's per-token shape — see [`@terrazzo/parser`](https://terrazzo.app/) for its fields. Keyed by DTCG flat path (`"color.accent.bg"`).
+
+### `ListedToken`
+
+The per-token shape from `@terrazzo/plugin-token-listing`, re-exported for typing convenience. Each entry carries the authoritative plugin-css-emitted CSS variable names, a CSS-ready `previewValue`, the pre-resolution `originalValue`, and a `source.loc` pointer to the authoring file + line. Composed map: [`TokenListingByPath`](#tokenlistingbypath).
+
+### `ParserInput`
+
+Retained Terrazzo parse output threaded through the project for downstream plugin emission. Consumers should treat this as opaque; reach for it only when wiring custom Terrazzo plugins.
+
+```ts
+interface ParserInput {
+  tokens: Record<string, TokenNormalized>;
+  sources: InputSourceWithDocument[];
+  resolver: Resolver;
+}
+```
+
+`InputSourceWithDocument` and `Resolver` come from `@terrazzo/parser`.
 
 ## Do / don't
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,16 +2,9 @@ export { CHROME_ROLES, DEFAULT_CHROME_MAP, type ChromeRole } from '#/chrome.ts';
 
 export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject, resolvePermutation } from '#/load.ts';
-export { projectCss, emitTypes } from '#/emit.ts';
-export { dataAttr, emitCss, type EmitCssOptions } from '#/css.ts';
+export { projectCss } from '#/emit.ts';
 export { permutationID } from '#/types.ts';
 export { analyzeAxisVariance, type AxisVarianceResult, type VarianceKind } from '#/variance.ts';
-export {
-  emitViaTerrazzo,
-  type EmitViaTerrazzoOptions,
-  type EmitSelectionEntry,
-  type EmittedFile,
-} from '#/emit-via-terrazzo.ts';
 export { type ListedToken, type TokenListingByPath } from '#/token-listing.ts';
 
 export type {


### PR DESCRIPTION
## Summary

Pre-1.0 dossier finding (#693, blocker). Every accidental export becomes a v1.0 stability commitment. This PR trims the surface to what's documented + actually consumed, and documents the symbols that already had real consumers but weren't listed in the reference.

## Retracted from `@unpunnyfuns/swatchbook-core`

Zero first-party consumers across the workspace (verified via grep across `packages/` and `apps/`):

- `emitTypes`, `emitCss`, `EmitCssOptions`
- `emitViaTerrazzo`, `EmitViaTerrazzoOptions`, `EmitSelectionEntry`, `EmittedFile`
- `dataAttr` (addon + blocks each have their own local copy)

Internal definitions stay in `src/emit.ts`, `src/css.ts`, `src/emit-via-terrazzo.ts`; only the public re-export at `src/index.ts` goes. If display-side tooling ever needs `emitViaTerrazzo`, it returns via an explicit need rather than a speculative export — supersedes the 2026-04-22 decision-log entry on `emitViaTerrazzo` scope.

`projectCss` stays public: consumed by `packages/mcp/src/server.ts:2` and `apps/docs/scripts/build-tokens.mts:18`. Now documented as a Function in `core.mdx`.

Blocks React `Context` exports (`AxesContext`, `ColorFormatContext`, `SwatchbookContext`, `PermutationContext`) stay public — initial inclination was to retract, but `packages/addon/src/preview.tsx` is the legitimate cross-package producer wrapping every story in `<SwatchbookContext.Provider>` etc.

## Newly documented in `core.mdx`

- **Functions**: `projectCss`, `analyzeAxisVariance`
- **Constants** (new section): `CHROME_ROLES`, `DEFAULT_CHROME_MAP`, `ChromeRole`
- **Types**: `AxisVarianceResult`, `VarianceKind`, `ResolvedPermutation`, `TokenMap`, `ListedToken` (as nested entries), `DiagnosticSeverity`, `ParserInput`

## Newly documented in `addon.mdx`

- `AddonOptions` typed shape, named type table
- Removed the phantom `GLOBAL_KEY` from the exported-constants example (constant doesn't exist; was stale)

## Versioning

Pre-1.0 retractions take a `minor` bump per project policy. Core gets the minor; addon gets a patch (docs only). Fixed-group versioning pulls all six packages to the next minor on release.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test` on `core`, `addon`, `blocks`, `mcp` — 19/19 tasks pass.
- [x] Verified `packages/mcp/src/server.ts` still imports `analyzeAxisVariance` + `projectCss` from the root.
- [x] Verified `packages/blocks/src/token-detail/AxisVariance.tsx` still imports from the `/variance` subpath.
- [x] Verified `packages/addon/src/preview.tsx` still imports the four contexts from blocks.

Milestone: Maintenance
Closes #693
Plan impact: supersedes the 2026-04-22 `emitViaTerrazzo` scope entry in the decisions log.