### PR TITLE
test(addon): cover useToken + dataAttr + ColorFormatSelector

### DIFF
--- a/.changeset/addon-test-coverage.md
+++ b/.changeset/addon-test-coverage.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Add unit coverage for `useToken`, `dataAttr`, and `ColorFormatSelector`. Brings the addon's direct test surface from 16 → 30 tests; sets up the jsdom + Testing Library scaffold (vitest config + virtual-module stub) the package didn't have before. `preview.tsx` and `manager.tsx` stay covered by Storybook play-functions — their integration shape (DOM mount, ambient module imports, Storybook channel comms) makes meaningful unit tests cost more than they return. No behavior changes.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -97,9 +97,12 @@
   },
   "devDependencies": {
     "@storybook/react-vite": "^10.3.5",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.6.0",
     "@types/picomatch": "^4.0.3",
     "@types/react": "^19.2.14",
+    "@vitejs/plugin-react": "^6.0.1",
+    "jsdom": "^29.0.2",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "storybook": "^10.3.5",

--- a/packages/addon/test/color-format-selector.test.tsx
+++ b/packages/addon/test/color-format-selector.test.tsx
@@ -1,0 +1,40 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ColorFormatSelector } from '#/ColorFormatSelector.tsx';
+
+afterEach(cleanup);
+
+describe('ColorFormatSelector', () => {
+  it('renders one pill per color format', () => {
+    render(<ColorFormatSelector active="hex" onSelect={() => {}} />);
+    for (const label of ['Hex', 'RGB', 'HSL', 'OKLCH', 'Raw (JSON)']) {
+      expect(screen.getByRole('button', { name: label })).toBeDefined();
+    }
+  });
+
+  it('marks the active pill with the `--active` modifier class', () => {
+    render(<ColorFormatSelector active="oklch" onSelect={() => {}} />);
+    const active = screen.getByRole('button', { name: 'OKLCH' });
+    expect(active.className).toContain('sb-switcher__pill--active');
+    const inactive = screen.getByRole('button', { name: 'Hex' });
+    expect(inactive.className).not.toContain('sb-switcher__pill--active');
+  });
+
+  it("invokes `onSelect` with the pill's format id on click", () => {
+    const onSelect = vi.fn();
+    render(<ColorFormatSelector active="hex" onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'RGB' }));
+    expect(onSelect).toHaveBeenCalledWith('rgb');
+  });
+
+  it('prevents default on mousedown so the toolbar popover keeps focus', () => {
+    // The popover uses an outside-mousedown listener to close; if pill
+    // mousedown bubbled normally, the popover would close before the
+    // click handler ran. Preventing default keeps the popover open.
+    render(<ColorFormatSelector active="hex" onSelect={() => {}} />);
+    const button = screen.getByRole('button', { name: 'RGB' });
+    const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    button.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+});

--- a/packages/addon/test/data-attr.test.ts
+++ b/packages/addon/test/data-attr.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from 'vitest';
+import { dataAttr } from '#/data-attr.ts';
+
+it('returns the bare `data-<key>` form when prefix is empty', () => {
+  expect(dataAttr('', 'mode')).toBe('data-mode');
+  expect(dataAttr('', 'theme')).toBe('data-theme');
+});
+
+it('prefixes the key as `data-<prefix>-<key>` when prefix is set', () => {
+  expect(dataAttr('sb', 'mode')).toBe('data-sb-mode');
+  expect(dataAttr('ds', 'theme')).toBe('data-ds-theme');
+});
+
+it('handles multi-segment prefixes verbatim — caller responsibility to sanitize', () => {
+  // The helper doesn't validate; this is a contract-of-trust test that
+  // documents the current behavior so we notice if it changes.
+  expect(dataAttr('my.scope', 'mode')).toBe('data-my.scope-mode');
+});
+
+it('handles empty key when prefix is set (caller responsibility, but contract-stable)', () => {
+  expect(dataAttr('sb', '')).toBe('data-sb-');
+});

