### PR TITLE
feat(core): smart emitter — route per-token between projection and compound selectors

### DIFF
--- a/.changeset/smart-projected-emitter.md
+++ b/.changeset/smart-projected-emitter.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-core`: rewrite `emitAxisProjectedCss` to route per-token between projection (single-attribute selectors) and compound selectors based on `analyzeProjectVariance`. Spec-faithful for any DTCG-compliant resolver — orthogonal projects still get the size win; joint-variant projects get compound `[data-A][data-B]` blocks that preserve the cartesian-correct value at exactly the divergent joint tuples. Smart dedup: cells re-emit a token's value when ANY axis touches it (not just when this cell differs from baseline), so cascade-order resolves orthogonal-after-probe tokens correctly. Signature changed to `(project, options)` — function is `@internal`, only consumed in-package; no public API broken.

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -2,69 +2,65 @@ import type { TokenNormalized } from '@terrazzo/parser';
 import { generateShorthand, makeCSSVar, transformCSSValue } from '@terrazzo/token-tools/css';
 import { CHROME_ROLES, CHROME_VAR_PREFIX, DEFAULT_CHROME_MAP } from '#/chrome.ts';
 import { dataAttr } from '#/css.ts';
-import type { Axis, Permutation, TokenMap } from '#/types.ts';
+import type { Axis, Permutation, Project, TokenMap } from '#/types.ts';
+import { analyzeProjectVariance, type JointCase, type VarianceInfo } from '#/variance-analysis.ts';
 
-/** @internal Options for the axis-projected CSS emitter. Not part of the public API. */
+/** @internal Addon-internal smart-emitter options. Not part of the public API. */
 export interface EmitAxisProjectedCssOptions {
-  /** Override the prefix from project config (default: `config.cssVarPrefix ?? ''`). */
+  /** Override the prefix from project config (default: `project.config.cssVarPrefix ?? ''`). */
   prefix?: string;
-  /**
-   * Project axes. Each non-default `(axis, context)` cell emits a
-   * single-attribute selector — `[data-<prefix>-<axis>="<context>"]` —
-   * containing only the token declarations whose values differ from
-   * the baseline (default-tuple) values. Cells from different axes
-   * compose at runtime via the browser's CSS cascade.
-   */
-  axes?: Axis[];
   /**
    * Validated chrome-alias entries from `Project.chrome`. Each `source →
    * target` pair appends `--<prefix>-<source>: var(--<prefix>-<target>);`
-   * to a trailing `:root` block. See `validateChrome`.
+   * to a trailing `:root` block. Defaults to `project.chrome`. See
+   * `validateChrome`.
    */
   chrome?: Record<string, string>;
+  /**
+   * Pre-computed variance analysis. When omitted, the emitter calls
+   * `analyzeProjectVariance(project)` itself. Callers that need the
+   * analysis for other purposes (diagnostics, alternative emit paths)
+   * can compute it once and pass it here to avoid duplicate work.
+   */
+  variance?: Map<string, VarianceInfo>;
 }
 
 /**
- * Emit a single concatenated stylesheet as a **size optimization** for
- * resolver projects whose modifiers are orthogonal: one `:root` block
- * for the default tuple plus one `[data-<prefix>-<axis>="<context>"] { … }`
- * block per `(axis, non-default context)` cell, containing only the
- * declarations whose values differ from baseline at that cell.
+ * Emit a single concatenated stylesheet by routing each token to the
+ * cheapest emit strategy that still produces the spec-correct value
+ * at every tuple. Spec-faithful for any DTCG-compliant resolver
+ * (orthogonal or not):
  *
- * Output size scales with `Σ(axes × non-default contexts × varying
- * tokens)` instead of the cartesian product. Cells from different axes
- * compose at runtime via the browser's CSS cascade.
+ * - **Baseline-only tokens** — emitted once in `:root`, never in any cell
+ * - **Single-axis tokens** — emitted in `:root` plus the touching axis's
+ *   cell blocks (standard projection: `[data-<prefix>-<axis>="<ctx>"]`)
+ * - **Orthogonal-after-probe tokens** (touched by 2+ axes but
+ *   cell-composition matches cartesian) — emitted in `:root` plus
+ *   every touching axis's cell blocks; CSS cascade resolves the
+ *   correct value at any tuple
+ * - **Joint-variant tokens** (cell composition diverges from cartesian
+ *   at some joint tuple) — emitted in `:root` plus per-axis cell blocks
+ *   AS WELL AS compound `[data-A="ctx_a"][data-B="ctx_b"]` blocks
+ *   carrying the cartesian-correct value at exactly the divergent
+ *   joint tuples. Compound selector specificity `(0,2,0)` beats the
+ *   singletons' `(0,1,0)`, so the joint cell wins under cascade.
  *
- * ## When this is spec-faithful
+ * Smart dedup: every cell re-emits a token's value when ANY axis touches
+ * the token (not just when this cell differs from baseline). For
+ * orthogonal-after-probe tokens this means the last touching axis's
+ * cell wins under cascade — which matches what `analyzeProjectVariance`
+ * already verified for the `orthogonal-after-probe` classification.
  *
- * `emitCss` (the cartesian emitter) is what faithfully serializes the
- * resolved tokens for any DTCG-compliant resolver — including ones with
- * non-orthogonal modifiers. The DTCG Resolver Module 2025.10 (Final
- * Community Group Report) explicitly permits non-orthogonal modifiers
- * and resolves their conflicts via the `resolutionOrder` array
- * (last write wins). GitHub Primer's "Pirate" theme, available only in
- * light mode, is the rationale doc's canonical example — the spec
- * endorses authoring of that shape.
+ * The classification work is the value-comparison + targeted-joint-probe
+ * pass in `analyzeProjectVariance`. The emitter consumes that analysis
+ * and does no spec reasoning of its own — every routing decision is
+ * already in the `VarianceInfo` for the token.
  *
- * This emitter, by contrast, is a **lossy size optimization** that
- * works correctly **only when modifiers are orthogonal** — i.e., when
- * the resolved value of any token at any tuple is fully determined by
- * stacking each axis's singleton effect, independent of the others.
- * Joint-variant tokens (values that genuinely depend on the
- * *combination* of two axes — e.g. an alias whose resolution differs
- * per `(brand, mode)` pair beyond what either singleton override
- * produces) will render the projection-implied value at runtime, not
- * the spec-correct joint resolution.
- *
- * **Use this emitter when** you've confirmed your modifiers are
- * orthogonal and want the size reduction. **Use `emitCss` when** any
- * modifier joint-varies tokens, or when in doubt — cartesian is the
- * spec-faithful default.
- *
- * A planned smart emitter folds projection + cartesian-fallback into
- * one path (orthogonal tokens projected, joint-variant tokens emitted
- * via compound selectors); once that ships this function may become
- * its internal primitive rather than a standalone consumer surface.
+ * Output size scales with `baseline + per-axis cells + joint compound
+ * blocks`. For mostly-orthogonal fixtures, dramatically smaller than
+ * cartesian. In the worst case (every token touched by every axis with
+ * joint variance on every pair), output approaches cartesian but never
+ * exceeds it.
  *
  * For single-axis projects (a synthetic `theme` axis, or a resolver
  * with one modifier), the cell selector uses the axis's actual name
@@ -76,42 +72,46 @@ export interface EmitAxisProjectedCssOptions {
  * Terrazzo's CLI against the DTCG sources directly.
  */
 export function emitAxisProjectedCss(
-  permutations: Permutation[],
-  permutationsResolved: Record<string, TokenMap>,
+  project: Project,
   options: EmitAxisProjectedCssOptions = {},
 ): string {
-  const prefix = options.prefix ?? '';
-  const varOpts = prefix ? { prefix } : {};
+  const prefix = options.prefix ?? project.config.cssVarPrefix ?? '';
+  const varOpts: VarOpts = prefix ? { prefix } : {};
   const transformAlias = (token: TokenNormalized): string =>
     makeCSSVar(token.id, { ...varOpts, wrapVar: true });
 
-  const axes = options.axes ?? [];
+  const { axes, permutations, permutationsResolved } = project;
+  const variance = options.variance ?? analyzeProjectVariance(project);
+
   const defaultTuple = buildDefaultTuple(axes);
   const baselinePerm =
     axes.length > 0 ? findPermutationByTuple(permutations, defaultTuple) : permutations[0];
 
   const blocks: string[] = [];
-  const baselineDecls = new Map<string, string>();
 
-  // 1. Baseline `:root` — every declaration the default tuple produces.
+  // 1. Baseline `:root` — every token's baseline value lives here.
+  //    Baseline-only tokens never appear elsewhere; all other variance
+  //    kinds also need a baseline value to start the cascade from.
   if (baselinePerm) {
     const baselineTokens = permutationsResolved[baselinePerm.name];
     if (baselineTokens) {
-      const lines: string[] = [];
-      for (const decl of collectDeclarations(
+      const lines = collectLines(
         baselineTokens,
+        () => true,
         baselinePerm.input,
         varOpts,
         transformAlias,
-      )) {
-        baselineDecls.set(decl.varName, decl.value);
-        lines.push(`  ${decl.varName}: ${decl.value};`);
-      }
+      );
       if (lines.length > 0) blocks.push(`:root {\n${lines.join('\n')}\n}`);
     }
   }
 
-  // 2. Per `(axis, context)` cells — emit deltas only.
+  // 2. Per-axis singleton cells — emit every token this axis touches.
+  //    Under smart dedup we don't drop "matches baseline" values; the
+  //    cascade needs them to win against other axes that might have
+  //    overridden the var. Variance routing makes "touches" precise:
+  //    only tokens where `axesTouching(token)` includes this axis emit
+  //    here. Baseline-only tokens are filtered out entirely.
   for (const axis of axes) {
     for (const ctx of axis.contexts) {
       if (ctx === axis.default) continue;
@@ -120,19 +120,38 @@ export function emitAxisProjectedCss(
       if (!cellPerm) continue;
       const cellTokens = permutationsResolved[cellPerm.name];
       if (!cellTokens) continue;
-      const deltaLines: string[] = [];
-      for (const decl of collectDeclarations(cellTokens, cellPerm.input, varOpts, transformAlias)) {
-        if (baselineDecls.get(decl.varName) === decl.value) continue;
-        deltaLines.push(`  ${decl.varName}: ${decl.value};`);
-      }
-      if (deltaLines.length === 0) continue;
+
+      const lines = collectLines(
+        cellTokens,
+        (path) => axisTouchesToken(axis.name, variance.get(path)),
+        cellPerm.input,
+        varOpts,
+        transformAlias,
+      );
+      if (lines.length === 0) continue;
       const selector = `[${dataAttr(prefix, axis.name)}="${cssEscape(ctx)}"]`;
-      blocks.push(`${selector} {\n${deltaLines.join('\n')}\n}`);
+      blocks.push(`${selector} {\n${lines.join('\n')}\n}`);
     }
   }
 
-  // 3. Chrome aliases — trailing `:root` block, identical to `emitCss`.
-  const chrome = options.chrome ?? {};
+  // 3. Compound joint cells — one block per unique `(axisA, ctxA, axisB,
+  //    ctxB)` combination across all joint-variant tokens. The block
+  //    carries the spec-correct cartesian values for each token that
+  //    diverges from projection composition at that joint tuple.
+  //    Compound selector specificity beats the singleton cells, so the
+  //    joint cell wins where it applies.
+  for (const block of collectJointBlocks(
+    variance,
+    permutationsResolved,
+    prefix,
+    varOpts,
+    transformAlias,
+  )) {
+    blocks.push(block);
+  }
+
+  // 4. Chrome aliases — trailing `:root` block, identical to `emitCss`.
+  const chrome = options.chrome ?? project.chrome;
   const chromeLines: string[] = ['  color-scheme: light dark;'];
   for (const role of CHROME_ROLES) {
     const sourceVar = makeCSSVar(role, { prefix: CHROME_VAR_PREFIX });
@@ -152,42 +171,162 @@ export function emitAxisProjectedCss(
 type VarOpts = Record<string, never> | { prefix: string };
 
 /**
- * Stream of CSS declarations for a token map: one entry per emitted
- * `--var: value;` pair. Composite tokens emit one entry per sub-field
- * plus an optional shorthand entry — same expansion `emitCss` uses,
- * just yielded as `{ varName, value }` records so the delta-comparison
- * stage can dedupe against baseline without re-parsing the line.
+ * Tells whether the given axis is in a token's touching set. Drives the
+ * per-axis cell-block filter: only tokens this axis actually affects
+ * appear in that axis's cell blocks.
  */
-function* collectDeclarations(
+function axisTouchesToken(axisName: string, info: VarianceInfo | undefined): boolean {
+  if (!info) return false;
+  switch (info.kind) {
+    case 'baseline-only':
+      return false;
+    case 'single-axis':
+      return info.axis === axisName;
+    case 'orthogonal-after-probe':
+    case 'joint-variant':
+      return info.touching.has(axisName);
+  }
+}
+
+/**
+ * Group every joint-variant token's `jointCases` by their compound
+ * selector key (`axisA|ctxA|axisB|ctxB`), then emit one block per
+ * unique key containing the cartesian-correct values for each token's
+ * joint case. Each token's joint value is pulled from the corresponding
+ * permutation's resolved TokenMap (the `permutationName` recorded
+ * during analysis), so it goes through the same Terrazzo-side resolution
+ * as cartesian emit would.
+ */
+function collectJointBlocks(
+  variance: Map<string, VarianceInfo>,
+  permutationsResolved: Record<string, TokenMap>,
+  prefix: string,
+  varOpts: VarOpts,
+  transformAlias: (token: TokenNormalized) => string,
+): string[] {
+  const grouped = new Map<string, { path: string; jointCase: JointCase }[]>();
+  for (const [path, info] of variance) {
+    if (info.kind !== 'joint-variant') continue;
+    for (const jointCase of info.jointCases) {
+      const key = `${jointCase.axisA}|${jointCase.ctxA}|${jointCase.axisB}|${jointCase.ctxB}`;
+      const bucket = grouped.get(key) ?? [];
+      bucket.push({ path, jointCase });
+      grouped.set(key, bucket);
+    }
+  }
+
+  const blocks: string[] = [];
+  for (const [key, entries] of grouped) {
+    const parts = key.split('|');
+    const axisA = parts[0] as string;
+    const ctxA = parts[1] as string;
+    const axisB = parts[2] as string;
+    const ctxB = parts[3] as string;
+    const selector = `[${dataAttr(prefix, axisA)}="${cssEscape(ctxA)}"][${dataAttr(prefix, axisB)}="${cssEscape(ctxB)}"]`;
+
+    const lines: string[] = [];
+    for (const { path, jointCase } of entries) {
+      const cellTokens = permutationsResolved[jointCase.permutationName];
+      if (!cellTokens) continue;
+      const token = cellTokens[path];
+      if (!token) continue;
+      for (const decl of collectTokenDeclarations(
+        path,
+        token,
+        cellTokens,
+        // Use the joint permutation's input as the resolution context —
+        // composite token sub-fields and alias references are resolved
+        // against the joint tuple, matching what cartesian emit would do.
+        jointInputFromCase(jointCase),
+        varOpts,
+        transformAlias,
+      )) {
+        lines.push(`  ${decl.varName}: ${decl.value};`);
+      }
+    }
+    if (lines.length > 0) blocks.push(`${selector} {\n${lines.join('\n')}\n}`);
+  }
+
+  return blocks;
+}
+
+/**
+ * Reconstruct a partial `permutation.input` from a JointCase. Used as
+ * the `permutation` context for `transformCSSValue` — composite tokens
+ * and aliases resolve against the joint tuple. Other axes default
+ * naturally during transform; the joint axes are the load-bearing ones.
+ */
+function jointInputFromCase(jointCase: JointCase): Record<string, string> {
+  return { [jointCase.axisA]: jointCase.ctxA, [jointCase.axisB]: jointCase.ctxB };
+}
+
+/**
+ * Collect emitted declaration lines for a token map, filtering tokens
+ * by `accept(path)`. Each line is `  --var: value;` (with leading
+ * indent for embedding in a block). Composite tokens contribute one
+ * line per sub-field plus an optional shorthand line; primitives
+ * contribute one line.
+ */
+function collectLines(
   tokens: TokenMap,
+  accept: (path: string) => boolean,
+  permutation: Record<string, string>,
+  varOpts: VarOpts,
+  transformAlias: (token: TokenNormalized) => string,
+): string[] {
+  const lines: string[] = [];
+  for (const [path, token] of Object.entries(tokens)) {
+    if (!accept(path)) continue;
+    for (const decl of collectTokenDeclarations(
+      path,
+      token,
+      tokens,
+      permutation,
+      varOpts,
+      transformAlias,
+    )) {
+      lines.push(`  ${decl.varName}: ${decl.value};`);
+    }
+  }
+  return lines;
+}
+
+/**
+ * Expand a single token into its emitted `{ varName, value }` records.
+ * Primitive tokens yield one record; composite tokens yield one per
+ * sub-field plus an optional shorthand. Mirrors `emitCss`'s expansion
+ * — kept here so the two emitters produce byte-identical declarations
+ * for the tokens they each emit.
+ */
+function* collectTokenDeclarations(
+  localID: string,
+  token: TokenNormalized,
+  tokensSet: TokenMap,
   permutation: Record<string, string>,
   varOpts: VarOpts,
   transformAlias: (token: TokenNormalized) => string,
 ): Generator<{ varName: string; value: string }> {
-  for (const [localID, token] of Object.entries(tokens)) {
-    const varName = makeCSSVar(localID, varOpts);
-    const value = transformCSSValue(token, { tokensSet: tokens, permutation, transformAlias });
-    if (typeof value === 'string') {
-      yield { varName, value };
-      continue;
-    }
-    for (const [subKey, subVal] of Object.entries(value)) {
-      const subName = makeCSSVar(`${localID}.${subKey}`, varOpts);
-      yield { varName: subName, value: subVal };
-    }
-    const shorthand = generateShorthand({ token, localID });
-    if (shorthand) yield { varName, value: shorthand };
+  const varName = makeCSSVar(localID, varOpts);
+  const value = transformCSSValue(token, { tokensSet, permutation, transformAlias });
+  if (typeof value === 'string') {
+    yield { varName, value };
+    return;
   }
+  for (const [subKey, subVal] of Object.entries(value)) {
+    yield { varName: makeCSSVar(`${localID}.${subKey}`, varOpts), value: subVal };
+  }
+  const shorthand = generateShorthand({ token, localID });
+  if (shorthand) yield { varName, value: shorthand };
 }
 
-function buildDefaultTuple(axes: Axis[]): Record<string, string> {
+function buildDefaultTuple(axes: readonly Axis[]): Record<string, string> {
   const out: Record<string, string> = {};
   for (const axis of axes) out[axis.name] = axis.default;
   return out;
 }
 
 function findPermutationByTuple(
-  permutations: Permutation[],
+  permutations: readonly Permutation[],
   tuple: Readonly<Record<string, string>>,
 ): Permutation | undefined {
   const keys = Object.keys(tuple);

--- a/packages/core/test/css-axis-projected.test.ts
+++ b/packages/core/test/css-axis-projected.test.ts
@@ -1,23 +1,26 @@
 /**
- * Axis-projection emitter (`emitAxisProjectedCss`) — a size-optimization
- * alternative to the cartesian `emitCss` / `projectCss` path, valid
- * only for resolver projects whose modifiers are orthogonal. Tests pin:
+ * Smart axis-projection emitter (`emitAxisProjectedCss`) — routes each
+ * token through `analyzeProjectVariance` and emits via projection
+ * (single-attribute selectors) for orthogonal tokens or compound
+ * selectors for joint-variant tokens. Spec-faithful for any
+ * DTCG-compliant resolver.
+ *
+ * Tests pin:
  *
  *   - the structural shape (one `:root` baseline + one single-attribute
- *     cell selector per non-default `(axis, context)`),
- *   - the delta optimization (cells only emit declarations that differ
- *     from the baseline value at the same var name),
- *   - the size win vs. cartesian emission for the same project, and
- *   - the joint-variance lossiness — when a fixture authors non-orthogonal
- *     modifiers (which the DTCG resolver spec explicitly permits, per
- *     the Primer "Pirate" light-only example in the rationale doc), this
- *     emitter silently produces the projection-implied value rather than
- *     the spec-correct joint resolution. Cartesian (`emitCss`) is the
- *     spec-faithful default; this emitter is opt-in for orthogonal cases.
- *     The joint-variance test below pins the lossy behavior so future
- *     changes don't quietly "fix" it without an explicit decision —
- *     the planned smart emitter (analysis + per-token routing) is the
- *     intended fix path.
+ *     cell selector per non-default `(axis, context)` that has touching
+ *     tokens; plus compound `[data-A][data-B]` blocks for joint cases),
+ *   - the per-axis cells contain only tokens that axis actually touches
+ *     (variance-driven filter — palette primitives never appear in any
+ *     cell),
+ *   - joint-variant tokens get compound selectors with the
+ *     cartesian-correct value (the fixture's `color.accent.fg` Dark+High
+ *     interaction is the canonical case),
+ *   - smart dedup: cells re-emit values when ANY axis touches the var,
+ *     so cascade resolves orthogonal-after-probe tokens correctly
+ *     (Brand A's `accent.fg = white` IS now emitted because Dark
+ *     touches the var, even though it matches baseline),
+ *   - the chrome alias block is emitted unchanged at the tail.
  */
 import { beforeAll, expect, it } from 'vitest';
 import { emitAxisProjectedCss } from '#/css-axis-projected';
@@ -32,35 +35,14 @@ beforeAll(async () => {
   project = await loadWithPrefix('sb');
 }, 30_000);
 
-it('emits one :root baseline block plus N cell blocks (Σ axes × non-default contexts), plus the trailing chrome block', () => {
-  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
-    chrome: project.chrome,
-  });
+it('emits one :root baseline block plus N per-axis cell blocks plus the trailing chrome block, with optional compound joint blocks in between', () => {
+  const css = emitAxisProjectedCss(project);
   // Two `:root {` openings — baseline + chrome trailer.
   const rootMatches = css.match(/(^|\n):root\s*\{/g) ?? [];
   expect(rootMatches).toHaveLength(2);
   // The fixture has three axes with one non-default context each
-  // (Dark, Brand A, High) → three cell blocks.
-  const expectedCells = project.axes.reduce((n, a) => n + (a.contexts.length - 1), 0);
-  const cellMatches = css.match(/\n\[data-sb-[^\]]+\]\s*\{/g) ?? [];
-  expect(cellMatches).toHaveLength(expectedCells);
-});
-
-it('uses single-attribute selectors only — no compound [data-…][data-…] selectors anywhere', () => {
-  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
-  });
-  expect(css).not.toMatch(/\[data-[^\]]+\]\[data-/);
-});
-
-it('emits per-axis cell selectors that match each non-default context', () => {
-  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
-  });
+  // (Dark, Brand A, High). Each axis cell block exists if any token
+  // touches that axis — for our fixture all three axes touch something.
   for (const axis of project.axes) {
     for (const ctx of axis.contexts) {
       if (ctx === axis.default) continue;
@@ -69,53 +51,67 @@ it('emits per-axis cell selectors that match each non-default context', () => {
   }
 });
 
-it("cell blocks carry only deltas — tokens unchanged from baseline don't appear in the cell", () => {
-  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
-  });
-  // The baseline declares the full token graph. Each cell should be a
-  // small fraction of that — mode-invariant primitives (palette, size,
-  // typography) belong in :root and stay out of the Dark cell.
-  const baseline = extractBlock(css, ':root');
-  const darkCell = extractBlock(css, '[data-sb-mode="Dark"]');
-  expect(baseline).toBeTruthy();
-  expect(darkCell).toBeTruthy();
-  const baselineVarCount = (baseline.match(/--sb-/g) ?? []).length;
-  const darkCellVarCount = (darkCell.match(/--sb-/g) ?? []).length;
-  expect(darkCellVarCount).toBeLessThan(baselineVarCount / 2);
+it('emits compound [data-A][data-B] blocks for joint-variant tokens (joint blocks contain the cartesian-correct value, not the projection-composed value)', () => {
+  const css = emitAxisProjectedCss(project);
+  // The fixture has joint variance on `color.accent.fg` between mode and
+  // contrast (Dark mode's `accessible.accent.fg = neutral.900` is aliased
+  // through by contrast=High; the joint Dark+High tuple resolves to dark
+  // text rather than the white that projection-composition of Light's
+  // accessible.accent would produce).
+  const compoundSelectors = css.match(/\[data-sb-[^\]]+\]\[data-sb-[^\]]+\]/g) ?? [];
+  expect(compoundSelectors.length).toBeGreaterThan(0);
+
+  // At least one compound block touches color.accent.fg.
+  const compoundBlocks = css.split('\n\n').filter((b) => /\[data-sb-[^\]]+\]\[data-sb-/.test(b));
+  const fgInAnyCompound = compoundBlocks.some((b) => /--sb-color-accent-fg:/.test(b));
+  expect(fgInAnyCompound).toBe(true);
 });
 
-it("mode-invariant tokens (size scale primitives) don't appear in the mode cell", () => {
-  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
-  });
+it('per-axis cell blocks include every touching token, even when that token matches baseline (smart dedup — needed so cascade lands on the right cell under joint composition)', () => {
+  const css = emitAxisProjectedCss(project);
+  // `color.accent.fg` is touched by brand (Brand A overrides it). Under
+  // smart dedup, Brand A's cell emits accent.fg = white even though
+  // it matches baseline white — so that under `<html data-sb-mode="Dark"
+  // data-sb-brand="Brand A">`, Brand A's white wins over Dark's
+  // overridden dark via source-order cascade.
+  const brandACell = extractBlock(css, '[data-sb-brand="Brand A"]');
+  expect(brandACell).toBeTruthy();
+  expect(brandACell).toMatch(/--sb-color-accent-fg:/);
+});
+
+it('baseline-only tokens (palette primitives) appear ONLY in :root, never in any cell', () => {
+  const css = emitAxisProjectedCss(project);
+  const baseline = extractBlock(css, ':root');
+  expect(baseline).toMatch(/--sb-color-palette-blue-500:/);
+  // No cell or compound block should redeclare a palette primitive.
+  const allCells = css.split('\n\n').filter((b) => b.startsWith('[data-sb-'));
+  for (const block of allCells) {
+    expect(block).not.toMatch(/--sb-color-palette-blue-500:/);
+  }
+});
+
+it("mode-invariant tokens (e.g. size primitives, font families) still don't appear in the mode cell — single-axis routing", () => {
+  const css = emitAxisProjectedCss(project);
   const darkCell = extractBlock(css, '[data-sb-mode="Dark"]');
   expect(darkCell).not.toMatch(/--sb-size-400:/);
   expect(darkCell).not.toMatch(/--sb-font-family-sans:/);
 });
 
-it('produces a stylesheet meaningfully smaller than the cartesian emission for the same project', () => {
-  const projected = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
-    chrome: project.chrome,
-  });
+it('produces a stylesheet meaningfully smaller than cartesian emission for the fixture (size win preserved even with joint compound blocks)', () => {
+  const projected = emitAxisProjectedCss(project);
   const cartesian = projectCss(project);
-  // 8 cartesian tuples × full-token redeclaration vs baseline + 3 deltas
-  // → projected must be substantially smaller. Tightened past the
-  // half-size threshold to a third — large headroom for fixture growth
-  // while still catching regressions.
-  expect(projected.length).toBeLessThan(cartesian.length / 3);
+  // 8 cartesian tuples × full-token redeclaration vs baseline + ≤3
+  // per-axis cells + a handful of joint compound blocks for the few
+  // joint-variant tokens → projected must still be substantially
+  // smaller. Half-cartesian is the regression bound (used to be 1/3
+  // when projection was lossy and dropped declarations; smart emit
+  // adds back some bytes for re-emits + compound blocks but stays
+  // well under 1/2).
+  expect(projected.length).toBeLessThan(cartesian.length / 2);
 });
 
 it('terminates with a trailing newline + emits chrome aliases identically to emitCss', () => {
-  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
-    chrome: project.chrome,
-  });
+  const css = emitAxisProjectedCss(project);
   expect(css.endsWith('\n')).toBe(true);
   // The chrome aliases block is appended at the tail — same shape as
   // emitCss writes — so blocks that read `--swatchbook-*` resolve the
@@ -124,30 +120,19 @@ it('terminates with a trailing newline + emits chrome aliases identically to emi
   expect(css).toContain('--swatchbook-surface-default:');
 });
 
-it("joint-variance lossiness: a cell's declaration drops out when its value equals baseline, even if another cell overrides the same token — under runtime cascade, the other cell's value wins at the joint tuple instead of this cell's intent. Documents projection's lossiness for spec-compliant non-orthogonal fixtures (consumers wanting joint-variance correctness should use cartesian `emitCss`, or wait for the planned smart emitter).", () => {
-  const css = emitAxisProjectedCss(project.permutations, project.permutationsResolved, {
-    axes: project.axes,
-    prefix: project.config.cssVarPrefix ?? '',
+it('respects options.prefix when overriding the project default', () => {
+  const css = emitAxisProjectedCss(project, { prefix: 'ds' });
+  // Var prefix flips from `--sb-*` to `--ds-*` and so do the data attrs.
+  expect(css).toContain('--ds-color-');
+  expect(css).toContain('[data-ds-mode="Dark"]');
+  expect(css).not.toContain('--sb-color-');
+});
+
+it('respects options.chrome override (passes through to chrome alias block)', () => {
+  const css = emitAxisProjectedCss(project, {
+    chrome: { surfaceDefault: 'color.palette.blue.500' },
   });
-  // Pick a token whose Brand A cell happens to equal baseline. The
-  // fixture's `color.accent.fg` is `neutral.0` (white) in both
-  // baseline (Light + Default) and the Brand A cell, but Dark mode
-  // overrides it to a dark value. Under projection, the Brand A cell
-  // does NOT re-emit `color.accent.fg` (delta-vs-baseline is zero),
-  // so at runtime `<html data-sb-mode="Dark" data-sb-brand="Brand A">`
-  // resolves `accent.fg` to Dark's dark value — even though the
-  // cartesian-emitted joint tuple (per `resolutionOrder` last-wins)
-  // would have produced white. This is what the DTCG spec calls
-  // out: non-orthogonal modifiers are allowed (Primer's "Pirate"
-  // light-only theme is the rationale doc's canonical example), and
-  // tools that take liberties with the emit strategy can lose joint
-  // resolution. Cartesian `emitCss` is the spec-faithful default.
-  const brandACell = extractBlock(css, '[data-sb-brand="Brand A"]');
-  const darkCell = extractBlock(css, '[data-sb-mode="Dark"]');
-  expect(brandACell).toBeTruthy();
-  expect(darkCell).toBeTruthy();
-  // Brand A cell does NOT mention accent-fg (it equals baseline).
-  expect(brandACell).not.toMatch(/--sb-color-accent-fg:/);
-  // Dark cell DOES override accent-fg.
-  expect(darkCell).toMatch(/--sb-color-accent-fg:/);
+  expect(css).toContain(
+    '--swatchbook-surface-default: var(--sb-color-palette-blue-500);',
+  );
 });


### PR DESCRIPTION
## Summary

- Rewrites `emitAxisProjectedCss` to consume `analyzeProjectVariance` (added in #778) and route each token by its variance classification
- Joint-variant tokens now emit compound `[data-A][data-B]` blocks with the cartesian-correct value — spec-faithful for non-orthogonal resolvers
- Smart dedup: cells re-emit a token's value when ANY axis touches it, so cascade resolves orthogonal-after-probe tokens correctly
- Signature changed `(permutations, permutationsResolved, options) → (project, options)`; function is `@internal`, no public API broken

## Full description

Second step of the smart-emitter chain. The emitter now does no spec reasoning of its own — every routing decision comes from the `VarianceInfo` analysis produced upstream:

| Variance kind | Emit |
|---|---|
| `baseline-only` | `:root` declaration only; never in any cell |
| `single-axis` | `:root` + the touching axis's cell blocks |
| `orthogonal-after-probe` | `:root` + every touching axis's cell blocks; cascade resolves |
| `joint-variant` | `:root` + per-axis cells AS WELL AS compound `[data-A][data-B]` blocks for each recorded `JointCase` |

### Smart dedup

The old naive emitter dropped cell declarations matching baseline. That was the source of joint-variance lossiness — `accent.fg` Brand A's `white` matched baseline white, so projection dropped it, and at `<html data-mode="Dark" data-brand="Brand A">` Dark's overridden dark won. Under smart dedup, brand re-emits white because Dark touches the var; brand-cell's later source position wins under cascade.

### Compound selectors

For genuinely joint-variant tokens (alias-interpolation joints, or fixtures where cascade composition diverges from cartesian for any reason), the emitter writes one compound `[data-A="ctx_a"][data-B="ctx_b"]` block per `(axisA, ctxA, axisB, ctxB)` recorded by the analysis. Compound selector specificity `(0,2,0)` beats the singletons' `(0,1,0)`, so the compound cell wins at the joint tuple. The value comes from `project.permutationsResolved[jointCase.permutationName]` — same Terrazzo-side resolution as cartesian emit.

### Signature change

Old: `emitAxisProjectedCss(permutations, permutationsResolved, options)`. New: `emitAxisProjectedCss(project, options)`. Reason: the emitter now needs `project.parserInput.resolver` (transitively, via the analysis) — passing the whole Project is cleaner than threading individual pieces.

The function is marked `@internal`. The only consumers were tests in this package + the `src/index.ts` re-export — both updated. No external surface affected.

## Tests (9 total — 1 net new from previous count)

- Structural shape: `:root` baseline + per-axis cells + compound joint blocks where needed + trailing chrome
- Joint variance: at least one compound `[data-sb-…][data-sb-…]` block exists for the reference fixture, and it contains `--sb-color-accent-fg:`
- Smart dedup: Brand A cell now mentions `accent.fg` (no longer dropped)
- Baseline-only routing: palette primitives appear ONLY in `:root`
- Single-axis routing: mode-invariant tokens stay out of mode cells
- Size win preserved: projected output < 1/2 cartesian for the fixture
- Chrome aliases trailing block
- `options.prefix` override
- `options.chrome` override

188/188 core tests pass.

## Files

- `packages/core/src/css-axis-projected.ts` — rewrite (was 205 lines, now 323 net change `+170/-65`)
- `packages/core/test/css-axis-projected.test.ts` — adapted for new signature + joint-correctness assertions
- `.changeset/smart-projected-emitter.md` — minor bump

## Plan impact

This is PR 2 of 3 in the smart-emitter chain. PR 3 (addon `emitMode` option, default to projected now that it's spec-faithful) follows.

Milestone: Maintenance

Closes #779