### PR TITLE
feat(addon): add emitMode option for cartesian vs projected CSS emit

### DIFF
--- a/.changeset/addon-emit-mode-option.md
+++ b/.changeset/addon-emit-mode-option.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-addon`: add `emitMode: 'cartesian' | 'projected'` option (default `'cartesian'`) controlling which CSS emitter populates the `virtual:swatchbook/tokens` module's `css` export. `'cartesian'` keeps the current behavior (compound-selector tuple blocks via `projectCss`); `'projected'` switches to the axis-projection emitter added in #771 (one `:root` baseline plus single-attribute cell blocks via `emitAxisProjectedCss`). Purely additive — every existing consumer stays on cartesian without doing anything.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -101,6 +101,7 @@
     "@types/node": "^25.6.0",
     "@types/picomatch": "^4.0.3",
     "@types/react": "^19.2.14",
+    "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser": "^4.1.4",
     "@vitest/browser-playwright": "^4.1.4",

--- a/packages/addon/src/options.ts
+++ b/packages/addon/src/options.ts
@@ -18,4 +18,21 @@ export interface AddonOptions {
    * tool-agnostic; integrations ship as separate packages.
    */
   integrations?: SwatchbookIntegration[];
+  /**
+   * Which CSS emitter populates the `css` export of
+   * `virtual:swatchbook/tokens`:
+   *
+   * - `'cartesian'` (default) — one block per cartesian tuple, scoped
+   *   by compound `[data-<axis>="<ctx>"][data-…]` selectors. Correct
+   *   for projects with joint-variant tokens (values that depend on
+   *   the combination of two axes, not each independently).
+   * - `'projected'` — one `:root` baseline plus one
+   *   `[data-<axis>="<ctx>"]` block per non-default cell, deltas only.
+   *   Composes via CSS cascade at runtime. Output size scales with
+   *   `Σ(axes × non-default contexts × varying tokens)` instead of
+   *   the cartesian product. Requires orthogonal axes — see
+   *   `emitAxisProjectedCss`'s doc-comment for the joint-variance
+   *   limitation.
+   */
+  emitMode?: 'cartesian' | 'projected';
 }

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -36,6 +36,7 @@ export async function viteFinal(
       config,
       cwd,
       ...(options.integrations !== undefined && { integrations: options.integrations }),
+      ...(options.emitMode !== undefined && { emitMode: options.emitMode }),
     }),
   );
 

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -5,7 +5,7 @@ import type {
   SwatchbookIntegration,
   TokenListingByPath,
 } from '@unpunnyfuns/swatchbook-core';
-import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { emitAxisProjectedCss, loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
 import { type FSWatcher, watch as fsWatch } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import picomatch from 'picomatch';
@@ -23,6 +23,13 @@ export interface SwatchbookPluginOptions {
   cwd: string;
   /** Display-side integrations — each may contribute a virtual module the preview imports. */
   integrations?: readonly SwatchbookIntegration[];
+  /**
+   * Which CSS emitter to use for the virtual module's `css` export.
+   * `'cartesian'` (default) calls `projectCss`; `'projected'` calls
+   * `emitAxisProjectedCss`. See `AddonOptions.emitMode` for the
+   * trade-offs.
+   */
+  emitMode?: 'cartesian' | 'projected';
 }
 
 /** `\0<virtualId>` — Vite convention for resolved virtual module IDs. */
@@ -40,13 +47,14 @@ export function swatchbookTokensPlugin({
   config,
   cwd,
   integrations = [],
+  emitMode = 'cartesian',
 }: SwatchbookPluginOptions): Plugin {
   let project: Project | undefined;
   let css = '';
 
   async function refresh(): Promise<void> {
     project = await loadProject(config, cwd);
-    css = projectCss(project);
+    css = composeProjectCss(project, emitMode);
   }
 
   /** Map of resolvedId → integration, indexed once. */
@@ -251,6 +259,27 @@ export function collectWatchPaths(
 function resolveFromCwd(p: string, cwd: string): string {
   if (isAbsolute(p)) return p;
   return resolvePath(cwd, p);
+}
+
+/**
+ * Dispatch between the two emitters based on `emitMode`. Extracted from
+ * the plugin's closure so unit tests can verify the dispatch without
+ * booting Vite — pass a project, get back the matching CSS string.
+ *
+ * @internal Exported for tests; not part of the public API.
+ */
+export function composeProjectCss(
+  project: Project,
+  emitMode: 'cartesian' | 'projected' = 'cartesian',
+): string {
+  if (emitMode === 'projected') {
+    return emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
+      prefix: project.config.cssVarPrefix ?? '',
+      axes: project.axes,
+      chrome: project.chrome,
+    });
+  }
+  return projectCss(project);
 }
 
 type SlimListedToken = Pick<

--- a/packages/addon/test/virtual-plugin.test.ts
+++ b/packages/addon/test/virtual-plugin.test.ts
@@ -1,12 +1,15 @@
-// Pragmatic exception: `collectWatchPaths` is not part of the public API,
-// but its real "surface" is Vite HMR file-watching behavior — which is
-// impractical to test end-to-end (tmp fs, watcher events, dev server).
-// Testing the pure function directly catches the common regressions
-// (brace expansion, absolute paths, sourceFiles fallback) at a fraction
-// of the cost.
+// Pragmatic exception: `collectWatchPaths` and `composeProjectCss` are
+// not part of the public API, but their real "surface" is plugin
+// behavior — Vite HMR file-watching + virtual-module CSS emission —
+// which is impractical to test end-to-end (tmp fs, watcher events,
+// dev server). Testing the pure functions directly catches the common
+// regressions at a fraction of the cost.
+import { dirname } from 'node:path';
+import { loadProject } from '@unpunnyfuns/swatchbook-core';
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
-import { describe, expect, it } from 'vitest';
-import { collectWatchPaths } from '#/virtual/plugin.ts';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { collectWatchPaths, composeProjectCss } from '#/virtual/plugin.ts';
 
 const CWD = '/project';
 
@@ -68,5 +71,51 @@ describe('collectWatchPaths', () => {
     const config: Config = { tokens: ['/abs/tokens/**/*.json'] };
     const paths = collectWatchPaths(config, undefined, CWD);
     expect(paths).toEqual(['/abs/tokens']);
+  });
+});
+
+describe('composeProjectCss', () => {
+  // beforeAll: loadProject takes ~1s; every test reads from the same project.
+  let fixtureProject: Project;
+  beforeAll(async () => {
+    fixtureProject = await loadProject(
+      {
+        tokens: ['tokens/**/*.json'],
+        resolver: resolverPath,
+        default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+        cssVarPrefix: 'sb',
+      },
+      dirname(tokensDir),
+    );
+  }, 30_000);
+
+  it('defaults to cartesian — compound selectors present for the fixture', () => {
+    const css = composeProjectCss(fixtureProject);
+    // Cartesian emission produces compound selectors when the project
+    // has multiple axes (mode × brand × contrast in the fixture).
+    expect(css).toMatch(/\[data-sb-[^\]]+\]\[data-sb-/);
+  });
+
+  it("'projected' emits single-attribute selectors only — no compound selectors anywhere", () => {
+    const css = composeProjectCss(fixtureProject, 'projected');
+    expect(css).not.toMatch(/\[data-sb-[^\]]+\]\[data-sb-/);
+    // And the projection-specific single-attribute selector IS present.
+    expect(css).toMatch(/\[data-sb-mode="Dark"\]/);
+  });
+
+  it("'projected' produces a stylesheet noticeably smaller than 'cartesian' for the fixture", () => {
+    const cartesian = composeProjectCss(fixtureProject, 'cartesian');
+    const projected = composeProjectCss(fixtureProject, 'projected');
+    // Same size relationship the core unit test pins — projection is
+    // under 1/3 the cartesian length for the reference fixture.
+    expect(projected.length).toBeLessThan(cartesian.length / 3);
+  });
+
+  it('both modes emit the chrome alias block at the tail', () => {
+    for (const mode of ['cartesian', 'projected'] as const) {
+      const css = composeProjectCss(fixtureProject, mode);
+      expect(css).toContain('--swatchbook-surface-default:');
+      expect(css).toContain('color-scheme: light dark;');
+    }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@unpunnyfuns/swatchbook-tokens':
+        specifier: workspace:*
+        version: link:../tokens
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))


### PR DESCRIPTION
## Summary

- New `AddonOptions.emitMode: 'cartesian' | 'projected'` (default `'cartesian'`)
- Threads through preset → plugin → `composeProjectCss` dispatch helper
- Tests cover both modes against the reference fixture

## Full description

Lets consumers opt the addon's virtual-module CSS over to the axis-projection emitter added in #771, without touching anything else. Default is `'cartesian'` so every existing consumer (including our own storybook) keeps the current behavior.

`composeProjectCss(project, emitMode)` is a tiny pure helper extracted from the plugin's closure so it can be unit-tested without booting Vite. The plugin's `refresh()` just calls it.

### What's not in this PR

- **Storybook is NOT flipped.** `apps/storybook/.storybook/main.ts` keeps the addon on cartesian. Flipping the dogfood is a deliberate separate change so any fixture joint-variance fallout surfaces in its own PR — our fixture's Brand A × Dark accent pattern is joint-variant, so flipping projection on would either fail a11y or require fixture rewrites.
- **No core changes.** `emitAxisProjectedCss` from #771 is what the projected mode calls.

### Tests

Four new tests in `packages/addon/test/virtual-plugin.test.ts`:

- Default mode emits compound selectors (cartesian)
- `'projected'` emits no compound selectors, single-attribute cells only
- `'projected'` output is < 1/3 the size of `'cartesian'` for the fixture
- Both modes emit the chrome alias block at the tail

Added `@unpunnyfuns/swatchbook-tokens` as a workspace devDep so the test can load the reference fixture.

Milestone: Maintenance

Closes #773

Plan impact: none.