### PR TITLE
test(storybook): play interactions for TokenTable search + ColorTable expand

### DIFF
--- a/apps/storybook/src/stories/ColorTable.stories.tsx
+++ b/apps/storybook/src/stories/ColorTable.stories.tsx
@@ -1,5 +1,5 @@
 import { ColorTable } from '@unpunnyfuns/swatchbook-blocks';
-import { expect, waitFor } from 'storybook/test';
+import { expect, userEvent, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -49,4 +49,38 @@ export const GroupedVariants = meta.story({
     variants: { hover: 'hover' },
   },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
+});
+
+/**
+ * Row-click expansion — clicking a row toggles the inline detail
+ * sub-row (hex / HSL / OKLCH breakdown, alias chain, description).
+ * Closes the "ColorTable — no expansion play" gap from #704.
+ */
+export const ExpandsOnRowClick = meta.story({
+  args: { filter: 'color.palette.blue.*' },
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvasElement }) => {
+    await assertTableRenders(canvasElement);
+    const firstRow = canvasElement.querySelector<HTMLElement>('[data-testid="color-table-row"]');
+    if (!firstRow) throw new Error('expected at least one color row');
+
+    expect(
+      canvasElement.querySelectorAll('[data-testid="color-table-detail"]').length,
+      'no detail rows visible before clicking',
+    ).toBe(0);
+
+    await userEvent.click(firstRow);
+    await waitFor(() => {
+      const detail = canvasElement.querySelector<HTMLElement>('[data-testid="color-table-detail"]');
+      expect(detail, 'expanded detail row appears after click').toBeTruthy();
+    });
+
+    await userEvent.click(firstRow);
+    await waitFor(() => {
+      expect(
+        canvasElement.querySelectorAll('[data-testid="color-table-detail"]').length,
+        'click again collapses the detail row',
+      ).toBe(0);
+    });
+  },
 });

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -61,6 +61,52 @@ export const DimensionsOnly = meta.story({
  * users get an "I am here" indicator. Chromatic skips this one — the
  * focus state is asserted via computed style, not pixels.
  */
+/**
+ * Search-input interaction — type a substring and the visible row set
+ * narrows to matching paths. Closes the "TokenTable — only render
+ * smoke, no search/sort play" gap from #704. The component-level
+ * coverage in `packages/blocks/test/token-table.test.tsx` already
+ * tests the underlying logic; this play function verifies the same
+ * contract end-to-end through the actual Storybook preview pipeline
+ * (decorator → snapshot → block render → user input).
+ */
+export const SearchFilters = meta.story({
+  parameters: { chromatic: { disableSnapshot: true } },
+  play: async ({ canvasElement }) => {
+    await assertTableRenders(canvasElement);
+    const search = canvasElement.querySelector<HTMLInputElement>(
+      '[data-testid="token-table-search"]',
+    );
+    if (!search) throw new Error('search input missing');
+
+    const visibleRowCount = (): number =>
+      canvasElement.querySelectorAll<HTMLElement>('[data-testid="token-table-row"]').length;
+    const before = visibleRowCount();
+    expect(before, 'table should have multiple rows before filtering').toBeGreaterThan(2);
+
+    await userEvent.type(search, 'surface');
+    await waitFor(() => {
+      const visible = canvasElement.querySelectorAll<HTMLElement>(
+        '[data-testid="token-table-row"]',
+      );
+      expect(visible.length, 'search should narrow row count').toBeLessThan(before);
+      expect(visible.length, 'at least one row matches "surface"').toBeGreaterThan(0);
+      for (const row of visible) {
+        expect(row.getAttribute('data-path') ?? '').toContain('surface');
+      }
+    });
+
+    // Clear and verify it un-narrows. `userEvent.clear` would be cleaner
+    // but isn't on every userEvent flavor; triple-click + delete is the
+    // portable form.
+    await userEvent.tripleClick(search);
+    await userEvent.keyboard('{Delete}');
+    await waitFor(() => {
+      expect(visibleRowCount()).toBe(before);
+    });
+  },
+});
+
 export const FocusVisibleRow = meta.story({
   parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvasElement }) => {


### PR DESCRIPTION
## Summary

Second slice of #704's pre-1.0 play-function gap.

## Coverage

- **\`TokenTable.SearchFilters\`** — types into the search input, asserts the visible-row count narrows, every remaining row's \`data-path\` contains the query; clears the input and asserts the count restores. Closes the explicit "TokenTable — no search play" gap.
- **\`ColorTable.ExpandsOnRowClick\`** — clicks a row, asserts the \`[data-testid="color-table-detail"]\` sub-row appears; clicks again, asserts it collapses. Closes the explicit "ColorTable — no expansion play" gap.

## What's not in scope (and why)

- **\`TokenTable\` column sort** — the component has \`sortBy\` / \`sortDir\` as props but no in-DOM control to click. The dossier's "column-sort interaction" bullet was a gap-against-spec, not gap-against-implementation. Adding sortable column headers is a feature; not a test gap.
- **\`ColorPalette\` swatch click** — palette swatches aren't interactive in the current code (no \`onClick\` / no \`button\`). Same gap-against-spec issue. The filter prop is already covered by the args-driven \`SysOnly\` / \`RefBlue\` stories.

If the swatch-click / column-sort features should exist, that's a feature issue, not a test issue.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook\` — 149/149 (147 + 2 new).
- [x] format / lint / typecheck clean.

## Remaining under #704

- Switcher localStorage persistence + UseToken \`LiveReadout\`.

Milestone: Maintenance
Refs #704 (third slice — switcher persistence + UseToken — remains)