### PR TITLE
perf(blocks): index permutations by canonical tuple key

### DIFF
--- a/.changeset/blocks-permutation-name-map.md
+++ b/.changeset/blocks-permutation-name-map.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+"@unpunnyfuns/swatchbook-mcp": patch
+"@unpunnyfuns/swatchbook-integrations": patch
+---
+
+`@unpunnyfuns/swatchbook-blocks`: index permutations by canonical tuple key once per snapshot, exposed as `permutationNameForTuple(tuple)` on `ProjectData`. `AxisVariance`'s grid drops its per-cell `permutations.find` scans for `O(1)` `Map.get` lookups. Bounded by the permutation count regardless of how many cells render.

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -53,6 +53,15 @@ export interface ProjectData {
    * (`AxisVariance` grid cells, future per-tuple block displays).
    */
   resolveAt: (tuple: Record<string, string>) => ResolvedTokens;
+  /**
+   * Look up the permutation name for a full tuple — `O(1)` against a
+   * `Map<canonicalKey, name>` built once per snapshot. Returns
+   * `undefined` when no permutation matches. Consumers that previously
+   * did `permutations.find(...)` per grid cell should use this
+   * instead to avoid quadratic-in-cell work as permutation counts
+   * grow.
+   */
+  permutationNameForTuple: (tuple: Record<string, string>) => string | undefined;
 }
 
 const STYLE_ELEMENT_ID = 'swatchbook-tokens';
@@ -71,6 +80,34 @@ function ensureStylesheet(css: string): void {
 function defaultTuple(axes: readonly VirtualAxis[]): Record<string, string> {
   const out: Record<string, string> = {};
   for (const axis of axes) out[axis.name] = axis.default;
+  return out;
+}
+
+/**
+ * Stable string key for a tuple — axes sorted by name + `:` separator.
+ * Matches the key form `buildResolveAt` uses in core so both surfaces
+ * agree on what counts as "the same tuple."
+ */
+function canonicalTupleKey(tuple: Readonly<Record<string, string>>): string {
+  return Object.keys(tuple)
+    .toSorted()
+    .map((k) => `${k}:${tuple[k]}`)
+    .join('|');
+}
+
+/**
+ * Build a `Map<canonicalKey, permutationName>` once per permutations
+ * list so per-tuple lookups go through O(1) `Map.get` instead of an
+ * `Array.prototype.find` scan per call. Bounded by the permutations
+ * count regardless of how many lookups consumers do.
+ */
+function buildPermutationNameByTuple(
+  permutations: readonly VirtualPermutation[],
+): ReadonlyMap<string, string> {
+  const out = new Map<string, string>();
+  for (const perm of permutations) {
+    out.set(canonicalTupleKey(perm.input as Record<string, string>), perm.name);
+  }
   return out;
 }
 
@@ -184,9 +221,13 @@ export function useProject(): ProjectData {
     permutationsResolved,
     activePermutation,
   ]);
+  const permutationNameByTuple = useMemo(
+    () => buildPermutationNameByTuple(permutations ?? []),
+    [permutations],
+  );
   const fallback = useVirtualModuleFallback(snapshot === null);
   if (snapshot !== null && resolveAt !== null) {
-    return snapshotToData(snapshot, resolveAt);
+    return snapshotToData(snapshot, resolveAt, permutationNameByTuple);
   }
   return fallback;
 }
@@ -194,6 +235,7 @@ export function useProject(): ProjectData {
 function snapshotToData(
   snapshot: ProjectSnapshot,
   resolveAt: (tuple: Record<string, string>) => ResolvedTokens,
+  permutationNameByTuple: ReadonlyMap<string, string>,
 ): ProjectData {
   return {
     activePermutation: snapshot.activePermutation,
@@ -211,6 +253,7 @@ function snapshotToData(
     listing: snapshot.listing ?? {},
     varianceByPath: snapshot.varianceByPath ?? {},
     resolveAt,
+    permutationNameForTuple: (tuple) => permutationNameByTuple.get(canonicalTupleKey(tuple)),
   };
 }
 
@@ -261,6 +304,10 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     [tokens.axes, tokens.cells, tokens.jointOverrides, tokens.defaultTuple],
   );
   const resolved = resolveAt(activeAxes);
+  const permutationNameByTuple = useMemo(
+    () => buildPermutationNameByTuple(tokens.permutations),
+    [tokens.permutations],
+  );
 
   return {
     activePermutation,
@@ -274,6 +321,7 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     listing: tokens.listing,
     varianceByPath: tokens.varianceByPath,
     resolveAt,
+    permutationNameForTuple: (tuple) => permutationNameByTuple.get(canonicalTupleKey(tuple)),
   };
 }
 

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -1,4 +1,4 @@
-import type { Axis, Permutation } from '@unpunnyfuns/swatchbook-core';
+import type { Axis } from '@unpunnyfuns/swatchbook-core';
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
@@ -18,8 +18,17 @@ interface Variance {
 }
 
 export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
