### PR TITLE
feat(addon): add emitMode option; default to 'projected'

### DIFF
--- a/.changeset/addon-emit-mode-projected-default.md
+++ b/.changeset/addon-emit-mode-projected-default.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-addon`: add `emitMode: 'cartesian' | 'projected'` option, defaulting to `'projected'`. The smart axis-projected emitter (`emitAxisProjectedCss`) now backs the addon's virtual-module `css` export — one `:root` baseline + per-cell deltas + compound `[data-A][data-B]` blocks for joint-variant tokens. Output is dramatically smaller than cartesian for typical fixtures while remaining spec-faithful for non-orthogonal DTCG resolvers. Pass `emitMode: 'cartesian'` to fall back to the explicit per-tuple fan-out (`projectCss`) — keep this in mind only for pathological cardinality where the projection analysis pass is too costly.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -101,6 +101,7 @@
     "@types/node": "^25.6.0",
     "@types/picomatch": "^4.0.3",
     "@types/react": "^19.2.14",
+    "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser": "^4.1.4",
     "@vitest/browser-playwright": "^4.1.4",

--- a/packages/addon/src/options.ts
+++ b/packages/addon/src/options.ts
@@ -18,4 +18,28 @@ export interface AddonOptions {
    * tool-agnostic; integrations ship as separate packages.
    */
   integrations?: SwatchbookIntegration[];
+  /**
+   * Which CSS emitter populates the `css` export of
+   * `virtual:swatchbook/tokens`. Defaults to `'projected'`.
+   *
+   * - `'projected'` (default) — smart axis-projected emit
+   *   (`emitAxisProjectedCss`). One `:root` baseline block, one
+   *   `[data-<axis>="<ctx>"]` block per non-default cell (deltas only
+   *   for tokens that axis touches), and compound `[data-A][data-B]`
+   *   blocks for joint-variant tokens that need cartesian-correct
+   *   values at specific joint tuples. Output size scales with
+   *   `Σ(axes × non-default contexts × touching tokens) + joint
+   *   compound blocks` — dramatically smaller than cartesian for
+   *   typical fixtures. Spec-faithful for any DTCG-compliant
+   *   resolver: orthogonal tokens project, joint-variant tokens fall
+   *   back to compound selectors automatically.
+   * - `'cartesian'` — explicit fan-out (`projectCss`). One block per
+   *   cartesian tuple, scoped by compound
+   *   `[data-<axis>="<ctx>"][data-…]` selectors. Output scales with
+   *   the cartesian product. Use only when the projection analysis
+   *   pass is too costly for your fixture (pathological cardinality
+   *   on the order of `terrazzo#752`'s 15M tuples), or when you have
+   *   a specific reason to want explicit per-tuple blocks.
+   */
+  emitMode?: 'cartesian' | 'projected';
 }

--- a/packages/addon/src/options.ts
+++ b/packages/addon/src/options.ts
@@ -36,10 +36,12 @@ export interface AddonOptions {
    * - `'cartesian'` — explicit fan-out (`projectCss`). One block per
    *   cartesian tuple, scoped by compound
    *   `[data-<axis>="<ctx>"][data-…]` selectors. Output scales with
-   *   the cartesian product. Use only when the projection analysis
-   *   pass is too costly for your fixture (pathological cardinality
-   *   on the order of `terrazzo#752`'s 15M tuples), or when you have
-   *   a specific reason to want explicit per-tuple blocks.
+   *   the cartesian product. Pick this when you want explicit
+   *   per-tuple blocks for debugging, regression-comparison against
+   *   the projected output, or because your tooling reads them
+   *   directly. Not an escape hatch for large cardinality — at the
+   *   scales where the projection analysis is expensive, the
+   *   cartesian output is just as unmanageable.
    */
   emitMode?: 'cartesian' | 'projected';
 }

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -36,6 +36,7 @@ export async function viteFinal(
       config,
       cwd,
       ...(options.integrations !== undefined && { integrations: options.integrations }),
+      ...(options.emitMode !== undefined && { emitMode: options.emitMode }),
     }),
   );
 

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -5,7 +5,7 @@ import type {
   SwatchbookIntegration,
   TokenListingByPath,
 } from '@unpunnyfuns/swatchbook-core';
