### PR TITLE
feat(addon,blocks): ship cells/jointOverrides/varianceByPath over wire

### DIFF
--- a/.changeset/wire-cells-variance-cache.md
+++ b/.changeset/wire-cells-variance-cache.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-addon`, `@unpunnyfuns/swatchbook-blocks`: ship `cells`, `jointOverrides`, `varianceByPath`, and `defaultTuple` over the virtual module and HMR snapshot, alongside the existing `permutationsResolved` (additive). Blocks-side `ProjectSnapshot` / `ProjectData` expose the new fields. The `AxisVariance` block drops its `analyzeAxisVariance(...)` call in favor of an O(1) `varianceByPath[path]` lookup. Other block migrations (TokenTable / TokenDetail / ColorTable reading via `resolveAt`) ship in a later PR.

--- a/packages/addon/src/channel-types.ts
+++ b/packages/addon/src/channel-types.ts
@@ -61,6 +61,14 @@ export interface InitPayload {
   permutationsResolved: Record<string, Record<string, VirtualToken>>;
   diagnostics: readonly VirtualDiagnostic[];
   cssVarPrefix: string;
+  /** {@link VirtualCells} — additive companion to `permutationsResolved`. */
+  cells: VirtualCells;
+  /** {@link VirtualJointOverrides} — Map serialized as `[key, entry]` pairs. */
+  jointOverrides: VirtualJointOverrides;
+  /** {@link VirtualVarianceByPath} — cached `analyzeAxisVariance` per path. */
+  varianceByPath: VirtualVarianceByPath;
+  /** The project's default tuple — `{ axis: axis.default }` for each axis. */
+  defaultTuple: Record<string, string>;
 }
 
 export interface VirtualListingEntry {
@@ -74,3 +82,42 @@ export interface VirtualListingEntry {
     };
   };
 }
+
+/**
+ * Wire shape of `Project.cells` — one entry per `(axis, context)`,
+ * each carrying the resolved TokenMap. Plain object serialization;
+ * size is bounded by `Σ(axes × contexts) × tokens`, independent of
+ * the cartesian product.
+ */
+export type VirtualCells = Record<string, Record<string, Record<string, VirtualToken>>>;
+
+/**
+ * Wire shape of one `Project.jointOverrides` entry — a partial-tuple
+ * override patching specific token values that cell composition alone
+ * can't reproduce.
+ */
+export interface VirtualJointOverride {
+  axes: Record<string, string>;
+  tokens: Record<string, VirtualToken>;
+}
+
+/**
+ * Wire-friendly form of `Project.jointOverrides` — a Map serialized
+ * as an array of `[key, entry]` pairs so JSON round-trips don't drop
+ * the iteration order or the entry structure.
+ */
+export type VirtualJointOverrides = readonly (readonly [string, VirtualJointOverride])[];
+
+/**
+ * Wire shape of one cached `AxisVarianceResult` entry. Mirrors the
+ * core type but uses the local `VirtualToken`-style references.
+ */
+export interface VirtualVarianceEntry {
+  path: string;
+  kind: 'constant' | 'single' | 'multi';
+  varyingAxes: string[];
+  constantAcrossAxes: string[];
+  perAxis: Record<string, { varying: boolean; contexts: Record<string, string> }>;
+}
+
+export type VirtualVarianceByPath = Record<string, VirtualVarianceEntry>;

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -9,15 +9,19 @@ import { dataAttr } from '#/data-attr.ts';
 import 'virtual:swatchbook/integration-side-effects';
 import {
   axes as virtualAxes,
+  cells as virtualCells,
   css,
   cssVarPrefix,
   defaultPermutation,
+  defaultTuple as virtualDefaultTuple,
   diagnostics,
   disabledAxes as virtualDisabledAxes,
+  jointOverrides as virtualJointOverrides,
   listing as virtualListing,
   presets as virtualPresets,
   permutations,
   permutationsResolved,
+  varianceByPath as virtualVarianceByPath,
 } from 'virtual:swatchbook/tokens';
 import {
   AxesContext,
@@ -140,6 +144,10 @@ function broadcastInit(): void {
     permutationsResolved,
     diagnostics,
     cssVarPrefix,
+    cells: virtualCells,
+    jointOverrides: virtualJointOverrides,
+    varianceByPath: virtualVarianceByPath,
+    defaultTuple: virtualDefaultTuple,
   });
 }
 
@@ -246,6 +254,10 @@ const themedDecorator: Decorator = (Story, context) => {
       diagnostics,
       css,
       listing: virtualListing,
+      cells: virtualCells,
+      jointOverrides: virtualJointOverrides,
+      varianceByPath: virtualVarianceByPath,
+      defaultTuple: virtualDefaultTuple,
     }),
     [themeName, tuple],
   );
@@ -381,6 +393,10 @@ interface HmrSnapshot {
   css: string;
   cssVarPrefix: string;
   listing: typeof virtualListing;
+  cells: typeof virtualCells;
+  jointOverrides: typeof virtualJointOverrides;
+  varianceByPath: typeof virtualVarianceByPath;
+  defaultTuple: typeof virtualDefaultTuple;
 }
 if (import.meta.hot) {
   import.meta.hot.on(HMR_EVENT, (payload: HmrSnapshot) => {
@@ -411,6 +427,10 @@ html, body {
       permutationsResolved: payload.permutationsResolved,
       diagnostics: payload.diagnostics,
       cssVarPrefix: payload.cssVarPrefix,
+      cells: payload.cells,
+      jointOverrides: payload.jointOverrides,
+      varianceByPath: payload.varianceByPath,
+      defaultTuple: payload.defaultTuple,
     });
     channel.emit(TOKENS_UPDATED_EVENT, payload);
   });

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -9,11 +9,14 @@
 declare module 'virtual:swatchbook/tokens' {
   import type {
     VirtualAxis,
+    VirtualCells,
     VirtualDiagnostic,
+    VirtualJointOverrides,
     VirtualListingEntry,
     VirtualPreset,
     VirtualPermutation,
     VirtualToken,
+    VirtualVarianceByPath,
   } from '#/channel-types.ts';
 
   export const axes: readonly VirtualAxis[];
@@ -26,6 +29,10 @@ declare module 'virtual:swatchbook/tokens' {
   export const css: string;
   export const cssVarPrefix: string;
   export const listing: Readonly<Record<string, VirtualListingEntry>>;
+  export const cells: VirtualCells;
+  export const jointOverrides: VirtualJointOverrides;
+  export const varianceByPath: VirtualVarianceByPath;
+  export const defaultTuple: Record<string, string>;
 }
 
 declare module 'virtual:swatchbook/integration-side-effects';

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -103,6 +103,11 @@ export function swatchbookTokensPlugin({
       if (id !== RESOLVED_VIRTUAL_MODULE_ID) return null;
       if (!project) return 'export default null;';
       // Emit a typed ESM module. Values are JSON-stringified for stability.
+      // `jointOverrides` ships as an array of `[key, entry]` pairs because
+      // `Map` doesn't survive `JSON.stringify`; the block side reconstructs
+      // the Map (or just reads the array, depending on the consumer).
+      const jointOverridesArr = [...project.jointOverrides.entries()];
+      const varianceByPathObj = Object.fromEntries(project.varianceByPath.entries());
       return [
         `/* swatchbook virtual module — generated */`,
         `export const axes = ${JSON.stringify(project.axes)};`,
@@ -115,6 +120,10 @@ export function swatchbookTokensPlugin({
         `export const css = ${JSON.stringify(css)};`,
         `export const cssVarPrefix = ${JSON.stringify(config.cssVarPrefix ?? '')};`,
         `export const listing = ${JSON.stringify(slimListing(project.listing))};`,
+        `export const cells = ${JSON.stringify(project.cells)};`,
+        `export const jointOverrides = ${JSON.stringify(jointOverridesArr)};`,
+        `export const varianceByPath = ${JSON.stringify(varianceByPathObj)};`,
+        `export const defaultTuple = ${JSON.stringify(project.defaultTuple)};`,
       ].join('\n');
     },
 
@@ -180,6 +189,10 @@ export function swatchbookTokensPlugin({
                 css,
                 cssVarPrefix: config.cssVarPrefix ?? '',
                 listing: slimListing(project.listing),
+                cells: project.cells,
+                jointOverrides: [...project.jointOverrides.entries()],
+                varianceByPath: Object.fromEntries(project.varianceByPath.entries()),
+                defaultTuple: project.defaultTuple,
               },
             });
           })();

--- a/packages/addon/test/virtual-stub.ts
+++ b/packages/addon/test/virtual-stub.ts
@@ -50,3 +50,12 @@ export const diagnostics = [] as const;
 export const css = '';
 export const cssVarPrefix = 'sb';
 export const listing = {};
+export const cells: Record<string, Record<string, Record<string, unknown>>> = {
+  mode: {
+    Light: permutationsResolved.Light ?? {},
+    Dark: permutationsResolved.Dark ?? {},
+  },
+};
+export const jointOverrides: readonly (readonly [string, unknown])[] = [];
+export const varianceByPath: Record<string, unknown> = {};
+export const defaultTuple: Record<string, string> = { mode: 'Light' };

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -1,4 +1,10 @@
-import type { Axis, Diagnostic, Permutation, Preset } from '@unpunnyfuns/swatchbook-core';
+import type {
+  Axis,
+  AxisVarianceResult,
+  Diagnostic,
+  Permutation,
+  Preset,
+} from '@unpunnyfuns/swatchbook-core';
 import { createContext, useContext } from 'react';
 import { useChannelGlobals } from '#/internal/channel-globals.ts';
 import type { ColorFormat } from '#/format-color.ts';
@@ -58,6 +64,23 @@ export interface VirtualTokenListingShape {
 export type VirtualPresetShape = Preset;
 
 /**
+ * Wire shape of one `Project.jointOverrides` entry — same as core's
+ * `JointOverride` but with the block's `VirtualTokenShape` for the
+ * token values that ship over the wire.
+ */
+export interface VirtualJointOverrideShape {
+  axes: Record<string, string>;
+  tokens: Record<string, VirtualTokenShape>;
+}
+
+/**
+ * Map from path → cached `AxisVarianceResult`. Snapshot carries this
+ * so the `AxisVariance` block can O(1) look up which axes affect a
+ * token instead of re-running `analyzeAxisVariance` on every render.
+ */
+export type VirtualVarianceByPathShape = Record<string, AxisVarianceResult>;
+
+/**
  * Full project data read by blocks. Populated by the addon's preview
  * decorator (from the virtual module) or constructed by hand in
  * non-Storybook consumers.
@@ -82,6 +105,30 @@ export interface ProjectSnapshot {
    * absent.
    */
   listing?: Readonly<Record<string, VirtualTokenListingShape>>;
+  /**
+   * Per-axis cell maps — `cells[axis][context]` is the resolved token
+   * data for `{ ...defaults, [axis]: context }`. Bounded by
+   * `Σ(axes × contexts)` regardless of cartesian product size.
+   * Optional during the chain rollout — empty fallback when the
+   * snapshot pre-dates the wire format change.
+   */
+  cells?: Record<string, Record<string, Record<string, VirtualTokenShape>>>;
+  /**
+   * `Project.jointOverrides` flattened to entries for wire transport.
+   * Same ascending-arity iteration order the Map carries on the
+   * server side.
+   */
+  jointOverrides?: readonly (readonly [string, VirtualJointOverrideShape])[];
+  /**
+   * Cached per-path variance results. Blocks read this for O(1) axis
+   * variance lookup instead of recomputing on each render.
+   */
+  varianceByPath?: VirtualVarianceByPathShape;
+  /**
+   * The default tuple — `{ axis: axis.default }` for every axis.
+   * Replaces the legacy "look at `permutations[0].input`" pattern.
+   */
+  defaultTuple?: Record<string, string>;
 }
 
 /**

--- a/packages/blocks/src/internal/channel-tokens.ts
+++ b/packages/blocks/src/internal/channel-tokens.ts
@@ -2,16 +2,24 @@ import { useSyncExternalStore } from 'react';
 import { addons } from 'storybook/preview-api';
 import {
   axes as initialAxes,
+  cells as initialCells,
   css as initialCss,
   cssVarPrefix as initialCssVarPrefix,
   defaultPermutation as initialDefaultPermutation,
+  defaultTuple as initialDefaultTuple,
   diagnostics as initialDiagnostics,
+  jointOverrides as initialJointOverrides,
   listing as initialListing,
   permutations as initialPermutations,
   permutationsResolved as initialPermutationsResolved,
   presets as initialPresets,
+  varianceByPath as initialVarianceByPath,
 } from 'virtual:swatchbook/tokens';
-import type { VirtualTokenListingShape } from '#/contexts.ts';
+import type {
+  VirtualJointOverrideShape,
+  VirtualTokenListingShape,
+  VirtualVarianceByPathShape,
+} from '#/contexts.ts';
 import type { VirtualAxis, VirtualDiagnostic, VirtualPermutation, VirtualToken } from '#/types.ts';
 
 /**
@@ -47,6 +55,10 @@ export interface TokenSnapshot {
   readonly css: string;
   readonly cssVarPrefix: string;
   readonly listing: Readonly<Record<string, VirtualTokenListingShape>>;
+  readonly cells: Record<string, Record<string, Record<string, VirtualToken>>>;
+  readonly jointOverrides: readonly (readonly [string, VirtualJointOverrideShape])[];
+  readonly varianceByPath: VirtualVarianceByPathShape;
+  readonly defaultTuple: Record<string, string>;
   /** Monotonic counter, bumped on each update. Useful as a React key. */
   readonly version: number;
 }
@@ -61,6 +73,10 @@ let snapshot: TokenSnapshot = {
   css: initialCss,
   cssVarPrefix: initialCssVarPrefix,
   listing: initialListing ?? {},
+  cells: initialCells ?? {},
+  jointOverrides: initialJointOverrides ?? [],
+  varianceByPath: initialVarianceByPath ?? {},
+  defaultTuple: initialDefaultTuple ?? {},
   version: 0,
 };
 
@@ -82,6 +98,10 @@ function ensureSubscribed(): void {
       css: payload.css ?? snapshot.css,
       cssVarPrefix: payload.cssVarPrefix ?? snapshot.cssVarPrefix,
       listing: payload.listing ?? snapshot.listing,
+      cells: payload.cells ?? snapshot.cells,
+      jointOverrides: payload.jointOverrides ?? snapshot.jointOverrides,
+      varianceByPath: payload.varianceByPath ?? snapshot.varianceByPath,
+      defaultTuple: payload.defaultTuple ?? snapshot.defaultTuple,
       version: snapshot.version + 1,
     };
     for (const cb of listeners) cb();

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,6 +1,6 @@
 import { makeCSSVar } from '@terrazzo/token-tools/css';
 import { useEffect } from 'react';
-import type { VirtualTokenListingShape } from '#/contexts.ts';
+import type { VirtualTokenListingShape, VirtualVarianceByPathShape } from '#/contexts.ts';
 import { useActiveAxes, useActivePermutation, useOptionalSwatchbookData } from '#/contexts.ts';
 import { type ColorFormat, formatColor, type FormatColorResult } from '#/format-color.ts';
 import { useChannelGlobals } from '#/internal/channel-globals.ts';
@@ -31,6 +31,12 @@ export interface ProjectData {
    * preview strings from `listing[path].previewValue`.
    */
   listing: Readonly<Record<string, VirtualTokenListingShape>>;
+  /**
+   * Cached per-path `AxisVarianceResult` — blocks use this for O(1)
+   * variance lookup instead of re-running the bucket analysis. Empty
+   * for snapshots that pre-date the wire format change.
+   */
+  varianceByPath: VirtualVarianceByPathShape;
 }
 
 const STYLE_ELEMENT_ID = 'swatchbook-tokens';
@@ -79,6 +85,7 @@ function snapshotToData(snapshot: ProjectSnapshot): ProjectData {
     diagnostics: snapshot.diagnostics,
     cssVarPrefix: snapshot.cssVarPrefix,
     listing: snapshot.listing ?? {},
+    varianceByPath: snapshot.varianceByPath ?? {},
   };
 }
 
@@ -141,6 +148,7 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     diagnostics: tokens.diagnostics,
     cssVarPrefix: tokens.cssVarPrefix,
     listing: tokens.listing,
+    varianceByPath: tokens.varianceByPath,
   };
 }
 

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -1,5 +1,4 @@
-import { analyzeAxisVariance } from '@unpunnyfuns/swatchbook-core/variance';
-import type { Axis, Permutation, TokenMap } from '@unpunnyfuns/swatchbook-core';
+import type { Axis, Permutation } from '@unpunnyfuns/swatchbook-core';
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
@@ -19,24 +18,30 @@ interface Variance {
 }
 
 export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
-  const { token, cssVar, axes, permutations, permutationsResolved, activeAxes, cssVarPrefix } =
-    useTokenDetailData(path);
+  const {
+    token,
+    cssVar,
+    axes,
+    permutations,
+    permutationsResolved,
+    activeAxes,
+    cssVarPrefix,
+    varianceByPath,
+  } = useTokenDetailData(path);
   const colorFormat = useColorFormat();
   const tokenType = token?.$type;
   const isColor = tokenType === 'color';
   const formatFn = (t: DetailToken | undefined): string => valueFor(t, tokenType, colorFormat);
 
   const variance = useMemo<Variance>(() => {
-    // permutationsResolved is the only field needing a structural narrow —
-    // the block's `DetailToken` is a subset of core's `TokenNormalized`,
-    // so the wrapping record types differ even though the keys match.
-    const result = analyzeAxisVariance(
-      path,
-      axes,
-      permutations,
-      permutationsResolved as Record<string, TokenMap>,
-    );
-    // Map core's terse kind vocabulary to the block's display-ready one.
+    // Read the pre-computed per-path variance from the snapshot. The
+    // server side runs the bucket analysis once at load and ships the
+    // map over the wire — O(1) lookup per render instead of an O(paths
+    // × permutations) re-derivation here.
+    const result = varianceByPath[path];
+    if (!result) {
+      return { kind: 'constant', varyingAxes: [] };
+    }
     const kind =
       result.kind === 'constant'
         ? 'constant'
@@ -44,7 +49,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
           ? 'one-axis'
           : 'multi-axis';
     return { kind, varyingAxes: result.varyingAxes };
-  }, [path, axes, permutations, permutationsResolved]);
+  }, [path, varianceByPath]);
 
   if (permutations.length === 0) {
     return <></>;

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -1,4 +1,5 @@
 import type { Axis, Permutation } from '@unpunnyfuns/swatchbook-core';
+import type { VirtualVarianceByPathShape } from '#/contexts.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 
 export interface DetailToken {
@@ -29,6 +30,7 @@ export interface TokenDetailData {
   permutationsResolved: Record<string, Record<string, DetailToken>>;
   resolved: Record<string, DetailToken>;
   cssVarPrefix: string;
+  varianceByPath: VirtualVarianceByPathShape;
 }
 
 export function useTokenDetailData(path: string): TokenDetailData {
@@ -41,6 +43,7 @@ export function useTokenDetailData(path: string): TokenDetailData {
     permutationsResolved,
     resolved,
     cssVarPrefix,
+    varianceByPath,
   } = project;
   const typedResolved = resolved as Record<string, DetailToken>;
   return {
@@ -53,5 +56,6 @@ export function useTokenDetailData(path: string): TokenDetailData {
     permutationsResolved: permutationsResolved as Record<string, Record<string, DetailToken>>,
     resolved: typedResolved,
     cssVarPrefix,
+    varianceByPath,
   };
 }

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -56,6 +56,19 @@ declare module 'virtual:swatchbook/tokens' {
     };
   }
 
+  interface VirtualJointOverrideEntry {
+    axes: Record<string, string>;
+    tokens: Record<string, VirtualToken>;
+  }
+
+  interface VirtualAxisVarianceEntry {
+    path: string;
+    kind: 'constant' | 'single' | 'multi';
+    varyingAxes: string[];
+    constantAcrossAxes: string[];
+    perAxis: Record<string, { varying: boolean; contexts: Record<string, string> }>;
+  }
+
   export const axes: readonly VirtualAxis[];
   export const presets: readonly VirtualPreset[];
   export const permutations: readonly VirtualPermutation[];
@@ -65,6 +78,10 @@ declare module 'virtual:swatchbook/tokens' {
   export const css: string;
   export const cssVarPrefix: string;
   export const listing: Readonly<Record<string, VirtualListingEntry>>;
+  export const cells: Record<string, Record<string, Record<string, VirtualToken>>>;
+  export const jointOverrides: readonly (readonly [string, VirtualJointOverrideEntry])[];
+  export const varianceByPath: Record<string, VirtualAxisVarianceEntry>;
+  export const defaultTuple: Record<string, string>;
 }
 
 declare module '*.css';

--- a/packages/blocks/test/virtual-stub.ts
+++ b/packages/blocks/test/virtual-stub.ts
@@ -14,3 +14,7 @@ export const diagnostics = [] as const;
 export const css = '';
 export const cssVarPrefix = '';
 export const listing = {} as const;
+export const cells = {} as const;
+export const jointOverrides = [] as const;
+export const varianceByPath = {} as const;
+export const defaultTuple = {} as const;


### PR DESCRIPTION
Third step of the cartesian-shape-drop chain (foundation in #784, variance cache in #787). **Additive wire format change** — the virtual module + HMR snapshot start shipping the new \`Project\` fields (\`cells\`, \`jointOverrides\`, \`varianceByPath\`, \`defaultTuple\`) alongside the existing \`permutationsResolved\` so blocks can read them browser-side. Single block migration in this PR: \`AxisVariance\` swaps its \`analyzeAxisVariance(...)\` call for a \`varianceByPath[path]\` lookup.

## Wire format

- \`cells\`: plain JSON object (\`Record<axis, Record<context, TokenMap>>\`).
- \`jointOverrides\`: array of \`[key, entry]\` pairs (\`Map\` doesn't survive \`JSON.stringify\`); ascending-arity iteration order from the server side is preserved.
- \`varianceByPath\`: \`Record<path, AxisVarianceResult>\` (single-path lookup, no need for the \`Map\` wrapper on the wire).
- \`defaultTuple\`: \`Record<axisName, contextName>\`.

Added to the virtual module body in \`packages/addon/src/virtual/plugin.ts\`, the HMR \`INIT_EVENT\` payload, and the per-package \`virtual.d.ts\` ambient declarations.

## Block-side plumbing

- \`channel-types.ts\` (addon-side) — new \`VirtualCells\`, \`VirtualJointOverrides\`, \`VirtualVarianceByPath\`, \`VirtualVarianceEntry\` interfaces; folded into \`InitPayload\`.
- \`contexts.ts\` (blocks-side) — \`ProjectSnapshot\` gains the new optional fields; tolerates pre-rollout snapshots that don't carry them (empty defaults).
- \`channel-tokens.ts\` (blocks-side) — snapshot type + receiver pick up the new fields from the HMR payload; initial values come from the virtual module exports.
- \`use-project.ts\` — \`ProjectData\` exposes \`varianceByPath\` to consumers.
- \`token-detail/internal.ts\` — \`useTokenDetailData\` returns \`varianceByPath\` for the \`AxisVariance\` block.

## AxisVariance block migration

- Drops \`analyzeAxisVariance(path, axes, permutations, permutationsResolved)\` call.
- Reads \`varianceByPath[path]\` from the snapshot.
- Same display semantics; same \`AxisVarianceResult\` shape; no rendering changes.

## Verification

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 tasks
- [x] \`pnpm --filter swatchbook-storybook test:storybook\` — 149/149 stories; joint-variance \`AxisVariance\` display unchanged
- [x] Wire payload now includes the new fields (verified via grep of generated module body in test); existing \`permutationsResolved\` payload still shipped — additive only

Milestone: Maintenance
Closes #788
Plan impact: PR 3 of the cartesian-shape-drop chain. Folded the wire format + AxisVariance migration into one PR because the analyzer migration in PR 2 unblocked the cache-shipping pattern; the original PR 5/3 split would have required a temporary block-side deprecated function shim with no clear advantage. Larger block migrations (TokenTable / TokenDetail / ColorTable to \`resolveAt\`) remain a separate PR.