-  const { token, cssVar, axes, permutations, activeAxes, cssVarPrefix, varianceByPath, resolveAt } =
-    useTokenDetailData(path);
+  const {
+    token,
+    cssVar,
+    axes,
+    permutations,
+    activeAxes,
+    cssVarPrefix,
+    varianceByPath,
+    resolveAt,
+    permutationNameForTuple,
+  } = useTokenDetailData(path);
   const colorFormat = useColorFormat();
   const tokenType = token?.$type;
   const isColor = tokenType === 'color';
@@ -82,7 +91,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
     if (!axis) return <></>;
     const contextValues = axis.contexts.map((ctx) => {
       const target = { ...activeAxes, [axisName]: ctx };
-      const themeName = tupleName(permutations, target) ?? '';
+      const themeName = permutationNameForTuple(target) ?? '';
       return {
         ctx,
         themeName,
@@ -162,7 +171,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
                   [rowAxis.name]: row,
                   [colAxis.name]: col,
                 };
-                const name = tupleName(permutations, target);
+                const name = permutationNameForTuple(target);
                 const value = formatFn(resolveAt(target)[path] as DetailToken | undefined);
                 return (
                   <td
@@ -204,16 +213,4 @@ function valueFor(
 ): string {
   if (!token) return '—';
   return formatTokenValue(token.$value, $type, format);
-}
-
-function tupleName(
-  permutations: readonly Permutation[],
-  tuple: Record<string, string>,
-): string | undefined {
-  const match = permutations.find((t) => {
-    const input = t.input;
-    const keys = Object.keys(input);
-    return keys.every((k) => input[k] === tuple[k]);
-  });
-  return match?.name;
 }

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -38,6 +38,13 @@ export interface TokenDetailData {
    * a derived tuple name.
    */
   resolveAt: (tuple: Record<string, string>) => Record<string, DetailToken>;
+  /**
+   * O(1) tuple → permutation-name lookup, backed by a `Map` built
+   * once per snapshot. The `AxisVariance` grid uses this to derive
+   * the `data-<prefix>-theme` attribute for each cell without an
+   * `Array.find` scan per render cell.
+   */
+  permutationNameForTuple: (tuple: Record<string, string>) => string | undefined;
 }
 
 export function useTokenDetailData(path: string): TokenDetailData {
@@ -52,6 +59,7 @@ export function useTokenDetailData(path: string): TokenDetailData {
     cssVarPrefix,
     varianceByPath,
     resolveAt,
+    permutationNameForTuple,
   } = project;
   const typedResolved = resolved as Record<string, DetailToken>;
   return {
@@ -66,5 +74,6 @@ export function useTokenDetailData(path: string): TokenDetailData {
     cssVarPrefix,
     varianceByPath,
     resolveAt: resolveAt as (tuple: Record<string, string>) => Record<string, DetailToken>,
+    permutationNameForTuple,
   };
 }


### PR DESCRIPTION
Found during the vercel-react-best-practices audit of #791 (rule \`js-set-map-lookups\`). Standalone perf cleanup, not part of the cartesian-shape-drop chain.

## Summary

\`AxisVariance.tsx\` previously called \`tupleName(permutations, target)\` per grid cell:

\`\`\`ts
function tupleName(permutations, tuple) {
  return permutations.find((t) => /* tuple equality */)?.name;
}
\`\`\`

That's \`O(permutations)\` per cell. \`useProject\` now builds a \`Map<canonicalTupleKey, permutationName>\` once per snapshot (memoized on \`tokens.permutations\` identity) and exposes a \`permutationNameForTuple(tuple): string | undefined\` accessor on \`ProjectData\`. The \`AxisVariance\` grid and single-axis row use the accessor instead of the local helper; the helper is deleted.

The canonical key form matches \`buildResolveAt\`'s in core (axes sorted by name + \`:\` separator), so both surfaces agree on what counts as "the same tuple".

## Verification

- [x] \`pnpm turbo run format:check lint typecheck test --filter @unpunnyfuns/swatchbook-blocks\` — 5/5 tasks
- [x] \`pnpm --filter swatchbook-storybook test:storybook\` — 149/149 stories, 0 \"Maximum update depth\" errors
- [x] \`useProject\`'s internal \`nameForTuple\` linear-scan callers (the snapshot-fallback path + the \`useVirtualModuleFallback\` derivation) kept as-is — they're 1-per-render, not in the per-cell hot path. Migrating them is part of #793's planned context-provider lift.

Milestone: Maintenance
Closes #792
Plan impact: independent of the cartesian-shape-drop chain. \`Project.permutations\` (and therefore the map's source data) goes away in PR 6, at which point the \`data-<prefix>-theme\` lookup pattern likely retires too — but until then, this brings AxisVariance's per-render cost back to linear in cells × axes instead of cells × permutations.