### PR TITLE
docs(core): honest the orthogonality framing on emitAxisProjectedCss

### DIFF
--- a/.changeset/honest-projection-orthogonality-framing.md
+++ b/.changeset/honest-projection-orthogonality-framing.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+"@unpunnyfuns/swatchbook-mcp": patch
+"@unpunnyfuns/swatchbook-integrations": patch
+---
+
+`@unpunnyfuns/swatchbook-core`: honest the orthogonality framing on `emitAxisProjectedCss`. JSDoc + test descriptions previously called the orthogonality requirement a "usage constraint," implying the consumer was responsible for authoring orthogonal modifiers. The DTCG Resolver Module 2025.10 spec explicitly permits non-orthogonal modifiers (Primer's "Pirate" light-only theme is the rationale doc's own example); projection is a lossy size optimization for them, not a contract. Cartesian (`emitCss`) is the spec-faithful default. Docs only — no behavior change.

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -25,34 +25,55 @@ export interface EmitAxisProjectedCssOptions {
 }
 
 /**
- * Emit a single concatenated stylesheet under the **axis-projection**
- * model: one `:root` block for the default tuple plus one
- * `[data-<prefix>-<axis>="<context>"] { … }` block per
- * `(axis, non-default context)` cell, containing only the declarations
- * whose values differ from baseline at that cell.
+ * Emit a single concatenated stylesheet as a **size optimization** for
+ * resolver projects whose modifiers are orthogonal: one `:root` block
+ * for the default tuple plus one `[data-<prefix>-<axis>="<context>"] { … }`
+ * block per `(axis, non-default context)` cell, containing only the
+ * declarations whose values differ from baseline at that cell.
  *
  * Output size scales with `Σ(axes × non-default contexts × varying
- * tokens)` instead of the cartesian product — bounded and small for
- * orthogonal axis projects.
+ * tokens)` instead of the cartesian product. Cells from different axes
+ * compose at runtime via the browser's CSS cascade.
  *
- * ## Orthogonality constraint
+ * ## When this is spec-faithful
  *
- * Axes must be orthogonal. A token whose value depends on the
- * *combination* of two axes (e.g. an alias whose resolution differs
+ * `emitCss` (the cartesian emitter) is what faithfully serializes the
+ * resolved tokens for any DTCG-compliant resolver — including ones with
+ * non-orthogonal modifiers. The DTCG Resolver Module 2025.10 (Final
+ * Community Group Report) explicitly permits non-orthogonal modifiers
+ * and resolves their conflicts via the `resolutionOrder` array
+ * (last write wins). GitHub Primer's "Pirate" theme, available only in
+ * light mode, is the rationale doc's canonical example — the spec
+ * endorses authoring of that shape.
+ *
+ * This emitter, by contrast, is a **lossy size optimization** that
+ * works correctly **only when modifiers are orthogonal** — i.e., when
+ * the resolved value of any token at any tuple is fully determined by
+ * stacking each axis's singleton effect, independent of the others.
+ * Joint-variant tokens (values that genuinely depend on the
+ * *combination* of two axes — e.g. an alias whose resolution differs
  * per `(brand, mode)` pair beyond what either singleton override
- * would produce) will render the projection-implied value at runtime,
- * not the true joint resolution. Document this as a usage constraint;
- * consumers that need joint precision should keep using `emitCss`.
+ * produces) will render the projection-implied value at runtime, not
+ * the spec-correct joint resolution.
+ *
+ * **Use this emitter when** you've confirmed your modifiers are
+ * orthogonal and want the size reduction. **Use `emitCss` when** any
+ * modifier joint-varies tokens, or when in doubt — cartesian is the
+ * spec-faithful default.
+ *
+ * A planned smart emitter folds projection + cartesian-fallback into
+ * one path (orthogonal tokens projected, joint-variant tokens emitted
+ * via compound selectors); once that ships this function may become
+ * its internal primitive rather than a standalone consumer surface.
  *
  * For single-axis projects (a synthetic `theme` axis, or a resolver
  * with one modifier), the cell selector uses the axis's actual name
  * — e.g. `[data-mode="Dark"]` — rather than the `theme` alias that
  * `emitCss` uses. Both forms are scope-equivalent on `<html>`.
  *
- * @internal Consumers should not depend on this function. The addon
- * may opt-in via a feature flag in a separate change; external
- * consumers driving their own build pipeline should use Terrazzo's
- * CLI against the DTCG sources directly.
+ * @internal Consumers should not depend on this function directly.
+ * External consumers driving their own build pipeline should use
+ * Terrazzo's CLI against the DTCG sources directly.
  */
 export function emitAxisProjectedCss(
   permutations: Permutation[],

--- a/packages/core/test/css-axis-projected.test.ts
+++ b/packages/core/test/css-axis-projected.test.ts
@@ -1,19 +1,23 @@
 /**
- * Axis-projection emitter (`emitAxisProjectedCss`) — an opt-in alternative
- * to the cartesian `emitCss`/`projectCss` path. Tests pin:
+ * Axis-projection emitter (`emitAxisProjectedCss`) — a size-optimization
+ * alternative to the cartesian `emitCss` / `projectCss` path, valid
+ * only for resolver projects whose modifiers are orthogonal. Tests pin:
  *
  *   - the structural shape (one `:root` baseline + one single-attribute
  *     cell selector per non-default `(axis, context)`),
  *   - the delta optimization (cells only emit declarations that differ
  *     from the baseline value at the same var name),
  *   - the size win vs. cartesian emission for the same project, and
- *   - the documented joint-variance limitation — cells from independent
- *     axes compose via CSS cascade, so a token whose value at one cell
- *     happens to match baseline silently drops out, which can let the
- *     other axis's cell win at runtime under the joint tuple. This
- *     behavior is the orthogonality contract, not a bug; the test pins
- *     it so future changes don't quietly "fix" it without an explicit
- *     decision.
+ *   - the joint-variance lossiness — when a fixture authors non-orthogonal
+ *     modifiers (which the DTCG resolver spec explicitly permits, per
+ *     the Primer "Pirate" light-only example in the rationale doc), this
+ *     emitter silently produces the projection-implied value rather than
+ *     the spec-correct joint resolution. Cartesian (`emitCss`) is the
+ *     spec-faithful default; this emitter is opt-in for orthogonal cases.
+ *     The joint-variance test below pins the lossy behavior so future
+ *     changes don't quietly "fix" it without an explicit decision —
+ *     the planned smart emitter (analysis + per-token routing) is the
+ *     intended fix path.
  */
 import { beforeAll, expect, it } from 'vitest';
 import { emitAxisProjectedCss } from '#/css-axis-projected';
@@ -120,7 +124,7 @@ it('terminates with a trailing newline + emits chrome aliases identically to emi
   expect(css).toContain('--swatchbook-surface-default:');
 });
 
