### PR TITLE
test(mcp): cover contrast + format-color pure functions

### DIFF
--- a/.changeset/mcp-pure-function-tests.md
+++ b/.changeset/mcp-pure-function-tests.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add unit coverage for `contrast.ts` and `format-color.ts` (DTCG color conversion + WCAG 2.1 / APCA contrast math). First of the test splits under #695. No behavior changes.

--- a/packages/mcp/test/contrast.test.ts
+++ b/packages/mcp/test/contrast.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { computeContrast } from '#/contrast.ts';
+
+const black = { colorSpace: 'srgb', components: [0, 0, 0] };
+const white = { colorSpace: 'srgb', components: [1, 1, 1] };
+const grey = { colorSpace: 'srgb', components: [0.5, 0.5, 0.5] };
+
+describe('computeContrast', () => {
+  it('returns null when either color cannot be normalized', () => {
+    expect(computeContrast(null, white)).toBeNull();
+    expect(computeContrast(white, null)).toBeNull();
+    expect(computeContrast({ colorSpace: 'srgb' }, white)).toBeNull();
+    expect(computeContrast(white, { components: [1, 0, 0] })).toBeNull();
+    expect(computeContrast('not an object', white)).toBeNull();
+  });
+
+  it('defaults to WCAG 2.1 and emits the AA/AAA threshold grid for black on white', () => {
+    const result = computeContrast(black, white);
+    expect(result?.algorithm).toBe('wcag21');
+    expect(result?.ratio).toBeGreaterThan(20);
+    expect(result?.wcag).toEqual({
+      aa: { normal: true, large: true },
+      aaa: { normal: true, large: true },
+    });
+  });
+
+  it('passes WCAG AA large but not AA normal at the 3:1–4.5:1 band', () => {
+    // 50% grey on white lands ~3.98:1 — passes large (≥3), fails normal (≥4.5).
+    const result = computeContrast(grey, white);
+    expect(result?.ratio).toBeGreaterThan(3);
+    expect(result?.ratio).toBeLessThan(4.5);
+    expect(result?.wcag?.aa).toEqual({ normal: false, large: true });
+  });
+
+  it('honors the algorithm flag and returns APCA bronze-tier passes', () => {
+    const result = computeContrast(black, white, 'apca');
+    expect(result?.algorithm).toBe('apca');
+    expect(result?.wcag).toBeUndefined();
+    expect(result?.apca?.body).toBe(true);
+    expect(result?.apca?.largeText).toBe(true);
+    expect(result?.apca?.nonText).toBe(true);
+  });
+
+  it('preserves APCA polarity: negative Lc when foreground is darker than background', () => {
+    const darkOnLight = computeContrast(black, white, 'apca');
+    const lightOnDark = computeContrast(white, black, 'apca');
+    expect(darkOnLight?.ratio).toBeLessThan(0);
+    expect(lightOnDark?.ratio).toBeGreaterThan(0);
+    // Magnitudes match within a small tolerance; the asymmetry is by spec.
+    expect(Math.abs(Math.abs(darkOnLight!.ratio) - Math.abs(lightOnDark!.ratio))).toBeLessThan(20);
+  });
+
+  it('accepts the `channels` alias for `components`', () => {
+    const altBlack = { colorSpace: 'srgb', channels: [0, 0, 0] };
+    const altWhite = { colorSpace: 'srgb', channels: [1, 1, 1] };
+    const result = computeContrast(altBlack, altWhite);
+    expect(result?.ratio).toBeGreaterThan(20);
+  });
+
+  it('treats `null` channel values as 0', () => {
+    const partialBlack = { colorSpace: 'srgb', components: [0, null, null] };
+    const result = computeContrast(partialBlack, white);
+    expect(result?.ratio).toBeGreaterThan(15);
+  });
+
+  it('returns null when colorjs.io rejects the color space', () => {
+    const bogus = { colorSpace: 'not-a-real-space', components: [0, 0, 0] };
+    expect(computeContrast(bogus, white)).toBeNull();
+  });
+});

