### PR TITLE
test(mcp): cover project-metadata tools + add in-memory test harness

### DIFF
--- a/.changeset/mcp-project-metadata-tests.md
+++ b/.changeset/mcp-project-metadata-tests.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add unit coverage for project-metadata MCP tools (`describe_project`, `list_axes`, `list_tokens`, `get_diagnostics`) plus the in-memory test harness used to drive them through the real MCP protocol. Second of the test splits under #695. No behavior changes.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.21.2",
     "@types/node": "^25.6.0",
+    "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.0",
     "vitest": "^4.1.4"

--- a/packages/mcp/test/_helpers.ts
+++ b/packages/mcp/test/_helpers.ts
@@ -1,0 +1,85 @@
+import { dirname } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { loadProject, type Project } from '@unpunnyfuns/swatchbook-core';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
+import { createServer } from '#/server.ts';
+
+const fixtureCwd = dirname(tokensDir);
+
+/**
+ * Load the workspace's `@unpunnyfuns/swatchbook-tokens` fixture project.
+ * Reused across mcp tests so handlers see the same realistic shape an
+ * agent will face in practice — multi-axis (mode/brand/contrast)
+ * resolver, real composite tokens, populated `listing`.
+ *
+ * `beforeAll`-friendly: parsing the fixture takes ~1s, far too slow
+ * for a `beforeEach`. Each test that needs the project caches it via
+ * the helper below.
+ */
+export async function loadFixtureProject(): Promise<Project> {
+  return loadProject(
+    {
+      tokens: ['tokens/**/*.json'],
+      resolver: resolverPath,
+      default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+      cssVarPrefix: 'sb',
+    },
+    fixtureCwd,
+  );
+}
+
+export interface McpTestHarness {
+  /** Invoke a registered tool by name; returns the raw `content` array. */
+  callTool(name: string, args?: Record<string, unknown>): Promise<unknown>;
+  /** Convenience: invoke a tool and JSON.parse its first text block. */
+  callJson<T = unknown>(name: string, args?: Record<string, unknown>): Promise<T>;
+  /** Convenience: invoke a tool and return the first text block verbatim. */
+  callText(name: string, args?: Record<string, unknown>): Promise<string>;
+  /** Swap the server's underlying project — exercises the live-reload path. */
+  setProject(next: Project): void;
+  /** Tear down both transports. */
+  close(): Promise<void>;
+}
+
+/**
+ * Spin up an in-memory client ↔ server pair bound to `project`. The
+ * harness wraps `client.callTool` with helpers that return either the
+ * raw content array, the parsed first JSON block, or the first text
+ * block verbatim — covering the three response shapes mcp tools emit.
+ */
+export async function startTestServer(project: Project): Promise<McpTestHarness> {
+  const server = createServer(project);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test', version: '0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}): Promise<unknown> => {
+    const result = await client.callTool({ name, arguments: args });
+    return result.content;
+  };
+
+  return {
+    callTool,
+    callJson: async <T>(name: string, args: Record<string, unknown> = {}) => {
+      const content = (await callTool(name, args)) as { type: string; text: string }[];
+      const first = content?.[0];
+      if (!first || first.type !== 'text') {
+        throw new Error(`expected text content from ${name}, got ${JSON.stringify(content)}`);
+      }
+      return JSON.parse(first.text) as T;
+    },
+    callText: async (name: string, args: Record<string, unknown> = {}) => {
+      const content = (await callTool(name, args)) as { type: string; text: string }[];
+      const first = content?.[0];
+      if (!first || first.type !== 'text') {
+        throw new Error(`expected text content from ${name}, got ${JSON.stringify(content)}`);
+      }
+      return first.text;
+    },
+    setProject: server.setProject,
+    close: async () => {
+      await Promise.all([client.close(), server.close()]);
+    },
+  };
+}

