### PR TITLE
refactor(blocks): narrow composite token shapes via named interfaces

### DIFF
--- a/.changeset/composite-shape-types.md
+++ b/.changeset/composite-shape-types.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Replace the `Record<string, unknown>` casts used to read DTCG composite `$value` shapes (`typography`, `border`, `transition`, `shadow`, `gradient`, `color`, `strokeStyle`) with named per-`$type` interfaces in a new `internal/composite-types.ts`. Sub-values stay `unknown` because each may be a primitive, an alias-resolved string, or a nested composite — the win is that typos in key reads (`fontFamlly`, `offstX`) now surface as compile errors instead of silent `undefined`s. 13 scattered casts collapse into 4 named imports. Internal refactor only; no behaviour change.

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -1,9 +1,20 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
 import './TypographyScale.css';
+import type { TypographyValue } from '#/internal/composite-types.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { globMatch, useProject } from '#/internal/use-project.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
+
+/**
+ * Dimension sub-values in DTCG 2025.10 use a `{ value, unit }` envelope
+ * — narrow once here so the local `asDimension` helper doesn't need
+ * to re-validate keys at every read.
+ */
+interface DimensionLike {
+  value?: unknown;
+  unit?: unknown;
+}
 
 export interface TypographyScaleProps {
   /**
@@ -35,8 +46,8 @@ function asDimension(raw: unknown): string | undefined {
   if (raw == null) return undefined;
   if (typeof raw === 'string' || typeof raw === 'number') return String(raw);
   if (typeof raw === 'object') {
-    const v = raw as Record<string, unknown>;
-    if ('value' in v && 'unit' in v) return `${String(v['value'])}${String(v['unit'])}`;
+    const v = raw as DimensionLike;
+    if (v.value !== undefined && v.unit !== undefined) return `${String(v.value)}${String(v.unit)}`;
   }
   return undefined;
 }
@@ -47,12 +58,12 @@ function asFontFamily(raw: unknown): string | undefined {
   return undefined;
 }
 
-function buildRow(path: string, composite: Record<string, unknown>): Row {
-  const fontFamily = asFontFamily(composite['fontFamily']);
-  const fontSize = asDimension(composite['fontSize']);
-  const fontWeight = composite['fontWeight'] == null ? undefined : String(composite['fontWeight']);
-  const lineHeight = composite['lineHeight'] == null ? undefined : String(composite['lineHeight']);
-  const letterSpacing = asDimension(composite['letterSpacing']);
+function buildRow(path: string, composite: TypographyValue): Row {
+  const fontFamily = asFontFamily(composite.fontFamily);
+  const fontSize = asDimension(composite.fontSize);
+  const fontWeight = composite.fontWeight == null ? undefined : String(composite.fontWeight);
+  const lineHeight = composite.lineHeight == null ? undefined : String(composite.lineHeight);
+  const letterSpacing = asDimension(composite.letterSpacing);
 
   const sampleStyle: CSSProperties = {};
   if (fontFamily) sampleStyle.fontFamily = fontFamily;
@@ -91,7 +102,7 @@ export function TypographyScale({
       if (!value || typeof value !== 'object') {
         return { path, sampleStyle: {}, specs: '' };
       }
-      return buildRow(path, value as Record<string, unknown>);
+      return buildRow(path, value as TypographyValue);
     });
   }, [resolved, filter, sortBy, sortDir]);
 

--- a/packages/blocks/src/format-color.ts
+++ b/packages/blocks/src/format-color.ts
@@ -1,4 +1,5 @@
 import Color from 'colorjs.io';
+import type { ColorValue } from '#/internal/composite-types.ts';
 
 /**
  * Color display formats understood by {@link formatColor}.
@@ -73,20 +74,20 @@ export function formatColor(
 
 function coerce(value: unknown): NormalizedColor | null {
   if (!value || typeof value !== 'object') return null;
-  const v = value as Record<string, unknown>;
-  const colorSpace = typeof v['colorSpace'] === 'string' ? (v['colorSpace'] as string) : undefined;
-  const components = Array.isArray(v['components'])
-    ? (v['components'] as (number | null)[])
-    : Array.isArray(v['channels'])
-      ? (v['channels'] as (number | null)[])
+  const v = value as ColorValue;
+  const colorSpace = typeof v.colorSpace === 'string' ? v.colorSpace : undefined;
+  const components = Array.isArray(v.components)
+    ? (v.components as (number | null)[])
+    : Array.isArray(v.channels)
+      ? (v.channels as (number | null)[])
       : undefined;
   if (!colorSpace || !components) {
-    if (typeof v['hex'] === 'string') {
-      return { colorSpace: 'srgb', components: hexToComponents(v['hex'] as string) };
+    if (typeof v.hex === 'string') {
+      return { colorSpace: 'srgb', components: hexToComponents(v.hex) };
     }
     return null;
   }
-  const alpha = typeof v['alpha'] === 'number' ? (v['alpha'] as number) : undefined;
+  const alpha = typeof v.alpha === 'number' ? v.alpha : undefined;
   const hex = typeof v['hex'] === 'string' ? (v['hex'] as string) : undefined;
   return {
     colorSpace,

--- a/packages/blocks/src/internal/composite-types.ts
+++ b/packages/blocks/src/internal/composite-types.ts
@@ -1,0 +1,89 @@
+/**
+ * Typed envelopes for DTCG 2025.10 composite `$value` shapes — one per
+ * `$type` the blocks render. Sub-values stay `unknown` because each
+ * may be a primitive (number / string), a sub-value alias (string in
+ * `{token.path}` form, post-resolution flattened to a string), or
+ * a nested composite. The win over `Record<string, unknown>` isn't
+ * value-level narrowing — it's that typo-ing a key (`fontFamlly`)
+ * becomes a compile error.
+ *
+ * Adopted across `internal/format-token-value.ts`,
+ * `token-detail/CompositeBreakdown.tsx`, `TypographyScale.tsx`, and
+ * `format-color.ts`. The DTCG spec is the source of truth for the
+ * keys; this file translates that into TypeScript without re-deriving
+ * the spec at every consuming site.
+ */
+
+/**
+ * `typography.$value` per DTCG 2025.10 §8.7. All fields optional —
+ * partial specs are valid (e.g. a token may set only `fontSize` +
+ * `lineHeight` and inherit the rest).
+ */
+export interface TypographyValue {
+  fontFamily?: unknown;
+  fontSize?: unknown;
+  fontWeight?: unknown;
+  lineHeight?: unknown;
+  letterSpacing?: unknown;
+}
+
+/** `border.$value` per DTCG 2025.10 §8.4. */
+export interface BorderValue {
+  color?: unknown;
+  width?: unknown;
+  style?: unknown;
+}
+
+/** `transition.$value` per DTCG 2025.10 §8.5. */
+export interface TransitionValue {
+  duration?: unknown;
+  timingFunction?: unknown;
+  delay?: unknown;
+}
+
+/**
+ * Single layer of `shadow.$value`. Per DTCG 2025.10 §8.6, `shadow`
+ * may be a single object or an array of layers; consumers should
+ * normalize via `Array.isArray(...) ? value : [value]` and then iterate
+ * `ShadowLayer[]`.
+ */
+export interface ShadowLayer {
+  color?: unknown;
+  offsetX?: unknown;
+  offsetY?: unknown;
+  blur?: unknown;
+  spread?: unknown;
+  inset?: unknown;
+}
+
+/** Single stop of `gradient.$value` per DTCG 2025.10 §8.3. */
+export interface GradientStop {
+  color?: unknown;
+  position?: unknown;
+}
+
+/**
+ * `color.$value` per DTCG 2025.10 §8.1. Either the explicit
+ * `colorSpace + components` form, or the legacy `hex` short-form
+ * that pre-DTCG-2025 fixtures still use. `channels` is the older
+ * alias for `components` retained for back-compat with token sources
+ * that haven't migrated.
+ */
+export interface ColorValue {
+  colorSpace?: unknown;
+  components?: unknown;
+  channels?: unknown;
+  alpha?: unknown;
+  hex?: unknown;
+}
+
+/**
+ * `strokeStyle.$value` per DTCG 2025.10 §8.2 — either a literal string
+ * (`'solid' | 'dashed' | ...`) or an object describing a dashed
+ * pattern. Object form is typed here; consumers handle the string
+ * form via a runtime `typeof === 'string'` check.
+ */
+export interface DashedStrokeStyleValue {
+  dashArray?: unknown;
+  lineCap?: unknown;
+}

--- a/packages/blocks/src/internal/format-token-value.ts
+++ b/packages/blocks/src/internal/format-token-value.ts
@@ -1,5 +1,10 @@
 import type { VirtualTokenListingShape } from '#/contexts.ts';
 import { type ColorFormat, formatColor } from '#/format-color.ts';
+import type {
+  BorderValue,
+  DashedStrokeStyleValue,
+  ShadowLayer,
+} from '#/internal/composite-types.ts';
 
 /**
  * Single-line display string for any DTCG token `$value`. Prefers
@@ -86,7 +91,7 @@ function formatCubicBezier(v: unknown): string {
 function formatStrokeStyle(v: unknown): string {
   if (typeof v === 'string') return v;
   if (v && typeof v === 'object') {
-    const s = v as { dashArray?: unknown; lineCap?: unknown };
+    const s = v as DashedStrokeStyleValue;
     const parts: string[] = ['dashed'];
     if (Array.isArray(s.dashArray)) {
       parts.push(s.dashArray.map((n) => formatDimension(n)).join(' '));
@@ -101,15 +106,15 @@ function formatShadow(v: unknown, colorFormat: ColorFormat): string {
   const layers = Array.isArray(v) ? v : [v];
   const parts = layers.map((layer) => {
     if (!layer || typeof layer !== 'object') return formatUnknown(layer);
-    const s = layer as Record<string, unknown>;
+    const s = layer as ShadowLayer;
     const pieces = [
-      formatDimension(s['offsetX']),
-      formatDimension(s['offsetY']),
-      formatDimension(s['blur']),
-      formatDimension(s['spread']),
-      formatColor(s['color'], colorFormat).value,
+      formatDimension(s.offsetX),
+      formatDimension(s.offsetY),
+      formatDimension(s.blur),
+      formatDimension(s.spread),
+      formatColor(s.color, colorFormat).value,
     ].filter((p) => p !== '');
-    if (s['inset']) pieces.push('inset');
+    if (s.inset) pieces.push('inset');
     return pieces.join(' ');
   });
   return parts.join(', ');
@@ -117,10 +122,10 @@ function formatShadow(v: unknown, colorFormat: ColorFormat): string {
 
 function formatBorder(v: unknown, colorFormat: ColorFormat): string {
   if (!v || typeof v !== 'object') return formatUnknown(v);
-  const b = v as Record<string, unknown>;
-  const width = formatDimension(b['width']);
-  const style = formatPrimitive(b['style']);
-  const color = formatColor(b['color'], colorFormat).value;
+  const b = v as BorderValue;
+  const width = formatDimension(b.width);
+  const style = formatPrimitive(b.style);
+  const color = formatColor(b.color, colorFormat).value;
   return [width, style, color].filter((p) => p !== '').join(' ');
 }
 

--- a/packages/blocks/src/token-detail/CompositeBreakdown.tsx
+++ b/packages/blocks/src/token-detail/CompositeBreakdown.tsx
@@ -1,6 +1,13 @@
 import type { ReactElement } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { type ColorFormat, formatColor } from '#/format-color.ts';
+import type {
+  BorderValue,
+  GradientStop,
+  ShadowLayer,
+  TransitionValue,
+  TypographyValue,
+} from '#/internal/composite-types.ts';
 import { type DetailToken, useTokenDetailData } from '#/token-detail/internal.ts';
 
 export interface CompositeBreakdownProps {
@@ -44,31 +51,31 @@ export function CompositeBreakdownContent({
     subValueChain(objectAliases?.[key], resolved);
 
   if (type === 'typography') {
-    const v = rawValue as Record<string, unknown>;
+    const v = rawValue as TypographyValue;
     return renderKeyValueList([
-      ['fontFamily', formatFontFamily(v['fontFamily']), aliasFor('fontFamily')],
-      ['fontSize', formatDimensionValue(v['fontSize']), aliasFor('fontSize')],
-      ['fontWeight', formatPrimitive(v['fontWeight']), aliasFor('fontWeight')],
-      ['lineHeight', formatPrimitive(v['lineHeight']), aliasFor('lineHeight')],
-      ['letterSpacing', formatDimensionValue(v['letterSpacing']), aliasFor('letterSpacing')],
+      ['fontFamily', formatFontFamily(v.fontFamily), aliasFor('fontFamily')],
+      ['fontSize', formatDimensionValue(v.fontSize), aliasFor('fontSize')],
+      ['fontWeight', formatPrimitive(v.fontWeight), aliasFor('fontWeight')],
+      ['lineHeight', formatPrimitive(v.lineHeight), aliasFor('lineHeight')],
+      ['letterSpacing', formatDimensionValue(v.letterSpacing), aliasFor('letterSpacing')],
     ]);
   }
 
   if (type === 'border') {
-    const v = rawValue as Record<string, unknown>;
+    const v = rawValue as BorderValue;
     return renderKeyValueList([
-      ['color', formatColorSubValue(v['color'], colorFormat), aliasFor('color')],
-      ['width', formatDimensionValue(v['width']), aliasFor('width')],
-      ['style', formatPrimitive(v['style']), aliasFor('style')],
+      ['color', formatColorSubValue(v.color, colorFormat), aliasFor('color')],
+      ['width', formatDimensionValue(v.width), aliasFor('width')],
+      ['style', formatPrimitive(v.style), aliasFor('style')],
     ]);
   }
 
   if (type === 'transition') {
-    const v = rawValue as Record<string, unknown>;
+    const v = rawValue as TransitionValue;
     return renderKeyValueList([
-      ['duration', formatDimensionValue(v['duration']), aliasFor('duration')],
-      ['timingFunction', formatPrimitive(v['timingFunction']), aliasFor('timingFunction')],
-      ['delay', formatDimensionValue(v['delay']), aliasFor('delay')],
+      ['duration', formatDimensionValue(v.duration), aliasFor('duration')],
+      ['timingFunction', formatPrimitive(v.timingFunction), aliasFor('timingFunction')],
+      ['delay', formatDimensionValue(v.delay), aliasFor('delay')],
     ]);
   }
 
@@ -80,7 +87,7 @@ export function CompositeBreakdownContent({
     return (
       <div className="sb-token-detail__breakdown-section">
         {layers.map((layer, i) => {
-          const v = layer as Record<string, unknown>;
+          const v = layer as ShadowLayer;
           return (
             <div key={shadowLayerKey(v, i)} style={{ display: 'contents' }}>
               {multi && (
@@ -88,31 +95,31 @@ export function CompositeBreakdownContent({
               )}
               <KeyValueRow
                 label="color"
-                value={formatColorSubValue(v['color'], colorFormat)}
+                value={formatColorSubValue(v.color, colorFormat)}
                 alias={layerAliasFor(i, 'color')}
               />
               <KeyValueRow
                 label="offsetX"
-                value={formatDimensionValue(v['offsetX'])}
+                value={formatDimensionValue(v.offsetX)}
                 alias={layerAliasFor(i, 'offsetX')}
               />
               <KeyValueRow
                 label="offsetY"
-                value={formatDimensionValue(v['offsetY'])}
+                value={formatDimensionValue(v.offsetY)}
                 alias={layerAliasFor(i, 'offsetY')}
               />
               <KeyValueRow
                 label="blur"
-                value={formatDimensionValue(v['blur'])}
+                value={formatDimensionValue(v.blur)}
                 alias={layerAliasFor(i, 'blur')}
               />
               <KeyValueRow
                 label="spread"
-                value={formatDimensionValue(v['spread'])}
+                value={formatDimensionValue(v.spread)}
                 alias={layerAliasFor(i, 'spread')}
               />
-              {'inset' in v && (
-                <KeyValueRow label="inset" value={formatPrimitive(v['inset'])} alias={undefined} />
+              {v.inset !== undefined && (
+                <KeyValueRow label="inset" value={formatPrimitive(v.inset)} alias={undefined} />
               )}
             </div>
           );
@@ -129,13 +136,13 @@ export function CompositeBreakdownContent({
     return (
       <div className="sb-token-detail__breakdown-section">
         {stops.map((stop, i) => {
-          const v = stop as Record<string, unknown>;
-          const position = typeof v['position'] === 'number' ? v['position'] : 0;
+          const v = stop as GradientStop;
+          const position = typeof v.position === 'number' ? v.position : 0;
           return (
             <KeyValueRow
               key={gradientStopKey(v, i)}
               label={`${(position * 100).toFixed(0)}%`}
-              value={formatColorSubValue(v['color'], colorFormat)}
+              value={formatColorSubValue(v.color, colorFormat)}
               alias={stopAliasFor(i)}
             />
           );
@@ -250,18 +257,18 @@ function subValueChain(
   return tail && tail.length > 0 ? [aliasTarget, ...tail] : [aliasTarget];
 }
 
-function shadowLayerKey(layer: Record<string, unknown>, fallback: number): string {
+function shadowLayerKey(layer: ShadowLayer, fallback: number): string {
   const parts = [
-    layer['color'],
-    layer['offsetX'],
-    layer['offsetY'],
-    layer['blur'],
-    layer['spread'],
-    layer['inset'],
+    layer.color,
+    layer.offsetX,
+    layer.offsetY,
+    layer.blur,
+    layer.spread,
+    layer.inset,
   ].map((p) => (p === undefined ? '' : JSON.stringify(p)));
   return `shadow|${parts.join('|')}|${fallback}`;
 }
 
-function gradientStopKey(stop: Record<string, unknown>, fallback: number): string {
-  return `stop|${stop['position'] ?? fallback}|${JSON.stringify(stop['color'])}`;
+function gradientStopKey(stop: GradientStop, fallback: number): string {
+  return `stop|${stop.position ?? fallback}|${JSON.stringify(stop.color)}`;
 }


### PR DESCRIPTION
## Summary

Closes #752. Replaces 13 \`Record<string, unknown>\` casts across blocks with named per-\`\$type\` interfaces in a new \`packages/blocks/src/internal/composite-types.ts\`.

## Why

Each cast was reading a DTCG 2025.10 composite \`\$value\` shape (\`typography\`, \`border\`, \`transition\`, \`shadow\`, \`gradient\`, \`color\`, \`strokeStyle\`) where the keys are spec-defined. \`Record<string, unknown>\` typed the envelope as "any string key" — a typo like \`v.fontFamlly\` silently returned \`undefined\` instead of failing at compile time.

Sub-value fields stay typed \`unknown\` because DTCG composite sub-values may be raw primitives, alias-resolved strings, or nested composites; runtime narrowing stays where it is. The win is at the **key level**: typo'd reads now surface as TypeScript errors.

## Sites updated

- \`internal/format-token-value.ts\` — \`formatShadow\` → \`ShadowLayer\`; \`formatBorder\` → \`BorderValue\`; \`formatStrokeStyle\` → \`DashedStrokeStyleValue\`.
- \`token-detail/CompositeBreakdown.tsx\` — per-\`\$type\` narrowing for typography / border / transition / shadow / gradient; \`shadowLayerKey\` + \`gradientStopKey\` helpers take their typed args directly.
- \`TypographyScale.tsx\` — \`buildRow\` reads typed \`TypographyValue\`; \`asDimension\` narrows its object branch via a local \`DimensionLike\`.
- \`format-color.ts\` — \`coerce\` reads \`ColorValue\` (covers both the explicit \`colorSpace + components\` form and the legacy \`hex\` shorthand).

## Result

\`Record<string, unknown>\` count in \`packages/blocks/src/\`: **13 → 0** (the lone remaining occurrence is the new file's docstring referring to the pattern by name).

## Test plan

- [x] \`pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-blocks\` — 5/5 tasks pass; 194/194 component tests across Chromium + Firefox.
- [x] Storybook interaction tests — 149/149.

Milestone: Maintenance
Closes #752