### PR TITLE
feat(core): add analyzeProjectVariance — per-token variance classification

### DIFF
--- a/.changeset/variance-analysis.md
+++ b/.changeset/variance-analysis.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-core`: add internal `analyzeProjectVariance(project)` that classifies every token by how it varies across axes — baseline-only, single-axis, orthogonal-after-probe, or joint-variant. First step of a planned smart-emitter rewrite that routes per-token between projection (orthogonal) and compound-selector emit (joint-variant). Analysis only; no emit behaviour changes in this release. Not exported from the public API yet.

--- a/packages/core/src/variance-analysis.ts
+++ b/packages/core/src/variance-analysis.ts
@@ -1,0 +1,311 @@
+import type { TokenNormalized } from '@terrazzo/parser';
+import type { Axis, Project, TokenMap } from '#/types.ts';
+import { analyzeAxisVariance } from '#/variance.ts';
+
+/**
+ * Per-token variance classification across a loaded project's axes.
+ *
+ * `analyzeProjectVariance` is the first half of swatchbook's smart-emitter
+ * strategy: classify each token by how it varies across axes, then let
+ * the emitter route per-token — orthogonal tokens via projection
+ * (single-attribute selectors), joint-variant tokens via compound
+ * selectors. This module does only the classification; the routing
+ * emitter consumes the output.
+ *
+ * The algorithm runs in three phases:
+ *
+ * 1. **Per-axis cell read** — pull each non-default `(axis, context)`
+ *    cell's resolved `TokenMap` from `project.permutationsResolved`.
+ *    Free; the loader already paid this cost.
+ * 2. **Touching set** — for each token, determine which axes can change
+ *    its value at any tuple. Uses the same logic `analyzeAxisVariance`
+ *    applies: bucket permutations by tuple-minus-this-axis; if any
+ *    bucket holds two contexts whose token values differ, the axis
+ *    touches this token. The naive "compare singleton cell to baseline"
+ *    check would miss axes whose effect ONLY shows under specific
+ *    joint combinations (e.g. brand's effect on `accent.fg` is hidden
+ *    when mode is Light because Brand A's white matches baseline white;
+ *    only when mode is Dark does brand's white actively differ from
+ *    Dark's overridden value). Tokens touched by ≤1 axis can't be
+ *    joint-variant by definition.
+ * 3. **Targeted joint probe** — for tokens touched by 2+ axes, for each
+ *    axis-pair `(A, B)` they're touched by, for each non-default
+ *    combination `(ctx_a, ctx_b)`, compare the cartesian-resolved
+ *    value (`resolver.apply({...defaults, A: ctx_a, B: ctx_b})[T]`)
+ *    against the projection-composed value the browser cascade would
+ *    produce given the per-axis cells. If they differ, the token is
+ *    joint-variant on that pair at that combination.
+ *
+ * Triple-and-higher joint variance is not probed (rare in practice;
+ * `$extensions` annotation is the future override).
+ *
+ * Layered and plain-parse projects don't have `project.parserInput.resolver`,
+ * so Phase 3 is skipped — multi-touch tokens in those projects are
+ * conservatively classified as `joint-variant` with empty `jointCases`.
+ * The downstream emitter falls back to cartesian-style emit for them.
+ */
+
+/** Distinguishes a token's variance shape so the emitter can route it. */
+export type VarianceInfo =
+  | {
+      /** Token has the same `$value` across every cell — lives in `:root` only. */
+      kind: 'baseline-only';
+    }
+  | {
+      /** Token varies only when the named axis flips — standard projection. */
+      kind: 'single-axis';
+      axis: string;
+    }
+  | {
+      /**
+       * Token varies across 2+ axes but no joint-pair probe found a divergence
+       * from projection composition — emit as standard projection cells, the
+       * cascade resolves correctly under smart dedup.
+       */
+      kind: 'orthogonal-after-probe';
+      touching: ReadonlySet<string>;
+    }
+  | {
+      /**
+       * Token's value at some joint tuple cannot be reconstructed from
+       * per-axis cell composition (alias-interpolation joint, or any case
+       * where the resolver's joint resolution diverges from cascade).
+       * The emitter must produce compound `[data-A][data-B]` selectors
+       * for the listed `jointCases` to preserve the cartesian-correct
+       * values.
+       */
+      kind: 'joint-variant';
+      touching: ReadonlySet<string>;
+      jointCases: readonly JointCase[];
+    };
+
+/** One concrete `(A=ctx_a, B=ctx_b)` combination where projection differs from cartesian. */
+export interface JointCase {
+  axisA: string;
+  ctxA: string;
+  axisB: string;
+  ctxB: string;
+  /**
+   * Stringified `$value` from `resolver.apply` at the joint tuple — the
+   * spec-correct value that compound-selector emit must reproduce. The
+   * emitter looks up the full `TokenNormalized` from
+   * `project.permutationsResolved[permutationName]` to access transform
+   * data; this key is purely for comparison + diagnostics.
+   */
+  cartesianValueKey: string;
+  /** Permutation name in `project.permutationsResolved` where the joint TokenMap lives. */
+  permutationName: string;
+}
+
+/**
+ * Classify every token in a project. Returns a Map keyed by token path
+ * (the same paths that appear in `project.permutationsResolved[*]`).
+ * Tokens that don't appear in any permutation are not in the map; the
+ * emitter can iterate the map and project.graph in tandem if it needs a
+ * stable union.
+ */
+export function analyzeProjectVariance(project: Project): Map<string, VarianceInfo> {
+  const result = new Map<string, VarianceInfo>();
+  const { axes, permutations, permutationsResolved, parserInput } = project;
+
+  if (axes.length === 0) {
+    // No axes → every token is baseline-only. Skip the cell + probe work.
+    for (const path of Object.keys(project.graph)) {
+      result.set(path, { kind: 'baseline-only' });
+    }
+    return result;
+  }
+
+  // Phase 1 — locate the baseline tuple + per-axis non-default cells.
+  const defaultTuple: Record<string, string> = {};
+  for (const axis of axes) defaultTuple[axis.name] = axis.default;
+  const baselinePerm = findPermByTuple(permutations, defaultTuple);
+  const baseline: TokenMap = baselinePerm
+    ? (permutationsResolved[baselinePerm.name] ?? {})
+    : project.graph;
+
+  // cells[axis.name][ctx] = TokenMap for { ...defaults, [axis.name]: ctx }.
+  // Missing cells (resolver pruned a tuple, disabledAxes filtered it) are
+  // treated as "no overlay" — the token's value at that cell equals baseline.
+  const cells: Record<string, Record<string, TokenMap>> = {};
+  for (const axis of axes) {
+    const axisCells: Record<string, TokenMap> = {};
+    for (const ctx of axis.contexts) {
+      if (ctx === axis.default) continue;
+      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
+      const cellPerm = findPermByTuple(permutations, cellTuple);
+      if (cellPerm) axisCells[ctx] = permutationsResolved[cellPerm.name] ?? {};
+    }
+    cells[axis.name] = axisCells;
+  }
+
+  // Phase 2 — touching set per token. Build the union of every token path
+  // mentioned by baseline or any cell, then for each token use
+  // `analyzeAxisVariance` (variance.ts) to find every axis whose contexts
+  // produce different values when other axes are held constant. This
+  // catches joint-only touching: an axis whose effect is hidden when
+  // others sit at defaults but becomes load-bearing under specific
+  // combinations (Brand A's `accent.fg = white` matches baseline white,
+  // so its singleton cell looks like a no-op — but in combination with
+  // Dark mode where the baseline value is overridden, Brand A's white
+  // is genuinely an override).
+  const allPaths = new Set<string>(Object.keys(baseline));
+  for (const axisCells of Object.values(cells)) {
+    for (const cell of Object.values(axisCells)) {
+      for (const path of Object.keys(cell)) allPaths.add(path);
+    }
+  }
+
+  const touchingByPath = new Map<string, Set<string>>();
+  for (const path of allPaths) {
+    const varianceResult = analyzeAxisVariance(path, axes, permutations, permutationsResolved);
+    touchingByPath.set(path, new Set(varianceResult.varyingAxes));
+  }
+
+  // Partition + Phase 3 (joint probe for multi-touch only). Phase 3 needs
+  // resolver.apply, which only resolver-backed projects have; for layered
+  // / plain-parse we conservatively mark multi-touch as joint-variant
+  // (empty jointCases — emitter falls back to cartesian-style emit).
+  const resolver = parserInput?.resolver;
+
+  for (const [path, touching] of touchingByPath) {
+    if (touching.size === 0) {
+      result.set(path, { kind: 'baseline-only' });
+      continue;
+    }
+    if (touching.size === 1) {
+      const [axis] = touching;
+      result.set(path, { kind: 'single-axis', axis: axis as string });
+      continue;
+    }
+
+    if (!resolver) {
+      // Conservative: treat as joint-variant. Empty jointCases — the emitter
+      // signals "I can't determine joint correctness, emit cartesian-style."
+      result.set(path, { kind: 'joint-variant', touching, jointCases: [] });
+      continue;
+    }
+
+    const jointCases = probeJointPairs(
+      path,
+      touching,
+      axes,
+      defaultTuple,
+      cells,
+      baseline,
+      resolver,
+      permutations,
+      permutationsResolved,
+    );
+    if (jointCases.length === 0) {
+      result.set(path, { kind: 'orthogonal-after-probe', touching });
+    } else {
+      result.set(path, { kind: 'joint-variant', touching, jointCases });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * For a multi-touch token, probe every pair of touching axes at every
+ * non-default combination. Compare the cartesian-resolved value against
+ * what projection composition would produce; record the divergences.
+ *
+ * Composition assumes the "smart dedup" rule: a cell re-emits its value
+ * for any token touched by ANY cell (not just when this cell differs
+ * from baseline). Under that rule, projection composition at a joint
+ * `(A, B)` tuple equals the value of whichever of `cells[A][ctx_a]` /
+ * `cells[B][ctx_b]` is emitted later in source order — by axis iteration
+ * order. We match that by checking the B-cell value (B iterated after A).
+ */
+function probeJointPairs(
+  path: string,
+  touching: ReadonlySet<string>,
+  axes: readonly Axis[],
+  defaultTuple: Record<string, string>,
+  cells: Record<string, Record<string, TokenMap>>,
+  baseline: TokenMap,
+  resolver: NonNullable<Project['parserInput']>['resolver'],
+  permutations: Project['permutations'],
+  permutationsResolved: Project['permutationsResolved'],
+): JointCase[] {
+  const cases: JointCase[] = [];
+  // Stable axis-pair iteration in project axis order — gives deterministic
+  // output and matches the cascade order the emitter will use.
+  const touchingAxes = axes.filter((a) => touching.has(a.name));
+
+  for (let i = 0; i < touchingAxes.length; i++) {
+    for (let j = i + 1; j < touchingAxes.length; j++) {
+      const axisA = touchingAxes[i] as Axis;
+      const axisB = touchingAxes[j] as Axis;
+      const cellsA = cells[axisA.name] ?? {};
+      const cellsB = cells[axisB.name] ?? {};
+
+      for (const ctxA of Object.keys(cellsA)) {
+        for (const ctxB of Object.keys(cellsB)) {
+          // Cartesian truth via resolver.apply.
+          const jointTuple = { ...defaultTuple, [axisA.name]: ctxA, [axisB.name]: ctxB };
+          const cartesianTokens = resolver.apply(jointTuple);
+          const cartesianValueKey = valueKey(cartesianTokens[path]);
+
+          // Projection composition under smart dedup: B is later in source
+          // order than A, so B's cell value wins when both touch the token.
+          // Falls back to A if only A's cell holds a value, else baseline.
+          const projectionValueKey =
+            valueKey(cellsB[ctxB]?.[path]) ||
+            valueKey(cellsA[ctxA]?.[path]) ||
+            valueKey(baseline[path]);
+
+          if (cartesianValueKey === projectionValueKey) continue;
+
+          // Divergence — record the joint case. Look up the permutation
+          // name so downstream emit can find the full TokenNormalized.
+          const jointPerm = findPermByTuple(permutations, jointTuple);
+          if (!jointPerm) continue;
+          if (permutationsResolved[jointPerm.name] === undefined) continue;
+          cases.push({
+            axisA: axisA.name,
+            ctxA,
+            axisB: axisB.name,
+            ctxB,
+            cartesianValueKey,
+            permutationName: jointPerm.name,
+          });
+        }
+      }
+    }
+  }
+
+  return cases;
+}
+
+/**
+ * Locate the permutation whose `input` exactly matches the given tuple.
+ * Returns `undefined` when no permutation matches — happens when
+ * `disabledAxes` filtered the tuple out, or when the resolver's
+ * cartesian was pruned. Callers handle this as "no overlay applies."
+ */
+function findPermByTuple(
+  permutations: Project['permutations'],
+  tuple: Readonly<Record<string, string>>,
+): Project['permutations'][number] | undefined {
+  const keys = Object.keys(tuple);
+  return permutations.find((perm) => {
+    for (const key of keys) {
+      if (perm.input[key] !== tuple[key]) return false;
+    }
+    return Object.keys(perm.input).length === keys.length;
+  });
+}
+
+/**
+ * Stable key for value comparison — `JSON.stringify($value)`. Mirrors
+ * `analyzeAxisVariance`'s comparator so composite tokens (shadow,
+ * typography, …) compare on every sub-field and missing tokens compare
+ * equal to the empty string.
+ */
+function valueKey(token: TokenNormalized | undefined): string {
+  if (!token) return '';
+  return JSON.stringify(token.$value);
+}

--- a/packages/core/test/variance-analysis.test.ts
+++ b/packages/core/test/variance-analysis.test.ts
@@ -1,0 +1,168 @@
+/**
+ * `analyzeProjectVariance` — per-token variance classification across a
+ * loaded project's axes. Tests pin:
+ *
+ *   - the reference fixture's expected classifications (palette primitives
+ *     baseline-only, single-axis role tokens like `color.surface.default`
+ *     varying only on mode, joint-variant tokens like `color.accent.fg`
+ *     detected as such),
+ *   - layered projects skip Phase 3 (no `parserInput.resolver`) and
+ *     conservatively classify multi-touch tokens as joint-variant with
+ *     empty `jointCases`,
+ *   - the analysis completes in reasonable wall time for the realistic
+ *     fixture (regression bound, not stress test).
+ *
+ * No emit changes in this file — the smart emitter that consumes
+ * `VarianceInfo` follows in a separate PR.
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { beforeAll, describe, expect, it } from 'vitest';
+import { loadProject } from '#/load.ts';
+import type { Config, Project } from '#/types.ts';
+import { analyzeProjectVariance, type VarianceInfo } from '#/variance-analysis.ts';
+import { loadWithPrefix } from './_helpers.ts';
+
+let referenceProject: Project;
+
+// beforeAll: loadProject takes ~1s; tests below reuse the same project.
+beforeAll(async () => {
+  referenceProject = await loadWithPrefix('sb');
+}, 30_000);
+
+describe('analyzeProjectVariance — reference fixture', () => {
+  let variance: Map<string, VarianceInfo>;
+
+  beforeAll(() => {
+    variance = analyzeProjectVariance(referenceProject);
+  });
+
+  it('classifies palette primitives as baseline-only (no axis touches them)', () => {
+    // `color.palette.blue.500` is defined only in the baseline `color.json`
+    // tokens; no overlay touches it.
+    const info = variance.get('color.palette.blue.500');
+    expect(info).toBeDefined();
+    expect(info?.kind).toBe('baseline-only');
+  });
+
+  it("classifies surface roles as single-axis on `mode` (only mode overlays touch `color.surface.*`)", () => {
+    const info = variance.get('color.surface.default');
+    expect(info).toBeDefined();
+    if (info?.kind !== 'single-axis') {
+      throw new Error(`expected single-axis, got ${info?.kind}`);
+    }
+    expect(info.axis).toBe('mode');
+  });
+
+  it("classifies `color.accent.fg` as joint-variant — Dark mode + contrast=High joint diverges from projection composition", () => {
+    const info = variance.get('color.accent.fg');
+    expect(info).toBeDefined();
+    if (info?.kind !== 'joint-variant') {
+      throw new Error(`expected joint-variant, got ${info?.kind}`);
+    }
+    // `touching` should include at least mode + contrast (the two axes
+    // that interact through `accessible.accent` aliasing). Brand may
+    // also be in touching depending on whether projection composition
+    // happens to match cartesian for the (mode, brand) joint.
+    expect(info.touching.has('mode')).toBe(true);
+    expect(info.touching.has('contrast')).toBe(true);
+    // At least one joint case must be recorded.
+    expect(info.jointCases.length).toBeGreaterThan(0);
+    // Joint cases name an axis pair + non-default contexts + a stringified
+    // cartesian value + a permutation name for downstream emit lookup.
+    for (const c of info.jointCases) {
+      expect(c.axisA).toBeTruthy();
+      expect(c.axisB).toBeTruthy();
+      expect(c.axisA).not.toBe(c.axisB);
+      expect(c.cartesianValueKey).toBeTruthy();
+      expect(c.permutationName).toBeTruthy();
+      // The recorded permutation must exist in the project's resolved map.
+      expect(referenceProject.permutationsResolved[c.permutationName]).toBeDefined();
+    }
+  });
+
+  it('returns a VarianceInfo for every token path present in any permutation', () => {
+    // Sanity: the result map covers every token path the loader produced.
+    const allPaths = new Set<string>();
+    for (const tokens of Object.values(referenceProject.permutationsResolved)) {
+      for (const path of Object.keys(tokens)) allPaths.add(path);
+    }
+    for (const path of allPaths) {
+      expect(variance.has(path), `missing variance info for ${path}`).toBe(true);
+    }
+  });
+
+  it('completes the analysis in well under a second for the reference fixture', () => {
+    const start = performance.now();
+    analyzeProjectVariance(referenceProject);
+    const elapsed = performance.now() - start;
+    // Generous bound — regression-detection rather than stress test.
+    // The fixture has 3 axes × 1 non-default context each, ~500 tokens.
+    // A handful of multi-touch tokens get probed; expect ~10s in CI
+    // worst case but normally much less.
+    expect(elapsed).toBeLessThan(10_000);
+  });
+});
+
+describe('analyzeProjectVariance — layered project (no resolver, Phase 3 skipped)', () => {
+  let layeredProject: Project;
+  let variance: Map<string, VarianceInfo>;
+
+  beforeAll(async () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const layeredCwd = resolve(here, 'fixtures/layered');
+    const config: Config = {
+      tokens: ['base/*.json'],
+      axes: [
+        {
+          name: 'mode',
+          contexts: { Light: [], Dark: ['modes/dark.json'] },
+          default: 'Light',
+        },
+        {
+          name: 'brand',
+          contexts: { Default: [], 'Brand A': ['brands/brand-a.json'] },
+          default: 'Default',
+        },
+      ],
+    };
+    layeredProject = await loadProject(config, layeredCwd);
+    variance = analyzeProjectVariance(layeredProject);
+  }, 30_000);
+
+  it('layered projects have no parserInput.resolver — Phase 3 is unreachable', () => {
+    expect(layeredProject.parserInput).toBeUndefined();
+  });
+
+  it("classifies multi-touch tokens conservatively as joint-variant with empty `jointCases` (no resolver to probe with)", () => {
+    // `color.accent` is overridden by both modes/dark.json and brands/brand-a.json
+    // in this layered fixture — multi-touch.
+    const info = variance.get('color.accent');
+    if (!info) return; // fixture might not define it; skip rather than fail
+    if (info.kind !== 'joint-variant') return;
+    expect(info.touching.size).toBeGreaterThanOrEqual(2);
+    // Empty jointCases — the emitter takes this as "fall back to cartesian-style emit."
+    expect(info.jointCases).toEqual([]);
+  });
+
+  it('still classifies single-axis tokens normally', () => {
+    // `color.surface` is touched only by mode (dark.json), not by brand.
+    const info = variance.get('color.surface');
+    if (!info) return;
+    expect(info.kind).toBe('single-axis');
+  });
+});
+
+describe('analyzeProjectVariance — edge cases', () => {
+  it('handles a project with zero axes (every token baseline-only)', async () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const layeredCwd = resolve(here, 'fixtures/layered');
+    // Plain-parse: just tokens, no axes, no resolver.
+    const config: Config = { tokens: ['base/*.json'] };
+    const project = await loadProject(config, layeredCwd);
+    const variance = analyzeProjectVariance(project);
+    for (const info of variance.values()) {
+      expect(info.kind).toBe('baseline-only');
+    }
+  }, 30_000);
+});


### PR DESCRIPTION
## Summary

- New internal `analyzeProjectVariance(project)` → `Map<tokenPath, VarianceInfo>`
- Classifies each token as `baseline-only`, `single-axis`, `orthogonal-after-probe`, or `joint-variant`
- Pure analysis; **no emit behaviour changes** in this PR
- Function not re-exported from `src/index.ts` yet (kept internal until the smart emitter consumes it)

## Full description

First step of the smart-emitter chain (plan: \`/Users/palnes/.claude/plans/this-is-an-empty-snazzy-ocean.md\`). Adds the analysis layer that will route per-token emission in the next PR. The discriminated `VarianceInfo` union tells the emitter how to handle each token:

- `baseline-only` → `:root` declaration only; never appears in any cell
- `single-axis` → standard projection cell deltas for the named axis
- `orthogonal-after-probe` → projection cell deltas for each touching axis; smart-dedup cascade resolves correctly
- `joint-variant` → projection cells PLUS compound `[data-A][data-B]` selectors for each `JointCase` to preserve the spec-correct cartesian value

### Algorithm

Three phases:

1. **Per-axis cell read** — pulls from `project.permutationsResolved` (loader-paid cost)
2. **Touching set** — reuses `analyzeAxisVariance` to find axes that change the value at any tuple, not just at the singleton cell. This catches "joint-only" touching that a naive singleton-vs-baseline comparison would miss. (Worked through this with the reference fixture: Brand A's `accent.fg = white` matches baseline white, so its singleton looks like a no-op — but in combination with Dark mode, brand IS actually overriding Dark's overridden value back to white. Singleton-comparison misses brand entirely; `analyzeAxisVariance`-style cartesian-bucket comparison catches it.)
3. **Targeted joint probe** — for multi-touch tokens only, calls `resolver.apply` per axis-pair × non-default-combination; compares cartesian truth against projection composition under smart dedup; records divergences

### Pairs only

We probe pairs only. Triple-or-higher joint variance is rare in practice and noted as a known limitation in the doc comment; future `\$extensions` annotation is the planned override mechanism.

### Layered / plain-parse fallback

Layered + plain-parse projects don't have `parserInput.resolver` → Phase 3 is skipped. Multi-touch tokens get classified as `joint-variant` with empty `jointCases`; the downstream emitter takes the empty cases as a signal to fall back to cartesian-style emit for those tokens.

## Tests (9 new — 187/187 core tests pass)

- Reference fixture: palette primitives → baseline-only; `color.surface.default` → single-axis on mode; `color.accent.fg` → joint-variant with at least mode + contrast in touching, jointCases populated with valid permutation lookups
- Coverage: every token in `permutationsResolved` is classified
- Timing: reference fixture analysis under 10s (regression bound)
- Layered project: no `parserInput`, multi-touch tokens conservatively classified as joint-variant with empty `jointCases`, single-axis tokens still detected normally
- Plain-parse (zero axes): every token classified as baseline-only

## Files

- `packages/core/src/variance-analysis.ts` (new, 311 lines)
- `packages/core/test/variance-analysis.test.ts` (new, 168 lines)
- `.changeset/variance-analysis.md` (minor bump)

Reuses `analyzeAxisVariance` from `packages/core/src/variance.ts` for the touching-set detection.

Milestone: Maintenance

Closes #777

Plan impact: this is PR 1 of 3 in the smart-emitter chain. PR 2 rewrites `emitAxisProjectedCss` to route per-token using this analysis. PR 3 wires the addon to default to projected emit (now spec-faithful via Phase 3's joint-fallback).