--- a/packages/addon/test/use-token.test.tsx
+++ b/packages/addon/test/use-token.test.tsx
@@ -1,0 +1,69 @@
+import { type ReactNode } from 'react';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PermutationContext } from '@unpunnyfuns/swatchbook-blocks';
+import { useToken } from '#/hooks/use-token.ts';
+
+function withPermutation(name: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <PermutationContext.Provider value={name}>{children}</PermutationContext.Provider>;
+  };
+}
+
+describe('useToken', () => {
+  it('returns the resolved value + `var(--…)` reference for the active permutation', () => {
+    const { result } = renderHook(() => useToken('color.accent.bg'), {
+      wrapper: withPermutation('Light'),
+    });
+    expect(result.current.value).toEqual({ colorSpace: 'srgb', components: [0, 0.4, 1] });
+    expect(result.current.cssVar).toBe('var(--sb-color-accent-bg)');
+    expect(result.current.type).toBe('color');
+    expect(result.current.description).toBe('Accent background');
+  });
+
+  it('returns a different resolved value when the active permutation changes', () => {
+    const { result: light } = renderHook(() => useToken('color.accent.bg'), {
+      wrapper: withPermutation('Light'),
+    });
+    const { result: dark } = renderHook(() => useToken('color.accent.bg'), {
+      wrapper: withPermutation('Dark'),
+    });
+    expect(light.current.value).not.toEqual(dark.current.value);
+    // cssVar is permutation-independent: blocks read CSS vars per
+    // selector on the page, not via the JS value.
+    expect(light.current.cssVar).toBe(dark.current.cssVar);
+  });
+
+  it('falls back to defaultPermutation when context is empty', () => {
+    // Without a provider, useActivePermutation returns the empty string.
+    // The hook then reads from `defaultPermutation` (`Light` in the stub).
+    const { result } = renderHook(() => useToken('color.accent.bg'));
+    expect(result.current.value).toEqual({ colorSpace: 'srgb', components: [0, 0.4, 1] });
+  });
+
+  it('returns undefined value + cssVar reference when the path is unknown', () => {
+    const { result } = renderHook(() => useToken('not.a.token'), {
+      wrapper: withPermutation('Light'),
+    });
+    expect(result.current.value).toBeUndefined();
+    expect(result.current.cssVar).toBe('var(--sb-not-a-token)');
+    expect(result.current.type).toBeUndefined();
+    expect(result.current.description).toBeUndefined();
+  });
+
+  it('returns a non-color token with the right $type', () => {
+    const { result } = renderHook(() => useToken('space.md'), {
+      wrapper: withPermutation('Light'),
+    });
+    expect(result.current.value).toBe('16px');
+    expect(result.current.type).toBe('dimension');
+    expect(result.current.cssVar).toBe('var(--sb-space-md)');
+  });
+
+  it('omits the `description` field when the token has no $description', () => {
+    const { result } = renderHook(() => useToken('space.md'), {
+      wrapper: withPermutation('Light'),
+    });
+    expect(result.current.description).toBeUndefined();
+  });
+});

--- a/packages/addon/test/virtual-integration-side-effects-stub.ts
+++ b/packages/addon/test/virtual-integration-side-effects-stub.ts
@@ -1,0 +1,9 @@
+/**
+ * No-op stand-in for `virtual:swatchbook/integration-side-effects`.
+ *
+ * The real virtual module's side-effect-only `import` is satisfied by a
+ * file that exports nothing — vitest needs an actual module to resolve,
+ * but it doesn't need to do anything. The dummy export below keeps
+ * linters that flag empty files happy without changing behavior.
+ */
+export const integrationSideEffectsStub = true;