--- a/packages/mcp/test/format-color.test.ts
+++ b/packages/mcp/test/format-color.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { ALL_COLOR_FORMATS, formatColor, formatColorEveryWay } from '#/format-color.ts';
+
+const red = { colorSpace: 'srgb', components: [1, 0, 0] };
+// P3 pure-green sits outside the sRGB gamut — used to exercise the fallback paths.
+const greenInP3 = { colorSpace: 'p3', components: [0, 1, 0] };
+
+describe('formatColor', () => {
+  it('returns null when the input is not a normalized color object', () => {
+    expect(formatColor(null, 'hex')).toBeNull();
+    expect(formatColor('not an object', 'hex')).toBeNull();
+    expect(formatColor({ components: [1, 0, 0] }, 'hex')).toBeNull();
+    expect(formatColor({ colorSpace: 'srgb' }, 'hex')).toBeNull();
+  });
+
+  it('"raw" stringifies the input JSON verbatim, regardless of fields', () => {
+    const result = formatColor({ colorSpace: 'srgb', components: [1, 0, 0] }, 'raw');
+    expect(result).toEqual({
+      format: 'raw',
+      value: JSON.stringify({ colorSpace: 'srgb', components: [1, 0, 0] }),
+      outOfGamut: false,
+    });
+  });
+
+  it('"hex" emits the canonical hex for in-gamut sRGB colors', () => {
+    const result = formatColor(red, 'hex');
+    expect(result?.format).toBe('hex');
+    expect(result?.value).toBe('#f00');
+    expect(result?.outOfGamut).toBe(false);
+  });
+
+  it('"hex" falls back to rgb() and flags `outOfGamut` for colors outside sRGB', () => {
+    const result = formatColor(greenInP3, 'hex');
+    expect(result?.format).toBe('hex');
+    expect(result?.value).toMatch(/^rgb\(/);
+    expect(result?.outOfGamut).toBe(true);
+  });
+
+  it('"rgb" returns a space-separated rgb() string and flags out-of-gamut', () => {
+    const inGamut = formatColor(red, 'rgb');
+    expect(inGamut?.value).toMatch(/^rgb\(/);
+    expect(inGamut?.outOfGamut).toBe(false);
+
+    const outOfGamut = formatColor(greenInP3, 'rgb');
+    expect(outOfGamut?.outOfGamut).toBe(true);
+  });
+
+  it('"hsl" returns an hsl() string and surfaces the sRGB-gamut check', () => {
+    const result = formatColor(red, 'hsl');
+    expect(result?.value).toMatch(/^hsl\(/);
+    expect(result?.outOfGamut).toBe(false);
+  });
+
+  it('"oklch" returns an oklch() string and never reports out-of-gamut (perceptual space covers all visible)', () => {
+    const fromSrgb = formatColor(red, 'oklch');
+    expect(fromSrgb?.value).toMatch(/^oklch\(/);
+    expect(fromSrgb?.outOfGamut).toBe(false);
+
+    const fromP3 = formatColor(greenInP3, 'oklch');
+    expect(fromP3?.value).toMatch(/^oklch\(/);
+    expect(fromP3?.outOfGamut).toBe(false);
+  });
+
+  it('accepts the `channels` alias for `components`', () => {
+    const result = formatColor({ colorSpace: 'srgb', channels: [1, 0, 0] }, 'hex');
+    expect(result?.value).toBe('#f00');
+  });
+
+  it('honors `alpha` when constructing the color', () => {
+    const translucent = { colorSpace: 'srgb', components: [1, 0, 0], alpha: 0.5 };
+    const result = formatColor(translucent, 'rgb');
+    expect(result?.value).toMatch(/\/ 0\.5/);
+  });
+
+  it('returns null when colorjs.io rejects the color space', () => {
+    const bogus = { colorSpace: 'not-a-real-space', components: [0, 0, 0] };
+    expect(formatColor(bogus, 'hex')).toBeNull();
+    expect(formatColor(bogus, 'rgb')).toBeNull();
+    expect(formatColor(bogus, 'hsl')).toBeNull();
+    expect(formatColor(bogus, 'oklch')).toBeNull();
+  });
+});
+
+describe('formatColorEveryWay', () => {
+  it('returns an entry per format the input renders cleanly in', () => {
+    const result = formatColorEveryWay(red);
+    expect(Object.keys(result).toSorted()).toEqual([...ALL_COLOR_FORMATS].toSorted());
+    expect(result.hex?.value).toBe('#f00');
+    expect(result.raw?.value).toBe(JSON.stringify(red));
+  });
+
+  it('omits formats where conversion failed (e.g. unknown color space)', () => {
+    const result = formatColorEveryWay({ colorSpace: 'not-a-real-space', components: [0, 0, 0] });
+    // "raw" never reads colorSpace; the converters all fail.
+    expect(Object.keys(result)).toEqual(['raw']);
+  });
+
+  it('returns an empty object for non-object input', () => {
+    expect(formatColorEveryWay(null)).toEqual({});
+    expect(formatColorEveryWay('nope')).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary

First split of #695's mcp coverage gap (pre-1.0 dossier blocker). Two pure-function source files, finite surface, no decisions needed — natural warmup ahead of the larger `server.ts` handler split.

- **`contrast.ts`** (8 tests) — WCAG 2.1 AA/AAA × normal/large threshold grid, APCA bronze-tier passes + signed-Lc polarity, `channels` field alias, null / invalid / unknown-colorspace handling.
- **`format-color.ts`** (13 tests) — every output format (`hex` / `rgb` / `hsl` / `oklch` / `raw`), the in-gamut → hex / out-of-gamut → `rgb()` fallback that `hex` uses to stay machine-readable for wide-gamut inputs, alpha threading, `channels` alias, `formatColorEveryWay`'s partial-result behaviour when some converters fail (e.g. unknown color space — only `raw` survives).

Net: `match.test.ts` (6) + `contrast.test.ts` (8) + `format-color.test.ts` (13) = 27 mcp tests, all passing.

## Follow-ups under the same parent issue

- **Split 1** — `server.ts` handler tests (happy path + diagnostic/error path per tool). Largest payoff; lands next.
- **Split 3** — `load-config.ts` (resolver vs layered path, env-var fallback, missing-file failure).
- **Split 4** — `bin.ts` if feasible; otherwise documented as a known gap.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-mcp` — 5/5 tasks pass.
- [x] All 27 mcp tests pass under vitest.

Milestone: Maintenance
Refs #695
Plan impact: progresses #695 split-2; doesn't close it.