### PR TITLE
fix(addon,switcher): a11y disclosure semantics for toolbar popover

### DIFF
--- a/.changeset/a11y-quick-wins.md
+++ b/.changeset/a11y-quick-wins.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+---
+
+A11y polish (first slice of #707):
+
+- **`@unpunnyfuns/swatchbook-addon` toolbar trigger** — adds `aria-haspopup="dialog"` + `aria-expanded` to the popover button so screen readers announce the disclosure state. (`aria-controls` is omitted because Storybook's `WithTooltipPure` portals the popover with a dynamically-generated id we can't anchor to.)
+- **`@unpunnyfuns/swatchbook-switcher` root** — switches `role="menu"` → `role="group"` with `aria-label="Swatchbook controls"`. The switcher is a settings panel (presets, axis selectors, color-format pills), not a command menu — ARIA `menu` would require `menuitem`-rolled children plus a roving tabindex, and the actual content is a panel of independent controls each of which exposes its own role + state.
+
+No visual changes. Pure assistive-tech announcement improvements.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -233,6 +233,13 @@ function AxesToolbar(): ReactElement {
       title,
       active: open,
       onClick: () => setOpen((prev) => !prev),
+      // Screen-reader disclosure semantics for the popover trigger. We
+      // don't set `aria-controls` because the popover is portaled by
+      // Storybook's `WithTooltipPure` with a dynamically-generated id we
+      // don't have a stable handle on; `aria-haspopup` + `aria-expanded`
+      // is the practical subset of the disclosure pattern.
+      'aria-haspopup': 'dialog' as const,
+      'aria-expanded': open,
     },
     h(SwatchbookIcon),
   );

--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -51,8 +51,14 @@ export function ThemeSwitcher({
   footer,
 }: ThemeSwitcherProps): ReactElement {
   return (
+    // `role="group"` + `aria-label` — the switcher is a settings panel
+    // (presets, per-axis selectors, color-format pills), not a command
+    // menu. WAI-ARIA `menu` would require `menuitem`-rolled children plus
+    // a roving tabindex; the actual content is a panel of independent
+    // controls each of which already exposes its own role + state.
     <div
-      role="menu"
+      role="group"
+      aria-label="Swatchbook controls"
       tabIndex={-1}
       className="sb-switcher"
       onKeyDown={onKeyDown}


### PR DESCRIPTION
## Summary

First slice of #707's a11y polish — two small, well-defined ARIA fixes. No visual changes.

### Toolbar trigger disclosure (`addon/src/manager.tsx`)

The popover button in the addon's toolbar didn't expose disclosure semantics. Adds:

- \`aria-haspopup="dialog"\` — the popover contains the swatchbook controls panel.
- \`aria-expanded={open}\` — current state.

\`aria-controls\` is intentionally omitted: Storybook's \`WithTooltipPure\` portals the popover body with a dynamically-generated id that we don't have a stable handle on from outside.

### Switcher role correction (`switcher/src/ThemeSwitcher.tsx`)

\`role="menu"\` was inaccurate. WAI-ARIA \`menu\` requires \`menuitem\`-rolled children plus a roving tabindex; the switcher's content is a panel of independent controls (preset pills, axis selectors, color-format pills) each of which exposes its own role + state. Swapped for \`role="group"\` with \`aria-label="Swatchbook controls"\`, which is the honest framing.

## Deferred sub-tasks from #707

The issue lists five sub-tasks; this PR ships two. The remaining three need their own scope:

- **TokenTable row \`role="button"\`** — the dossier's prescription is technically wrong. \`<tr role="button">\` overrides the implicit row role and strips AT users of table-navigation announcements. Existing tests fail on the change for this reason. Needs design discussion: button vs link semantics, whether to nest a real button inside the first cell, or accept the row-as-clickable affordance without the role override.
- **TokenNavigator full tree pattern** — structural change (refactor focus to the treeitem element, add aria-controls, add arrow-key navigation). Standalone PR.
- **DetailOverlay focus-trap** — behavior + lifecycle change (focus-trap on mount, Esc-to-close, focus restore). Standalone PR.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test\` across addon / blocks / switcher — 15/15 tasks pass.
- [ ] Manual keyboard walkthrough of toolbar popover (screen reader announces "Swatchbook theme, button, has popup dialog, collapsed/expanded").

Milestone: Maintenance
Refs #707 (umbrella stays open; 3 sub-tasks remain)