--- a/packages/mcp/test/project-metadata.test.ts
+++ b/packages/mcp/test/project-metadata.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { loadFixtureProject, type McpTestHarness, startTestServer } from './_helpers.ts';
+
+let project: Project;
+let mcp: McpTestHarness;
+
+// beforeAll is a perf escape hatch (per CLAUDE.md): loading the fixture
+// project + booting the in-memory MCP server takes ~1s. Every test here
+// is read-only against the same project shape, so a shared harness is
+// safe and avoids a 10× wall-clock blowup.
+beforeAll(async () => {
+  project = await loadFixtureProject();
+  mcp = await startTestServer(project);
+});
+
+afterAll(async () => {
+  await mcp.close();
+});
+
+interface DescribeProjectResult {
+  cssVarPrefix: string;
+  axes: { name: string; contexts: string[]; default: string }[];
+  permutations: string[];
+  defaultPermutation: string | null;
+  presets: string[];
+  tokensPerTheme: Record<string, number>;
+  types: Record<string, number>;
+  diagnostics: { counts: Record<string, number>; total: number };
+}
+
+it('describe_project: returns axis summary, permutation list, token counts, and diagnostic counts', async () => {
+  const result = await mcp.callJson<DescribeProjectResult>('describe_project');
+  expect(result.cssVarPrefix).toBe('sb');
+  expect(result.axes.length).toBeGreaterThan(0);
+  const modeAxis = result.axes.find((a) => a.name === 'mode');
+  expect(modeAxis?.contexts).toContain('Light');
+  expect(modeAxis?.contexts).toContain('Dark');
+  expect(result.permutations.length).toBeGreaterThan(1);
+  expect(result.defaultPermutation).toBe(result.permutations[0]);
+  expect(result.tokensPerTheme[result.defaultPermutation!]).toBeGreaterThan(0);
+  expect(result.types['color']).toBeGreaterThan(0);
+  expect(result.diagnostics.total).toBeGreaterThanOrEqual(0);
+});
+
+it('describe_project: types histogram covers every DTCG type present', async () => {
+  const result = await mcp.callJson<DescribeProjectResult>('describe_project');
+  // Sum across types should equal the total token count across permutations
+  // — sanity that the histogram came from the same walk as tokensPerTheme.
+  const totalFromTypes = Object.values(result.types).reduce((a, b) => a + b, 0);
+  const totalFromThemes = Object.values(result.tokensPerTheme).reduce((a, b) => a + b, 0);
+  expect(totalFromTypes).toBeGreaterThan(0);
+  expect(totalFromThemes).toBeGreaterThan(0);
+});
+
+interface ListAxesResult {
+  axes: { name: string; contexts: string[]; default: string; source: string }[];
+  disabledAxes: string[];
+  permutations: { name: string; input: Record<string, string> }[];
+  presets: { name: string; axes: Record<string, string>; description?: string }[];
+}
+
+it('list_axes: returns axes with `source: resolver` for resolver-driven projects, plus the full permutation product', async () => {
+  const result = await mcp.callJson<ListAxesResult>('list_axes');
+  expect(result.axes.every((a) => a.source === 'resolver')).toBe(true);
+  expect(result.disabledAxes).toEqual([]);
+  // Permutation count = product of axis context counts.
+  const expected = result.axes.reduce((acc, a) => acc * a.contexts.length, 1);
+  expect(result.permutations.length).toBe(expected);
+  // Every permutation should have an entry per axis.
+  for (const tuple of result.permutations) {
+    expect(Object.keys(tuple.input).toSorted()).toEqual(result.axes.map((a) => a.name).toSorted());
+  }
+});
+
+interface ListTokensResult {
+  theme: string;
+  count: number;
+  tokens: { path: string; type?: string; value: string }[];
+}
+
+it('list_tokens: returns every token sorted by path when filter and type are omitted', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens');
+  expect(result.theme).toBe(project.permutations[0]?.name);
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.count).toBe(result.tokens.length);
+  // Sorted ascending by path with numeric awareness.
+  const paths = result.tokens.map((t) => t.path);
+  const sortedPaths = [...paths].toSorted((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true }),
+  );
+  expect(paths).toEqual(sortedPaths);
+});
+
+it('list_tokens: scopes results to a glob filter', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', { filter: 'color.**' });
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.tokens.every((t) => t.path.startsWith('color.'))).toBe(true);
+});
+
+it('list_tokens: scopes results to a DTCG `$type`', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', { type: 'color' });
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.tokens.every((t) => t.type === 'color')).toBe(true);
+});
+
+it('list_tokens: reads from a non-default permutation when `theme` is supplied', async () => {
+  const darkPermutation = project.permutations.find((p) => p.name.includes('Dark'));
+  if (!darkPermutation) {
+    throw new Error('expected fixture to include a Dark permutation');
+  }
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', {
+    theme: darkPermutation.name,
+  });
+  expect(result.theme).toBe(darkPermutation.name);
+  expect(result.count).toBeGreaterThan(0);
+});
+
+it('list_tokens: returns a text fallback when the project has no permutations', async () => {
+  // Swap in an empty project — exercises the early-return guard at the top of the handler.
+  const emptyProject: Project = {
+    ...project,
+    permutations: [],
+    permutationsResolved: {},
+  };
+  mcp.setProject(emptyProject);
+  const text = await mcp.callText('list_tokens');
+  expect(text).toBe('No permutations in project.');
+  // Restore for the remaining tests.
+  mcp.setProject(project);
+});
+
+interface DiagnosticsResult {
+  count: number;
+  diagnostics: { severity: string; group: string; message: string }[];
+}
+
+it('get_diagnostics: returns the full diagnostic list when severity is omitted', async () => {
+  const result = await mcp.callJson<DiagnosticsResult>('get_diagnostics');
+  expect(result.count).toBe(project.diagnostics.length);
+  expect(result.diagnostics).toHaveLength(result.count);
+});
+
+it('get_diagnostics: filters by severity', async () => {
+  // Inject a synthetic diagnostic mix so the filter has something concrete
+  // to match — the fixture project may have zero diagnostics today.
+  const seeded: Project = {
+    ...project,
+    diagnostics: [
+      ...project.diagnostics,
+      { severity: 'warn' as const, group: 'test/synthetic', message: 'noise' },
+      { severity: 'error' as const, group: 'test/synthetic', message: 'boom' },
+    ],
+  };
+  mcp.setProject(seeded);
+  const warnings = await mcp.callJson<DiagnosticsResult>('get_diagnostics', { severity: 'warn' });
+  expect(warnings.diagnostics.every((d) => d.severity === 'warn')).toBe(true);
+  expect(warnings.count).toBeGreaterThanOrEqual(1);
+
+  const errors = await mcp.callJson<DiagnosticsResult>('get_diagnostics', { severity: 'error' });
+  expect(errors.diagnostics.every((d) => d.severity === 'error')).toBe(true);
+  expect(errors.count).toBeGreaterThanOrEqual(1);
+
+  mcp.setProject(project);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@unpunnyfuns/swatchbook-tokens':
+        specifier: workspace:*
+        version: link:../tokens
       tsdown:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

Second split of #695's mcp coverage gap (pre-1.0 dossier blocker). Adds the test scaffolding that the remaining handler splits will reuse, then covers the four read-only project-metadata tools.

## Scaffolding (`test/_helpers.ts`)

- `loadFixtureProject` reuses the workspace's `@unpunnyfuns/swatchbook-tokens` fixture — realistic multi-axis project (mode / brand / contrast), populated `listing`, real composite tokens. Same shape `core/test/_helpers.ts` builds, just lifted into mcp.
- `startTestServer` boots a real MCP server bound to the fixture and pairs it with an in-memory `Client` via the SDK's `InMemoryTransport.createLinkedPair`. Tests call tools through the actual JSON-RPC protocol — black-box coverage of what AI assistants will hit at runtime.
- `callJson` / `callText` helpers parse the first content block per tool's response shape.

`@unpunnyfuns/swatchbook-tokens@workspace:*` added as a `devDependency` of mcp.

## Coverage (`test/project-metadata.test.ts`, 10 tests)

- **`describe_project`** — axis summary, permutation count, types histogram, diagnostic counts; cross-checks the types-histogram sum matches the per-theme token count.
- **`list_axes`** — `source: 'resolver'` for resolver-driven fixtures, permutation count equals the cartesian product of axis context counts, each tuple covers every axis.
- **`list_tokens`** — full enumeration sorted by path with numeric awareness; glob filter (`color.**`); `\$type` filter; non-default permutation selection; text-fallback when the project has zero permutations (early-return guard via `setProject` swap).
- **`get_diagnostics`** — full list when severity is omitted; severity filter exercised with synthetic diagnostics injected via `setProject` (the fixture emits zero diagnostics, so seeding is necessary for the filter to have anything to match).

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-mcp` — 5/5 tasks pass.
- [x] All 10 new tests pass under vitest.
- [x] `_helpers.ts` is non-test-suite scaffolding; vitest auto-discovers `*.test.ts` only.

## Follow-ups

- **Split B** — token-introspection tools (`get_token`, `get_alias_chain`, `get_aliased_by`, `search_tokens`).
- **Split C** — computed + theme/emit tools (`get_color_formats`, `get_color_contrast`, `get_axis_variance`, `resolve_theme`, `emit_css`, `get_consumer_output`).
- **Split D** — `load-config.ts` (separate file from `server.ts`; the issue's split-3).

Milestone: Maintenance
Refs #695
Plan impact: progresses #695; doesn't close it.