### PR TITLE
test(mcp): cover computed + emit tools

### DIFF
--- a/.changeset/mcp-computed-and-emit-tests.md
+++ b/.changeset/mcp-computed-and-emit-tests.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add unit coverage for the computed + emit MCP tools (`get_color_formats`, `get_color_contrast`, `get_axis_variance`, `resolve_theme`, `emit_css`, `get_consumer_output`). Fourth of the test splits under #695 — closes the `server.ts` handler coverage gap. No behavior changes.

--- a/.changeset/mcp-project-metadata-tests.md
+++ b/.changeset/mcp-project-metadata-tests.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add unit coverage for project-metadata MCP tools (`describe_project`, `list_axes`, `list_tokens`, `get_diagnostics`) plus the in-memory test harness used to drive them through the real MCP protocol. Second of the test splits under #695. No behavior changes.

--- a/.changeset/mcp-token-introspection-tests.md
+++ b/.changeset/mcp-token-introspection-tests.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add unit coverage for token-introspection MCP tools (`get_token`, `get_alias_chain`, `get_aliased_by`, `search_tokens`). Third of the test splits under #695. No behavior changes.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -67,6 +67,7 @@
   "devDependencies": {
     "@modelcontextprotocol/inspector": "^0.21.2",
     "@types/node": "^25.6.0",
+    "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "tsdown": "^0.21.9",
     "typescript": "^6.0.0",
     "vitest": "^4.1.4"

--- a/packages/mcp/test/_helpers.ts
+++ b/packages/mcp/test/_helpers.ts
@@ -1,0 +1,85 @@
+import { dirname } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { loadProject, type Project } from '@unpunnyfuns/swatchbook-core';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
+import { createServer } from '#/server.ts';
+
+const fixtureCwd = dirname(tokensDir);
+
+/**
+ * Load the workspace's `@unpunnyfuns/swatchbook-tokens` fixture project.
+ * Reused across mcp tests so handlers see the same realistic shape an
+ * agent will face in practice — multi-axis (mode/brand/contrast)
+ * resolver, real composite tokens, populated `listing`.
+ *
+ * `beforeAll`-friendly: parsing the fixture takes ~1s, far too slow
+ * for a `beforeEach`. Each test that needs the project caches it via
+ * the helper below.
+ */
+export async function loadFixtureProject(): Promise<Project> {
+  return loadProject(
+    {
+      tokens: ['tokens/**/*.json'],
+      resolver: resolverPath,
+      default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+      cssVarPrefix: 'sb',
+    },
+    fixtureCwd,
+  );
+}
+
+export interface McpTestHarness {
+  /** Invoke a registered tool by name; returns the raw `content` array. */
+  callTool(name: string, args?: Record<string, unknown>): Promise<unknown>;
+  /** Convenience: invoke a tool and JSON.parse its first text block. */
+  callJson<T = unknown>(name: string, args?: Record<string, unknown>): Promise<T>;
+  /** Convenience: invoke a tool and return the first text block verbatim. */
+  callText(name: string, args?: Record<string, unknown>): Promise<string>;
+  /** Swap the server's underlying project — exercises the live-reload path. */
+  setProject(next: Project): void;
+  /** Tear down both transports. */
+  close(): Promise<void>;
+}
+
+/**
+ * Spin up an in-memory client ↔ server pair bound to `project`. The
+ * harness wraps `client.callTool` with helpers that return either the
+ * raw content array, the parsed first JSON block, or the first text
+ * block verbatim — covering the three response shapes mcp tools emit.
+ */
+export async function startTestServer(project: Project): Promise<McpTestHarness> {
+  const server = createServer(project);
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: 'test', version: '0' });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+
+  const callTool = async (name: string, args: Record<string, unknown> = {}): Promise<unknown> => {
+    const result = await client.callTool({ name, arguments: args });
+    return result.content;
+  };
+
+  return {
+    callTool,
+    callJson: async <T>(name: string, args: Record<string, unknown> = {}) => {
+      const content = (await callTool(name, args)) as { type: string; text: string }[];
+      const first = content?.[0];
+      if (!first || first.type !== 'text') {
+        throw new Error(`expected text content from ${name}, got ${JSON.stringify(content)}`);
+      }
+      return JSON.parse(first.text) as T;
+    },
+    callText: async (name: string, args: Record<string, unknown> = {}) => {
+      const content = (await callTool(name, args)) as { type: string; text: string }[];
+      const first = content?.[0];
+      if (!first || first.type !== 'text') {
+        throw new Error(`expected text content from ${name}, got ${JSON.stringify(content)}`);
+      }
+      return first.text;
+    },
+    setProject: server.setProject,
+    close: async () => {
+      await Promise.all([client.close(), server.close()]);
+    },
+  };
+}

