### PR TITLE
refactor(core,blocks,addon): consolidate parallel type definitions

### DIFF
--- a/.changeset/consolidate-parallel-types.md
+++ b/.changeset/consolidate-parallel-types.md
@@ -1,0 +1,21 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Consolidate parallel type definitions: `@unpunnyfuns/swatchbook-blocks`'s `VirtualAxisShape` / `VirtualPermutationShape` / `VirtualDiagnosticShape` / `VirtualPresetShape` are now type-aliases of core's authoritative `Axis` / `Permutation` / `Diagnostic` / `Preset`. Internal `VirtualAxisLike` / `VirtualPermutationLike` helpers in blocks removed; core's types are used directly.
+
+Two array fields on core's types tighten to `readonly` so the existing immutable usage flows through cleanly:
+
+- `Axis.contexts: readonly string[]` (was `string[]`)
+- `Permutation.sources: readonly string[]` (was `string[]`)
+
+No first-party site mutates either array; consumers who treated them as immutable already match the tightened contract.
+
+Side cleanups while we were in here:
+
+- New `cssVarAsNumber` helper in blocks centralises the `var(--…)` → `CSSProperties.fontWeight` / `lineHeight` pattern. The four scattered `as unknown as number` casts are gone.
+- New `SwatchbookGlobals` / `StoryParameters` types in addon narrow the Storybook globals + parameters bags around the keys the addon actually owns. Eliminates seven `Record<string, unknown>` casts in `preview.tsx`.
+
+Composite-token shape narrowing (DTCG `$type` discriminated unions over shadow / border / gradient / typography) deferred to a follow-up — touches a different surface and is its own surgery.

