### PR TITLE
feat(mcp,integrations): consume resolveAt in MCP tools and css-in-js

### DIFF
--- a/.changeset/mcp-integrations-consume-resolve-at.md
+++ b/.changeset/mcp-integrations-consume-resolve-at.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-mcp`, `@unpunnyfuns/swatchbook-integrations`: server-side consumers switch from indexing `Project.permutationsResolved[name]` to calling `project.resolveAt(tuple)`. MCP builds a small `tupleByName: Map<permutationName, axisTuple>` once per project (refreshed on `setProject`) so tools that accept a `theme` name parameter map it to a tuple in O(1) before calling `resolveAt`. `get_axis_variance` drops its redundant `permutations.some` existence scan — `varianceByPath.has(path)` covers it. MCP tool inputs / outputs are unchanged. The `css-in-js` integration's `collectPaths` switches to `resolveAt(theme.input)` for the same iteration. After this PR only `loadProject` itself materializes the cartesian permutation map; the next PR drops that.

--- a/packages/integrations/src/css-in-js.ts
+++ b/packages/integrations/src/css-in-js.ts
@@ -95,7 +95,7 @@ function renderTheme(project: Project): string {
 function collectPaths(project: Project): string[] {
   const all = new Set<string>();
   for (const theme of project.permutations) {
-    const tokens = project.permutationsResolved[theme.name] ?? {};
+    const tokens = project.resolveAt(theme.input as Record<string, string>);
     for (const path of Object.keys(tokens)) all.add(path);
   }
   return [...all].toSorted();

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,4 +1,4 @@
-import type { Project } from '@unpunnyfuns/swatchbook-core';
+import type { Project, TokenMap } from '@unpunnyfuns/swatchbook-core';
 import { projectCss } from '@unpunnyfuns/swatchbook-core';
 import { fuzzyFilter, fuzzyMatches } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -18,6 +18,13 @@ export function createServer(initial: Project): McpServer & {
   setProject: (next: Project) => void;
 } {
   let project = initial;
+  // Reverse lookup `permutationName → axisTuple`, refreshed on each
+  // `setProject` swap. Tool handlers that accept a `theme` name
+  // parameter use this to map it to a tuple in O(1) before calling
+  // `project.resolveAt(tuple)` — replaces the direct
+  // `project.permutationsResolved[name]` indexing the tools used
+  // before the cells migration.
+  let tupleByName = buildTupleByName(initial);
   const server = new McpServer(
     {
       name: '@unpunnyfuns/swatchbook-mcp',
@@ -30,6 +37,18 @@ export function createServer(initial: Project): McpServer & {
   ) as McpServer & { setProject: (next: Project) => void };
   server.setProject = (next: Project) => {
     project = next;
+    tupleByName = buildTupleByName(next);
+  };
+
+  /**
+   * Resolve tokens for a `theme` name parameter. Falls back to the
+   * project's default tuple when the name doesn't match any known
+   * permutation (also covers the no-theme-provided path).
+   */
+  const tokensForTheme = (themeName: string | undefined): TokenMap => {
+    const tuple =
+      (themeName !== undefined ? tupleByName.get(themeName) : undefined) ?? project.defaultTuple;
+    return project.resolveAt(tuple);
   };
 
   server.registerTool(
@@ -43,7 +62,7 @@ export function createServer(initial: Project): McpServer & {
       const typeCounts: Record<string, number> = {};
       const tokensPerTheme: Record<string, number> = {};
       for (const theme of project.permutations) {
-        const tokens = project.permutationsResolved[theme.name] ?? {};
+        const tokens = project.resolveAt(theme.input as Record<string, string>);
         tokensPerTheme[theme.name] = Object.keys(tokens).length;
         for (const token of Object.values(tokens)) {
           if (token.$type) typeCounts[token.$type] = (typeCounts[token.$type] ?? 0) + 1;
@@ -104,7 +123,7 @@ export function createServer(initial: Project): McpServer & {
       if (!themeName) {
         return textResult('No permutations in project.');
       }
-      const tokens = project.permutationsResolved[themeName] ?? {};
+      const tokens = tokensForTheme(themeName);
       const rows: { path: string; type?: string; value: string }[] = [];
       for (const [path, token] of Object.entries(tokens)) {
         if (type && token.$type !== type) continue;
@@ -140,7 +159,7 @@ export function createServer(initial: Project): McpServer & {
       let found = false;
 
       for (const theme of project.permutations) {
-        const token = project.permutationsResolved[theme.name]?.[path];
+        const token = project.resolveAt(theme.input as Record<string, string>)[path];
         if (!token) continue;
         found = true;
         type ??= token.$type;
@@ -208,7 +227,7 @@ export function createServer(initial: Project): McpServer & {
       const perTheme: Record<string, { aliasOf?: string; chain: readonly string[] }> = {};
       let found = false;
       for (const theme of project.permutations) {
-        const token = project.permutationsResolved[theme.name]?.[path];
+        const token = project.resolveAt(theme.input as Record<string, string>)[path];
         if (!token) continue;
         found = true;
         const chain: string[] = [path];
@@ -243,7 +262,7 @@ export function createServer(initial: Project): McpServer & {
       const depth = maxDepth ?? 6;
       const themeName = project.permutations[0]?.name;
       if (!themeName) return textResult('No permutations in project.');
-      const tokens = project.permutationsResolved[themeName] ?? {};
+      const tokens = tokensForTheme(themeName);
       if (!tokens[path]) return textResult(`Token not found: ${path}`);
 
       interface Node {
@@ -289,7 +308,7 @@ export function createServer(initial: Project): McpServer & {
     ({ path, theme }) => {
       const themeName = theme ?? project.permutations[0]?.name;
       if (!themeName) return textResult('No permutations in project.');
-      const token = project.permutationsResolved[themeName]?.[path];
+      const token = tokensForTheme(themeName)[path];
       if (!token) return textResult(`Token not found: ${path}`);
       if (token.$type !== 'color') {
         return textResult(`Token ${path} is not a color (got $type=${token.$type ?? 'unknown'}).`);
@@ -329,8 +348,9 @@ export function createServer(initial: Project): McpServer & {
     ({ foreground, background, theme, algorithm }) => {
       const themeName = theme ?? project.permutations[0]?.name;
       if (!themeName) return textResult('No permutations in project.');
-      const fgTok = project.permutationsResolved[themeName]?.[foreground];
-      const bgTok = project.permutationsResolved[themeName]?.[background];
+      const tokens = tokensForTheme(themeName);
+      const fgTok = tokens[foreground];
+      const bgTok = tokens[background];
       if (!fgTok) return textResult(`Foreground token not found: ${foreground}`);
       if (!bgTok) return textResult(`Background token not found: ${background}`);
       if (fgTok.$type !== 'color') {
@@ -369,8 +389,9 @@ export function createServer(initial: Project): McpServer & {
     },
     ({ path }) => {
       if (project.permutations.length === 0) return textResult('No permutations in project.');
-      const exists = project.permutations.some((t) => project.permutationsResolved[t.name]?.[path]);
-      if (!exists) return textResult(`Token not found in any theme: ${path}`);
+      // `varianceByPath` covers every path that appears in any
+      // permutation's resolved map; presence here is the same
+      // existence signal the prior `permutations.some` scan provided.
       const cached = project.varianceByPath.get(path);
       if (!cached) return textResult(`Token not found in any theme: ${path}`);
       return jsonResult(cached);
@@ -394,7 +415,7 @@ export function createServer(initial: Project): McpServer & {
     ({ query, theme, limit }) => {
       const themeName = theme ?? project.permutations[0]?.name;
       if (!themeName) return textResult('No permutations in project.');
-      const tokens = project.permutationsResolved[themeName] ?? {};
+      const tokens = tokensForTheme(themeName);
       const max = limit ?? 50;
 
       const candidates = Object.entries(tokens).map(([path, token]) => {
@@ -463,7 +484,7 @@ export function createServer(initial: Project): McpServer & {
           return true;
         })?.name ?? project.permutations[0]?.name;
       if (!themeName) return textResult('No matching theme.');
-      const tokens = project.permutationsResolved[themeName] ?? {};
+      const tokens = project.resolveAt(active);
       const resolved: Record<
         string,
         { value: string; type?: string; aliasOf?: string; aliasChain?: readonly string[] }
@@ -518,7 +539,7 @@ export function createServer(initial: Project): McpServer & {
         })?.name ??
         project.permutations[0]?.name ??
         '';
-      const token = themeName ? project.permutationsResolved[themeName]?.[path] : undefined;
+      const token = project.resolveAt(activeTuple)[path];
       if (!token) return textResult(`Token not found: ${path}`);
 
       const cssVar = `var(--${prefix ? `${prefix}-` : ''}${path.replaceAll('.', '-')})`;
@@ -569,6 +590,19 @@ export function createServer(initial: Project): McpServer & {
   );
 
   return server;
+}
+
+/**
+ * Build a `Map<permutationName, axisTuple>` so the per-theme tool
+ * handlers can avoid an `Array.find` scan per request. Bounded by the
+ * permutation count.
+ */
+function buildTupleByName(project: Project): Map<string, Record<string, string>> {
+  const out = new Map<string, Record<string, string>>();
+  for (const perm of project.permutations) {
+    out.set(perm.name, perm.input as Record<string, string>);
+  }
+  return out;
 }
 
 function stringifyValue(value: unknown): string {


### PR DESCRIPTION
Fifth step of the cartesian-shape-drop chain (foundation #784, variance cache #787, wire format #789, block migration #791). Server-side consumers of \`Project.permutationsResolved\` switch to \`project.resolveAt(tuple)\`. After this PR only \`loadProject\` itself materializes the cartesian map; the next PR drops that.

## Summary

**MCP** (\`packages/mcp/src/server.ts\`):

- Builds a small \`tupleByName: Map<permutationName, axisTuple>\` once per project, refreshed on \`setProject\`. Tools that accept a \`theme\` name parameter use it to map name → tuple in O(1), then call \`project.resolveAt(tuple)\` for the TokenMap.
- New \`tokensForTheme(themeName)\` helper closes over the map; falls back to \`project.defaultTuple\` when the name doesn't match a known permutation (or no theme was provided).
- Per-theme iteration tools (\`describe_project\`, \`get_token\`, \`get_alias_chain\`) iterate \`project.permutations\` the same way but use \`resolveAt(theme.input)\` for the per-permutation TokenMap.
- \`get_axis_variance\` drops its redundant \`permutations.some(t => permutationsResolved[t.name]?.[path])\` existence check — \`varianceByPath.has(path)\` is the same signal and is the future-proof one.
- Tool input / output shapes unchanged. Agent-facing API is stable across the migration.

**Integrations** (\`packages/integrations/src/css-in-js.ts\`):

- \`collectPaths\` iterates \`permutations\` for the per-theme tuple but reads the TokenMap via \`resolveAt(theme.input)\`. Same set of paths, same emission output.

## Doesn't change

- \`projectCss\` (used by MCP's \`emit_css\` tool) still reads the cartesian map directly — it's the cartesian emitter; the smart-emitter path replaces it in the docs-side and addon already via \`emitAxisProjectedCss\`.
- The addon's \`useToken\` hook (\`packages/addon/src/hooks/use-token.ts\`) keeps reading the virtual module's \`permutationsResolved\` export — same lifecycle as the addon preview's per-render flow; migrates alongside PR 6's wire-format drop.

## Verification

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 tasks
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-mcp test\` — 76/76 tests
- [x] \`pnpm --filter swatchbook-storybook test:storybook\` — 149/149 stories (css-in-js integration is loaded by the storybook config); 0 \"Maximum update depth\" errors

Milestone: Maintenance
Closes #795
Plan impact: PR 5 of the cartesian-shape-drop chain. All consumers of \`permutationsResolved\` outside \`loadProject\` itself are now on \`resolveAt\`; PR 6 can drop the materialization cleanly.