### PR TITLE
feat(blocks): consume resolveAt instead of permutationsResolved

### DIFF
--- a/.changeset/blocks-consume-resolve-at.md
+++ b/.changeset/blocks-consume-resolve-at.md
@@ -1,0 +1,12 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-core`: expose `buildResolveAt` via the new `./resolve-at` subpath — a small, dep-free entry point browser-side consumers can import without dragging the loader / Terrazzo runtime through their bundles.
+
+`@unpunnyfuns/swatchbook-blocks`: blocks now consume `resolveAt(activeTuple)` instead of indexing `permutationsResolved[activePermutation]` for the current `resolved` token map. `ProjectData` exposes `resolveAt` so per-tuple consumers (the `AxisVariance` block's grid cells) can read any tuple's values without `permutations.find` + tuple-name scans. Snapshots that pre-date the cells wire format fall back to `permutationsResolved` indexing — covers hand-built test snapshots and the docs-site path.

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -197,7 +197,11 @@ function snapshotToData(
 ): ProjectData {
   return {
     activePermutation: snapshot.activePermutation,
-    activeAxes: { ...snapshot.activeAxes },
+    // Pass `snapshot.activeAxes` through directly rather than spreading
+    // into a fresh object — the snapshot already exposes it as a
+    // read-only record, and a new identity per render would invite
+    // the same memo-stability bug `resolveAt` had.
+    activeAxes: snapshot.activeAxes as Record<string, string>,
     axes: snapshot.axes,
     permutations: snapshot.permutations,
     permutationsResolved: snapshot.permutationsResolved,

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,5 +1,13 @@
+import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
+import type {
+  Axis,
+  Cells,
+  JointOverride,
+  JointOverrides,
+  TokenMap,
+} from '@unpunnyfuns/swatchbook-core';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import type { VirtualTokenListingShape, VirtualVarianceByPathShape } from '#/contexts.ts';
 import { useActiveAxes, useActivePermutation, useOptionalSwatchbookData } from '#/contexts.ts';
 import { type ColorFormat, formatColor, type FormatColorResult } from '#/format-color.ts';
@@ -37,6 +45,14 @@ export interface ProjectData {
    * for snapshots that pre-date the wire format change.
    */
   varianceByPath: VirtualVarianceByPathShape;
+  /**
+   * Compose the resolved `TokenMap` for any tuple of axis selections.
+   * Built browser-side from `cells + jointOverrides` shipped over the
+   * wire — no resolver needed. Replaces direct
+   * `permutationsResolved[name]` reads for tuple-keyed lookups
+   * (`AxisVariance` grid cells, future per-tuple block displays).
+   */
+  resolveAt: (tuple: Record<string, string>) => ResolvedTokens;
 }
 
 const STYLE_ELEMENT_ID = 'swatchbook-tokens';
@@ -74,18 +90,47 @@ function nameForTuple(
   return match?.name;
 }
 
-function snapshotToData(snapshot: ProjectSnapshot): ProjectData {
-  return {
-    activePermutation: snapshot.activePermutation,
-    activeAxes: { ...snapshot.activeAxes },
-    axes: snapshot.axes,
-    permutations: snapshot.permutations,
-    permutationsResolved: snapshot.permutationsResolved,
-    resolved: snapshot.permutationsResolved[snapshot.activePermutation] ?? {},
-    diagnostics: snapshot.diagnostics,
-    cssVarPrefix: snapshot.cssVarPrefix,
-    listing: snapshot.listing ?? {},
-    varianceByPath: snapshot.varianceByPath ?? {},
+/**
+ * Reconstruct a `resolveAt` accessor from snapshot data. The wire
+ * format ships `cells` as plain JSON and `jointOverrides` as an
+ * array of `[key, entry]` pairs (Map doesn't survive JSON.stringify);
+ * this hydrates them and wraps `buildResolveAt` from core. Stable
+ * identity across calls with the same snapshot — `useMemo` keyed on
+ * the snapshot fields produces a referentially stable function.
+ */
+function makeResolveAt(snapshot: {
+  axes: readonly VirtualAxis[];
+  cells?: ProjectSnapshot['cells'];
+  jointOverrides?: ProjectSnapshot['jointOverrides'];
+  defaultTuple?: ProjectSnapshot['defaultTuple'];
+}): (tuple: Record<string, string>) => ResolvedTokens {
+  const cells = (snapshot.cells ?? {}) as Cells;
+  const jointOverrides: JointOverrides = new Map<string, JointOverride>(
+    (snapshot.jointOverrides ?? []) as readonly (readonly [string, JointOverride])[],
+  );
+  const defaults = snapshot.defaultTuple ?? defaultTuple(snapshot.axes);
+  const resolver = buildResolveAt(
+    snapshot.axes as readonly Axis[],
+    cells,
+    jointOverrides,
+    defaults,
+  );
+  return (tuple) => resolver(tuple) as TokenMap as ResolvedTokens;
+}
+
+/**
+ * Build the `resolveAt` accessor for a snapshot, falling back to
+ * indexing `permutationsResolved` by tuple name when the snapshot
+ * pre-dates the wire format change and doesn't carry `cells`.
+ */
+function snapshotResolveAt(
+  snapshot: ProjectSnapshot,
+): (tuple: Record<string, string>) => ResolvedTokens {
+  const hasCells = Object.keys(snapshot.cells ?? {}).length > 0;
+  if (hasCells) return makeResolveAt(snapshot);
+  return (tuple) => {
+    const name = nameForTuple(snapshot.permutations, tuple) ?? snapshot.activePermutation;
+    return snapshot.permutationsResolved[name] ?? {};
   };
 }
 
@@ -103,8 +148,66 @@ function snapshotToData(snapshot: ProjectSnapshot): ProjectData {
  */
 export function useProject(): ProjectData {
   const snapshot = useOptionalSwatchbookData();
+  // Memoize against the stable underlying fields, NOT the snapshot
+  // wrapper. Storybook rebuilds `context.globals` identity on every
+  // render → the preview's `tuple` useMemo invalidates → the
+  // provider's snapshot useMemo rebuilds. Keying off `snapshot`
+  // would mean `makeResolveAt` runs on every render, producing a
+  // fresh closure with a fresh internal memo, so `resolved` would
+  // have a new identity each render. Downstream block
+  // `useMemo([resolved, …])` calls would recompute forever; the
+  // `TokenNavigator`'s focus-repair `useEffect` (deps include the
+  // recomputed `flatVisible`) would `setState` in an infinite loop.
+  // The underlying `cells` / `jointOverrides` / `permutations`
+  // references are stable module-level exports, so depending on
+  // them directly keeps `resolveAt` (and the resolved map it
+  // returns) referentially stable across renders.
+  const axes = snapshot?.axes;
+  const cells = snapshot?.cells;
+  const jointOverrides = snapshot?.jointOverrides;
+  const dataDefaultTuple = snapshot?.defaultTuple;
+  const permutations = snapshot?.permutations;
+  const permutationsResolved = snapshot?.permutationsResolved;
+  const activePermutation = snapshot?.activePermutation;
+  const resolveAt = useMemo(() => {
+    if (!snapshot) return null;
+    return snapshotResolveAt(snapshot);
+    // The deps below are deliberately the stable inner fields rather
+    // than `snapshot` itself; see the long block comment above.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    axes,
+    cells,
+    jointOverrides,
+    dataDefaultTuple,
+    permutations,
+    permutationsResolved,
+    activePermutation,
+  ]);
   const fallback = useVirtualModuleFallback(snapshot === null);
-  return snapshot !== null ? snapshotToData(snapshot) : fallback;
+  if (snapshot !== null && resolveAt !== null) {
+    return snapshotToData(snapshot, resolveAt);
+  }
+  return fallback;
+}
+
+function snapshotToData(
+  snapshot: ProjectSnapshot,
+  resolveAt: (tuple: Record<string, string>) => ResolvedTokens,
+): ProjectData {
+  return {
+    activePermutation: snapshot.activePermutation,
+    activeAxes: { ...snapshot.activeAxes },
+    axes: snapshot.axes,
+    permutations: snapshot.permutations,
+    permutationsResolved: snapshot.permutationsResolved,
+    resolved: resolveAt(snapshot.activeAxes),
+    diagnostics: snapshot.diagnostics,
+    cssVarPrefix: snapshot.cssVarPrefix,
+    listing: snapshot.listing ?? {},
+    varianceByPath: snapshot.varianceByPath ?? {},
+    resolveAt,
+  };
 }
 
 function useVirtualModuleFallback(enabled: boolean): ProjectData {
@@ -138,17 +241,35 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     tokens.permutations[0]?.name ||
     '';
 
+  // `buildResolveAt` returns a closure that memoizes on the canonical
+  // tuple key, so wrapping the call in another `useMemo` would be
+  // redundant — the inner memo handles the per-tuple cache. We only
+  // need `useMemo` for the outer `resolveAt` itself so React's
+  // reference equality stays stable between renders.
+  const resolveAt = useMemo(
+    () =>
+      makeResolveAt({
+        axes: tokens.axes,
+        cells: tokens.cells,
+        jointOverrides: tokens.jointOverrides,
+        defaultTuple: tokens.defaultTuple,
+      }),
+    [tokens.axes, tokens.cells, tokens.jointOverrides, tokens.defaultTuple],
+  );
+  const resolved = resolveAt(activeAxes);
+
   return {
     activePermutation,
     activeAxes,
     axes: tokens.axes,
     permutations: tokens.permutations,
     permutationsResolved: tokens.permutationsResolved,
-    resolved: tokens.permutationsResolved[activePermutation] ?? {},
+    resolved,
     diagnostics: tokens.diagnostics,
     cssVarPrefix: tokens.cssVarPrefix,
     listing: tokens.listing,
     varianceByPath: tokens.varianceByPath,
+    resolveAt,
   };
 }
 

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -18,16 +18,8 @@ interface Variance {
 }
 
 export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
-  const {
-    token,
-    cssVar,
-    axes,
-    permutations,
-    permutationsResolved,
-    activeAxes,
-    cssVarPrefix,
-    varianceByPath,
-  } = useTokenDetailData(path);
+  const { token, cssVar, axes, permutations, activeAxes, cssVarPrefix, varianceByPath, resolveAt } =
+    useTokenDetailData(path);
   const colorFormat = useColorFormat();
   const tokenType = token?.$type;
   const isColor = tokenType === 'color';
@@ -56,10 +48,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
   }
 
   if (variance.kind === 'constant') {
-    const anyPermutation = permutations[0];
-    const value = anyPermutation
-      ? formatFn(permutationsResolved[anyPermutation.name]?.[path])
-      : '—';
+    const value = formatFn(resolveAt(activeAxes)[path] as DetailToken | undefined);
     return (
       <>
         <div className="sb-token-detail__section-header">Values across axes</div>
@@ -93,15 +82,11 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
     if (!axis) return <></>;
     const contextValues = axis.contexts.map((ctx) => {
       const target = { ...activeAxes, [axisName]: ctx };
-      const match = permutations.find((t) => {
-        const input = t.input;
-        return Object.keys(input).every((k) => input[k] === target[k]);
-      });
-      const name = match?.name ?? '';
+      const themeName = tupleName(permutations, target) ?? '';
       return {
         ctx,
-        themeName: name,
-        value: name ? formatFn(permutationsResolved[name]?.[path]) : '—',
+        themeName,
+        value: formatFn(resolveAt(target)[path] as DetailToken | undefined),
       };
     });
     return (
@@ -178,7 +163,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
                   [colAxis.name]: col,
                 };
                 const name = tupleName(permutations, target);
-                const value = name ? formatFn(permutationsResolved[name]?.[path]) : '—';
+                const value = formatFn(resolveAt(target)[path] as DetailToken | undefined);
                 return (
                   <td
                     key={col}

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -31,6 +31,13 @@ export interface TokenDetailData {
   resolved: Record<string, DetailToken>;
   cssVarPrefix: string;
   varianceByPath: VirtualVarianceByPathShape;
+  /**
+   * Pure-function accessor that composes the resolved tokens for any
+   * tuple of axis selections — used by the `AxisVariance` grid to
+   * read per-cell values without indexing `permutationsResolved` by
+   * a derived tuple name.
+   */
+  resolveAt: (tuple: Record<string, string>) => Record<string, DetailToken>;
 }
 
 export function useTokenDetailData(path: string): TokenDetailData {
@@ -44,6 +51,7 @@ export function useTokenDetailData(path: string): TokenDetailData {
     resolved,
     cssVarPrefix,
     varianceByPath,
+    resolveAt,
   } = project;
   const typedResolved = resolved as Record<string, DetailToken>;
   return {
@@ -57,5 +65,6 @@ export function useTokenDetailData(path: string): TokenDetailData {
     resolved: typedResolved,
     cssVarPrefix,
     varianceByPath,
+    resolveAt: resolveAt as (tuple: Record<string, string>) => Record<string, DetailToken>,
   };
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,10 @@
     "./fuzzy": {
       "types": "./dist/fuzzy.d.mts",
       "import": "./dist/fuzzy.mjs"
+    },
+    "./resolve-at": {
+      "types": "./dist/resolve-at.d.mts",
+      "import": "./dist/resolve-at.mjs"
     }
   },
   "imports": {
@@ -48,7 +52,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsdown src/index.ts src/variance.ts src/fuzzy.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown src/index.ts src/variance.ts src/fuzzy.ts src/resolve-at.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
Fourth step of the cartesian-shape-drop chain (foundation in #784, variance cache in #787, wire format in #789). Blocks switch from indexing \`permutationsResolved[activePermutation]\` to calling \`resolveAt(activeTuple)\` — the pure-function accessor over \`cells + jointOverrides\` that PR 1 introduced. \`resolveAt\` is reconstructed browser-side from data shipped in PR 3, with a small dep-free \`./resolve-at\` subpath added to core for the runtime import.

## Summary

- **Core**: new \`./resolve-at\` subpath export re-exporting \`buildResolveAt\`. Built standalone via tsdown so blocks can import it without the loader / Terrazzo runtime pulling in.
- **Blocks**: \`useProject\` reconstructs \`resolveAt\` from snapshot data; \`project.resolved\` is now \`resolveAt(activeAxes)\`; \`ProjectData\` exposes \`resolveAt\` for per-tuple consumers.
- **AxisVariance** grid: per-cell value reads use \`resolveAt(target)[path]\` instead of \`permutationsResolved[name]?.[path]\`. The \`tupleName\` helper stays only to derive the legacy \`data-<prefix>-theme\` attribute on the color swatch.
- **Fallback**: snapshots without \`cells\` (hand-built test fixtures, MDX consumers, docs-site path) fall back to the existing \`permutationsResolved\` lookup so consumers that pre-date the wire format change keep working.

## Subtlety — memoization key

Storybook rebuilds \`context.globals\` identity per render → the preview's \`tuple\` useMemo invalidates → the provider's snapshot useMemo rebuilds → snapshot wrapper identity changes per render. Keying \`useMemo\` for \`resolveAt\` on \`[snapshot]\` would mean a fresh \`makeResolveAt\` closure every render, fresh internal memo, fresh \`resolved\` map identity, and downstream \`useMemo([resolved, …])\` calls cascade-recompute. The \`TokenNavigator\`'s focus-repair effect (deps include the cascaded \`flatVisible\`) then \`setState\`s in a loop. Fix: memoize on the underlying stable fields (\`axes\`, \`cells\`, \`jointOverrides\`, \`defaultTuple\`, etc.) which are module-level virtual-module exports with stable identity.

## Verification

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 tasks
- [x] \`pnpm --filter swatchbook-storybook test:storybook\` — 149/149 (after rebuilding blocks/addon so storybook picks up the new dist)
- [x] Zero \"Maximum update depth exceeded\" errors in the storybook log
- [x] Wire still ships \`permutationsResolved\` for back-compat; the final PR drops it alongside the loadProject change

Milestone: Maintenance
Closes #790
Plan impact: PR 4 of the cartesian-shape-drop chain. Hit a real React stability bug during implementation (snapshot wrapper rebuilt per render) — documented inline because it'll bite future maintainers who refactor the memo deps. Larger MCP / integrations migrations stay for the next PR.