-import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { emitAxisProjectedCss, loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
 import { type FSWatcher, watch as fsWatch } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import picomatch from 'picomatch';
@@ -23,6 +23,13 @@ export interface SwatchbookPluginOptions {
   cwd: string;
   /** Display-side integrations — each may contribute a virtual module the preview imports. */
   integrations?: readonly SwatchbookIntegration[];
+  /**
+   * Which CSS emitter to use for the virtual module's `css` export.
+   * `'projected'` (default) calls the smart `emitAxisProjectedCss`;
+   * `'cartesian'` calls `projectCss` for explicit per-tuple fan-out.
+   * See `AddonOptions.emitMode` for trade-offs.
+   */
+  emitMode?: 'cartesian' | 'projected';
 }
 
 /** `\0<virtualId>` — Vite convention for resolved virtual module IDs. */
@@ -40,13 +47,14 @@ export function swatchbookTokensPlugin({
   config,
   cwd,
   integrations = [],
+  emitMode = 'projected',
 }: SwatchbookPluginOptions): Plugin {
   let project: Project | undefined;
   let css = '';
 
   async function refresh(): Promise<void> {
     project = await loadProject(config, cwd);
-    css = projectCss(project);
+    css = composeProjectCss(project, emitMode);
   }
 
   /** Map of resolvedId → integration, indexed once. */
@@ -251,6 +259,25 @@ export function collectWatchPaths(
 function resolveFromCwd(p: string, cwd: string): string {
   if (isAbsolute(p)) return p;
   return resolvePath(cwd, p);
+}
+
+/**
+ * Dispatch between the two CSS emitters based on `emitMode`. Extracted
+ * from the plugin's closure so unit tests can verify the dispatch
+ * without booting Vite — pass a project + mode, get the matching CSS.
+ *
+ * The plugin defaults to `'projected'` (the smart axis-projected
+ * emitter); `'cartesian'` calls `projectCss` for explicit per-tuple
+ * fan-out.
+ *
+ * @internal Exported for tests; not part of the public API.
+ */
+export function composeProjectCss(
+  project: Project,
+  emitMode: 'cartesian' | 'projected' = 'projected',
+): string {
+  if (emitMode === 'cartesian') return projectCss(project);
+  return emitAxisProjectedCss(project);
 }
 
 type SlimListedToken = Pick<

--- a/packages/addon/test/compose-project-css.test.ts
+++ b/packages/addon/test/compose-project-css.test.ts
@@ -1,0 +1,47 @@
+// `composeProjectCss` is the plugin's emit-mode dispatch helper. The
+// plugin defaults to `'projected'` and the addon documents that as the
+// public default; these tests pin both that dispatch table and the
+// observable shape difference between the two emitters at the fixture
+// scale.
+//
+// Exported for tests only; not part of the public API.
+import { dirname } from 'node:path';
+import { loadProject } from '@unpunnyfuns/swatchbook-core';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
+import { beforeAll, expect, it } from 'vitest';
+import { composeProjectCss } from '#/virtual/plugin.ts';
+
+let fixtureProject: Project;
+
+// `loadProject` for the reference fixture is ~1s. `beforeAll` is the
+// documented perf-escape hatch for genuinely expensive shared setup;
+// every test reads from the same project.
+beforeAll(async () => {
+  fixtureProject = await loadProject({ resolver: resolverPath }, dirname(resolverPath));
+}, 30_000);
+
+it("defaults to projected emit when no mode is passed (matches the addon's documented default)", () => {
+  expect(composeProjectCss(fixtureProject)).toBe(composeProjectCss(fixtureProject, 'projected'));
+});
+
+it("mode='projected' routes through the smart axis-projected emitter — output is meaningfully smaller than cartesian for the fixture", () => {
+  const projected = composeProjectCss(fixtureProject, 'projected');
+  const cartesian = composeProjectCss(fixtureProject, 'cartesian');
+  expect(projected.length).toBeLessThan(cartesian.length / 2);
+});
+
+it("mode='cartesian' fans every non-default tuple into a compound selector — the fixture's three axes × two contexts each produce the joint Dark+Brand A+High block", () => {
+  const cartesian = composeProjectCss(fixtureProject, 'cartesian');
+  expect(cartesian).toMatch(
+    /\[data-swatch-mode="Dark"\]\[data-swatch-brand="Brand A"\]\[data-swatch-contrast="High"\]/,
+  );
+});
+
+it('both modes terminate with a trailing newline and include the chrome alias block (shape parity at the tail)', () => {
+  for (const mode of ['projected', 'cartesian'] as const) {
+    const css = composeProjectCss(fixtureProject, mode);
+    expect(css.endsWith('\n')).toBe(true);
+    expect(css).toContain('--swatchbook-surface-default:');
+  }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -215,6 +215,9 @@ importers:
       '@types/react':
         specifier: ^19.2.14
         version: 19.2.14
+      '@unpunnyfuns/swatchbook-tokens':
+        specifier: workspace:*
+        version: link:../tokens
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))


### PR DESCRIPTION
Third and final step of the smart-emitter chain. Wires the smart `emitAxisProjectedCss` (#780) into the addon as the default, with a `'cartesian'` opt-out.

## Summary

- `AddonOptions.emitMode: 'cartesian' | 'projected'`, defaulting to `'projected'`. JSDoc covers when each mode applies — `'cartesian'` is for consumers who want explicit per-tuple blocks (debugging, regression-comparison against the projected output, or tooling that reads them directly); it isn't an escape hatch for large cardinality.
- Thread through `preset.ts` → `swatchbookTokensPlugin` options.
- `plugin.ts` adds a small `composeProjectCss(project, emitMode)` dispatch helper; `refresh()` calls it instead of `projectCss` directly.
- New `test/compose-project-css.test.ts` pins the dispatch table against the reference fixture (default → projected, projected ≪ cartesian, cartesian fans the joint Dark+Brand A+High tuple, both modes carry the chrome trailer).
- Storybook (and any consumer that doesn't override `emitMode`) now dogfoods the projected default.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-addon typecheck` — clean
- [x] `pnpm --filter @unpunnyfuns/swatchbook-addon test` — 44/44 (9 files)
- [x] `pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-addon --filter @unpunnyfuns/swatchbook-core` — 11/11 tasks pass
- [x] `pnpm --filter swatchbook-storybook test:storybook` — 149/149 tests across 36 story files; joint-variance stories (`BrandADarkPreset`, `PerAxisDataAttrs`) pass without skips

Milestone: Maintenance
Closes #781
Plan impact: PR 3 of the smart-emitter chain — completes the plan; no plan-body changes needed.