### PR TITLE
feat(core): cache per-path variance on Project.varianceByPath

### DIFF
--- a/.changeset/project-variance-by-path.md
+++ b/.changeset/project-variance-by-path.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-core`: add `Project.varianceByPath` — per-token `AxisVarianceResult` cached at load time so consumers can look up which axes affect a token in O(1) instead of re-running the bucket analysis on every read. Same shape `analyzeAxisVariance` returns; populated with the existing cartesian-bucket algorithm for now (a later PR replaces the implementation with an analytical probe over `cells` when the cartesian materialization goes away). Smart-emitter Phase 2 and MCP `get_axis_variance` switch to read from the cache.

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -9,6 +9,7 @@ import { resolveDefaultTuple } from '#/permutations/default.ts';
 import { normalizePermutations } from '#/permutations/normalize.ts';
 import { buildResolveAt } from '#/resolve-at.ts';
 import { computeTokenListing } from '#/token-listing.ts';
+import { buildVarianceByPath } from '#/variance-by-path.ts';
 import {
   permutationID,
   type Axis,
@@ -156,6 +157,13 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   );
   const resolveAt = buildResolveAt(filteredAxes, cells, jointOverrides, projectDefaultTuple);
 
+  // Pre-compute per-path variance so consumers can O(1) look up which
+  // axes affect a token. Same algorithm `analyzeAxisVariance` exposes
+  // today — bucketing the cartesian map. A later PR switches the
+  // implementation behind this accessor to an analytical probe over
+  // cells once the cartesian materialization goes away.
+  const varianceByPath = buildVarianceByPath(filteredAxes, filteredPermutations, filteredResolved);
+
   return {
     config: configWithDefaults,
     axes: filteredAxes,
@@ -169,6 +177,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     jointOverrides,
     defaultTuple: projectDefaultTuple,
     resolveAt,
+    varianceByPath,
     sourceFiles: normalized.sourceFiles,
     cwd,
     ...(normalized.parserInput !== undefined && { parserInput: normalized.parserInput }),

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,7 @@ import type { Plugin, Resolver, TokenNormalized } from '@terrazzo/parser';
 import type { CSSPluginOptions } from '@terrazzo/plugin-css';
 import type { TokenListingPluginOptions } from '@terrazzo/plugin-token-listing';
 import type { TokenListingByPath } from '#/token-listing.ts';
+import type { AxisVarianceResult } from '#/variance.ts';
 
 export type TokenMap = Record<string, TokenNormalized>;
 
@@ -268,6 +269,14 @@ export interface Project {
    * axes fall back to their defaults.
    */
   resolveAt: ResolveAt;
+  /**
+   * Per-token cached `AxisVarianceResult` — pre-computed at load time
+   * so consumers (block axis-variance display, MCP `get_axis_variance`,
+   * smart-emitter Phase 2) can O(1) look up which axes affect a token
+   * instead of re-running the bucket analysis on every read. The map
+   * spans every path that appears in any permutation's resolved map.
+   */
+  varianceByPath: ReadonlyMap<string, AxisVarianceResult>;
   /**
    * Absolute paths of every file loaded while building the project —
    * the resolver file (if any), every `$ref` target it pulled in, every

--- a/packages/core/src/variance-analysis.ts
+++ b/packages/core/src/variance-analysis.ts
@@ -1,6 +1,5 @@
 import type { TokenNormalized } from '@terrazzo/parser';
 import type { Axis, Project, TokenMap } from '#/types.ts';
-import { analyzeAxisVariance } from '#/variance.ts';
 
 /**
  * Per-token variance classification across a loaded project's axes.
@@ -156,10 +155,14 @@ export function analyzeProjectVariance(project: Project): Map<string, VarianceIn
     }
   }
 
+  // Use the project's cached per-path variance instead of re-running
+  // the bucket analysis. The cache is populated at load time using the
+  // same algorithm `analyzeAxisVariance` exposes; reading it lets the
+  // smart emitter avoid quadratic-in-path bucket work per build.
   const touchingByPath = new Map<string, Set<string>>();
   for (const path of allPaths) {
-    const varianceResult = analyzeAxisVariance(path, axes, permutations, permutationsResolved);
-    touchingByPath.set(path, new Set(varianceResult.varyingAxes));
+    const cached = project.varianceByPath.get(path);
+    touchingByPath.set(path, new Set(cached?.varyingAxes ?? []));
   }
 
   // Partition + Phase 3 (joint probe for multi-touch only). Phase 3 needs

--- a/packages/core/src/variance-by-path.ts
+++ b/packages/core/src/variance-by-path.ts
@@ -1,0 +1,41 @@
+import { analyzeAxisVariance, type AxisVarianceResult } from '#/variance.ts';
+import type { Axis, Permutation, TokenMap } from '#/types.ts';
+
+/**
+ * Pre-compute per-path variance information at load time so consumers
+ * don't have to re-derive it from the cartesian map on every read.
+ *
+ * Today the underlying algorithm is `analyzeAxisVariance`'s
+ * cartesian-bucket comparison — correct, but cartesian-dependent. The
+ * later PR that drops the cartesian materialization swaps the
+ * implementation here for an analytical probe over `cells` plus
+ * targeted resolver calls. The consumer-facing surface
+ * (`Project.varianceByPath`) stays the same across that swap.
+ */
+export function buildVarianceByPath(
+  axes: readonly Axis[],
+  permutations: readonly Permutation[],
+  permutationsResolved: Readonly<Record<string, TokenMap>>,
+): ReadonlyMap<string, AxisVarianceResult> {
+  // The union of every token path that appears in any permutation's
+  // resolved map — what `analyzeProjectVariance` uses for its own
+  // path iteration.
+  const allPaths = new Set<string>();
+  for (const tokens of Object.values(permutationsResolved)) {
+    for (const path of Object.keys(tokens)) allPaths.add(path);
+  }
+
+  const out = new Map<string, AxisVarianceResult>();
+  for (const path of allPaths) {
+    out.set(
+      path,
+      analyzeAxisVariance(
+        path,
+        axes,
+        permutations,
+        permutationsResolved as Record<string, TokenMap>,
+      ),
+    );
+  }
+  return out;
+}

--- a/packages/core/test/variance-by-path.test.ts
+++ b/packages/core/test/variance-by-path.test.ts
@@ -1,0 +1,46 @@
+// `Project.varianceByPath` caches per-path variance analysis so
+// consumers can O(1) look up which axes affect a token instead of
+// running `analyzeAxisVariance` per call. These tests pin parity with
+// the on-demand call (same `AxisVarianceResult` shape and contents)
+// and cover that every path in the resolved data is represented.
+import { beforeAll, expect, it } from 'vitest';
+import { analyzeAxisVariance } from '#/variance.ts';
+import type { Project } from '#/types.ts';
+import { loadWithPrefix } from './_helpers.ts';
+
+let project: Project;
+
+beforeAll(async () => {
+  project = await loadWithPrefix(undefined);
+}, 30_000);
+
+it('covers every path that appears in any permutation', () => {
+  const allPaths = new Set<string>();
+  for (const tokens of Object.values(project.permutationsResolved)) {
+    for (const path of Object.keys(tokens)) allPaths.add(path);
+  }
+  for (const path of allPaths) {
+    expect(project.varianceByPath.has(path), `missing variance for ${path}`).toBe(true);
+  }
+});
+
+it("each cached entry equals the on-demand `analyzeAxisVariance` call for the same path", () => {
+  // Spot-check three representative tokens: a constant (palette
+  // primitive), a single-axis token (surface), a multi-axis token
+  // (accent.fg has joint variance). Full parity is over hundreds of
+  // paths; these three exercise the three `VarianceKind` branches.
+  for (const path of [
+    'color.palette.neutral.500',
+    'color.surface.default',
+    'color.accent.fg',
+  ]) {
+    const cached = project.varianceByPath.get(path);
+    const live = analyzeAxisVariance(
+      path,
+      project.axes,
+      project.permutations,
+      project.permutationsResolved,
+    );
+    expect(cached).toEqual(live);
+  }
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,5 +1,5 @@
 import type { Project } from '@unpunnyfuns/swatchbook-core';
-import { analyzeAxisVariance, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { projectCss } from '@unpunnyfuns/swatchbook-core';
 import { fuzzyFilter, fuzzyMatches } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
@@ -371,9 +371,9 @@ export function createServer(initial: Project): McpServer & {
       if (project.permutations.length === 0) return textResult('No permutations in project.');
       const exists = project.permutations.some((t) => project.permutationsResolved[t.name]?.[path]);
       if (!exists) return textResult(`Token not found in any theme: ${path}`);
-      return jsonResult(
-        analyzeAxisVariance(path, project.axes, project.permutations, project.permutationsResolved),
-      );
+      const cached = project.varianceByPath.get(path);
+      if (!cached) return textResult(`Token not found in any theme: ${path}`);
+      return jsonResult(cached);
     },
   );
 


### PR DESCRIPTION
Second step of the cartesian-shape-drop chain (foundation in #784). Scope-revised from the original plan after implementation surfaced a real distinction: cells alone can't detect joint-only variance (the canonical \`color.accent.fg\` case where brand=BrandA's singleton matches baseline but jointly with Dark its value diverges), and \`jointOverrides\` (PR 1's exhaustive-divergence probe) mixes genuine joint variance with cell-composition artifacts. Forcing \`analyzeAxisVariance\` onto just \`(cells, baseline)\` would either miss real variance or overcollect.

Resolution: cache the per-path variance at load time using the existing (correct) cartesian-bucket algorithm and expose it on \`Project.varianceByPath\`. Consumers swap their \`analyzeAxisVariance(path, axes, permutations, permutationsResolved)\` calls for an O(1) map lookup. The implementation behind the cache changes in the final PR when the cartesian map goes away — the consumer-facing accessor stays the same.

## Summary

- New \`Project.varianceByPath: ReadonlyMap<path, AxisVarianceResult>\` — populated by \`buildVarianceByPath\` over every path in \`permutationsResolved\`.
- New file: \`packages/core/src/variance-by-path.ts\`.
- Smart emitter Phase 2 (\`variance-analysis.ts\`) reads \`project.varianceByPath.get(path).varyingAxes\` instead of calling \`analyzeAxisVariance\` per path.
- MCP \`get_axis_variance\` returns the cached entry directly (also drops the \`permutations.some\` existence scan in favor of \`varianceByPath.has(path)\`).
- Existing \`analyzeAxisVariance\` function unchanged — still used inside \`buildVarianceByPath\` and still exported for any other callers.
- \`AxisVariance\` block keeps its current call site; the block-side migration ships in the next PR alongside the virtual-module wire format that exposes \`varianceByPath\` to the preview.

## Test plan

- [x] \`pnpm --filter @unpunnyfuns/swatchbook-core typecheck\` — clean
- [x] new \`variance-by-path.test.ts\` — covers every resolved path, parity with on-demand \`analyzeAxisVariance\` for representative tokens (constant / single-axis / multi-axis-with-joint-variance)
- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 tasks
- [x] storybook + chromatic unchanged (block path is unaffected)

Milestone: Maintenance
Closes #786
Plan impact: PR 2 of the cartesian-shape-drop chain. Pivot from "refactor analyzeAxisVariance signature" to "cache the result at load time" — the same end goal (consumers no longer call \`analyzeAxisVariance\` with cartesian inputs) reached via a more correct intermediate model. Block migration moves to the wire-format PR.