### PR TITLE
test(mcp): cover token-introspection tools

### DIFF
--- a/.changeset/mcp-project-metadata-tests.md
+++ b/.changeset/mcp-project-metadata-tests.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add unit coverage for project-metadata MCP tools (`describe_project`, `list_axes`, `list_tokens`, `get_diagnostics`) plus the in-memory test harness used to drive them through the real MCP protocol. Second of the test splits under #695. No behavior changes.

--- a/.changeset/mcp-token-introspection-tests.md
+++ b/.changeset/mcp-token-introspection-tests.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add unit coverage for token-introspection MCP tools (`get_token`, `get_alias_chain`, `get_aliased_by`, `search_tokens`). Third of the test splits under #695. No behavior changes.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.21.2",
     "@types/node": "^25.6.0",
+    "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.0",
     "vitest": "^4.1.4"

--- a/packages/mcp/test/_helpers.ts
+++ b/packages/mcp/test/_helpers.ts
@@ -1,0 +1,85 @@
+import { dirname } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { loadProject, type Project } from '@unpunnyfuns/swatchbook-core';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
+import { createServer } from '#/server.ts';
+
+const fixtureCwd = dirname(tokensDir);
+
+/**
+ * Load the workspace's `@unpunnyfuns/swatchbook-tokens` fixture project.
+ * Reused across mcp tests so handlers see the same realistic shape an
+ * agent will face in practice — multi-axis (mode/brand/contrast)
+ * resolver, real composite tokens, populated `listing`.
+ *
+ * `beforeAll`-friendly: parsing the fixture takes ~1s, far too slow
+ * for a `beforeEach`. Each test that needs the project caches it via
+ * the helper below.
+ */
+export async function loadFixtureProject(): Promise<Project> {
+  return loadProject(
+    {
+      tokens: ['tokens/**/*.json'],
+      resolver: resolverPath,
+      default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+      cssVarPrefix: 'sb',
+    },
+    fixtureCwd,
+  );
+}
+
+export interface McpTestHarness {
+  /** Invoke a registered tool by name; returns the raw `content` array. */
+  callTool(name: string, args?: Record<string, unknown>): Promise<unknown>;
+  /** Convenience: invoke a tool and JSON.parse its first text block. */
+  callJson<T = unknown>(name: string, args?: Record<string, unknown>): Promise<T>;
+  /** Convenience: invoke a tool and return the first text block verbatim. */
+  callText(name: string, args?: Record<string, unknown>): Promise<string>;
+  /** Swap the server's underlying project — exercises the live-reload path. */
+  setProject(next: Project): void;
+  /** Tear down both transports. */
+  close(): Promise<void>;
+}
+
+/**
+ * Spin up an in-memory client ↔ server pair bound to `project`. The
+ * harness wraps `client.callTool` with helpers that return either the
+ * raw content array, the parsed first JSON block, or the first text
+ * block verbatim — covering the three response shapes mcp tools emit.
+ */
+export async function startTestServer(project: Project): Promise<McpTestHarness> {
+  const server = createServer(project);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test', version: '0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}): Promise<unknown> => {
+    const result = await client.callTool({ name, arguments: args });
+    return result.content;
+  };
+
+  return {
+    callTool,
+    callJson: async <T>(name: string, args: Record<string, unknown> = {}) => {
+      const content = (await callTool(name, args)) as { type: string; text: string }[];
+      const first = content?.[0];
+      if (!first || first.type !== 'text') {
+        throw new Error(`expected text content from ${name}, got ${JSON.stringify(content)}`);
+      }
+      return JSON.parse(first.text) as T;
+    },
+    callText: async (name: string, args: Record<string, unknown> = {}) => {
+      const content = (await callTool(name, args)) as { type: string; text: string }[];
+      const first = content?.[0];
+      if (!first || first.type !== 'text') {
+        throw new Error(`expected text content from ${name}, got ${JSON.stringify(content)}`);
+      }
+      return first.text;
+    },
+    setProject: server.setProject,
+    close: async () => {
+      await Promise.all([client.close(), server.close()]);
+    },
+  };
+}

