### PR TITLE
feat(core): add opt-in emitAxisProjectedCss alongside existing emitCss

### DIFF
--- a/.changeset/emit-axis-projected-css.md
+++ b/.changeset/emit-axis-projected-css.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-core`: add `emitAxisProjectedCss(permutations, permutationsResolved, options?)` as an opt-in alternative to `emitCss` / `projectCss`. Emits one `:root` baseline block plus one `[data-<prefix>-<axis>="<context>"] { … }` block per non-default axis cell, carrying only the declarations that differ from baseline at that cell. Output composes via CSS cascade at runtime instead of fanning out across the cartesian tuple space. Axes must be orthogonal — see the function's doc-comment for the joint-variance limitation. Purely additive: existing `emitCss` / `projectCss` behavior unchanged.

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -1,0 +1,183 @@
+import type { TokenNormalized } from '@terrazzo/parser';
+import { generateShorthand, makeCSSVar, transformCSSValue } from '@terrazzo/token-tools/css';
+import { CHROME_ROLES, CHROME_VAR_PREFIX, DEFAULT_CHROME_MAP } from '#/chrome.ts';
+import { dataAttr } from '#/css.ts';
+import type { Axis, Permutation, TokenMap } from '#/types.ts';
+
+/** @internal Options for the axis-projected CSS emitter. Not part of the public API. */
+export interface EmitAxisProjectedCssOptions {
+  /** Override the prefix from project config (default: `config.cssVarPrefix ?? ''`). */
+  prefix?: string;
+  /**
+   * Project axes. Each non-default `(axis, context)` cell emits a
+   * single-attribute selector — `[data-<prefix>-<axis>="<context>"]` —
+   * containing only the token declarations whose values differ from
+   * the baseline (default-tuple) values. Cells from different axes
+   * compose at runtime via the browser's CSS cascade.
+   */
+  axes?: Axis[];
+  /**
+   * Validated chrome-alias entries from `Project.chrome`. Each `source →
+   * target` pair appends `--<prefix>-<source>: var(--<prefix>-<target>);`
+   * to a trailing `:root` block. See `validateChrome`.
+   */
+  chrome?: Record<string, string>;
+}
+
+/**
+ * Emit a single concatenated stylesheet under the **axis-projection**
+ * model: one `:root` block for the default tuple plus one
+ * `[data-<prefix>-<axis>="<context>"] { … }` block per
+ * `(axis, non-default context)` cell, containing only the declarations
+ * whose values differ from baseline at that cell.
+ *
+ * Output size scales with `Σ(axes × non-default contexts × varying
+ * tokens)` instead of the cartesian product — bounded and small for
+ * orthogonal axis projects.
+ *
+ * ## Orthogonality constraint
+ *
+ * Axes must be orthogonal. A token whose value depends on the
+ * *combination* of two axes (e.g. an alias whose resolution differs
+ * per `(brand, mode)` pair beyond what either singleton override
+ * would produce) will render the projection-implied value at runtime,
+ * not the true joint resolution. Document this as a usage constraint;
+ * consumers that need joint precision should keep using `emitCss`.
+ *
+ * For single-axis projects (a synthetic `theme` axis, or a resolver
+ * with one modifier), the cell selector uses the axis's actual name
+ * — e.g. `[data-mode="Dark"]` — rather than the `theme` alias that
+ * `emitCss` uses. Both forms are scope-equivalent on `<html>`.
+ *
+ * @internal Consumers should not depend on this function. The addon
+ * may opt-in via a feature flag in a separate change; external
+ * consumers driving their own build pipeline should use Terrazzo's
+ * CLI against the DTCG sources directly.
+ */
+export function emitAxisProjectedCss(
+  permutations: Permutation[],
+  permutationsResolved: Record<string, TokenMap>,
+  options: EmitAxisProjectedCssOptions = {},
+): string {
+  const prefix = options.prefix ?? '';
+  const varOpts = prefix ? { prefix } : {};
+  const transformAlias = (token: TokenNormalized): string =>
+    makeCSSVar(token.id, { ...varOpts, wrapVar: true });
+
+  const axes = options.axes ?? [];
+  const defaultTuple = buildDefaultTuple(axes);
+  const baselinePerm =
+    axes.length > 0 ? findPermutationByTuple(permutations, defaultTuple) : permutations[0];
+
+  const blocks: string[] = [];
+  const baselineDecls = new Map<string, string>();
+
+  // 1. Baseline `:root` — every declaration the default tuple produces.
+  if (baselinePerm) {
+    const baselineTokens = permutationsResolved[baselinePerm.name];
+    if (baselineTokens) {
+      const lines: string[] = [];
+      for (const decl of collectDeclarations(
+        baselineTokens,
+        baselinePerm.input,
+        varOpts,
+        transformAlias,
+      )) {
+        baselineDecls.set(decl.varName, decl.value);
+        lines.push(`  ${decl.varName}: ${decl.value};`);
+      }
+      if (lines.length > 0) blocks.push(`:root {\n${lines.join('\n')}\n}`);
+    }
+  }
+
+  // 2. Per `(axis, context)` cells — emit deltas only.
+  for (const axis of axes) {
+    for (const ctx of axis.contexts) {
+      if (ctx === axis.default) continue;
+      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
+      const cellPerm = findPermutationByTuple(permutations, cellTuple);
+      if (!cellPerm) continue;
+      const cellTokens = permutationsResolved[cellPerm.name];
+      if (!cellTokens) continue;
+      const deltaLines: string[] = [];
+      for (const decl of collectDeclarations(cellTokens, cellPerm.input, varOpts, transformAlias)) {
+        if (baselineDecls.get(decl.varName) === decl.value) continue;
+        deltaLines.push(`  ${decl.varName}: ${decl.value};`);
+      }
+      if (deltaLines.length === 0) continue;
+      const selector = `[${dataAttr(prefix, axis.name)}="${cssEscape(ctx)}"]`;
+      blocks.push(`${selector} {\n${deltaLines.join('\n')}\n}`);
+    }
+  }
+
+  // 3. Chrome aliases — trailing `:root` block, identical to `emitCss`.
+  const chrome = options.chrome ?? {};
+  const chromeLines: string[] = ['  color-scheme: light dark;'];
+  for (const role of CHROME_ROLES) {
+    const sourceVar = makeCSSVar(role, { prefix: CHROME_VAR_PREFIX });
+    const target = chrome[role];
+    if (target !== undefined) {
+      const targetVar = makeCSSVar(target, { ...varOpts, wrapVar: true });
+      chromeLines.push(`  ${sourceVar}: ${targetVar};`);
+    } else {
+      chromeLines.push(`  ${sourceVar}: ${DEFAULT_CHROME_MAP[role]};`);
+    }
+  }
+  blocks.push(`:root {\n${chromeLines.join('\n')}\n}`);
+
+  return `${blocks.join('\n\n')}\n`;
+}
+
+type VarOpts = Record<string, never> | { prefix: string };
+
+/**
+ * Stream of CSS declarations for a token map: one entry per emitted
+ * `--var: value;` pair. Composite tokens emit one entry per sub-field
+ * plus an optional shorthand entry — same expansion `emitCss` uses,
+ * just yielded as `{ varName, value }` records so the delta-comparison
+ * stage can dedupe against baseline without re-parsing the line.
+ */
+function* collectDeclarations(
+  tokens: TokenMap,
+  permutation: Record<string, string>,
+  varOpts: VarOpts,
+  transformAlias: (token: TokenNormalized) => string,
+): Generator<{ varName: string; value: string }> {
+  for (const [localID, token] of Object.entries(tokens)) {
+    const varName = makeCSSVar(localID, varOpts);
+    const value = transformCSSValue(token, { tokensSet: tokens, permutation, transformAlias });
+    if (typeof value === 'string') {
+      yield { varName, value };
+      continue;
+    }
+    for (const [subKey, subVal] of Object.entries(value)) {
+      const subName = makeCSSVar(`${localID}.${subKey}`, varOpts);
+      yield { varName: subName, value: subVal };
+    }
+    const shorthand = generateShorthand({ token, localID });
+    if (shorthand) yield { varName, value: shorthand };
+  }
+}
+
+function buildDefaultTuple(axes: Axis[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of axes) out[axis.name] = axis.default;
+  return out;
+}
+
+function findPermutationByTuple(
+  permutations: Permutation[],
+  tuple: Readonly<Record<string, string>>,
+): Permutation | undefined {
+  const keys = Object.keys(tuple);
+  return permutations.find((perm) => {
+    for (const key of keys) {
+      if (perm.input[key] !== tuple[key]) return false;
+    }
+    return Object.keys(perm.input).length === keys.length;
+  });
+}
+
+function cssEscape(name: string): string {
+  return name.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export { CHROME_ROLES, DEFAULT_CHROME_MAP, type ChromeRole } from '#/chrome.ts';
 export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject, resolvePermutation } from '#/load.ts';
 export { projectCss } from '#/emit.ts';
+export { emitAxisProjectedCss } from '#/css-axis-projected.ts';
 export { permutationID } from '#/types.ts';
 export { analyzeAxisVariance, type AxisVarianceResult, type VarianceKind } from '#/variance.ts';
 export { type ListedToken, type TokenListingByPath } from '#/token-listing.ts';

--- a/packages/core/test/css-axis-projected.test.ts
+++ b/packages/core/test/css-axis-projected.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Axis-projection emitter (`emitAxisProjectedCss`) — an opt-in alternative
+ * to the cartesian `emitCss`/`projectCss` path. Tests pin:
+ *
+ *   - the structural shape (one `:root` baseline + one single-attribute
+ *     cell selector per non-default `(axis, context)`),
+ *   - the delta optimization (cells only emit declarations that differ
+ *     from the baseline value at the same var name),
+ *   - the size win vs. cartesian emission for the same project, and
+ *   - the documented joint-variance limitation — cells from independent
+ *     axes compose via CSS cascade, so a token whose value at one cell
+ *     happens to match baseline silently drops out, which can let the
+ *     other axis's cell win at runtime under the joint tuple. This
+ *     behavior is the orthogonality contract, not a bug; the test pins
+ *     it so future changes don't quietly "fix" it without an explicit
+ *     decision.
+ */
+import { beforeAll, expect, it } from 'vitest';
+import { emitAxisProjectedCss } from '#/css-axis-projected';
+import { projectCss } from '#/emit';
+import type { Project } from '#/types';
+import { extractBlock, loadWithPrefix } from './_helpers';
+
+let project: Project;
+
+// beforeAll: loadProject takes ~1s; every test reads from the same project.
+beforeAll(async () => {
+  project = await loadWithPrefix('sb');
+}, 30_000);
+
+it('emits one :root baseline block plus N cell blocks (Σ axes × non-default contexts), plus the trailing chrome block', () => {
+  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+    chrome: project.chrome,
+  });
+  // Two `:root {` openings — baseline + chrome trailer.
+  const rootMatches = css.match(/(^|\n):root\s*\{/g) ?? [];
+  expect(rootMatches).toHaveLength(2);
+  // The fixture has three axes with one non-default context each
+  // (Dark, Brand A, High) → three cell blocks.
+  const expectedCells = project.axes.reduce((n, a) => n + (a.contexts.length - 1), 0);
+  const cellMatches = css.match(/\n\[data-sb-[^\]]+\]\s*\{/g) ?? [];
+  expect(cellMatches).toHaveLength(expectedCells);
+});
+
+it('uses single-attribute selectors only — no compound [data-…][data-…] selectors anywhere', () => {
+  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+  });
+  expect(css).not.toMatch(/\[data-[^\]]+\]\[data-/);
+});
+
+it('emits per-axis cell selectors that match each non-default context', () => {
+  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+  });
+  for (const axis of project.axes) {
+    for (const ctx of axis.contexts) {
+      if (ctx === axis.default) continue;
+      expect(css).toContain(`[data-sb-${axis.name}="${ctx}"]`);
+    }
+  }
+});
+
+it("cell blocks carry only deltas — tokens unchanged from baseline don't appear in the cell", () => {
+  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+  });
+  // The baseline declares the full token graph. Each cell should be a
+  // small fraction of that — mode-invariant primitives (palette, size,
+  // typography) belong in :root and stay out of the Dark cell.
+  const baseline = extractBlock(css, ':root');
+  const darkCell = extractBlock(css, '[data-sb-mode="Dark"]');
+  expect(baseline).toBeTruthy();
+  expect(darkCell).toBeTruthy();
+  const baselineVarCount = (baseline.match(/--sb-/g) ?? []).length;
+  const darkCellVarCount = (darkCell.match(/--sb-/g) ?? []).length;
+  expect(darkCellVarCount).toBeLessThan(baselineVarCount / 2);
+});
+
+it("mode-invariant tokens (size scale primitives) don't appear in the mode cell", () => {
+  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+  });
+  const darkCell = extractBlock(css, '[data-sb-mode="Dark"]');
+  expect(darkCell).not.toMatch(/--sb-size-400:/);
+  expect(darkCell).not.toMatch(/--sb-font-family-sans:/);
+});
+
+it('produces a stylesheet meaningfully smaller than the cartesian emission for the same project', () => {
+  const projected = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+    chrome: project.chrome,
+  });
+  const cartesian = projectCss(project);
+  // 8 cartesian tuples × full-token redeclaration vs baseline + 3 deltas
+  // → projected must be substantially smaller. Tightened past the
+  // half-size threshold to a third — large headroom for fixture growth
+  // while still catching regressions.
+  expect(projected.length).toBeLessThan(cartesian.length / 3);
+});
+
+it('terminates with a trailing newline + emits chrome aliases identically to emitCss', () => {
+  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+    chrome: project.chrome,
+  });
+  expect(css.endsWith('\n')).toBe(true);
+  // The chrome aliases block is appended at the tail — same shape as
+  // emitCss writes — so blocks that read `--swatchbook-*` resolve the
+  // same way regardless of which emitter ran.
+  expect(css).toContain('color-scheme: light dark;');
+  expect(css).toContain('--swatchbook-surface-default:');
+});
+
+it('joint-variance constraint: when an axis cell has the same value as baseline for a token, the declaration drops out — even if another axis cell sets that same token differently. This is the documented orthogonality contract.', () => {
+  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+    axes: project.axes,
+    prefix: project.config.cssVarPrefix ?? '',
+  });
+  // Pick a token whose Brand A cell happens to equal baseline. The
+  // fixture's `color.accent.fg` is `neutral.0` (white) in both
+  // baseline (Light + Default) and the Brand A cell, but Dark mode
+  // overrides it to a dark value. Under projection, the Brand A cell
+  // does NOT re-emit `color.accent.fg` (delta-vs-baseline is zero),
+  // so at runtime `<html data-sb-mode="Dark" data-sb-brand="Brand A">`
+  // resolves `accent.fg` to Dark's dark value — even though the
+  // cartesian-emitted joint tuple would have produced white.
+  const brandACell = extractBlock(css, '[data-sb-brand="Brand A"]');
+  const darkCell = extractBlock(css, '[data-sb-mode="Dark"]');
+  expect(brandACell).toBeTruthy();
+  expect(darkCell).toBeTruthy();
+  // Brand A cell does NOT mention accent-fg (it equals baseline).
+  expect(brandACell).not.toMatch(/--sb-color-accent-fg:/);
+  // Dark cell DOES override accent-fg.
+  expect(darkCell).toMatch(/--sb-color-accent-fg:/);
+});


### PR DESCRIPTION
## Summary

- New `emitAxisProjectedCss(permutations, permutationsResolved, options?)` exported from `@unpunnyfuns/swatchbook-core`
- Emits `:root` baseline + one single-attribute `[data-<prefix>-<axis>="<ctx>"]` block per non-default axis cell, carrying only the deltas vs baseline
- Output composes via CSS cascade at runtime — scales with `Σ(axes × non-default contexts × varying tokens)` instead of the cartesian product
- Tests pin the structural shape, the size win vs `projectCss`, and the documented orthogonality constraint

## Full description

Adds a second emit function alongside (not replacing) `emitCss`/`projectCss`. For consumers whose axes are orthogonal — each axis's effect on a token's value is independent of the others, which is the design-intent norm — projection produces a stylesheet a fraction the size of the cartesian-tuple emission. The fixture in this PR shrinks from 8 full-token blocks to 1 baseline + 3 cell deltas; the size-comparison test asserts projection is under 1/3 the cartesian length.

The new function reuses the same `transformCSSValue` / `generateShorthand` / `makeCSSVar` plumbing as `emitCss` so the emitted declarations are byte-identical for the tokens that DO get emitted; the difference is purely which blocks each declaration lands in.

### Orthogonality constraint

A token whose value depends on the *combination* of two axes will render the projection-implied value, not the joint resolution. Concretely: if `mode=Dark` overrides `color.accent.fg` to a dark value, and `brand=Brand A` "happens to" use the same value as baseline (so projection drops the brand cell's declaration), then under the joint tuple `<html data-mode="Dark" data-brand="Brand A">` the cascade keeps Dark's value. The cartesian-emitted `[data-mode="Dark"][data-brand="Brand A"]` selector would have held whichever the resolver computed for that exact joint state.

This is the documented orthogonality contract — pinned in the new `joint-variance constraint` test so a future "fix" doesn't quietly change the behavior without an explicit decision. Consumers that need joint precision keep using `projectCss`.

## Scope

- `packages/core/src/css-axis-projected.ts` — new file, `emitAxisProjectedCss` + supporting helpers (helpers duplicated rather than extracted from `css.ts` to keep the diff additive; can refactor in a follow-up if drift becomes a concern)
- `packages/core/src/index.ts` — one-line export
- `packages/core/test/css-axis-projected.test.ts` — 8 new tests
- `.changeset/emit-axis-projected-css.md` — minor bump

No changes to `emitCss`, `projectCss`, `Project`, or any consumer. The addon's preview keeps using `projectCss`; wiring projection through a feature flag is a separate follow-up.

Milestone: Maintenance

Closes #771

Plan impact: none.