### PR TITLE
feat(core): add Project.cells + resolveAt — additive foundation

### DIFF
--- a/.changeset/project-cells-resolve-at-foundation.md
+++ b/.changeset/project-cells-resolve-at-foundation.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-core`: add `Project.cells`, `Project.jointOverrides`, `Project.defaultTuple`, and `Project.resolveAt(tuple)` alongside the existing cartesian shape. `cells[axisName][contextName]` holds the resolved `TokenMap` for `{ ...defaultTuple, [axisName]: contextName }` — bounded by `Σ(axes × contexts)` regardless of cartesian product size. `jointOverrides` carries the divergent partial-tuple values that cell composition cannot reconstruct on its own, populated by an exhaustive arity-ascending probe so `resolveAt(tuple)` is exactly equivalent to `permutationsResolved[permutationID(tuple)]` for every fixture tuple (covers joint variance at any order, not just pairs). Additive — no consumer migration required; foundation for the subsequent PRs that move blocks / MCP / virtual module off the cartesian map.

--- a/packages/core/src/cells.ts
+++ b/packages/core/src/cells.ts
@@ -1,0 +1,47 @@
+import type { Axis, Cells, Permutation, TokenMap } from '#/types.ts';
+
+/**
+ * Derive `Project.cells` from the existing cartesian-shaped permutation
+ * data. One entry per `(axis, context)` — pulled from the singleton
+ * permutation whose tuple is `{ ...defaultTuple, [axisName]: contextName }`.
+ *
+ * This is the additive form: shipped on `Project` alongside the
+ * existing `permutationsResolved` so downstream consumers can adopt
+ * the cells shape without changing the load path. A follow-up PR
+ * switches `loadResolverPermutations` to populate `cells` directly via
+ * `resolver.apply` per `(axis, context)`, at which point the cartesian
+ * map goes away and this derivation does too.
+ */
+export function buildCells(
+  axes: readonly Axis[],
+  permutations: readonly Permutation[],
+  permutationsResolved: Readonly<Record<string, TokenMap>>,
+  defaultTuple: Readonly<Record<string, string>>,
+): Cells {
+  const cells: Cells = {};
+  for (const axis of axes) {
+    const axisCells: Record<string, TokenMap> = {};
+    for (const ctx of axis.contexts) {
+      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
+      const perm = findPermByTuple(permutations, cellTuple);
+      if (!perm) continue;
+      const resolved = permutationsResolved[perm.name];
+      if (resolved) axisCells[ctx] = resolved;
+    }
+    cells[axis.name] = axisCells;
+  }
+  return cells;
+}
+
+function findPermByTuple(
+  permutations: readonly Permutation[],
+  tuple: Readonly<Record<string, string>>,
+): Permutation | undefined {
+  const keys = Object.keys(tuple);
+  return permutations.find((perm) => {
+    for (const key of keys) {
+      if (perm.input[key] !== tuple[key]) return false;
+    }
+    return Object.keys(perm.input).length === keys.length;
+  });
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject, resolvePermutation } from '#/load.ts';
 export { projectCss } from '#/emit.ts';
 export { emitAxisProjectedCss } from '#/css-axis-projected.ts';
+export { jointOverrideKey } from '#/joint-overrides.ts';
 export { permutationID } from '#/types.ts';
 export { analyzeAxisVariance, type AxisVarianceResult, type VarianceKind } from '#/variance.ts';
 export { type ListedToken, type TokenListingByPath } from '#/token-listing.ts';
@@ -11,13 +12,17 @@ export { type ListedToken, type TokenListingByPath } from '#/token-listing.ts';
 export type {
   Axis,
   AxisConfig,
+  Cells,
   Config,
   Diagnostic,
   DiagnosticSeverity,
+  JointOverride,
+  JointOverrides,
   ParserInput,
   Permutation,
   Preset,
   Project,
+  ResolveAt,
   ResolvedPermutation,
   SwatchbookIntegration,
   TokenMap,

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -1,0 +1,106 @@
+import { buildResolveAt } from '#/resolve-at.ts';
+import type { Axis, Cells, JointOverride, JointOverrides, Permutation, TokenMap } from '#/types.ts';
+
+/**
+ * Extract joint-override entries by exhaustive cartesian-divergence
+ * probe — for every non-baseline permutation in
+ * `permutationsResolved`, compose via cells alone (no overrides yet),
+ * compare against the cartesian-resolved TokenMap, and record the
+ * divergent tokens as a joint override keyed by the permutation's
+ * non-default partial tuple.
+ *
+ * This is the PR-1 derivation. It guarantees `composeAt` is exactly
+ * equivalent to `permutationsResolved` for every cartesian tuple,
+ * including all-orders joint variance for free — no Phase 3 pair-only
+ * probe gap. The follow-up that drops the cartesian materialization
+ * replaces this with an analytical probe over the resolver directly.
+ *
+ * Override keys are sorted by arity on insertion so map iteration in
+ * `composeAt` applies lower-order overrides before higher-order ones.
+ */
+export function buildJointOverrides(
+  axes: readonly Axis[],
+  permutations: readonly Permutation[],
+  permutationsResolved: Readonly<Record<string, TokenMap>>,
+  cells: Cells,
+  defaultTuple: Readonly<Record<string, string>>,
+): JointOverrides {
+  // Probe in ascending arity. At each arity, compose against all
+  // lower-arity overrides already recorded; the arity-N override
+  // corrects any cases where the arity-(N-1) overrides set the wrong
+  // value at an N-axis tuple. This is what makes the "higher arity
+  // wins" property hold without losing the lower-arity benefits.
+  const accumulated = new Map<string, JointOverride>();
+
+  // Group permutations by partial-tuple arity (count of non-default axes).
+  const byArity = new Map<number, Permutation[]>();
+  let maxArity = 0;
+  for (const perm of permutations) {
+    let arity = 0;
+    for (const axis of axes) {
+      if (perm.input[axis.name] !== undefined && perm.input[axis.name] !== axis.default) {
+        arity += 1;
+      }
+    }
+    if (arity === 0) continue;
+    if (!byArity.has(arity)) byArity.set(arity, []);
+    byArity.get(arity)!.push(perm);
+    if (arity > maxArity) maxArity = arity;
+  }
+
+  for (let arity = 1; arity <= maxArity; arity++) {
+    const perms = byArity.get(arity) ?? [];
+    const composer = buildResolveAt(axes, cells, accumulated, defaultTuple);
+    for (const perm of perms) {
+      const cartesian = permutationsResolved[perm.name];
+      if (!cartesian) continue;
+      const partialAxes: Record<string, string> = {};
+      for (const axis of axes) {
+        const v = perm.input[axis.name];
+        if (v !== undefined && v !== axis.default) partialAxes[axis.name] = v;
+      }
+      const composed = composer(perm.input);
+      const divergent: TokenMap = {};
+      for (const path of Object.keys(cartesian)) {
+        const cVal = cartesian[path];
+        if (!cVal) continue;
+        if (!sameValue(cVal, composed[path])) divergent[path] = cVal;
+      }
+      if (Object.keys(divergent).length === 0) continue;
+      accumulated.set(canonicalKey(partialAxes), {
+        axes: partialAxes,
+        tokens: divergent,
+      });
+    }
+  }
+
+  return accumulated;
+}
+
+/**
+ * Canonical key for a partial tuple — axes sorted by name so
+ * `{A:a,B:b}` and `{B:b,A:a}` produce the same lookup key.
+ */
+export function jointOverrideKey(axes: Readonly<Record<string, string>>): string {
+  return canonicalKey(axes);
+}
+
+function canonicalKey(axes: Readonly<Record<string, string>>): string {
+  return Object.keys(axes)
+    .toSorted()
+    .map((k) => `${k}:${axes[k]}`)
+    .join('|');
+}
+
+function sameValue(a: unknown, b: unknown): boolean {
+  // Stable structural comparison on `$value` — same key
+  // `analyzeAxisVariance` uses for variance bucketing.
+  return JSON.stringify(getValue(a)) === JSON.stringify(getValue(b));
+}
+
+function getValue(t: unknown): unknown {
+  if (t && typeof t === 'object' && '$value' in t) {
+    return (t as { $value: unknown }).$value;
+  }
+  return undefined;
+}

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,10 +1,13 @@
+import { buildCells } from '#/cells.ts';
 import { validateChrome } from '#/chrome.ts';
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
 import { validateDisabledAxes } from '#/disabled-axes.ts';
+import { buildJointOverrides } from '#/joint-overrides.ts';
 import { fillPresetTuple, validatePresets } from '#/presets.ts';
 import { validateCssOptions } from '#/terrazzo-options.ts';
 import { resolveDefaultTuple } from '#/permutations/default.ts';
 import { normalizePermutations } from '#/permutations/normalize.ts';
+import { buildResolveAt } from '#/resolve-at.ts';
 import { computeTokenListing } from '#/token-listing.ts';
 import {
   permutationID,
@@ -121,6 +124,38 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
         )
       : { listing: {}, diagnostics: [] };
 
+  // Build the cells / jointOverrides / resolveAt surface alongside the
+  // existing cartesian shape. Additive only — downstream consumers can
+  // migrate to the new fields without breaking until a follow-up PR
+  // drops the cartesian materialization. `defaultTuple` here is the
+  // post-disabledAxes-filter version, matching what `cells` is keyed
+  // against.
+  const projectDefaultTuple: Record<string, string> = {};
+  for (const axis of filteredAxes) projectDefaultTuple[axis.name] = axis.default;
+
+  const cells = buildCells(
+    filteredAxes,
+    filteredPermutations,
+    filteredResolved,
+    projectDefaultTuple,
+  );
+
+  // Exhaustive cartesian-divergence probe — for every non-baseline
+  // permutation, compose via cells alone and record any divergent
+  // tokens as a joint override keyed by the permutation's non-default
+  // partial tuple. Guarantees `resolveAt` is exactly equivalent to
+  // `permutationsResolved` for every cartesian tuple. The follow-up
+  // that drops the cartesian map replaces this with an analytical
+  // probe over the resolver directly.
+  const jointOverrides = buildJointOverrides(
+    filteredAxes,
+    filteredPermutations,
+    filteredResolved,
+    cells,
+    projectDefaultTuple,
+  );
+  const resolveAt = buildResolveAt(filteredAxes, cells, jointOverrides, projectDefaultTuple);
+
   return {
     config: configWithDefaults,
     axes: filteredAxes,
@@ -130,6 +165,10 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     permutations: filteredPermutations,
     permutationsResolved: filteredResolved,
     graph,
+    cells,
+    jointOverrides,
+    defaultTuple: projectDefaultTuple,
+    resolveAt,
     sourceFiles: normalized.sourceFiles,
     cwd,
     ...(normalized.parserInput !== undefined && { parserInput: normalized.parserInput }),

--- a/packages/core/src/resolve-at.ts
+++ b/packages/core/src/resolve-at.ts
@@ -1,0 +1,84 @@
+import type { Axis, Cells, JointOverrides, ResolveAt, TokenMap } from '#/types.ts';
+
+/**
+ * Build a `resolveAt(tuple)` accessor that composes the full
+ * `TokenMap` for any tuple of axis selections — no resolver call
+ * needed.
+ *
+ * Composition rules:
+ *
+ *   1. Start from the baseline cell (any axis's default-context map;
+ *      they agree by construction since every default-cell is the
+ *      result of `resolver.apply(defaultTuple)`).
+ *   2. For each axis whose tuple value differs from its default, layer
+ *      `cells[axis][value]` over the result in project axis order.
+ *      Cells contain the full TokenMap, so orthogonal-axis cells re-emit
+ *      baseline values harmlessly while single-axis-variant tokens get
+ *      their per-axis values written.
+ *   3. Apply joint overrides whose `axes` is a subset of the requested
+ *      tuple, in ascending arity. Higher-order divergences win because
+ *      `jointOverrides` is sorted on construction.
+ *
+ * Partial tuples are allowed — any axis missing from `tuple` falls
+ * back to its `defaultTuple` value. Results are memoized on the
+ * canonical (post-default-fill) tuple key.
+ */
+export function buildResolveAt(
+  axes: readonly Axis[],
+  cells: Cells,
+  jointOverrides: JointOverrides,
+  defaultTuple: Readonly<Record<string, string>>,
+): ResolveAt {
+  const memo = new Map<string, TokenMap>();
+  return function resolveAt(tuple: Record<string, string>): TokenMap {
+    const full: Record<string, string> = { ...defaultTuple };
+    for (const axis of axes) {
+      const val = tuple[axis.name];
+      if (val !== undefined) full[axis.name] = val;
+    }
+    const key = canonicalKey(full);
+    const cached = memo.get(key);
+    if (cached) return cached;
+
+    const result: TokenMap = {};
+    // Step 1: baseline from any axis's default cell.
+    const firstAxis = axes[0];
+    if (firstAxis) {
+      const baseline = cells[firstAxis.name]?.[firstAxis.default];
+      if (baseline) Object.assign(result, baseline);
+    }
+    // Step 2: layer non-default cells in project axis order.
+    for (const axis of axes) {
+      const ctx = full[axis.name];
+      if (ctx === undefined || ctx === axis.default) continue;
+      const cell = cells[axis.name]?.[ctx];
+      if (cell) Object.assign(result, cell);
+    }
+    // Step 3: joint overrides. Map iteration is insertion order =
+    // ascending arity, so larger overrides naturally win.
+    for (const override of jointOverrides.values()) {
+      if (!isSubset(override.axes, full)) continue;
+      Object.assign(result, override.tokens);
+    }
+
+    memo.set(key, result);
+    return result;
+  };
+}
+
+function isSubset(
+  sub: Readonly<Record<string, string>>,
+  full: Readonly<Record<string, string>>,
+): boolean {
+  for (const key of Object.keys(sub)) {
+    if (full[key] !== sub[key]) return false;
+  }
+  return true;
+}
+
+function canonicalKey(tuple: Readonly<Record<string, string>>): string {
+  return Object.keys(tuple)
+    .toSorted()
+    .map((k) => `${k}:${tuple[k]}`)
+    .join('|');
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,44 @@ import type { TokenListingByPath } from '#/token-listing.ts';
 
 export type TokenMap = Record<string, TokenNormalized>;
 
+/**
+ * Per-axis cell maps. `cells[axisName][contextName]` is the resolved
+ * `TokenMap` for `{ ...defaults, [axisName]: contextName }` — the
+ * single-attribute slice of the resolver's modifier space. Size is
+ * bounded by `Σ(axes × contexts)`, independent of the cartesian
+ * product. Forms the primary input to `composeAt` / `resolveAt`.
+ */
+export type Cells = Record<string, Record<string, TokenMap>>;
+
+/**
+ * One divergent partial tuple identified by `analyzeProjectVariance`.
+ * A combination of axis selections at which the resolver's resolved
+ * value diverges from cascade composition over `cells` — kept around
+ * so `composeAt` can patch the divergence back in.
+ */
+export interface JointOverride {
+  /** axisName → contextName for the divergent combination (at any arity ≥ 2). */
+  axes: Record<string, string>;
+  /** Only the tokens whose resolved value at this tuple diverges from cascade composition. */
+  tokens: TokenMap;
+}
+
+/**
+ * All joint-variant overrides for a project, keyed by canonical
+ * stringification of `JointOverride.axes`. Iteration order is
+ * ascending arity so higher-order divergences win over lower-order
+ * ones when applied in sequence.
+ */
+export type JointOverrides = ReadonlyMap<string, JointOverride>;
+
+/**
+ * Compute the resolved `TokenMap` for any tuple of axis selections
+ * without touching the resolver. Pure function over `cells +
+ * jointOverrides + axes + defaultTuple`; accepts partial tuples
+ * (missing axes fall back to their defaults).
+ */
+export type ResolveAt = (tuple: Record<string, string>) => TokenMap;
+
 /** A single permutation of the resolver's modifier space — one entry per cartesian-product tuple. */
 export interface Permutation {
   name: string;
@@ -201,6 +239,35 @@ export interface Project {
   permutationsResolved: Record<string, TokenMap>;
   /** Default permutation's resolved tokens — convenience for global views. */
   graph: TokenMap;
+  /**
+   * Per-axis resolved `TokenMap`s — `cells[axisName][contextName]` is
+   * the resolved tokens for `{ ...defaultTuple, [axisName]: contextName }`.
+   * Bounded by `Σ(axes × contexts)`, independent of the cartesian
+   * product. The primary input to {@link resolveAt}.
+   */
+  cells: Cells;
+  /**
+   * Joint-variant partial-tuple overrides — token values that diverge
+   * from cascade composition over `cells` and need to be patched in
+   * by {@link resolveAt}. Currently extracted from the pair-only joint
+   * cases identified by `analyzeProjectVariance`; extends to N-order
+   * in a follow-up.
+   */
+  jointOverrides: JointOverrides;
+  /**
+   * The default tuple — `{ axisName: axis.default }` for every axis,
+   * after `disabledAxes` filtering and any `config.default` overrides
+   * applied. Replaces the legacy "look at `permutations[0].input`"
+   * pattern for downstream consumers.
+   */
+  defaultTuple: Record<string, string>;
+  /**
+   * Compose the resolved `TokenMap` for any tuple of axis selections.
+   * Pure function over `cells + jointOverrides + axes + defaultTuple`,
+   * memoized on the tuple key. Partial tuples are allowed — missing
+   * axes fall back to their defaults.
+   */
+  resolveAt: ResolveAt;
   /**
    * Absolute paths of every file loaded while building the project —
    * the resolver file (if any), every `$ref` target it pulled in, every

--- a/packages/core/test/cells.test.ts
+++ b/packages/core/test/cells.test.ts
@@ -1,0 +1,53 @@
+// `Project.cells` is the per-axis singleton TokenMap surface that
+// replaces direct reads from `permutationsResolved` for the smart
+// emitter + downstream consumers. The PR-1 form derives it from the
+// existing cartesian map; these tests pin the parity (every cell
+// matches the corresponding singleton permutation's TokenMap) so the
+// later PR that switches the load path to direct resolver calls has a
+// clean equivalence baseline.
+import { beforeAll, expect, it } from 'vitest';
+import type { Project } from '#/types';
+import { loadWithPrefix } from './_helpers';
+
+let project: Project;
+
+beforeAll(async () => {
+  project = await loadWithPrefix('sb');
+}, 30_000);
+
+it("populates one cell per (axis, context) — including each axis's default — for the reference fixture", () => {
+  for (const axis of project.axes) {
+    for (const ctx of axis.contexts) {
+      expect(project.cells[axis.name]?.[ctx]).toBeDefined();
+    }
+  }
+});
+
+it("every cell equals the corresponding singleton permutation's TokenMap (`{ ...defaults, [axis]: ctx }`)", () => {
+  const defaults: Record<string, string> = {};
+  for (const axis of project.axes) defaults[axis.name] = axis.default;
+
+  for (const axis of project.axes) {
+    for (const ctx of axis.contexts) {
+      const tuple = { ...defaults, [axis.name]: ctx };
+      const perm = project.permutations.find((p) =>
+        Object.keys(tuple).every((k) => p.input[k] === tuple[k]) &&
+        Object.keys(p.input).length === Object.keys(tuple).length,
+      );
+      expect(perm, `missing permutation for ${JSON.stringify(tuple)}`).toBeDefined();
+      const expected = project.permutationsResolved[perm!.name];
+      expect(project.cells[axis.name]?.[ctx]).toBe(expected);
+    }
+  }
+});
+
+it('axes with disjoint context names live under their own axis keys (no cross-axis collision)', () => {
+  // Every axis name is a distinct key; no axis can read another axis's cells.
+  const axisNames = project.axes.map((a) => a.name);
+  for (const name of axisNames) {
+    expect(project.cells).toHaveProperty(name);
+  }
+  // Spot-check: the `mode` axis's `Dark` cell is not reachable via the
+  // `brand` axis key (the cell shape is per-axis, not flat).
+  expect(project.cells.brand?.Dark).toBeUndefined();
+});

--- a/packages/core/test/joint-overrides.test.ts
+++ b/packages/core/test/joint-overrides.test.ts
@@ -1,0 +1,39 @@
+// `buildJointOverrides` extracts only the divergent partial-tuple
+// entries from `analyzeProjectVariance`'s output — those are the
+// values `composeAt` cannot reconstruct from cells alone. The reference
+// fixture has joint variance on the accessible-accent chain; this test
+// pins that we identify those entries without overcollecting.
+import { beforeAll, expect, it } from 'vitest';
+import type { Project } from '#/types';
+import { loadWithPrefix } from './_helpers';
+
+let project: Project;
+
+beforeAll(async () => {
+  project = await loadWithPrefix('sb');
+}, 30_000);
+
+it('produces at least one entry for the reference fixture (which has a known joint-variance case on color.accent.fg)', () => {
+  expect(project.jointOverrides.size).toBeGreaterThan(0);
+});
+
+it("every entry covers a partial tuple of size ≥ 2 (joint by definition; singleton variance is single-axis, captured in cells)", () => {
+  for (const override of project.jointOverrides.values()) {
+    expect(Object.keys(override.axes).length).toBeGreaterThanOrEqual(2);
+  }
+});
+
+it('every entry holds at least one token whose value at the partial tuple diverges from cascade composition', () => {
+  for (const override of project.jointOverrides.values()) {
+    expect(Object.keys(override.tokens).length).toBeGreaterThan(0);
+  }
+});
+
+it("iteration order is ascending arity (so composition can apply lower-order overrides before higher-order ones)", () => {
+  let prevArity = 0;
+  for (const override of project.jointOverrides.values()) {
+    const arity = Object.keys(override.axes).length;
+    expect(arity).toBeGreaterThanOrEqual(prevArity);
+    prevArity = arity;
+  }
+});

--- a/packages/core/test/resolve-at.test.ts
+++ b/packages/core/test/resolve-at.test.ts
@@ -1,0 +1,68 @@
+// `Project.resolveAt(tuple)` is the load-time-built lazy accessor that
+// replaces direct `permutationsResolved[name]` reads. These tests pin
+// equivalence — for every tuple in the fixture's cartesian map,
+// `resolveAt` produces the same TokenMap structure (same set of paths,
+// same `$value` per path) as direct cartesian lookup. The smart-dedup
+// + joint-override composition handles the joint-variance fixture
+// (`color.accent.fg` under mode=Dark + brand=Brand A) without ever
+// invoking the resolver again.
+import { beforeAll, expect, it } from 'vitest';
+import type { Project } from '#/types';
+import { loadWithPrefix } from './_helpers';
+
+let project: Project;
+
+beforeAll(async () => {
+  project = await loadWithPrefix('sb');
+}, 30_000);
+
+function valueKey(value: unknown): string {
+  return JSON.stringify(value);
+}
+
+it('matches the cartesian-resolved TokenMap for every fixture tuple, value-by-value', () => {
+  for (const perm of project.permutations) {
+    const expected = project.permutationsResolved[perm.name] ?? {};
+    const actual = project.resolveAt(perm.input);
+    const expectedPaths = Object.keys(expected).toSorted();
+    const actualPaths = Object.keys(actual).toSorted();
+    expect(actualPaths).toEqual(expectedPaths);
+    for (const path of expectedPaths) {
+      const expectedVal = valueKey(expected[path]?.$value);
+      const actualVal = valueKey(actual[path]?.$value);
+      expect(actualVal, `tuple=${perm.name} path=${path}`).toBe(expectedVal);
+    }
+  }
+});
+
+it("partial tuples fall back to each axis's default — `resolveAt({})` equals `resolveAt(defaultTuple)`", () => {
+  const emptyTuple = project.resolveAt({});
+  const defaultTuple = project.resolveAt(project.defaultTuple);
+  expect(emptyTuple).toBe(defaultTuple);
+});
+
+it('repeated calls with the same tuple return the same instance (memoization)', () => {
+  const tuple = { ...project.defaultTuple, mode: 'Dark' };
+  expect(project.resolveAt(tuple)).toBe(project.resolveAt(tuple));
+});
+
+it("reproduces the fixture's joint-variance value (Dark + Brand A) via joint overrides — `accent.fg` is dark, not white", () => {
+  // The joint-variance case the smart emitter chain pinned:
+  // baseline accent.fg = white; under mode=Dark alone, `accessible.accent.fg`
+  // overrides to a dark value; under brand=Brand A alone, accent.fg is white;
+  // jointly, the cartesian resolves to the dark Brand A value, not white.
+  const jointTuple = { ...project.defaultTuple, mode: 'Dark', brand: 'Brand A' };
+  const expected = project.permutationsResolved['Dark · Brand A · Normal'];
+  expect(expected, 'fixture missing the expected joint permutation').toBeDefined();
+  const actual = project.resolveAt(jointTuple);
+  const expectedVal = valueKey(expected?.['color.accent.fg']?.$value);
+  const actualVal = valueKey(actual['color.accent.fg']?.$value);
+  expect(actualVal).toBe(expectedVal);
+});
+
+it("doesn't materialize a joint override entry for tuples that compose correctly from cells alone", () => {
+  // Sanity check: cells alone handle orthogonal-after-probe and
+  // single-axis tokens, so the joint-override count is small relative
+  // to the fixture's cartesian size.
+  expect(project.jointOverrides.size).toBeLessThan(project.permutations.length);
+});


### PR DESCRIPTION
First step of the cartesian-shape-drop chain. **Additive only** — keeps `Project.permutations` / `permutationsResolved` exactly as-is and derives the new fields from them. No consumer migration in this PR.

## Summary

- `Project.cells: Record<axisName, Record<contextName, TokenMap>>` — one entry per `(axis, context)` including each axis's default. Bounded by `Σ(axes × contexts)`, independent of the cartesian product.
- `Project.jointOverrides: ReadonlyMap<string, JointOverride>` — divergent partial-tuple overrides. Populated by an arity-ascending exhaustive probe against the existing cartesian map: for each non-baseline permutation in ascending arity, compose via `cells + lower-arity-overrides-so-far` and record any cartesian-divergent tokens at this permutation's partial-tuple key. The arity-ascending order means higher-arity overrides correct cases where lower-arity overrides set the wrong value at compound tuples — covers joint variance at any order, not just pairs.
- `Project.defaultTuple: Record<string, string>` — replaces the legacy "look at `permutations[0].input`" pattern.
- `Project.resolveAt(tuple): TokenMap` — pure-function accessor; composes baseline + per-axis cells in project order + joint overrides whose partial tuple is a subset of the requested tuple, in ascending arity. Memoized.

New files: `packages/core/src/cells.ts`, `packages/core/src/resolve-at.ts`, `packages/core/src/joint-overrides.ts`. Exported types: `Cells`, `JointOverride`, `JointOverrides`, `ResolveAt`. Helper export: `jointOverrideKey`.

## Test plan

- [x] `pnpm --filter @unpunnyfuns/swatchbook-core typecheck` — clean
- [x] `pnpm --filter @unpunnyfuns/swatchbook-core test` — 200/200 (34 files); new tests `cells.test.ts`, `resolve-at.test.ts`, `joint-overrides.test.ts` pass
- [x] `resolve-at.test.ts` pins `resolveAt(perm.input)` value-equals `permutationsResolved[perm.name]` for every fixture permutation, including the joint-variance case on `color.accent.fg` under `mode=Dark + brand=Brand A`
- [x] `pnpm turbo run format:check lint typecheck test` — 37/37 tasks pass

Milestone: Maintenance
Closes #783
Plan impact: PR 1 of the cartesian-shape-drop chain (6 PRs total) — no plan-body changes; algorithm switched from "extract joint cases from analyzeProjectVariance" to "exhaustive arity-ascending probe" because the former missed cases where a non-touching axis's full-cell value overwrites another axis's delta. The new approach is correct by construction and naturally handles N-order joints.