--- a/packages/mcp/test/computed-and-emit.test.ts
+++ b/packages/mcp/test/computed-and-emit.test.ts
@@ -1,0 +1,232 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { loadFixtureProject, type McpTestHarness, startTestServer } from './_helpers.ts';
+
+let project: Project;
+let mcp: McpTestHarness;
+
+// beforeAll perf escape hatch (per CLAUDE.md): fixture + server boot ~1s.
+beforeAll(async () => {
+  project = await loadFixtureProject();
+  mcp = await startTestServer(project);
+});
+
+afterAll(async () => {
+  await mcp.close();
+});
+
+// Fixture invariants (see packages/tokens/tokens/):
+//   color.surface.default — alias to a palette neutral; color $type
+//   color.palette.neutral.0 — primitive color
+const COLOR_TOKEN = 'color.surface.default';
+const NEUTRAL_FG = 'color.palette.neutral.900';
+const NEUTRAL_BG = 'color.palette.neutral.0';
+
+interface ColorFormatsResult {
+  path: string;
+  theme: string;
+  formats: Record<string, { format: string; value: string; outOfGamut: boolean }>;
+}
+
+it('get_color_formats: returns hex / rgb / hsl / oklch / raw entries for a color token', async () => {
+  const result = await mcp.callJson<ColorFormatsResult>('get_color_formats', { path: COLOR_TOKEN });
+  expect(result.path).toBe(COLOR_TOKEN);
+  expect(result.formats['hex']?.value).toMatch(/^#|^rgb\(/);
+  expect(result.formats['rgb']?.value).toMatch(/^rgb\(/);
+  expect(result.formats['oklch']?.value).toMatch(/^oklch\(/);
+  expect(result.formats['raw']).toBeDefined();
+});
+
+it('get_color_formats: returns text fallback for a non-color $type', async () => {
+  // Pick a size token from the fixture.
+  const sizeEntry = Object.entries(
+    project.permutationsResolved[project.permutations[0]!.name]!,
+  ).find(([, t]) => t.$type === 'dimension');
+  expect(sizeEntry).toBeDefined();
+  const [sizePath] = sizeEntry!;
+  const text = await mcp.callText('get_color_formats', { path: sizePath });
+  expect(text).toMatch(/^Token .* is not a color/);
+});
+
+it('get_color_formats: returns text fallback for an unknown path', async () => {
+  const text = await mcp.callText('get_color_formats', { path: 'never.heard.of.it' });
+  expect(text).toBe('Token not found: never.heard.of.it');
+});
+
+interface ContrastResult {
+  theme: string;
+  foreground: { path: string; value: string };
+  background: { path: string; value: string };
+  algorithm: 'wcag21' | 'apca';
+  ratio: number;
+  wcag?: { aa: { normal: boolean; large: boolean }; aaa: { normal: boolean; large: boolean } };
+  apca?: { lc: number; body: boolean; largeText: boolean; nonText: boolean };
+}
+
+it('get_color_contrast: defaults to WCAG and returns AA/AAA passes for high-contrast pairings', async () => {
+  const result = await mcp.callJson<ContrastResult>('get_color_contrast', {
+    foreground: NEUTRAL_FG,
+    background: NEUTRAL_BG,
+  });
+  expect(result.algorithm).toBe('wcag21');
+  expect(result.ratio).toBeGreaterThan(4.5);
+  expect(result.wcag?.aa.normal).toBe(true);
+  expect(result.apca).toBeUndefined();
+});
+
+it('get_color_contrast: honors the algorithm flag (APCA returns signed Lc + bronze-tier passes)', async () => {
+  const result = await mcp.callJson<ContrastResult>('get_color_contrast', {
+    foreground: NEUTRAL_FG,
+    background: NEUTRAL_BG,
+    algorithm: 'apca',
+  });
+  expect(result.algorithm).toBe('apca');
+  expect(result.apca).toBeDefined();
+  expect(result.wcag).toBeUndefined();
+});
+
+it('get_color_contrast: returns text fallback when either token is not a color', async () => {
+  const sizeEntry = Object.entries(
+    project.permutationsResolved[project.permutations[0]!.name]!,
+  ).find(([, t]) => t.$type === 'dimension');
+  const [sizePath] = sizeEntry!;
+  const text = await mcp.callText('get_color_contrast', {
+    foreground: sizePath,
+    background: NEUTRAL_BG,
+  });
+  expect(text).toMatch(/Foreground .* is not a color/);
+});
+
+it('get_color_contrast: returns text fallback when either token is missing', async () => {
+  const missingFg = await mcp.callText('get_color_contrast', {
+    foreground: 'no.such.path',
+    background: NEUTRAL_BG,
+  });
+  expect(missingFg).toBe('Foreground token not found: no.such.path');
+  const missingBg = await mcp.callText('get_color_contrast', {
+    foreground: NEUTRAL_FG,
+    background: 'no.such.path',
+  });
+  expect(missingBg).toBe('Background token not found: no.such.path');
+});
+
+interface AxisVarianceResult {
+  path: string;
+  kind: 'constant' | 'single' | 'multi';
+  varyingAxes: string[];
+  constantAcrossAxes: string[];
+  perAxis: Record<string, { varying: boolean; contexts: Record<string, string> }>;
+}
+
+it('get_axis_variance: classifies a mode-only token as `single` varying on `mode`', async () => {
+  const result = await mcp.callJson<AxisVarianceResult>('get_axis_variance', { path: COLOR_TOKEN });
+  expect(result.path).toBe(COLOR_TOKEN);
+  // color.surface.default is themed by Light/Dark — at least `mode` varies.
+  expect(result.varyingAxes).toContain('mode');
+  // Every axis is keyed in perAxis, regardless of varying.
+  expect(Object.keys(result.perAxis).toSorted()).toEqual(
+    project.axes.map((a) => a.name).toSorted(),
+  );
+});
+
+it('get_axis_variance: classifies a primitive as `constant` across every axis', async () => {
+  const result = await mcp.callJson<AxisVarianceResult>('get_axis_variance', {
+    path: 'color.palette.neutral.0',
+  });
+  expect(result.kind).toBe('constant');
+  expect(result.varyingAxes).toEqual([]);
+  expect(result.constantAcrossAxes.length).toBe(project.axes.length);
+});
+
+it('get_axis_variance: returns text fallback for unknown paths', async () => {
+  const text = await mcp.callText('get_axis_variance', { path: 'no.such.token' });
+  expect(text).toBe('Token not found in any theme: no.such.token');
+});
+
+interface ResolveThemeResult {
+  theme: string;
+  tuple: Record<string, string>;
+  count: number;
+  tokens: Record<string, { value: string; type?: string }>;
+}
+
+it('resolve_theme: returns the full token map for a partial tuple, filling axis defaults', async () => {
+  const result = await mcp.callJson<ResolveThemeResult>('resolve_theme', {
+    tuple: { mode: 'Dark' },
+  });
+  expect(result.tuple['mode']).toBe('Dark');
+  // Other axes filled from their defaults.
+  for (const axis of project.axes) {
+    expect(result.tuple[axis.name]).toBeTruthy();
+  }
+  expect(result.count).toBeGreaterThan(0);
+});
+
+it("resolve_theme: invalid axis context falls back to that axis's default", async () => {
+  const result = await mcp.callJson<ResolveThemeResult>('resolve_theme', {
+    tuple: { mode: 'NotARealMode' },
+  });
+  const modeAxis = project.axes.find((a) => a.name === 'mode')!;
+  expect(result.tuple['mode']).toBe(modeAxis.default);
+});
+
+it('resolve_theme: scopes the returned map via filter and $type', async () => {
+  const result = await mcp.callJson<ResolveThemeResult>('resolve_theme', {
+    tuple: {},
+    filter: 'color.**',
+    type: 'color',
+  });
+  expect(result.count).toBe(Object.keys(result.tokens).length);
+  for (const [path, entry] of Object.entries(result.tokens)) {
+    expect(path).toMatch(/^color\./);
+    expect(entry.type).toBe('color');
+  }
+});
+
+it('emit_css: returns a stylesheet with :root + per-tuple selectors', async () => {
+  const css = await mcp.callText('emit_css');
+  expect(css).toContain(':root');
+  // The non-default permutations get attribute selectors with the data-sb-* prefix.
+  expect(css).toMatch(/data-sb-mode/);
+  // CSS vars use the project prefix.
+  expect(css).toMatch(/--sb-color-/);
+});
+
+interface ConsumerOutputResult {
+  path: string;
+  cssVar: string;
+  value: string;
+  type?: string;
+  theme: string;
+  tuple: Record<string, string>;
+  attrs: Record<string, string>;
+  selector: string;
+  usageSnippet: string;
+}
+
+it('get_consumer_output: returns cssVar + attrs + selector for a token at the default tuple', async () => {
+  const result = await mcp.callJson<ConsumerOutputResult>('get_consumer_output', {
+    path: COLOR_TOKEN,
+  });
+  expect(result.cssVar).toBe(`var(--sb-${COLOR_TOKEN.replaceAll('.', '-')})`);
+  expect(result.usageSnippet).toBe(`color: ${result.cssVar};`);
+  expect(result.selector).toContain('data-sb-');
+  for (const axis of project.axes) {
+    expect(result.tuple[axis.name]).toBe(axis.default);
+    expect(result.attrs[`data-sb-${axis.name}`]).toBe(axis.default);
+  }
+});
+
+it('get_consumer_output: composes the selector from a supplied non-default tuple', async () => {
+  const result = await mcp.callJson<ConsumerOutputResult>('get_consumer_output', {
+    path: COLOR_TOKEN,
+    tuple: { mode: 'Dark' },
+  });
+  expect(result.tuple['mode']).toBe('Dark');
+  expect(result.selector).toContain('[data-sb-mode="Dark"]');
+});
+
+it('get_consumer_output: returns text fallback for unknown paths', async () => {
+  const text = await mcp.callText('get_consumer_output', { path: 'nope.gone.away' });
+  expect(text).toBe('Token not found: nope.gone.away');
+});

--- a/packages/mcp/test/project-metadata.test.ts
+++ b/packages/mcp/test/project-metadata.test.ts
@@ -1,0 +1,165 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { loadFixtureProject, type McpTestHarness, startTestServer } from './_helpers.ts';
+
+let project: Project;
+let mcp: McpTestHarness;
+
+// beforeAll is a perf escape hatch (per CLAUDE.md): loading the fixture
+// project + booting the in-memory MCP server takes ~1s. Every test here
+// is read-only against the same project shape, so a shared harness is
+// safe and avoids a 10× wall-clock blowup.
+beforeAll(async () => {
+  project = await loadFixtureProject();
+  mcp = await startTestServer(project);
+});
+
+afterAll(async () => {
+  await mcp.close();
+});
+
+interface DescribeProjectResult {
+  cssVarPrefix: string;
+  axes: { name: string; contexts: string[]; default: string }[];
+  permutations: string[];
+  defaultPermutation: string | null;
+  presets: string[];
+  tokensPerTheme: Record<string, number>;
+  types: Record<string, number>;
+  diagnostics: { counts: Record<string, number>; total: number };
+}
+
+it('describe_project: returns axis summary, permutation list, token counts, and diagnostic counts', async () => {
+  const result = await mcp.callJson<DescribeProjectResult>('describe_project');
+  expect(result.cssVarPrefix).toBe('sb');
+  expect(result.axes.length).toBeGreaterThan(0);
+  const modeAxis = result.axes.find((a) => a.name === 'mode');
+  expect(modeAxis?.contexts).toContain('Light');
+  expect(modeAxis?.contexts).toContain('Dark');
+  expect(result.permutations.length).toBeGreaterThan(1);
+  expect(result.defaultPermutation).toBe(result.permutations[0]);
+  expect(result.tokensPerTheme[result.defaultPermutation!]).toBeGreaterThan(0);
+  expect(result.types['color']).toBeGreaterThan(0);
+  expect(result.diagnostics.total).toBeGreaterThanOrEqual(0);
+});
+
+it('describe_project: types histogram covers every DTCG type present', async () => {
+  const result = await mcp.callJson<DescribeProjectResult>('describe_project');
+  // Sum across types should equal the total token count across permutations
+  // — sanity that the histogram came from the same walk as tokensPerTheme.
+  const totalFromTypes = Object.values(result.types).reduce((a, b) => a + b, 0);
+  const totalFromThemes = Object.values(result.tokensPerTheme).reduce((a, b) => a + b, 0);
+  expect(totalFromTypes).toBeGreaterThan(0);
+  expect(totalFromThemes).toBeGreaterThan(0);
+});
+
+interface ListAxesResult {
+  axes: { name: string; contexts: string[]; default: string; source: string }[];
+  disabledAxes: string[];
+  permutations: { name: string; input: Record<string, string> }[];
+  presets: { name: string; axes: Record<string, string>; description?: string }[];
+}
+
+it('list_axes: returns axes with `source: resolver` for resolver-driven projects, plus the full permutation product', async () => {
+  const result = await mcp.callJson<ListAxesResult>('list_axes');
+  expect(result.axes.every((a) => a.source === 'resolver')).toBe(true);
+  expect(result.disabledAxes).toEqual([]);
+  // Permutation count = product of axis context counts.
+  const expected = result.axes.reduce((acc, a) => acc * a.contexts.length, 1);
+  expect(result.permutations.length).toBe(expected);
+  // Every permutation should have an entry per axis.
+  for (const tuple of result.permutations) {
+    expect(Object.keys(tuple.input).toSorted()).toEqual(result.axes.map((a) => a.name).toSorted());
+  }
+});
+
+interface ListTokensResult {
+  theme: string;
+  count: number;
+  tokens: { path: string; type?: string; value: string }[];
+}
+
+it('list_tokens: returns every token sorted by path when filter and type are omitted', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens');
+  expect(result.theme).toBe(project.permutations[0]?.name);
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.count).toBe(result.tokens.length);
+  // Sorted ascending by path with numeric awareness.
+  const paths = result.tokens.map((t) => t.path);
+  const sortedPaths = [...paths].toSorted((a, b) =>
+    a.localeCompare(b, undefined, { numeric: true }),
+  );
+  expect(paths).toEqual(sortedPaths);
+});
+
+it('list_tokens: scopes results to a glob filter', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', { filter: 'color.**' });
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.tokens.every((t) => t.path.startsWith('color.'))).toBe(true);
+});
+
+it('list_tokens: scopes results to a DTCG `$type`', async () => {
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', { type: 'color' });
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.tokens.every((t) => t.type === 'color')).toBe(true);
+});
+
+it('list_tokens: reads from a non-default permutation when `theme` is supplied', async () => {
+  const darkPermutation = project.permutations.find((p) => p.name.includes('Dark'));
+  if (!darkPermutation) {
+    throw new Error('expected fixture to include a Dark permutation');
+  }
+  const result = await mcp.callJson<ListTokensResult>('list_tokens', {
+    theme: darkPermutation.name,
+  });
+  expect(result.theme).toBe(darkPermutation.name);
+  expect(result.count).toBeGreaterThan(0);
+});
+
+it('list_tokens: returns a text fallback when the project has no permutations', async () => {
+  // Swap in an empty project — exercises the early-return guard at the top of the handler.
+  const emptyProject: Project = {
+    ...project,
+    permutations: [],
+    permutationsResolved: {},
+  };
+  mcp.setProject(emptyProject);
+  const text = await mcp.callText('list_tokens');
+  expect(text).toBe('No permutations in project.');
+  // Restore for the remaining tests.
+  mcp.setProject(project);
+});
+
+interface DiagnosticsResult {
+  count: number;
+  diagnostics: { severity: string; group: string; message: string }[];
+}
+
+it('get_diagnostics: returns the full diagnostic list when severity is omitted', async () => {
+  const result = await mcp.callJson<DiagnosticsResult>('get_diagnostics');
+  expect(result.count).toBe(project.diagnostics.length);
+  expect(result.diagnostics).toHaveLength(result.count);
+});
+
+it('get_diagnostics: filters by severity', async () => {
+  // Inject a synthetic diagnostic mix so the filter has something concrete
+  // to match — the fixture project may have zero diagnostics today.
+  const seeded: Project = {
+    ...project,
+    diagnostics: [
+      ...project.diagnostics,
+      { severity: 'warn' as const, group: 'test/synthetic', message: 'noise' },
+      { severity: 'error' as const, group: 'test/synthetic', message: 'boom' },
+    ],
+  };
+  mcp.setProject(seeded);
+  const warnings = await mcp.callJson<DiagnosticsResult>('get_diagnostics', { severity: 'warn' });
+  expect(warnings.diagnostics.every((d) => d.severity === 'warn')).toBe(true);
+  expect(warnings.count).toBeGreaterThanOrEqual(1);
+
+  const errors = await mcp.callJson<DiagnosticsResult>('get_diagnostics', { severity: 'error' });
+  expect(errors.diagnostics.every((d) => d.severity === 'error')).toBe(true);
+  expect(errors.count).toBeGreaterThanOrEqual(1);
+
+  mcp.setProject(project);
+});

