### PR TITLE
chore(switcher): drop dead permutations prop

### DIFF
--- a/.changeset/drop-switcher-permutations-prop.md
+++ b/.changeset/drop-switcher-permutations-prop.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-switcher`: remove the unused `permutations` prop from `<ThemeSwitcher>` and the `SwitcherPermutation` type from the public exports. The prop was declared but never read inside the component; the addon's manager and the storybook example are updated to drop the dead pass-through.

--- a/apps/storybook/src/stories/Toolbar.stories.tsx
+++ b/apps/storybook/src/stories/Toolbar.stories.tsx
@@ -74,7 +74,6 @@ function ToolbarHarness(): ReactElement {
       <ThemeSwitcher
         axes={FIXTURE_AXES}
         presets={FIXTURE_PRESETS}
-        permutations={[]}
         activeTuple={activeTuple}
         defaults={FIXTURE_DEFAULTS}
         lastApplied={lastApplied}

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -6,7 +6,6 @@ import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-ap
 import {
   type InitPayload,
   type VirtualAxis as AxisEntry,
-  type VirtualPermutation as PermutationEntry,
   type VirtualPreset as PresetEntry,
 } from '#/channel-types.ts';
 import {
@@ -35,7 +34,6 @@ const h = React.createElement;
 
 const EMPTY_AXES: readonly AxisEntry[] = [];
 const EMPTY_PRESETS: readonly PresetEntry[] = [];
-const EMPTY_PERMUTATIONS: readonly PermutationEntry[] = [];
 
 /**
  * Root toolbar glyph — a split-circle ("yinyang") mark: a faint filled
@@ -106,7 +104,6 @@ function AxesToolbar(): ReactElement {
 
   const axes = payload?.axes ?? EMPTY_AXES;
   const presets = payload?.presets ?? EMPTY_PRESETS;
-  const permutations = payload?.permutations ?? EMPTY_PERMUTATIONS;
   const defaults = useMemo(() => defaultTupleFor(axes), [axes]);
   const [lastApplied, setLastApplied] = useState<string | null>(null);
   const globalTuple = globals[AXES_GLOBAL_KEY] as Record<string, string> | undefined;
@@ -247,7 +244,6 @@ function AxesToolbar(): ReactElement {
   const tooltipBody = h(ThemeSwitcher, {
     axes,
     presets,
-    permutations,
     activeTuple,
     defaults,
     lastApplied,

--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -1,15 +1,13 @@
 import cx from 'clsx';
 import React, { type KeyboardEvent, type ReactElement } from 'react';
 import './ThemeSwitcher.css';
-import type { SwitcherAxis, SwitcherPreset, SwitcherPermutation } from '#/types.ts';
+import type { SwitcherAxis, SwitcherPreset } from '#/types.ts';
 
 export interface ThemeSwitcherProps {
   /** Project axes the UI renders one section per. */
   axes: readonly SwitcherAxis[];
   /** Saved preset snapshots rendered above the axes, if any. */
   presets?: readonly SwitcherPreset[];
-  /** Full permutation list — only consulted for the "modified since preset applied" dot. */
-  permutations?: readonly SwitcherPermutation[];
   /** Active axis tuple, keyed by axis name. */
   activeTuple: Readonly<Record<string, string>>;
   /** Default tuple used to fill in omitted preset axes. */
@@ -41,7 +39,6 @@ export interface ThemeSwitcherProps {
 export function ThemeSwitcher({
   axes,
   presets = [],
-  permutations = [],
   activeTuple,
   defaults,
   lastApplied,
@@ -69,7 +66,6 @@ export function ThemeSwitcher({
           <PresetsSection
             presets={presets}
             axes={axes}
-            permutations={permutations}
             defaults={defaults}
             activeTuple={activeTuple}
             lastApplied={lastApplied}
@@ -128,7 +124,6 @@ function OptionPill({ label, active, title, onClick, trailing }: OptionPillProps
 interface PresetsSectionProps {
   presets: readonly SwitcherPreset[];
   axes: readonly SwitcherAxis[];
-  permutations: readonly SwitcherPermutation[];
   defaults: Readonly<Record<string, string>>;
   activeTuple: Readonly<Record<string, string>>;
   lastApplied: string | null;

--- a/packages/switcher/src/index.ts
+++ b/packages/switcher/src/index.ts
@@ -1,2 +1,2 @@
 export { ThemeSwitcher, type ThemeSwitcherProps } from '#/ThemeSwitcher.tsx';
-export type { SwitcherAxis, SwitcherPreset, SwitcherPermutation } from '#/types.ts';
+export type { SwitcherAxis, SwitcherPreset } from '#/types.ts';

--- a/packages/switcher/src/types.ts
+++ b/packages/switcher/src/types.ts
@@ -18,8 +18,3 @@ export interface SwitcherPreset {
   axes: Partial<Record<string, string>>;
   description?: string;
 }
-
-export interface SwitcherPermutation {
-  name: string;
-  input: Record<string, string>;
-}


### PR DESCRIPTION
## Summary

- Drops the unused `permutations` prop from `<ThemeSwitcher>` + the matching `SwitcherPermutation` type
- Updates the two pass-through call sites (addon manager + storybook example)

## Full description

The prop was declared on `<ThemeSwitcher>` and threaded into `PresetsSection` but never destructured or read inside the function body. The doc comment claimed it was "only consulted for the 'modified since preset applied' dot," but that dot is computed by comparing the active tuple against the preset tuple directly — no permutation list participates.

Surface dropped:
- `ThemeSwitcherProps.permutations`
- `SwitcherPermutation` type
- `PresetsSectionProps.permutations` (internal)

The wire-protocol `payload.permutations` field on the addon's INIT event and the matching `VirtualPermutation` type stay in place for now — they're still emitted by the preview and consumed elsewhere; that cleanup is its own change.

Pre-1.0 minor bump per the project's semver policy.

Milestone: Maintenance

Closes #767

Plan impact: none.