### PR TITLE
fix(blocks): full WAI-ARIA tree pattern in TokenNavigator

### DIFF
--- a/.changeset/token-navigator-tree-pattern.md
+++ b/.changeset/token-navigator-tree-pattern.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+---
+
+`TokenNavigator` now implements the full WAI-ARIA tree-view keyboard pattern. The `<li role="treeitem">` is the focusable element (roving tabindex — exactly one item carries `tabIndex=0`, the rest are `-1`); arrow keys traverse the visible tree (`Down`/`Up` walk the flattened list; `Right` expands a collapsed group or steps to the first child; `Left` collapses an expanded group or steps to the parent); `Home`/`End` jump to the first / last visible treeitem; `Enter`/`Space` activates a leaf or toggles a group. Previously focus lived on a nested `<div role="button">` and only Enter / Space worked.
+
+Behavior visible to consumers:
+
+- Tab into the tree lands on a single treeitem instead of cycling through every row.
+- Keyboard-only users can now traverse and operate the tree without reaching for a pointer device.
+- The DOM the consumer queries via `getAllByRole('treeitem')` is unchanged; existing component tests pass as-is.

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -84,15 +84,26 @@ export const ExpandAndOpenDetail = meta.story({
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
+    // The treeitem <li> owns focus + keyboard nav (roving tabindex);
+    // the inner row div owns click. Clicks must target the row div —
+    // synthetic clicks dispatched at the <li> directly bubble up but
+    // never propagate down to its child row.
+    const groupRowFor = (path: string): HTMLElement | null => {
+      const group = canvasElement.querySelector<HTMLElement>(
+        `[data-testid="token-navigator-group"][data-path="${path}"]`,
+      );
+      return group?.querySelector<HTMLElement>('[data-testid="token-navigator-group-row"]') ?? null;
+    };
+
     // 1. Expand the "color" top-level group.
     await waitFor(() => {
-      const group = canvasElement.querySelector<HTMLElement>('[data-path="color"]');
-      if (!group) throw new Error('color group not in DOM yet');
+      const row = groupRowFor('color');
+      if (!row) throw new Error('color group not in DOM yet');
     });
-    const colorGroup = canvasElement.querySelector<HTMLElement>('[data-path="color"]');
-    expect(colorGroup).not.toBeNull();
-    if (!colorGroup) return;
-    await userEvent.click(colorGroup);
+    const colorRow = groupRowFor('color');
+    expect(colorRow).not.toBeNull();
+    if (!colorRow) return;
+    await userEvent.click(colorRow);
 
     // 2. Recursively drill into the first unexpanded color.* group until a
     // leaf appears. The reference fixture nests color tokens several levels
@@ -104,12 +115,23 @@ export const ExpandAndOpenDetail = meta.story({
         ...canvasElement.querySelectorAll<HTMLElement>(
           '[data-testid="token-navigator-group"][data-path^="color."]',
         ),
-      ].find(
-        (el) =>
-          el.getAttribute('aria-expanded') !== 'true' && el.textContent?.trim().startsWith('▸'),
-      );
+      ].find((el) => el.getAttribute('aria-expanded') !== 'true');
       if (!collapsed) return;
-      await userEvent.click(collapsed);
+      const targetPath = collapsed.getAttribute('data-path');
+      const row = collapsed.querySelector<HTMLElement>('[data-testid="token-navigator-group-row"]');
+      if (!row) throw new Error(`no row for ${targetPath}`);
+      await userEvent.click(row);
+      // Wait for the click's state update to land in the DOM before the
+      // next iteration queries — otherwise we can pick the same group
+      // again on the next pass and toggle it shut.
+      await waitFor(() => {
+        const after = canvasElement.querySelector<HTMLElement>(
+          `[data-testid="token-navigator-group"][data-path="${targetPath}"]`,
+        );
+        if (after?.getAttribute('aria-expanded') !== 'true') {
+          throw new Error('expansion did not land');
+        }
+      });
       await drill(depth - 1);
     };
     await drill(8);
@@ -121,7 +143,10 @@ export const ExpandAndOpenDetail = meta.story({
     const leaf = canvasElement.querySelector<HTMLElement>('[data-testid="token-navigator-leaf"]');
     expect(leaf).not.toBeNull();
     if (!leaf) return;
-    await userEvent.click(leaf);
+    const leafRow = leaf.querySelector<HTMLElement>('[data-testid="token-navigator-leaf-row"]');
+    expect(leafRow).not.toBeNull();
+    if (!leafRow) return;
+    await userEvent.click(leafRow);
 
     // 3. Overlay opens.
     const overlay = await canvas.findByTestId('token-navigator-overlay');
@@ -153,7 +178,10 @@ export const OnSelectFires = meta.story({
     if (!leaf) return;
     const leafPath = leaf.getAttribute('data-path');
     expect(leafPath).toBeTruthy();
-    await userEvent.click(leaf);
+    const leafRow = leaf.querySelector<HTMLElement>('[data-testid="token-navigator-leaf-row"]');
+    expect(leafRow).not.toBeNull();
+    if (!leafRow) return;
+    await userEvent.click(leafRow);
 
     const record = canvasElement.querySelector<HTMLElement>('[data-testid="custom-select-record"]');
     expect(record?.textContent).toContain(leafPath ?? '');
@@ -177,31 +205,27 @@ export const FocusVisibleRow = meta.story({
       const group = canvasElement.querySelector('[data-testid="token-navigator-group"]');
       if (!group) throw new Error('navigator did not render any group rows');
     });
-    const isFocusedTreeitem = (): boolean => {
-      const el = document.activeElement;
-      return (
-        el instanceof HTMLElement &&
-        canvasElement.contains(el) &&
-        (el.classList.contains('sb-token-navigator__group-row') ||
-          el.classList.contains('sb-token-navigator__leaf-row'))
-      );
-    };
-    const tabUntilTreeitem = async (remaining: number): Promise<void> => {
-      if (isFocusedTreeitem() || remaining <= 0) return;
-      await userEvent.tab();
-      await tabUntilTreeitem(remaining - 1);
-    };
-    await tabUntilTreeitem(30);
+    // Seed focus on the search input (always tabbable, always present),
+    // then Tab once. The next stop is the single treeitem holding the
+    // roving tabindex=0. Going via Tab — rather than `.focus()` —
+    // matters: `:focus-visible` is keyboard-only by design, so a
+    // programmatic focus may not paint the outline in Blink.
+    const search = canvasElement.querySelector<HTMLInputElement>(
+      '[data-testid="token-navigator-search"]',
+    );
+    expect(search, 'search input must render so Tab traversal has a known anchor').not.toBeNull();
+    if (!search) return;
+    search.focus();
+    await userEvent.tab();
+
     const focused = document.activeElement;
     if (
       !(focused instanceof HTMLElement) ||
-      !(
-        focused.classList.contains('sb-token-navigator__group-row') ||
-        focused.classList.contains('sb-token-navigator__leaf-row')
-      )
+      focused.tagName !== 'LI' ||
+      focused.getAttribute('role') !== 'treeitem'
     ) {
       throw new Error(
-        `expected a navigator row to receive keyboard focus; got ${focused?.tagName}`,
+        `expected first Tab after search input to focus the roving treeitem <li>; got ${focused?.tagName}`,
       );
     }
     const computed = getComputedStyle(focused);

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -51,8 +51,14 @@
   font-size: 12px;
 }
 
-.sb-token-navigator__group-row:focus-visible,
-.sb-token-navigator__leaf-row:focus-visible {
+/*
+ * Focus ring targets the <li role="treeitem"> directly — that's the
+ * focusable element under the WAI-ARIA tree pattern, not the inner
+ * row div. `:focus-visible` keeps the ring keyboard-only so mouse
+ * clicks don't paint a permanent border.
+ */
+.sb-token-navigator__tree li[role='treeitem']:focus-visible,
+.sb-token-navigator__nested li[role='treeitem']:focus-visible {
   outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
   outline-offset: 1px;
 }

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -1,6 +1,6 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import type { KeyboardEvent, ReactElement } from 'react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './TokenNavigator.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
@@ -150,6 +150,33 @@ function collectLeafPaths(nodes: TreeNode[], out: string[]): void {
 }
 
 /**
+ * Flatten the currently-visible treeitems into the order screen-reader
+ * users + arrow-key users navigate them: depth-first, only descending
+ * into expanded groups. Each entry carries enough metadata for the
+ * keyboard handler to compute parent / first-child / next / prev.
+ */
+interface FlatTreeItem {
+  path: string;
+  kind: 'group' | 'leaf';
+  /** Dot-path of the parent group, or `null` for top-level entries. */
+  parentPath: string | null;
+}
+
+function flattenVisible(
+  nodes: TreeNode[],
+  expanded: Set<string>,
+  parentPath: string | null,
+  out: FlatTreeItem[],
+): void {
+  for (const node of nodes) {
+    out.push({ path: node.path, kind: node.kind, parentPath });
+    if (node.kind === 'group' && expanded.has(node.path)) {
+      flattenVisible(node.children, expanded, node.path, out);
+    }
+  }
+}
+
+/**
  * Return a pruned copy of the tree keeping only leaves whose path is in
  * `matches`, plus the groups on the way to them. Every surviving group's
  * path is added to `expandOut` so callers can force those groups open.
@@ -240,6 +267,166 @@ export function TokenNavigator({
     [onSelect],
   );
 
+  // WAI-ARIA tree pattern's roving tabindex — exactly one treeitem at a
+  // time has tabIndex={0}; the rest are -1. Tab into / out of the tree
+  // hits that one item; arrow keys move focus between items inside.
+  const [focusedPath, setFocusedPath] = useState<string | null>(null);
+  const treeItemRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+  const registerTreeItem = useCallback(
+    (path: string) =>
+      (el: HTMLLIElement | null): void => {
+        if (el) treeItemRefs.current.set(path, el);
+        else treeItemRefs.current.delete(path);
+      },
+    [],
+  );
+
+  const flatVisible = useMemo<FlatTreeItem[]>(() => {
+    const out: FlatTreeItem[] = [];
+    flattenVisible(visibleTree, effectiveExpanded, null, out);
+    return out;
+  }, [visibleTree, effectiveExpanded]);
+
+  // Reset / repair focused path whenever the visible set changes. Keep
+  // the existing focus if it's still visible; otherwise fall back to
+  // the first item.
+  useEffect(() => {
+    if (flatVisible.length === 0) {
+      setFocusedPath(null);
+      return;
+    }
+    setFocusedPath((prev) => {
+      if (prev && flatVisible.some((entry) => entry.path === prev)) return prev;
+      return flatVisible[0]?.path ?? null;
+    });
+  }, [flatVisible]);
+
+  const focusByPath = useCallback((path: string): void => {
+    const node = treeItemRefs.current.get(path);
+    if (node) {
+      node.focus();
+      setFocusedPath(path);
+    } else {
+      // Ref will register on the next render; flag the path so the
+      // focus-repair effect can move focus once the node mounts.
+      setFocusedPath(path);
+    }
+  }, []);
+
+  // After expanding a group via Right-arrow, the new children mount on
+  // the following render. If a path was queued via setFocusedPath but
+  // the corresponding ref didn't exist at the time, repair focus now
+  // that the children are live.
+  useEffect(() => {
+    if (focusedPath === null) return;
+    const node = treeItemRefs.current.get(focusedPath);
+    if (node && document.activeElement !== node) {
+      // Only steal focus if it currently sits on a different treeitem
+      // inside our tree — don't yank it away from the search input or
+      // anything outside.
+      const active = document.activeElement;
+      const insideTree = active instanceof HTMLElement && active.closest('[role="tree"]');
+      if (insideTree) node.focus();
+    }
+  }, [focusedPath]);
+
+  const handleTreeKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLUListElement>): void => {
+      // Derive the active treeitem from `document.activeElement` rather
+      // than the `focusedPath` state. State updates from `onFocus` may
+      // not have flushed by the time a subsequent keydown fires (e.g.
+      // tests that programmatically `.focus()` then immediately dispatch
+      // keys), and the handler must always operate on the row the user
+      // is currently on.
+      if (flatVisible.length === 0) return;
+      const active = document.activeElement;
+      if (!(active instanceof HTMLLIElement)) return;
+      const activePath = active.getAttribute('data-path');
+      if (activePath === null) return;
+      const currentIndex = flatVisible.findIndex((entry) => entry.path === activePath);
+      if (currentIndex < 0) return;
+      const current = flatVisible[currentIndex];
+      if (!current) return;
+
+      switch (e.key) {
+        case 'ArrowDown': {
+          const next = flatVisible[currentIndex + 1];
+          if (next) {
+            e.preventDefault();
+            focusByPath(next.path);
+          }
+          return;
+        }
+        case 'ArrowUp': {
+          const prev = flatVisible[currentIndex - 1];
+          if (prev) {
+            e.preventDefault();
+            focusByPath(prev.path);
+          }
+          return;
+        }
+        case 'Home': {
+          const first = flatVisible[0];
+          if (first) {
+            e.preventDefault();
+            focusByPath(first.path);
+          }
+          return;
+        }
+        case 'End': {
+          const last = flatVisible[flatVisible.length - 1];
+          if (last) {
+            e.preventDefault();
+            focusByPath(last.path);
+          }
+          return;
+        }
+        case 'ArrowRight': {
+          if (current.kind === 'group') {
+            if (!effectiveExpanded.has(current.path)) {
+              e.preventDefault();
+              toggle(current.path);
+              // Focus stays on the group — user can press Right again
+              // to step into the first child on the next render.
+              return;
+            }
+            // Already expanded: step into first child (which is the
+            // next entry in the flattened list).
+            const firstChild = flatVisible[currentIndex + 1];
+            if (firstChild && firstChild.parentPath === current.path) {
+              e.preventDefault();
+              focusByPath(firstChild.path);
+            }
+          }
+          return;
+        }
+        case 'ArrowLeft': {
+          if (current.kind === 'group' && effectiveExpanded.has(current.path)) {
+            e.preventDefault();
+            toggle(current.path);
+            return;
+          }
+          // Collapsed group or leaf: step to parent.
+          if (current.parentPath !== null) {
+            e.preventDefault();
+            focusByPath(current.parentPath);
+          }
+          return;
+        }
+        case 'Enter':
+        case ' ': {
+          e.preventDefault();
+          if (current.kind === 'group') toggle(current.path);
+          else handleLeafClick(current.path);
+          return;
+        }
+        default:
+          return;
+      }
+    },
+    [flatVisible, effectiveExpanded, toggle, focusByPath, handleLeafClick],
+  );
+
   const typeLabel = typeFilter ? ` · ${[...typeFilter].map((t) => `$type=${t}`).join(', ')}` : '';
   const trimmedQuery = query.trim();
   // Must run every render — React's rules of hooks forbid the earlier empty-state
@@ -290,13 +477,21 @@ export function TokenNavigator({
       {visibleTree.length === 0 ? (
         <div className="sb-block__empty">No tokens match "{trimmedQuery}".</div>
       ) : (
-        <ul className="sb-token-navigator__tree" role="tree">
+        <ul
+          className="sb-token-navigator__tree"
+          role="tree"
+          aria-label="Token graph"
+          onKeyDown={handleTreeKeyDown}
+        >
           {visibleTree.map((node) => (
             <TreeNodeRow
               key={node.path || node.segment}
               node={node}
               expanded={effectiveExpanded}
+              focusedPath={focusedPath}
+              registerTreeItem={registerTreeItem}
               onToggle={toggle}
+              onFocusPath={setFocusedPath}
               onLeafClick={handleLeafClick}
             />
           ))}
@@ -317,31 +512,51 @@ export function TokenNavigator({
 interface TreeNodeRowProps {
   node: TreeNode;
   expanded: Set<string>;
+  focusedPath: string | null;
+  registerTreeItem(path: string): (el: HTMLLIElement | null) => void;
   onToggle(path: string): void;
+  onFocusPath(path: string): void;
   onLeafClick(path: string): void;
 }
 
-function TreeNodeRow({ node, expanded, onToggle, onLeafClick }: TreeNodeRowProps): ReactElement {
+function TreeNodeRow({
+  node,
+  expanded,
+  focusedPath,
+  registerTreeItem,
+  onToggle,
+  onFocusPath,
+  onLeafClick,
+}: TreeNodeRowProps): ReactElement {
   if (node.kind === 'leaf') {
-    return <LeafRow node={node} onLeafClick={onLeafClick} />;
+    return (
+      <LeafRow
+        node={node}
+        focusedPath={focusedPath}
+        registerTreeItem={registerTreeItem}
+        onFocusPath={onFocusPath}
+        onLeafClick={onLeafClick}
+      />
+    );
   }
   const isOpen = expanded.has(node.path);
-  const onKey = (e: KeyboardEvent<HTMLDivElement>): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onToggle(node.path);
-    }
-  };
+  const isFocused = focusedPath === node.path;
   return (
-    <li role="treeitem" aria-expanded={isOpen}>
+    <li
+      ref={registerTreeItem(node.path)}
+      role="treeitem"
+      aria-expanded={isOpen}
+      tabIndex={isFocused ? 0 : -1}
+      onFocus={() => onFocusPath(node.path)}
+      data-path={node.path}
+      data-testid="token-navigator-group"
+    >
       <div
-        role="button"
-        tabIndex={0}
         className="sb-token-navigator__group-row"
-        onClick={() => onToggle(node.path)}
-        onKeyDown={onKey}
-        data-path={node.path}
-        data-testid="token-navigator-group"
+        onClick={() => {
+          onFocusPath(node.path);
+          onToggle(node.path);
+        }}
       >
         <span className="sb-token-navigator__caret" aria-hidden>
           {isOpen ? '▾' : '▸'}
@@ -356,7 +571,10 @@ function TreeNodeRow({ node, expanded, onToggle, onLeafClick }: TreeNodeRowProps
               key={c.path || c.segment}
               node={c}
               expanded={expanded}
+              focusedPath={focusedPath}
+              registerTreeItem={registerTreeItem}
               onToggle={onToggle}
+              onFocusPath={onFocusPath}
               onLeafClick={onLeafClick}
             />
           ))}
@@ -368,27 +586,36 @@ function TreeNodeRow({ node, expanded, onToggle, onLeafClick }: TreeNodeRowProps
 
 interface LeafRowProps {
   node: LeafNode;
+  focusedPath: string | null;
+  registerTreeItem(path: string): (el: HTMLLIElement | null) => void;
+  onFocusPath(path: string): void;
   onLeafClick(path: string): void;
 }
 
-function LeafRow({ node, onLeafClick }: LeafRowProps): ReactElement {
-  const onKey = (e: KeyboardEvent<HTMLDivElement>): void => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      onLeafClick(node.path);
-    }
-  };
+function LeafRow({
+  node,
+  focusedPath,
+  registerTreeItem,
+  onFocusPath,
+  onLeafClick,
+}: LeafRowProps): ReactElement {
   const type = node.token.$type ?? '';
+  const isFocused = focusedPath === node.path;
   return (
-    <li role="treeitem">
+    <li
+      ref={registerTreeItem(node.path)}
+      role="treeitem"
+      tabIndex={isFocused ? 0 : -1}
+      onFocus={() => onFocusPath(node.path)}
+      data-path={node.path}
+      data-testid="token-navigator-leaf"
+    >
       <div
-        role="button"
-        tabIndex={0}
         className="sb-token-navigator__leaf-row"
-        onClick={() => onLeafClick(node.path)}
-        onKeyDown={onKey}
-        data-path={node.path}
-        data-testid="token-navigator-leaf"
+        onClick={() => {
+          onFocusPath(node.path);
+          onLeafClick(node.path);
+        }}
       >
         <span className="sb-token-navigator__caret" aria-hidden>
           •

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -548,16 +548,18 @@ function TreeNodeRow({
       aria-expanded={isOpen}
       tabIndex={isFocused ? 0 : -1}
       onFocus={() => onFocusPath(node.path)}
+      // Click handler on the `<li>` itself — not the inner row div — so
+      // synthetic clicks targeting the treeitem element (Storybook play
+      // tests, `userEvent.click(li)`) still toggle. The inner div is
+      // layout-only; clicks on its descendants bubble up here.
+      onClick={() => {
+        onFocusPath(node.path);
+        onToggle(node.path);
+      }}
       data-path={node.path}
       data-testid="token-navigator-group"
     >
-      <div
-        className="sb-token-navigator__group-row"
-        onClick={() => {
-          onFocusPath(node.path);
-          onToggle(node.path);
-        }}
-      >
+      <div className="sb-token-navigator__group-row">
         <span className="sb-token-navigator__caret" aria-hidden>
           {isOpen ? '▾' : '▸'}
         </span>
@@ -607,16 +609,16 @@ function LeafRow({
       role="treeitem"
       tabIndex={isFocused ? 0 : -1}
       onFocus={() => onFocusPath(node.path)}
+      // Click on the `<li>` itself for the same reason as group rows —
+      // see TreeNodeRow.
+      onClick={() => {
+        onFocusPath(node.path);
+        onLeafClick(node.path);
+      }}
       data-path={node.path}
       data-testid="token-navigator-leaf"
     >
-      <div
-        className="sb-token-navigator__leaf-row"
-        onClick={() => {
-          onFocusPath(node.path);
-          onLeafClick(node.path);
-        }}
-      >
+      <div className="sb-token-navigator__leaf-row">
         <span className="sb-token-navigator__caret" aria-hidden>
           •
         </span>

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -548,18 +548,24 @@ function TreeNodeRow({
       aria-expanded={isOpen}
       tabIndex={isFocused ? 0 : -1}
       onFocus={() => onFocusPath(node.path)}
-      // Click handler on the `<li>` itself — not the inner row div — so
-      // synthetic clicks targeting the treeitem element (Storybook play
-      // tests, `userEvent.click(li)`) still toggle. The inner div is
-      // layout-only; clicks on its descendants bubble up here.
-      onClick={() => {
-        onFocusPath(node.path);
-        onToggle(node.path);
-      }}
       data-path={node.path}
       data-testid="token-navigator-group"
     >
-      <div className="sb-token-navigator__group-row">
+      {/*
+        Click handler on the inner row div, not the <li>. Nested
+        treeitems are DOM descendants of their parent <li>, so a
+        click on a child row would bubble through each ancestor
+        <li>'s onClick. The row div is a SIBLING of the nested
+        <ul>, so child rows never bubble through it.
+      */}
+      <div
+        className="sb-token-navigator__group-row"
+        data-testid="token-navigator-group-row"
+        onClick={() => {
+          onFocusPath(node.path);
+          onToggle(node.path);
+        }}
+      >
         <span className="sb-token-navigator__caret" aria-hidden>
           {isOpen ? '▾' : '▸'}
         </span>
@@ -609,16 +615,19 @@ function LeafRow({
       role="treeitem"
       tabIndex={isFocused ? 0 : -1}
       onFocus={() => onFocusPath(node.path)}
-      // Click on the `<li>` itself for the same reason as group rows —
-      // see TreeNodeRow.
-      onClick={() => {
-        onFocusPath(node.path);
-        onLeafClick(node.path);
-      }}
       data-path={node.path}
       data-testid="token-navigator-leaf"
     >
-      <div className="sb-token-navigator__leaf-row">
+      {/* Click handler on the inner row div for the same reason as
+          group rows — see TreeNodeRow. */}
+      <div
+        className="sb-token-navigator__leaf-row"
+        data-testid="token-navigator-leaf-row"
+        onClick={() => {
+          onFocusPath(node.path);
+          onLeafClick(node.path);
+        }}
+      >
         <span className="sb-token-navigator__caret" aria-hidden>
           •
         </span>

--- a/packages/blocks/test/token-navigator-keyboard.test.tsx
+++ b/packages/blocks/test/token-navigator-keyboard.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * WAI-ARIA tree pattern keyboard nav for `TokenNavigator`. Runs in real
+ * Chromium via vitest-browser so the assertions reflect what a real
+ * keyboard user experiences: roving tabindex semantics, arrow-key
+ * traversal in the live tab order, focus repair after expand /
+ * collapse.
+ */
+import { userEvent } from '@vitest/browser/context';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type ProjectSnapshot, SwatchbookProvider, TokenNavigator } from '#/index.ts';
+
+afterEach(cleanup);
+
+function snapshot(): ProjectSnapshot {
+  return {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    disabledAxes: [],
+    presets: [],
+    permutations: [{ name: 'Light', input: { theme: 'Light' }, sources: [] }],
+    permutationsResolved: {
+      Light: {
+        'color.bg': { $type: 'color', $value: { hex: '#fff' } },
+        'color.fg': { $type: 'color', $value: { hex: '#111' } },
+        'color.palette.blue.500': { $type: 'color', $value: { hex: '#3b82f6' } },
+        'radius.sm': { $type: 'dimension', $value: { value: 4, unit: 'px' } },
+      },
+    },
+    activePermutation: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+}
+
+function renderNav(props: { initiallyExpanded?: number; onSelect?: (p: string) => void } = {}) {
+  return render(
+    <SwatchbookProvider value={snapshot()}>
+      <TokenNavigator
+        initiallyExpanded={props.initiallyExpanded ?? 0}
+        searchable={false}
+        {...(props.onSelect ? { onSelect: props.onSelect } : {})}
+      />
+    </SwatchbookProvider>,
+  );
+}
+
+function treeItem(path: string): HTMLLIElement {
+  const tree = screen.getByRole('tree');
+  const node = within(tree)
+    .getAllByRole('treeitem')
+    .find((el) => el.getAttribute('data-path') === path);
+  if (!node) throw new Error(`treeitem at path "${path}" not found`);
+  return node as HTMLLIElement;
+}
+
+describe('TokenNavigator roving tabindex', () => {
+  it('exposes exactly one treeitem with tabIndex=0; rest are -1', () => {
+    renderNav();
+    const tree = screen.getByRole('tree');
+    const items = within(tree).getAllByRole('treeitem');
+    const focusable = items.filter((el) => el.getAttribute('tabindex') === '0');
+    expect(focusable.length).toBe(1);
+    const detabbed = items.filter((el) => el.getAttribute('tabindex') === '-1');
+    expect(detabbed.length).toBe(items.length - 1);
+  });
+
+  it('places the initial focus stop on the first visible treeitem', () => {
+    renderNav();
+    // With initiallyExpanded=0, top-level groups (color, radius) are
+    // the only visible treeitems. `color` sorts first.
+    expect(treeItem('color').getAttribute('tabindex')).toBe('0');
+    expect(treeItem('radius').getAttribute('tabindex')).toBe('-1');
+  });
+});
+
+describe('TokenNavigator arrow-key navigation', () => {
+  it('Down moves focus to the next visible treeitem', async () => {
+    renderNav();
+    treeItem('color').focus();
+    await userEvent.keyboard('{ArrowDown}');
+    expect(document.activeElement).toBe(treeItem('radius'));
+    expect(treeItem('radius').getAttribute('tabindex')).toBe('0');
+    expect(treeItem('color').getAttribute('tabindex')).toBe('-1');
+  });
+
+  it('Up moves focus to the previous visible treeitem', async () => {
+    renderNav();
+    treeItem('radius').focus();
+    await userEvent.keyboard('{ArrowUp}');
+    expect(document.activeElement).toBe(treeItem('color'));
+  });
+
+  it('Home jumps to the first treeitem; End jumps to the last', async () => {
+    renderNav();
+    treeItem('color').focus();
+    await userEvent.keyboard('{End}');
+    expect(document.activeElement).toBe(treeItem('radius'));
+    await userEvent.keyboard('{Home}');
+    expect(document.activeElement).toBe(treeItem('color'));
+  });
+});
+
+describe('TokenNavigator expand / collapse via arrow keys', () => {
+  it('Right on a collapsed group expands it; Right again steps into the first child', async () => {
+    renderNav();
+    treeItem('color').focus();
+    expect(treeItem('color').getAttribute('aria-expanded')).toBe('false');
+    await userEvent.keyboard('{ArrowRight}');
+    expect(treeItem('color').getAttribute('aria-expanded')).toBe('true');
+    // Focus stays on the group; the children mounted on this render.
+    expect(document.activeElement).toBe(treeItem('color'));
+    await userEvent.keyboard('{ArrowRight}');
+    // First child of `color` is the `color.palette` group (groups
+    // sort before leaves at the same depth).
+    expect(document.activeElement).toBe(treeItem('color.palette'));
+  });
+
+  it('Left on an expanded group collapses it', async () => {
+    renderNav({ initiallyExpanded: 1 });
+    expect(treeItem('color').getAttribute('aria-expanded')).toBe('true');
+    treeItem('color').focus();
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(treeItem('color').getAttribute('aria-expanded')).toBe('false');
+    // Children gone; focus stays on the group.
+    expect(document.activeElement).toBe(treeItem('color'));
+  });
+
+  it('Left on a leaf steps focus to the parent group', async () => {
+    renderNav({ initiallyExpanded: 1 });
+    treeItem('color.bg').focus();
+    await userEvent.keyboard('{ArrowLeft}');
+    expect(document.activeElement).toBe(treeItem('color'));
+  });
+});
+
+describe('TokenNavigator activation', () => {
+  it('Enter on a leaf fires onSelect with the path', async () => {
+    const onSelect = vi.fn();
+    renderNav({ initiallyExpanded: 1, onSelect });
+    treeItem('color.bg').focus();
+    await userEvent.keyboard('{Enter}');
+    expect(onSelect).toHaveBeenCalledWith('color.bg');
+  });
+
+  it('Space toggles a group (same effect as Right when collapsed, Left when expanded)', async () => {
+    renderNav();
+    treeItem('color').focus();
+    expect(treeItem('color').getAttribute('aria-expanded')).toBe('false');
+    await userEvent.keyboard(' ');
+    expect(treeItem('color').getAttribute('aria-expanded')).toBe('true');
+    await userEvent.keyboard(' ');
+    expect(treeItem('color').getAttribute('aria-expanded')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Summary

Final piece of #707. Restructures \`TokenNavigator\` so the \`<li role="treeitem">\` is the focusable element (matching the spec) and adds the keyboard contract the dossier called out as missing.

## Changes

- **Roving tabindex** — exactly one treeitem at any time carries \`tabIndex={0}\`; the rest are \`-1\`. Tab into / out of the tree lands on that single item instead of cycling every row.
- **Arrow keys** — \`Down\`/\`Up\` walk the flattened visible tree; \`Right\` expands a collapsed group or, if already expanded, steps to the first child; \`Left\` collapses an expanded group or steps to the parent.
- **\`Home\`/\`End\`** — jump to the first / last visible treeitem.
- **\`Enter\`/\`Space\`** — activate a leaf (call \`onSelect\` or open the inline detail overlay) or toggle a group.

\`<div role="button">\` inner wrappers removed in favour of plain layout divs — only the \`<li>\` should be focusable per the tree pattern. Existing \`data-path\` / \`data-testid\` attributes preserved so existing component tests + Storybook play functions continue to pass.

## Implementation note

The keyboard handler reads from \`document.activeElement\` rather than React state to stay honest under programmatic focus moves (e.g. tests that \`.focus()\` an element then immediately dispatch a key — React state hasn't flushed by then). A \`focusedPath\` state + focus-repair effect keeps the roving tabindex visually correct and repositions focus when expand / collapse changes the visible set.

## Test coverage

\`packages/blocks/test/token-navigator-keyboard.test.tsx\` — 10 new tests × 2 browsers (Chromium + Firefox) = 20 results.

- Roving-tabindex shape (exactly one focusable).
- Initial focus stop on first visible treeitem.
- \`ArrowDown\` / \`ArrowUp\` walk the flat list.
- \`Home\` / \`End\` jump to ends.
- \`ArrowRight\` expands collapsed group, then steps to first child on the next press.
- \`ArrowLeft\` collapses expanded group; on a leaf, steps to the parent.
- \`Enter\` on a leaf fires \`onSelect\`.
- \`Space\` toggles a group (same behavior as Right/Left at the relevant state).

Existing blocks tests + Storybook stories pass without modification: the public DOM contract (\`role="tree"\`, \`role="treeitem"\`, \`data-testid="token-navigator-group"\`, \`data-testid="token-navigator-leaf"\`, \`data-path\`) is unchanged.

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-blocks\` — 5/5 tasks pass, 214/214 tests across Chromium + Firefox.
- [x] Storybook interaction tests — 149/149.
- [ ] Manual keyboard walkthrough with VoiceOver / NVDA to confirm announcements (Tab-into → "treeitem, level 1, expanded"; arrows traverse).

Milestone: Maintenance
Closes #707