--- a/packages/mcp/test/token-introspection.test.ts
+++ b/packages/mcp/test/token-introspection.test.ts
@@ -1,0 +1,202 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { loadFixtureProject, type McpTestHarness, startTestServer } from './_helpers.ts';
+
+let project: Project;
+let mcp: McpTestHarness;
+
+// beforeAll is a perf escape hatch (per CLAUDE.md): the fixture + server
+// boot is ~1s, far too slow per-test. Tests here are read-only.
+beforeAll(async () => {
+  project = await loadFixtureProject();
+  mcp = await startTestServer(project);
+});
+
+afterAll(async () => {
+  await mcp.close();
+});
+
+// Known fixture invariants (see packages/tokens/tokens/):
+//   color.surface.default  → aliases color.palette.neutral.0 in Light mode
+//   color.palette.neutral.0 → primitive, aliased BY several surface/text roles
+const ALIAS_TOKEN = 'color.surface.default';
+const PRIMITIVE_TOKEN = 'color.palette.neutral.0';
+
+interface GetTokenResult {
+  path: string;
+  type?: string;
+  description?: string;
+  cssVar: string;
+  aliasedBy?: readonly string[];
+  perTheme: Record<string, { value: string; aliasOf?: string; aliasChain?: readonly string[] }>;
+}
+
+it('get_token: returns the alias chain and resolved value per permutation', async () => {
+  const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });
+  expect(result.path).toBe(ALIAS_TOKEN);
+  expect(result.type).toBe('color');
+  // cssVar uses the project prefix and dot→dash substitution.
+  expect(result.cssVar).toBe(`var(--sb-${ALIAS_TOKEN.replaceAll('.', '-')})`);
+  expect(Object.keys(result.perTheme).length).toBe(project.permutations.length);
+  // Every permutation entry carries a value; aliased ones name their target.
+  for (const entry of Object.values(result.perTheme)) {
+    expect(entry.value).toBeTruthy();
+    if (entry.aliasOf) {
+      expect(entry.aliasOf).toMatch(/^color\./);
+    }
+  }
+});
+
+it('get_token: returns the cssVar without a prefix segment when cssVarPrefix is empty', async () => {
+  const unprefixed: Project = { ...project, config: { ...project.config, cssVarPrefix: '' } };
+  mcp.setProject(unprefixed);
+  try {
+    const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });
+    expect(result.cssVar).toBe(`var(--${ALIAS_TOKEN.replaceAll('.', '-')})`);
+  } finally {
+    mcp.setProject(project);
+  }
+});
+
+it('get_token: returns a text "not found" response for unknown paths', async () => {
+  const text = await mcp.callText('get_token', { path: 'does.not.exist' });
+  expect(text).toBe('Token not found: does.not.exist');
+});
+
+interface GetAliasChainResult {
+  path: string;
+  perTheme: Record<string, { aliasOf?: string; chain: readonly string[] }>;
+}
+
+it('get_alias_chain: returns the forward chain per permutation for an alias token', async () => {
+  const result = await mcp.callJson<GetAliasChainResult>('get_alias_chain', { path: ALIAS_TOKEN });
+  expect(result.path).toBe(ALIAS_TOKEN);
+  expect(Object.keys(result.perTheme).length).toBe(project.permutations.length);
+  for (const entry of Object.values(result.perTheme)) {
+    expect(entry.chain[0]).toBe(ALIAS_TOKEN);
+    // Aliased tokens have at least one further hop; primitive variants would
+    // produce a single-element chain.
+    expect(entry.chain.length).toBeGreaterThanOrEqual(1);
+  }
+});
+
+it('get_alias_chain: returns a single-element chain for primitive tokens', async () => {
+  const result = await mcp.callJson<GetAliasChainResult>('get_alias_chain', {
+    path: PRIMITIVE_TOKEN,
+  });
+  for (const entry of Object.values(result.perTheme)) {
+    expect(entry.chain).toEqual([PRIMITIVE_TOKEN]);
+    expect(entry.aliasOf).toBeUndefined();
+  }
+});
+
+it('get_alias_chain: returns text "not found" for unknown paths', async () => {
+  const text = await mcp.callText('get_alias_chain', { path: 'nope.nope' });
+  expect(text).toBe('Token not found: nope.nope');
+});
+
+interface AliasedByNode {
+  path: string;
+  depth: number;
+  truncated?: boolean;
+  children: AliasedByNode[];
+}
+
+it('get_aliased_by: walks the reverse alias tree from a primitive', async () => {
+  const root = await mcp.callJson<AliasedByNode>('get_aliased_by', { path: PRIMITIVE_TOKEN });
+  expect(root.path).toBe(PRIMITIVE_TOKEN);
+  expect(root.depth).toBe(0);
+  expect(root.children.length).toBeGreaterThan(0);
+  // Every child should sit one level deeper.
+  for (const child of root.children) {
+    expect(child.depth).toBe(1);
+  }
+});
+
+it('get_aliased_by: caps recursion at `maxDepth`', async () => {
+  const shallow = await mcp.callJson<AliasedByNode>('get_aliased_by', {
+    path: PRIMITIVE_TOKEN,
+    maxDepth: 1,
+  });
+  expect(shallow.depth).toBe(0);
+  // With maxDepth: 1, immediate children at depth 1 either have no children
+  // or are marked `truncated` — depending on whether they have aliased-bys.
+  for (const child of shallow.children) {
+    expect(child.depth).toBe(1);
+    if (child.truncated) {
+      expect(child.children).toEqual([]);
+    }
+  }
+});
+
+it('get_aliased_by: returns an empty tree for tokens that nothing aliases', async () => {
+  // `color.surface.default` is itself an alias — nothing aliases it.
+  const root = await mcp.callJson<AliasedByNode>('get_aliased_by', { path: ALIAS_TOKEN });
+  expect(root.path).toBe(ALIAS_TOKEN);
+  expect(root.children).toEqual([]);
+});
+
+it('get_aliased_by: returns text "not found" for unknown paths', async () => {
+  const text = await mcp.callText('get_aliased_by', { path: 'gone.gone' });
+  expect(text).toBe('Token not found: gone.gone');
+});
+
+it('get_aliased_by: returns text fallback when the project has no permutations', async () => {
+  const empty: Project = { ...project, permutations: [], permutationsResolved: {} };
+  mcp.setProject(empty);
+  try {
+    const text = await mcp.callText('get_aliased_by', { path: PRIMITIVE_TOKEN });
+    expect(text).toBe('No permutations in project.');
+  } finally {
+    mcp.setProject(project);
+  }
+});
+
+interface SearchTokensResult {
+  query: string;
+  theme: string;
+  count: number;
+  truncated: boolean;
+  hits: {
+    path: string;
+    type?: string;
+    matchedIn: ('path' | 'description' | 'value')[];
+    snippet: string;
+  }[];
+}
+
+it('search_tokens: returns ranked fuzzy hits scoped to the default permutation', async () => {
+  const result = await mcp.callJson<SearchTokensResult>('search_tokens', { query: 'surface' });
+  expect(result.theme).toBe(project.permutations[0]?.name);
+  expect(result.count).toBeGreaterThan(0);
+  expect(result.count).toBe(result.hits.length);
+  expect(result.truncated).toBe(false);
+  // Every hit names where the match landed.
+  for (const hit of result.hits) {
+    expect(hit.matchedIn.length).toBeGreaterThan(0);
+  }
+  // At least one hit should be a `color.surface.*` token.
+  expect(result.hits.some((h) => h.path.startsWith('color.surface.'))).toBe(true);
+});
+
+it('search_tokens: marks `truncated: true` when the result count equals `limit`', async () => {
+  const result = await mcp.callJson<SearchTokensResult>('search_tokens', {
+    query: 'color',
+    limit: 3,
+  });
+  expect(result.hits.length).toBeLessThanOrEqual(3);
+  if (result.hits.length === 3) {
+    expect(result.truncated).toBe(true);
+  }
+});
+
+it('search_tokens: returns text fallback when the project has no permutations', async () => {
+  const empty: Project = { ...project, permutations: [], permutationsResolved: {} };
+  mcp.setProject(empty);
+  try {
+    const text = await mcp.callText('search_tokens', { query: 'whatever' });
+    expect(text).toBe('No permutations in project.');
+  } finally {
+    mcp.setProject(project);
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      '@unpunnyfuns/swatchbook-tokens':
+        specifier: workspace:*
+        version: link:../tokens
       tsdown:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

Fourth split of #695's mcp coverage gap. Stacked on top of #745, which is stacked on #744. **Closes #695's `server.ts` handler portion** — `load-config.ts` (issue's split 3) remains as a separate follow-up.

## Coverage (`test/computed-and-emit.test.ts`, 17 tests)

- **`get_color_formats`** — hex/rgb/hsl/oklch/raw entries for a color token, non-color \$type text fallback, unknown-path text fallback.
- **`get_color_contrast`** — WCAG default (AA/AAA passes for high-contrast pairings), APCA via the \`algorithm\` flag (signed Lc + bronze-tier passes), text fallbacks for non-color \$type and missing tokens.
- **`get_axis_variance`** — \`single\` classification with \`mode\` in \`varyingAxes\` for a themed token, \`constant\` classification for a primitive across every axis, unknown-path text fallback.
- **`resolve_theme`** — partial tuple filled from axis defaults, invalid axis-context fallback to defaults, filter + \$type scoping.
- **`emit_css`** — stylesheet contains \`:root\`, per-tuple \`data-sb-mode\` selectors, and \`--sb-color-\` prefixed vars.
- **`get_consumer_output`** — cssVar / attrs / selector / usageSnippet for the default tuple, selector composition from a non-default tuple, unknown-path text fallback.

## Combined coverage state

| File | Tests |
| --- | --- |
| match.test.ts | 6 |
| contrast.test.ts | 8 |
| format-color.test.ts | 13 |
| project-metadata.test.ts | 10 |
| token-introspection.test.ts | 14 |
| **computed-and-emit.test.ts** | **17** |
| **Total** | **68** |

Every tool handler in \`server.ts\` now has at least one happy-path test and one diagnostic-or-error test — the acceptance criterion from #695.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-mcp\` — 5/5 tasks pass.
- [x] All 17 new tests pass; whole mcp suite is 68/68.

## Follow-ups

- **\`load-config.ts\`** coverage (#695 split 3) — separate file from \`server.ts\`, lands as a separate PR.
- **\`bin.ts\`** (#695 split 4) — optional per the issue; document the gap if not feasible.

Milestone: Maintenance
Closes #695 (server.ts portion; load-config follow-up tracked separately)