--- a/packages/addon/test/virtual-stub.ts
+++ b/packages/addon/test/virtual-stub.ts
@@ -1,0 +1,52 @@
+/**
+ * Stand-in for `virtual:swatchbook/tokens` under test. The fixture is
+ * deliberately tiny — one axis with two contexts, two tokens — so tests
+ * stay focused on hook behavior rather than fixture shape.
+ *
+ * Tests that need a different payload swap module state via
+ * `vi.doMock('virtual:swatchbook/tokens', () => …)` ahead of importing
+ * the unit under test.
+ */
+export const axes = [
+  {
+    name: 'mode',
+    contexts: ['Light', 'Dark'],
+    default: 'Light',
+    source: 'resolver' as const,
+  },
+];
+export const disabledAxes = [] as readonly string[];
+export const presets = [] as const;
+export const permutations = [
+  { name: 'Light', input: { mode: 'Light' }, sources: [] },
+  { name: 'Dark', input: { mode: 'Dark' }, sources: [] },
+];
+export const defaultPermutation = 'Light';
+export const permutationsResolved: Record<string, Record<string, unknown>> = {
+  Light: {
+    'color.accent.bg': {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0, 0.4, 1] },
+      $description: 'Accent background',
+    },
+    'space.md': {
+      $type: 'dimension',
+      $value: '16px',
+    },
+  },
+  Dark: {
+    'color.accent.bg': {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0.3, 0.6, 1] },
+      $description: 'Accent background',
+    },
+    'space.md': {
+      $type: 'dimension',
+      $value: '16px',
+    },
+  },
+};
+export const diagnostics = [] as const;
+export const css = '';
+export const cssVarPrefix = 'sb';
+export const listing = {};

--- a/packages/addon/vitest.config.ts
+++ b/packages/addon/vitest.config.ts
@@ -1,0 +1,22 @@
+import { fileURLToPath } from 'node:url';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      'virtual:swatchbook/tokens': fileURLToPath(
+        new URL('./test/virtual-stub.ts', import.meta.url),
+      ),
+      'virtual:swatchbook/integration-side-effects': fileURLToPath(
+        new URL('./test/virtual-integration-side-effects-stub.ts', import.meta.url),
+      ),
+    },
+  },
+  test: {
+    include: ['test/**/*.test.{ts,tsx}'],
+    environment: 'jsdom',
+    reporters: ['default'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -203,6 +203,9 @@ importers:
       '@storybook/react-vite':
         specifier: ^10.3.5
         version: 10.3.5(esbuild@0.27.7)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(rollup@4.60.3)(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@2.8.8)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(typescript@6.0.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))(webpack@5.106.2(esbuild@0.27.7))
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
@@ -212,6 +215,12 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))
+      jsdom:
+        specifier: ^29.0.2
+        version: 29.0.2
       react:
         specifier: ^19.2.4
         version: 19.2.5


### PR DESCRIPTION
## Summary

Pre-1.0 dossier finding #703 (defer). Brings the addon's direct test surface from 16 → 30 tests and sets up the jsdom + Testing Library scaffold the package didn't have.

## Coverage

- **`dataAttr`** (4 tests) — prefix on / off, multi-segment prefix pass-through, empty-key contract stability.
- **`ColorFormatSelector`** (4 tests) — renders one pill per format, the active pill carries the \`--active\` modifier, \`onSelect\` fires with the right format id, mousedown preventDefault keeps the popover open.
- **`useToken`** (6 tests) — value + cssVar for the active permutation, per-permutation value swap on context change, fallback to \`defaultPermutation\` when context is empty, undefined-value behaviour for unknown paths, non-color tokens with the right \`\$type\`, optional \`\$description\` omitted when absent.

## `preview.tsx` and `manager.tsx`

Kept covered by Storybook play-functions in \`apps/storybook\`. Both are integration-shaped (DOM mount, Storybook channel comms, ambient virtual-module imports). Issue acceptance explicitly allowed a "covered by Storybook play" note in lieu of unit tests — that's documented in the commit message and changeset.

## Test scaffolding

The addon had no \`vitest.config.ts\` until this PR — the existing 16 tests are pure-Node and worked without jsdom. The hook + component tests need:

- \`vitest.config.ts\` with jsdom env, React plugin, virtual-module aliases pointing at test stubs.
- \`test/virtual-stub.ts\` — minimal fixture (one axis, two contexts, two tokens) so tests stay focused on hook behaviour.
- \`test/virtual-integration-side-effects-stub.ts\` — no-op for the side-effect-only import in \`preview.tsx\` (kept for future preview tests that may want it).
- New devDeps pinned to the same versions blocks uses: \`@testing-library/react\` ^16.3.2, \`@vitejs/plugin-react\` ^6.0.1, \`jsdom\` ^29.0.2.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-addon\` — 7/7 tasks pass.
- [x] All 30 addon tests pass under vitest.

Milestone: Maintenance
Closes #703