--- a/packages/mcp/test/project-metadata.test.ts
+++ b/packages/mcp/test/project-metadata.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { loadFixtureProject, type McpTestHarness, startTestServer } from './_helpers.ts';
+
+let project: Project;
+let mcp: McpTestHarness;
+
+// beforeAll is a perf escape hatch (per CLAUDE.md): loading the fixture
+// project + booting the in-memory MCP server takes ~1s. Every test here
+// is read-only against the same project shape, so a shared harness is
+// safe and avoids a 10× wall-clock blowup.
+beforeAll(async () => {
+  project = await loadFixtureProject();
+  mcp = await startTestServer(project);
+});
+
+afterAll(async () => {
+  await mcp.close();
+});
+
+interface DescribeProjectResult {
+  cssVarPrefix: string;
+  axes: { name: string; contexts: string[]; default: string }[];
+  permutations: string[];
+  defaultPermutation: string | null;
+  presets: string[];
+  tokensPerTheme: Record<string, number>;
+  types: Record<string, number>;
+  diagnostics: { counts: Record<string, number>; total: number };
+}
+
+it('describe_project: returns axis summary, permutation list, token counts, and diagnostic counts', async () => {
+  const result = await mcp.callJson<DescribeProjectResult>('describe_project');
+  expect(result.cssVarPrefix).toBe('sb');
+  expect(result.axes.length).toBeGreaterThan(0);
+  const modeAxis = result.axes.find((a) => a.name === 'mode');
+  expect(modeAxis?.contexts).toContain('Light');
+  expect(modeAxis?.contexts).toContain('Dark');
+  expect(result.permutations.length).toBeGreaterThan(1);
+  expect(result.defaultPermutation).toBe(result.permutations[0]);
+  expect(result.tokensPerTheme[result.defaultPermutation!]).toBeGreaterThan(0);
+  expect(result.types['color']).toBeGreaterThan(0);
+  expect(result.diagnostics.total).toBeGreaterThanOrEqual(0);
+});
+
+it('describe_project: types histogram covers every DTCG type present', async () => {
+  const result = await mcp.callJson<DescribeProjectResult>('describe_project');
+  // Sum across types should equal the total token count across permutations
+  // — sanity that the histogram came from the same walk as tokensPerTheme.
+  const totalFromTypes = Object.values(result.types).reduce((a, b) => a + b, 0);
+  const totalFromThemes = Object.values(result.tokensPerTheme).reduce((a, b) => a + b, 0);
+  expect(totalFromTypes).toBeGreaterThan(0);
+  expect(totalFromThemes).toBeGreaterThan(0);
+});
+
+interface ListAxesResult {
+  axes: { name: string; contexts: string[]; default: string; source: string }[];
+  disabledAxes: string[];
+  permutations: { name: string; input: Record<string, string> }[];
+  presets: { name: string; axes: Record<string, string>; description?: string }[];
+}
+
+it('list_axes: returns axes with `source: resolver` for resolver-driven projects, plus the full permutation product', async () => {
+  const result = await mcp.callJson<ListAxesResult>('list_axes');
+  expect(result.axes.every((a) => a.source === 'resolver')).toBe(true);
+  expect(result.disabledAxes).toEqual([]);
+  // Permutation count = product of axis context counts.
+  const expected = result.axes.reduce((acc, a) => acc * a.contexts.length, 1);
+  expect(result.permutations.length).toBe(expected);
+  // Every permutation should have an entry per axis.
+  for (const tuple of result.permutations) {
+    expect(Object.keys(tuple.input).toSorted()).toEqual(result.axes.map((a) => a.name).toSorted());
+  }
+});
+
+interface ListTokensResult {
+  theme: string;
+  count: number;
+  tokens: { path: string; type?: string; value: string }[];
+}
+
+it('list_tokens: returns every token sorted by path when filter and type are omitted', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens');
+  expect(result.theme).toBe(project.permutations[0]?.name);
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.count).toBe(result.tokens.length);
+  // Sorted ascending by path with numeric awareness.
+  const paths = result.tokens.map((t) => t.path);
+  const sortedPaths = [...paths].toSorted((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true }),
+  );
+  expect(paths).toEqual(sortedPaths);
+});
+
+it('list_tokens: scopes results to a glob filter', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', { filter: 'color.**' });
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.tokens.every((t) => t.path.startsWith('color.'))).toBe(true);
+});
+
+it('list_tokens: scopes results to a DTCG `$type`', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', { type: 'color' });
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.tokens.every((t) => t.type === 'color')).toBe(true);
+});
+
+it('list_tokens: reads from a non-default permutation when `theme` is supplied', async () => {
+  const darkPermutation = project.permutations.find((p) => p.name.includes('Dark'));
+  if (!darkPermutation) {
+    throw new Error('expected fixture to include a Dark permutation');
+  }
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', {
+    theme: darkPermutation.name,
+  });
+  expect(result.theme).toBe(darkPermutation.name);
+  expect(result.count).toBeGreaterThan(0);
+});
+
+it('list_tokens: returns a text fallback when the project has no permutations', async () => {
+  // Swap in an empty project — exercises the early-return guard at the top of the handler.
+  const emptyProject: Project = {
+    ...project,
+    permutations: [],
+    permutationsResolved: {},
+  };
+  mcp.setProject(emptyProject);
+  const text = await mcp.callText('list_tokens');
+  expect(text).toBe('No permutations in project.');
+  // Restore for the remaining tests.
+  mcp.setProject(project);
+});
+
+interface DiagnosticsResult {
+  count: number;
+  diagnostics: { severity: string; group: string; message: string }[];
+}
+
+it('get_diagnostics: returns the full diagnostic list when severity is omitted', async () => {
+  const result = await mcp.callJson<DiagnosticsResult>('get_diagnostics');
+  expect(result.count).toBe(project.diagnostics.length);
+  expect(result.diagnostics).toHaveLength(result.count);
+});
+
+it('get_diagnostics: filters by severity', async () => {
+  // Inject a synthetic diagnostic mix so the filter has something concrete
+  // to match — the fixture project may have zero diagnostics today.
+  const seeded: Project = {
+    ...project,
+    diagnostics: [
+      ...project.diagnostics,
+      { severity: 'warn' as const, group: 'test/synthetic', message: 'noise' },
+      { severity: 'error' as const, group: 'test/synthetic', message: 'boom' },
+    ],
+  };
+  mcp.setProject(seeded);
+  const warnings = await mcp.callJson<DiagnosticsResult>('get_diagnostics', { severity: 'warn' });
+  expect(warnings.diagnostics.every((d) => d.severity === 'warn')).toBe(true);
+  expect(warnings.count).toBeGreaterThanOrEqual(1);
+
+  const errors = await mcp.callJson<DiagnosticsResult>('get_diagnostics', { severity: 'error' });
+  expect(errors.diagnostics.every((d) => d.severity === 'error')).toBe(true);
+  expect(errors.count).toBeGreaterThanOrEqual(1);
+
+  mcp.setProject(project);
+});

