### PR TITLE
test(storybook): add LiveReadout play for the useToken hook

### DIFF
--- a/apps/storybook/src/stories/UseToken.stories.tsx
+++ b/apps/storybook/src/stories/UseToken.stories.tsx
@@ -1,10 +1,15 @@
 import { useToken } from '@unpunnyfuns/swatchbook-addon/hooks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 
 function TokenProbe({ path }: { path: string }) {
   const info = useToken(path);
   return (
     <div
+      data-testid="probe"
+      data-path={path}
+      data-css-var={info.cssVar}
+      data-type={info.type ?? ''}
       style={{
         display: 'grid',
         gridTemplateColumns: '260px 1fr',
@@ -57,4 +62,33 @@ const meta = preview.meta({
 
 export default meta;
 
-export const LiveReadout = meta.story();
+/**
+ * Verify each probe in the grid renders with the right shape: a
+ * `var(--sb-<path-with-dashes>)` cssVar, an axis-stable string, and a
+ * non-empty `type` for tokens whose `$type` is set. Per-permutation
+ * value reactivity is exercised in `UseTokenUpdates`; this story
+ * verifies the no-axis-input contract — the hook produces deterministic
+ * output for a static set of paths under the default tuple.
+ */
+export const LiveReadout = meta.story({
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const probes = canvasElement.querySelectorAll<HTMLElement>('[data-testid="probe"]');
+      expect(probes.length, 'every path renders its own probe').toBe(6);
+    });
+    const probes = Array.from(canvasElement.querySelectorAll<HTMLElement>('[data-testid="probe"]'));
+    for (const probe of probes) {
+      const path = probe.getAttribute('data-path') ?? '';
+      const cssVar = probe.getAttribute('data-css-var') ?? '';
+      expect(cssVar, `${path} should have a var(...) reference`).toMatch(/^var\(--sb-/);
+      expect(cssVar, `${path}'s cssVar should mirror the path with dashes`).toContain(
+        path.replaceAll('.', '-'),
+      );
+    }
+    const expectedTyped = ['color.surface.default', 'color.text.default', 'color.accent.bg'];
+    for (const path of expectedTyped) {
+      const probe = probes.find((p) => p.getAttribute('data-path') === path);
+      expect(probe?.getAttribute('data-type'), `${path} should expose a $type`).toBeTruthy();
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Third and final slice of #704. \`UseToken.LiveReadout\` was the only story in its file with no play function — it just rendered the six-probe grid without asserting anything. The dossier flagged it as the explicit gap: per-permutation reactivity was already tested via \`UseTokenUpdates.Light\`/\`Dark\`, but the no-axis-input contract (deterministic output under the default tuple) had no assertion.

## Coverage

New play function asserts:

- Six probes render (one per path the grid declares).
- Every probe carries a \`var(--sb-<path-with-dashes>)\` cssVar that mirrors its dot-path with dashes — the hook's documented format.
- The three color-typed paths expose a non-empty \`\$type\`. (Some of the other paths reference token aliases that may not be present in every fixture state; this keeps the assertion fixture-stable without locking down every path's type.)

Adds \`data-testid="probe"\` + \`data-path\` / \`data-css-var\` / \`data-type\` attributes to \`TokenProbe\` so play functions can read the hook's output without scraping rendered text.

## What's not in scope

**Switcher localStorage persistence** from the issue's bullet list — neither the switcher nor the addon touches \`localStorage\`. Storybook itself persists globals via URL params, but that's the framework's concern, not testable from a play function. Gap-against-spec, not gap-against-implementation. Calling this out here so the issue can close.

## Cumulative state on #704

| PR | Slice | Tests added |
|----|----|----|
| #756 | Toolbar widget plays | +4 |
| #757 | Block interactions (TokenTable search, ColorTable expand) | +2 |
| this | UseToken LiveReadout | +1 |

Storybook tests go from 143 → 150 across the trio.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-storybook test:storybook\` — green on this branch alone (143 + 1 = 144 here; full 150 when all three slices merge).
- [x] format / lint / typecheck clean.

Milestone: Maintenance
Closes #704