--- a/packages/addon/src/globals.ts
+++ b/packages/addon/src/globals.ts
@@ -1,0 +1,50 @@
+/**
+ * Typed shapes for the slice of Storybook globals + parameters the
+ * swatchbook addon reads. Storybook itself types both as broad bags
+ * (`Globals` / `Parameters`) — these interfaces document the keys the
+ * addon owns and pin them so the decorator + the live globals-applier
+ * don't need scattered `Record<string, unknown>` casts.
+ */
+
+import type { ColorFormat } from '@unpunnyfuns/swatchbook-blocks';
+
+/**
+ * Globals keys written by the addon's toolbar and read by its decorator.
+ *
+ * - `swatchbookAxes` — active axis tuple (axis name → context name).
+ * - `swatchbookColorFormat` — display-side color format for blocks. Does
+ *   not affect emitted CSS.
+ * - `swatchbookTheme` — legacy composed permutation ID, written in
+ *   lockstep with `swatchbookAxes` for back-compat with consumers that
+ *   only read the composed string.
+ *
+ * The index signature retains Storybook's other globals — consumers who
+ * stash unrelated globals on the same bag don't get type errors.
+ */
+export interface SwatchbookGlobals {
+  swatchbookAxes?: Record<string, string>;
+  swatchbookColorFormat?: ColorFormat;
+  swatchbookTheme?: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Per-story `parameters.swatchbook` namespace. All fields optional — most
+ * stories don't override anything.
+ */
+export interface SwatchbookParameters {
+  /** Per-story tuple override. Highest priority input. */
+  axes?: Record<string, string>;
+  /** Per-story composed permutation ID. Second priority. */
+  permutation?: string;
+  /** Legacy alias for `permutation`. */
+  theme?: string;
+}
+
+/**
+ * Storybook's parameters bag, narrowed on the `swatchbook` namespace.
+ */
+export interface StoryParameters {
+  swatchbook?: SwatchbookParameters;
+  [key: string]: unknown;
+}

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -35,10 +35,10 @@ import {
   INIT_EVENT,
   INIT_REQUEST_EVENT,
   PREVIEW_MOUSEDOWN_EVENT,
-  PARAM_KEY,
   STYLE_ELEMENT_ID,
   TOKENS_UPDATED_EVENT,
 } from '#/constants.ts';
+import type { StoryParameters, SwatchbookGlobals } from '#/globals.ts';
 
 /** CSS var name with the active prefix applied. */
 function v(name: string): string {
@@ -180,17 +180,16 @@ function normalizeTuple(partial: Readonly<Record<string, string>>): Record<strin
  *   4. virtual module default.
  */
 function resolveTuple(
-  globals: Record<string, unknown>,
-  parameters: Record<string, Record<string, unknown>>,
+  globals: SwatchbookGlobals,
+  parameters: StoryParameters,
 ): Record<string, string> {
-  const param = parameters[PARAM_KEY];
-  const paramAxes = param?.['axes'];
-  if (paramAxes && typeof paramAxes === 'object') {
-    return normalizeTuple(paramAxes as Record<string, string>);
+  const param = parameters.swatchbook;
+  const paramAxes = param?.axes;
+  if (paramAxes) {
+    return normalizeTuple(paramAxes);
   }
-  const paramPermutation = param?.['permutation'];
-  if (typeof paramPermutation === 'string') {
-    const hit = tupleForName(paramPermutation);
+  if (param?.permutation) {
+    const hit = tupleForName(param.permutation);
     if (hit) return normalizeTuple(hit);
   }
   const globalAxes = globals[AXES_GLOBAL_KEY];
@@ -200,7 +199,7 @@ function resolveTuple(
   return defaultTuple();
 }
 
-function resolveColorFormat(globals: Record<string, unknown>): ColorFormat {
+function resolveColorFormat(globals: SwatchbookGlobals): ColorFormat {
   const raw = globals[COLOR_FORMAT_GLOBAL_KEY];
   if (typeof raw === 'string' && (COLOR_FORMATS as readonly string[]).includes(raw)) {
     return raw as ColorFormat;
@@ -209,18 +208,10 @@ function resolveColorFormat(globals: Record<string, unknown>): ColorFormat {
 }
 
 const themedDecorator: Decorator = (Story, context) => {
-  const tuple = useMemo(
-    () =>
-      resolveTuple(
-        context.globals as Record<string, unknown>,
-        context.parameters as Record<string, Record<string, unknown>>,
-      ),
-    [context.globals, context.parameters],
-  );
-  const colorFormat = useMemo(
-    () => resolveColorFormat(context.globals as Record<string, unknown>),
-    [context.globals],
-  );
+  const globals = context.globals as SwatchbookGlobals;
+  const parameters = context.parameters as StoryParameters;
+  const tuple = useMemo(() => resolveTuple(globals, parameters), [globals, parameters]);
+  const colorFormat = useMemo(() => resolveColorFormat(globals), [globals]);
   const themeName = useMemo(() => matchPermutationName(tuple), [tuple]);
 
   useEffect(() => {
@@ -338,12 +329,12 @@ function installGlobalAxisApplier(): void {
    * a late-mounting manager can ask for the payload.
    */
   channel.on(INIT_REQUEST_EVENT, broadcastInit);
-  const apply = (globals: Record<string, unknown>): void => {
+  const apply = (globals: SwatchbookGlobals): void => {
     ensureStylesheet();
     const tuple = resolveTuple(globals, {});
     setRootAxes(matchPermutationName(tuple), tuple);
   };
-  const onGlobals = (payload: { globals?: Record<string, unknown> }): void => {
+  const onGlobals = (payload: { globals?: SwatchbookGlobals }): void => {
     if (payload.globals) apply(payload.globals);
   };
   channel.on('globalsUpdated', onGlobals);

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -1,6 +1,7 @@
-import type { CSSProperties, ReactElement } from 'react';
+import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './FontWeightScale.css';
+import { cssVarAsNumber } from '#/internal/css-var-style.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -88,7 +89,7 @@ export function FontWeightScale({
           </div>
           <div
             className="sb-font-weight-scale__sample"
-            style={{ fontWeight: row.cssVar as unknown as CSSProperties['fontWeight'] }}
+            style={{ fontWeight: cssVarAsNumber(row.cssVar) }}
           >
             {sample}
           </div>

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -1,38 +1,29 @@
+import type { Axis, Diagnostic, Permutation, Preset } from '@unpunnyfuns/swatchbook-core';
 import { createContext, useContext } from 'react';
 import { useChannelGlobals } from '#/internal/channel-globals.ts';
 import type { ColorFormat } from '#/format-color.ts';
 
 /**
- * Typed shape of the addon's `virtual:swatchbook/tokens` module, duplicated
- * as value-importable interfaces so consumers outside the addon's Vite
- * plugin (unit tests, custom React apps) can construct a snapshot by hand.
+ * Typed shape of the addon's `virtual:swatchbook/tokens` module.
  *
- * The ambient `declare module 'virtual:swatchbook/tokens'` declarations in
- * `packages/addon/src/virtual.d.ts` describe the same payload; the two
- * stay in sync by eye.
+ * The axis / permutation / diagnostic / preset entries are deliberate
+ * type-aliases of core's authoritative shapes — the virtual module
+ * publishes those shapes verbatim, so single-sourcing the types prevents
+ * silent drift the moment core grows a field the plugin doesn't
+ * serialise.
+ *
+ * Token / listing shapes stay as narrowed interfaces because blocks
+ * only read a subset of Terrazzo's full token / listing structure; the
+ * narrower shape documents what's actually relied on.
+ *
+ * The ambient `declare module 'virtual:swatchbook/tokens'` declarations
+ * in `packages/addon/src/virtual.d.ts` describe the same payload.
  */
-export interface VirtualAxisShape {
-  name: string;
-  contexts: readonly string[];
-  default: string;
-  description?: string;
-  source: 'resolver' | 'layered' | 'synthetic';
-}
+export type VirtualAxisShape = Axis;
 
-export interface VirtualPermutationShape {
-  name: string;
-  input: Record<string, string>;
-  sources: string[];
-}
+export type VirtualPermutationShape = Permutation;
 
-export interface VirtualDiagnosticShape {
-  severity: 'error' | 'warn' | 'info';
-  group: string;
-  message: string;
-  filename?: string;
-  line?: number;
-  column?: number;
-}
+export type VirtualDiagnosticShape = Diagnostic;
 
 export interface VirtualTokenShape {
   $type?: string;
@@ -64,11 +55,7 @@ export interface VirtualTokenListingShape {
   };
 }
 
-export interface VirtualPresetShape {
-  name: string;
-  axes: Partial<Record<string, string>>;
-  description?: string;
-}
+export type VirtualPresetShape = Preset;
 
 /**
  * Full project data read by blocks. Populated by the addon's preview

--- a/packages/blocks/src/internal/channel-globals.ts
+++ b/packages/blocks/src/internal/channel-globals.ts
@@ -31,17 +31,23 @@ function isColorFormat(value: unknown): value is ColorFormat {
   return typeof value === 'string' && (COLOR_FORMATS as readonly string[]).includes(value);
 }
 
+interface SwatchbookGlobalsPayload {
+  swatchbookAxes?: Record<string, string>;
+  swatchbookColorFormat?: ColorFormat;
+  [key: string]: unknown;
+}
+
 function ensureSubscribed(): void {
   if (subscribed || typeof window === 'undefined') return;
   subscribed = true;
   const channel = addons.getChannel();
-  const onGlobals = (payload: { globals?: Record<string, unknown> }): void => {
+  const onGlobals = (payload: { globals?: SwatchbookGlobalsPayload }): void => {
     const globals = payload.globals;
     if (!globals) return;
     let next = snapshot;
     const nextAxes = globals[AXES_GLOBAL_KEY];
     if (nextAxes && typeof nextAxes === 'object') {
-      next = { ...next, axes: nextAxes as Record<string, string> };
+      next = { ...next, axes: nextAxes };
     }
     const nextFormat = globals[COLOR_FORMAT_GLOBAL_KEY];
     if (isColorFormat(nextFormat)) {

--- a/packages/blocks/src/internal/css-var-style.ts
+++ b/packages/blocks/src/internal/css-var-style.ts
@@ -1,0 +1,15 @@
+/**
+ * Coerce a CSS `var(--…)` reference into the numeric slot of a React
+ * inline-style property.
+ *
+ * React's `CSSProperties` types unitless properties (`fontWeight`,
+ * `lineHeight`, `zIndex`, …) as `number`. The DOM accepts a string at
+ * runtime — the rendered stylesheet just receives whatever React passes —
+ * so a `var(--font-weight)` reference works functionally. TypeScript still
+ * complains. Centralising the type assertion in one named helper keeps
+ * the gap visible (and greppable) instead of scattering casts across
+ * block components that want CSS-var-driven typography or layout values.
+ */
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error — React's CSSProperties slot is `number`; the DOM tolerates a CSS var string.
+export const cssVarAsNumber = (varRef: string): number => varRef;

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -1,21 +1,12 @@
 import { analyzeAxisVariance } from '@unpunnyfuns/swatchbook-core/variance';
-import type {
-  Axis as CoreAxis,
-  Permutation as CorePermutation,
-  TokenMap,
-} from '@unpunnyfuns/swatchbook-core';
+import type { Axis, Permutation, TokenMap } from '@unpunnyfuns/swatchbook-core';
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import type { ColorFormat } from '#/format-color.ts';
 import { dataAttr } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
-import {
-  type DetailToken,
-  type VirtualAxisLike,
-  type VirtualPermutationLike,
-  useTokenDetailData,
-} from '#/token-detail/internal.ts';
+import { type DetailToken, useTokenDetailData } from '#/token-detail/internal.ts';
 
 export interface AxisVarianceProps {
   /** Full dot-path of the token. */
@@ -36,11 +27,14 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
   const formatFn = (t: DetailToken | undefined): string => valueFor(t, tokenType, colorFormat);
 
   const variance = useMemo<Variance>(() => {
+    // permutationsResolved is the only field needing a structural narrow —
+    // the block's `DetailToken` is a subset of core's `TokenNormalized`,
+    // so the wrapping record types differ even though the keys match.
     const result = analyzeAxisVariance(
       path,
-      axes as unknown as readonly CoreAxis[],
-      permutations as unknown as readonly CorePermutation[],
-      permutationsResolved as unknown as Record<string, TokenMap>,
+      axes,
+      permutations,
+      permutationsResolved as Record<string, TokenMap>,
     );
     // Map core's terse kind vocabulary to the block's display-ready one.
     const kind =
@@ -141,7 +135,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
 
   const varying = variance.varyingAxes
     .map((name) => axes.find((a) => a.name === name))
-    .filter((a): a is VirtualAxisLike => Boolean(a))
+    .filter((a): a is Axis => Boolean(a))
     .toSorted((a, b) => b.contexts.length - a.contexts.length);
   const [rowAxis, colAxis, ...extra] = varying;
   if (!rowAxis || !colAxis) return <></>;
@@ -223,7 +217,7 @@ function valueFor(
 }
 
 function tupleName(
-  permutations: readonly VirtualPermutationLike[],
+  permutations: readonly Permutation[],
   tuple: Record<string, string>,
 ): string | undefined {
   const match = permutations.find((t) => {

--- a/packages/blocks/src/token-detail/CompositePreview.tsx
+++ b/packages/blocks/src/token-detail/CompositePreview.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useEffect, useState } from 'react';
+import { cssVarAsNumber } from '#/internal/css-var-style.ts';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
 
@@ -44,8 +45,8 @@ export function CompositePreviewContent({
         style={{
           fontFamily: `var(${base}-font-family)`,
           fontSize: `var(${base}-font-size)`,
-          fontWeight: `var(${base}-font-weight)` as unknown as number,
-          lineHeight: `var(${base}-line-height)` as unknown as number,
+          fontWeight: cssVarAsNumber(`var(${base}-font-weight)`),
+          lineHeight: cssVarAsNumber(`var(${base}-line-height)`),
           letterSpacing: `var(${base}-letter-spacing)`,
         }}
       >
@@ -87,7 +88,7 @@ export function CompositePreviewContent({
     return (
       <div
         className="sb-token-detail__font-weight-sample"
-        style={{ fontWeight: cssVar as unknown as number }}
+        style={{ fontWeight: cssVarAsNumber(cssVar) }}
       >
         Aa
       </div>

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -1,3 +1,4 @@
+import type { Axis, Permutation } from '@unpunnyfuns/swatchbook-core';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface DetailToken {
@@ -18,25 +19,13 @@ export interface DetailToken {
   partialAliasOf?: unknown;
 }
 
-export interface VirtualAxisLike {
-  readonly name: string;
-  readonly contexts: readonly string[];
-  readonly default: string;
-  readonly source: 'resolver' | 'layered' | 'synthetic';
-}
-
-export interface VirtualPermutationLike {
-  readonly name: string;
-  readonly input: Record<string, string>;
-}
-
 export interface TokenDetailData {
   token: DetailToken | undefined;
   cssVar: string;
   activePermutation: string;
   activeAxes: Record<string, string>;
-  axes: readonly VirtualAxisLike[];
-  permutations: readonly VirtualPermutationLike[];
+  axes: readonly Axis[];
+  permutations: readonly Permutation[];
   permutationsResolved: Record<string, Record<string, DetailToken>>;
   resolved: Record<string, DetailToken>;
   cssVarPrefix: string;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -12,7 +12,7 @@ export interface Permutation {
   /** The resolver input tuple (e.g. `{ theme: 'Light' }` or `{ mode: 'Dark', brand: 'Brand A' }`). */
   input: Record<string, string>;
   /** Reserved for future use. Empty for resolver mode. */
-  sources: string[];
+  sources: readonly string[];
 }
 
 /**
@@ -23,7 +23,7 @@ export interface Permutation {
  */
 export interface Axis {
   name: string;
-  contexts: string[];
+  contexts: readonly string[];
   default: string;
   description?: string;
   source: 'resolver' | 'layered' | 'synthetic';


### PR DESCRIPTION
## Summary

Pre-1.0 dossier finding #701 (defer). Three clusters collapsed.

### Type-alias to core's authoritative shapes

`blocks/src/contexts.ts` defined its own `VirtualAxisShape` / `VirtualPermutationShape` / `VirtualDiagnosticShape` / `VirtualPresetShape` that drifted by eye from core's `Axis` / `Permutation` / `Diagnostic` / `Preset`. Switched all four to type-aliases so the compiler catches future drift instead of "stays in sync by eye." Blocks's internal `VirtualAxisLike` / `VirtualPermutationLike` helpers in `token-detail/internal.ts` dropped entirely — core's types now flow through `useTokenDetailData`. The three `as unknown as readonly CoreAxis[]` casts in `AxisVariance.tsx` disappear.

\`Axis.contexts\` and \`Permutation.sources\` tighten to \`readonly string[]\`. No first-party site mutates either; consumers who treated them as immutable already match the tightened contract. Public-API change → core **minor** bump.

### CSS-var-as-number helper

Four `as unknown as number` / `as unknown as CSSProperties['fontWeight']` casts across `FontWeightScale.tsx` + `CompositePreview.tsx` fed CSS \`var(--…)\` references into React's numeric style slots. Centralised into a single `cssVarAsNumber()` helper in `blocks/src/internal/css-var-style.ts` with one \`@ts-expect-error\` directive that documents the runtime/type gap.

### Typed Storybook globals + parameters

Seven `Record<string, unknown>` casts in `addon/src/preview.tsx` flattened via new `SwatchbookGlobals` / `StoryParameters` / `SwatchbookParameters` interfaces in `addon/src/globals.ts`. Blocks's `channel-globals.ts` narrowed in parallel with an inline `SwatchbookGlobalsPayload` type.

## Result

- **`as unknown as` casts** in \`packages/{blocks,addon}/src/\`: **7 → 0** ✓ (the issue's hard acceptance criterion).
- **`Record<string, unknown>` count**: **22 → 14** (~36% cut). The remaining 14 live in composite-token shape sites (\`format-token-value.ts\`, \`CompositeBreakdown.tsx\`, \`TypographyScale.tsx\`, \`format-color.ts\`) — proper fix is DTCG \`\$type\` discriminated unions over shadow / border / gradient / typography. Separate surgery, separate PR.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test\` across core / blocks / addon — 15/15 tasks pass.
- [x] Verified zero remaining \`as unknown as\` in blocks/addon via grep.

## Follow-ups

- Composite-token shape narrowing (the remaining \`Record<string, unknown>\` cluster). Filing a separate issue after this lands.

Milestone: Maintenance
Refs #701 (composite-shape follow-up to be filed)