--- a/packages/mcp/test/token-introspection.test.ts
+++ b/packages/mcp/test/token-introspection.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { loadFixtureProject, type McpTestHarness, startTestServer } from './_helpers.ts';
+
+let project: Project;
+let mcp: McpTestHarness;
+
+// beforeAll is a perf escape hatch (per CLAUDE.md): the fixture + server
+// boot is ~1s, far too slow per-test. Tests here are read-only.
+beforeAll(async () => {
+  project = await loadFixtureProject();
+  mcp = await startTestServer(project);
+});
+
+afterAll(async () => {
+  await mcp.close();
+});
+
+// Known fixture invariants (see packages/tokens/tokens/):
+//   color.surface.default  → aliases color.palette.neutral.0 in Light mode
+//   color.palette.neutral.0 → primitive, aliased BY several surface/text roles
+const ALIAS_TOKEN = 'color.surface.default';
+const PRIMITIVE_TOKEN = 'color.palette.neutral.0';
+
+interface GetTokenResult {
+  path: string;
+  type?: string;
+  description?: string;
+  cssVar: string;
+  aliasedBy?: readonly string[];
+  perTheme: Record<string, { value: string; aliasOf?: string; aliasChain?: readonly string[] }>;
+}
+
+it('get_token: returns the alias chain and resolved value per permutation', async () => {
+  const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });
+  expect(result.path).toBe(ALIAS_TOKEN);
+  expect(result.type).toBe('color');
+  // cssVar uses the project prefix and dot→dash substitution.
+  expect(result.cssVar).toBe(`var(--sb-${ALIAS_TOKEN.replaceAll('.', '-')})`);
+  expect(Object.keys(result.perTheme).length).toBe(project.permutations.length);
+  // Every permutation entry carries a value; aliased ones name their target.
+  for (const entry of Object.values(result.perTheme)) {
+    expect(entry.value).toBeTruthy();
+    if (entry.aliasOf) {
+      expect(entry.aliasOf).toMatch(/^color\./);
+    }
+  }
+});
+
+it('get_token: returns the cssVar without a prefix segment when cssVarPrefix is empty', async () => {
+  const unprefixed: Project = { ...project, config: { ...project.config, cssVarPrefix: '' } };
+  mcp.setProject(unprefixed);
+  try {
+    const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });
+    expect(result.cssVar).toBe(`var(--${ALIAS_TOKEN.replaceAll('.', '-')})`);
+  } finally {
+    mcp.setProject(project);
+  }
+});
+
+it('get_token: returns a text "not found" response for unknown paths', async () => {
+  const text = await mcp.callText('get_token', { path: 'does.not.exist' });
+  expect(text).toBe('Token not found: does.not.exist');
+});
+
+interface GetAliasChainResult {
+  path: string;
+  perTheme: Record<string, { aliasOf?: string; chain: readonly string[] }>;
+}
+
+it('get_alias_chain: returns the forward chain per permutation for an alias token', async () => {
+  const result = await mcp.callJson<GetAliasChainResult>('get_alias_chain', { path: ALIAS_TOKEN });
+  expect(result.path).toBe(ALIAS_TOKEN);
+  expect(Object.keys(result.perTheme).length).toBe(project.permutations.length);
+  for (const entry of Object.values(result.perTheme)) {
+    expect(entry.chain[0]).toBe(ALIAS_TOKEN);
+    // Aliased tokens have at least one further hop; primitive variants would
+    // produce a single-element chain.
+    expect(entry.chain.length).toBeGreaterThanOrEqual(1);
+  }
+});
+
+it('get_alias_chain: returns a single-element chain for primitive tokens', async () => {
+  const result = await mcp.callJson<GetAliasChainResult>('get_alias_chain', {
+    path: PRIMITIVE_TOKEN,
+  });
+  for (const entry of Object.values(result.perTheme)) {
+    expect(entry.chain).toEqual([PRIMITIVE_TOKEN]);
+    expect(entry.aliasOf).toBeUndefined();
+  }
+});
+
+it('get_alias_chain: returns text "not found" for unknown paths', async () => {
+  const text = await mcp.callText('get_alias_chain', { path: 'nope.nope' });
+  expect(text).toBe('Token not found: nope.nope');
+});
+
+interface AliasedByNode {
+  path: string;
+  depth: number;
+  truncated?: boolean;
+  children: AliasedByNode[];
+}
+
+it('get_aliased_by: walks the reverse alias tree from a primitive', async () => {
+  const root = await mcp.callJson<AliasedByNode>('get_aliased_by', { path: PRIMITIVE_TOKEN });
+  expect(root.path).toBe(PRIMITIVE_TOKEN);
+  expect(root.depth).toBe(0);
+  expect(root.children.length).toBeGreaterThan(0);
+  // Every child should sit one level deeper.
+  for (const child of root.children) {
+    expect(child.depth).toBe(1);
+  }
+});
+
+it('get_aliased_by: caps recursion at `maxDepth`', async () => {
+  const shallow = await mcp.callJson<AliasedByNode>('get_aliased_by', {
+    path: PRIMITIVE_TOKEN,
+    maxDepth: 1,
+  });
+  expect(shallow.depth).toBe(0);
+  // With maxDepth: 1, immediate children at depth 1 either have no children
+  // or are marked `truncated` — depending on whether they have aliased-bys.
+  for (const child of shallow.children) {
+    expect(child.depth).toBe(1);
+    if (child.truncated) {
+      expect(child.children).toEqual([]);
+    }
+  }
+});
+
+it('get_aliased_by: returns an empty tree for tokens that nothing aliases', async () => {
+  // `color.surface.default` is itself an alias — nothing aliases it.
+  const root = await mcp.callJson<AliasedByNode>('get_aliased_by', { path: ALIAS_TOKEN });
+  expect(root.path).toBe(ALIAS_TOKEN);
+  expect(root.children).toEqual([]);
+});
+
+it('get_aliased_by: returns text "not found" for unknown paths', async () => {
+  const text = await mcp.callText('get_aliased_by', { path: 'gone.gone' });
+  expect(text).toBe('Token not found: gone.gone');
+});
+
+it('get_aliased_by: returns text fallback when the project has no permutations', async () => {
+  const empty: Project = { ...project, permutations: [], permutationsResolved: {} };
+  mcp.setProject(empty);
+  try {
+    const text = await mcp.callText('get_aliased_by', { path: PRIMITIVE_TOKEN });
+    expect(text).toBe('No permutations in project.');
+  } finally {
+    mcp.setProject(project);
+  }
+});
+
+interface SearchTokensResult {
+  query: string;
+  theme: string;
+  count: number;
+  truncated: boolean;
+  hits: {
+    path: string;
+    type?: string;
+    matchedIn: ('path' | 'description' | 'value')[];
+    snippet: string;
+  }[];
+}
+
+it('search_tokens: returns ranked fuzzy hits scoped to the default permutation', async () => {
+  const result = await mcp.callJson<SearchTokensResult>('search_tokens', { query: 'surface' });
+  expect(result.theme).toBe(project.permutations[0]?.name);
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.count).toBe(result.hits.length);
+  expect(result.truncated).toBe(false);
+  // Every hit names where the match landed.
+  for (const hit of result.hits) {
+    expect(hit.matchedIn.length).toBeGreaterThan(0);
+  }
+  // At least one hit should be a `color.surface.*` token.
+  expect(result.hits.some((h) => h.path.startsWith('color.surface.'))).toBe(true);
+});
+
+it('search_tokens: marks `truncated: true` when the result count equals `limit`', async () => {
+  const result = await mcp.callJson<SearchTokensResult>('search_tokens', {
+    query: 'color',
+    limit: 3,
+  });
+  expect(result.hits.length).toBeLessThanOrEqual(3);
+  if (result.hits.length === 3) {
+    expect(result.truncated).toBe(true);
+  }
+});
+
+it('search_tokens: returns text fallback when the project has no permutations', async () => {
+  const empty: Project = { ...project, permutations: [], permutationsResolved: {} };
+  mcp.setProject(empty);
+  try {
+    const text = await mcp.callText('search_tokens', { query: 'whatever' });
+    expect(text).toBe('No permutations in project.');
+  } finally {
+    mcp.setProject(project);
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@unpunnyfuns/swatchbook-tokens':
+        specifier: workspace:*
+        version: link:../tokens
       tsdown:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

Third split of #695's mcp coverage gap (pre-1.0 dossier blocker). Stacked on top of #744 — depends on the test harness `_helpers.ts` that #744 introduces. Will rebase onto main automatically when #744 lands.

## Coverage (`test/token-introspection.test.ts`, 14 tests)

- **`get_token`** — full per-permutation details, cssVar with project prefix, cssVar with empty prefix (covers the prefix-segment branch), text "not found" path.
- **`get_alias_chain`** — forward chain per permutation for an alias token (`color.surface.default`), single-element chain for a primitive (`color.palette.neutral.0`), text "not found" path.
- **`get_aliased_by`** — BFS walk from a primitive (every child at depth 1), `maxDepth` cap (children correctly marked `truncated`), empty tree for tokens nothing aliases, text "not found" path, text fallback when the project has zero permutations.
- **`search_tokens`** — ranked fuzzy hits scoped to default permutation, the `matchedIn` classification (path / description / value), `truncated` flag when hit count equals `limit`, text fallback when project has zero permutations.

Fixture invariants documented as comment constants at the top of the file (`ALIAS_TOKEN`, `PRIMITIVE_TOKEN`) so the assertions stay readable when someone visits cold.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-mcp` — 5/5 tasks pass.
- [x] All 14 new tests pass under vitest.

## Follow-ups

- **Split C** — computed + theme/emit tools (`get_color_formats`, `get_color_contrast`, `get_axis_variance`, `resolve_theme`, `emit_css`, `get_consumer_output`).
- **Split D** — `load-config.ts` (separate source file).

Milestone: Maintenance
Refs #695
Plan impact: progresses #695; doesn't close it.