-it('joint-variance constraint: when an axis cell has the same value as baseline for a token, the declaration drops out — even if another axis cell sets that same token differently. This is the documented orthogonality contract.', () => {
+it("joint-variance lossiness: a cell's declaration drops out when its value equals baseline, even if another cell overrides the same token — under runtime cascade, the other cell's value wins at the joint tuple instead of this cell's intent. Documents projection's lossiness for spec-compliant non-orthogonal fixtures (consumers wanting joint-variance correctness should use cartesian `emitCss`, or wait for the planned smart emitter).", () => {
   const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
     axes: project.axes,
     prefix: project.config.cssVarPrefix ?? '',
@@ -132,7 +136,12 @@ it('joint-variance constraint: when an axis cell has the same value as baseline 
   // does NOT re-emit `color.accent.fg` (delta-vs-baseline is zero),
   // so at runtime `<html data-sb-mode="Dark" data-sb-brand="Brand A">`
   // resolves `accent.fg` to Dark's dark value — even though the
-  // cartesian-emitted joint tuple would have produced white.
+  // cartesian-emitted joint tuple (per `resolutionOrder` last-wins)
+  // would have produced white. This is what the DTCG spec calls
+  // out: non-orthogonal modifiers are allowed (Primer's "Pirate"
+  // light-only theme is the rationale doc's canonical example), and
+  // tools that take liberties with the emit strategy can lose joint
+  // resolution. Cartesian `emitCss` is the spec-faithful default.
   const brandACell = extractBlock(css, '[data-sb-brand="Brand A"]');
   const darkCell = extractBlock(css, '[data-sb-mode="Dark"]');
   expect(brandACell).toBeTruthy();


### PR DESCRIPTION
## Summary

- JSDoc + test descriptions on `emitAxisProjectedCss` previously framed the orthogonality requirement as a "usage constraint" — implying the consumer was responsible for authoring orthogonal modifiers
- The DTCG Resolver Module 2025.10 spec (Final Community Group Report) explicitly permits non-orthogonal modifiers; GitHub Primer's "Pirate" light-only theme is the rationale doc's canonical example
- Reframe as: projection is a lossy size optimization for non-orthogonal fixtures; cartesian (`emitCss`) is the spec-faithful default; the planned smart emitter is the intended fix for the lossy case

## Full description

Docs only — no behavior change. Updates:

- `packages/core/src/css-axis-projected.ts` — function JSDoc names the spec context, frames projection as size optimization rather than contract, points consumers at `emitCss` for spec-faithful default
- `packages/core/test/css-axis-projected.test.ts` — file header docblock + the `joint-variance constraint` test name/description renamed to `joint-variance lossiness` with honest commentary on what the test pins and why

Carries patch bump per project semver policy.

Milestone: Maintenance

Closes #775

Plan impact: none — this is the first PR in the chain leading toward the smart-emitter rewrite; subsequent PRs (variance analysis function, smart emitter, addon wiring) are independent and follow.