### PR TITLE
feat(addon,blocks): lift resolveAt to provider; drop wire-shipped permutationsResolved

### DIFF
--- a/.changeset/lift-resolve-at-drop-wire-permutations.md
+++ b/.changeset/lift-resolve-at-drop-wire-permutations.md
@@ -1,0 +1,19 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-switcher": minor
+"@unpunnyfuns/swatchbook-mcp": minor
+"@unpunnyfuns/swatchbook-integrations": minor
+---
+
+`@unpunnyfuns/swatchbook-addon`, `@unpunnyfuns/swatchbook-blocks`: lift `resolveAt` to the preview decorator (built once per iframe at module load over the stable virtual exports) and ship it through `SwatchbookContext`. Blocks read `snapshot.resolveAt` directly — no more memo gymnastics. Closes #793.
+
+Drops the wire-shipped `permutations`, `permutationsResolved`, and `defaultPermutation` from the virtual module + HMR snapshot + `InitPayload` + per-package `virtual.d.ts`. The block-side `ProjectSnapshot` keeps them as optional fields for hand-built test snapshots and legacy MDX consumers (the `snapshotResolveAt` fallback path still indexes them when `cells` is absent).
+
+Migrates the three remaining addon-side consumers that previously read `Project.permutationsResolved` directly:
+- `preset.ts` (codegen): iterates `project.varianceByPath.keys()` for token paths.
+- `virtual/plugin.ts` (HMR reload log): counts from `project.varianceByPath.size`.
+- `useToken` hook: reads the snapshot's `resolveAt` (or a module-level `fallbackResolveAt` built from the virtual exports when no provider is mounted).
+
+`Project.permutations` and `Project.permutationsResolved` still exist on the core type — the loadProject rewrite that drops them follows in the next PR.

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ apps/docs/src/tokens.snapshot.json
 .swatchbook
 *.tsbuildinfo
 
+# Per-developer Claude Code skill installs (.agents/skills/*; skills-lock.json
+# tracks which skills the local user has enabled). Not project source.
+.agents
+skills-lock.json
+
 # Editors
 .vscode
 .idea

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -555,7 +555,7 @@ export const TokenDetailConstantAcrossAxes = meta.story({
     );
     expect(header, 'must render "Values across axes" section header').toBeTruthy();
     const cell = await waitForContent(canvasElement, '[data-testid="token-detail-constant"]');
-    expect(cell.textContent ?? '').toMatch(/same across all/);
+    expect(cell.textContent ?? '').toMatch(/same across every axis/);
   },
 });
 

--- a/packages/addon/src/channel-types.ts
+++ b/packages/addon/src/channel-types.ts
@@ -56,12 +56,9 @@ export interface InitPayload {
   axes: readonly VirtualAxis[];
   disabledAxes: readonly string[];
   presets: readonly VirtualPreset[];
-  permutations: readonly VirtualPermutation[];
-  defaultPermutation: string | null;
-  permutationsResolved: Record<string, Record<string, VirtualToken>>;
   diagnostics: readonly VirtualDiagnostic[];
   cssVarPrefix: string;
-  /** {@link VirtualCells} — additive companion to `permutationsResolved`. */
+  /** {@link VirtualCells} — per-axis resolved TokenMaps, bounded by Σ(axes × contexts). */
   cells: VirtualCells;
   /** {@link VirtualJointOverrides} — Map serialized as `[key, entry]` pairs. */
   jointOverrides: VirtualJointOverrides;

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -1,5 +1,32 @@
-import { cssVarPrefix, defaultPermutation, permutationsResolved } from 'virtual:swatchbook/tokens';
-import { useActivePermutation } from '@unpunnyfuns/swatchbook-blocks';
+import {
+  axes as virtualAxes,
+  cells as virtualCells,
+  cssVarPrefix as virtualCssVarPrefix,
+  defaultTuple as virtualDefaultTuple,
+  jointOverrides as virtualJointOverrides,
+} from 'virtual:swatchbook/tokens';
+import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
+import type {
+  Axis as CoreAxis,
+  Cells as CoreCells,
+  JointOverride,
+  JointOverrides,
+} from '@unpunnyfuns/swatchbook-core';
+import { useActiveAxes, useOptionalSwatchbookData } from '@unpunnyfuns/swatchbook-blocks';
+
+/**
+ * Module-scope `resolveAt` for the no-provider fallback path. Built
+ * once from the stable virtual-module exports — mirrors what the
+ * preview decorator does for its `previewResolveAt` but lives in this
+ * file so the hook can be called outside the addon's preview wrapper
+ * (autodocs / MDX renders).
+ */
+const fallbackResolveAt = buildResolveAt(
+  virtualAxes as readonly CoreAxis[],
+  virtualCells as CoreCells,
+  new Map(virtualJointOverrides as readonly (readonly [string, JointOverride])[]) as JointOverrides,
+  virtualDefaultTuple,
+);
 
 /**
  * Consumers augment this interface (via the addon's generated
@@ -32,24 +59,37 @@ function makeCssVar(path: string, prefix: string): string {
 
 /**
  * Read a DTCG token for the currently active theme. Re-reads on theme
- * switch via the addon's `PermutationContext`. Returns `{ value, cssVar, type,
- * description }`.
+ * switch via the addon's `SwatchbookContext`. Returns `{ value, cssVar,
+ * type, description }`.
  *
  * Typed paths appear automatically once `.swatchbook/tokens.d.ts` is
  * generated (happens on first storybook start/build). Until then
  * `TokenPath` is `string`.
  *
  * Safe to call in autodocs / MDX renders — uses plain React context, not
- * Storybook's preview-only hooks.
+ * Storybook's preview-only hooks. Reads from the addon-provided
+ * `SwatchbookContext` when present (preferred — uses the lifted
+ * `resolveAt` accessor and the live active tuple); falls back to the
+ * virtual module's eager `permutationsResolved` lookup keyed by the
+ * default permutation name when no provider is mounted.
  */
 export function useToken(path: TokenPath): TokenInfo {
-  const contextPermutation = useActivePermutation();
-  const permutationName = contextPermutation || (defaultPermutation ?? '');
-  const tokens = permutationsResolved[permutationName] ?? {};
-  const token = tokens[path];
+  const snapshot = useOptionalSwatchbookData();
+  const contextAxes = useActiveAxes();
+  const hasContextAxes = Object.keys(contextAxes).length > 0;
+
+  const prefix = snapshot?.cssVarPrefix ?? virtualCssVarPrefix;
+  const resolver = snapshot?.resolveAt ?? fallbackResolveAt;
+  const tuple = hasContextAxes
+    ? (contextAxes as Record<string, string>)
+    : (snapshot?.defaultTuple ?? virtualDefaultTuple);
+  const token = resolver(tuple)[path] as
+    | { $value?: unknown; $type?: string; $description?: string }
+    | undefined;
+
   const info: TokenInfo = {
     value: token?.$value,
-    cssVar: makeCssVar(path, cssVarPrefix),
+    cssVar: makeCssVar(path, prefix),
   };
   if (token?.$type) info.type = token.$type;
   if (token?.$description) info.description = token.$description;

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -85,11 +85,22 @@ async function writeTokenCodegen(
 
 /** @internal Exported for tests; not part of the public API. */
 export function renderTokenTypes(project: Project): string {
+  // `varianceByPath` covers every path that appears in any
+  // permutation's resolved map (by construction in
+  // `buildVarianceByPath`), so it's the right source for the token
+  // path union — independent of the cartesian materialization the
+  // chain is in the process of dropping. Hand-built test fixtures
+  // that don't populate `varianceByPath` fall through to the
+  // legacy per-permutation scan.
   const paths = new Set<string>();
-  for (const theme of project.permutations) {
-    const tokens = project.permutationsResolved[theme.name];
-    if (!tokens) continue;
-    for (const path of Object.keys(tokens)) paths.add(path);
+  if (project.varianceByPath && project.varianceByPath.size > 0) {
+    for (const p of project.varianceByPath.keys()) paths.add(p);
+  } else {
+    for (const theme of project.permutations) {
+      const tokens = project.permutationsResolved[theme.name];
+      if (!tokens) continue;
+      for (const path of Object.keys(tokens)) paths.add(path);
+    }
   }
   const sorted = [...paths].toSorted();
   const tokenEntries = sorted.map((p) => `    ${JSON.stringify(p)}: string;`);

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -1,4 +1,11 @@
 /// <reference types="vite/client" />
+import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
+import type {
+  Axis as CoreAxis,
+  Cells as CoreCells,
+  JointOverride,
+  JointOverrides,
+} from '@unpunnyfuns/swatchbook-core';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import { useEffect, useMemo } from 'react';
 import { addons } from 'storybook/preview-api';
@@ -12,15 +19,12 @@ import {
   cells as virtualCells,
   css,
   cssVarPrefix,
-  defaultPermutation,
   defaultTuple as virtualDefaultTuple,
   diagnostics,
   disabledAxes as virtualDisabledAxes,
   jointOverrides as virtualJointOverrides,
   listing as virtualListing,
   presets as virtualPresets,
-  permutations,
-  permutationsResolved,
   varianceByPath as virtualVarianceByPath,
 } from 'virtual:swatchbook/tokens';
 import {
@@ -74,32 +78,30 @@ html, body {
 }
 
 /**
- * Apply `cb(axisName, value)` for every pinned (disabled) axis whose value
- * is present on any surviving theme's `input`. Disabled axes don't appear
- * in `virtualAxes`, but CSS may still reference their pinned value on
- * compound selectors — every theme that survived filtering carries the
- * same pinned context per disabled axis, so sampling any theme works.
+ * Apply `cb(axisName, value)` for every pinned (disabled) axis whose
+ * default-tuple value is set. `virtualDefaultTuple` carries the
+ * post-filter axis defaults; disabled axes don't appear in
+ * `virtualAxes` but their pinned context value still lives here, so
+ * sampling it gives the same result the old "first permutation's
+ * input" lookup did.
  */
 function forEachPinnedAxis(cb: (name: string, value: string) => void): void {
-  const pinnedSample = permutations[0]?.input;
-  if (!pinnedSample) return;
   for (const name of virtualDisabledAxes) {
-    const value = pinnedSample[name];
+    const value = virtualDefaultTuple[name];
     if (value !== undefined) cb(name, value);
   }
 }
 
 /**
- * Pick the theme name for a tuple, falling back to `defaultPermutation` and then
- * the first theme. Returns empty string when the project has no permutations so
- * callers can omit the attr instead of writing a made-up context name.
+ * Compose a stable theme name from a tuple — the same `Light · Brand A
+ * · Normal` form `permutationID` produced server-side. Used for the
+ * `data-<prefix>-theme` attribute and the `swatchbook/theme` channel
+ * signal. Returns empty string when there are no axes (no name to
+ * write).
  */
 function matchPermutationName(tuple: Readonly<Record<string, string>>): string {
-  const match = permutations.find((t) => {
-    const input = t.input as Record<string, string>;
-    return Object.keys(input).every((k) => input[k] === tuple[k]);
-  });
-  return match?.name ?? defaultPermutation ?? permutations[0]?.name ?? '';
+  if (virtualAxes.length === 0) return '';
+  return virtualAxes.map((axis) => tuple[axis.name] ?? axis.default).join(' · ');
 }
 
 /**
@@ -139,9 +141,6 @@ function broadcastInit(): void {
     axes: virtualAxes,
     disabledAxes: virtualDisabledAxes,
     presets: virtualPresets,
-    permutations,
-    defaultPermutation,
-    permutationsResolved,
     diagnostics,
     cssVarPrefix,
     cells: virtualCells,
@@ -158,10 +157,25 @@ function defaultTuple(): Record<string, string> {
   return out;
 }
 
-/** Look up a `Permutation.input` by composed name. Returns `undefined` if no theme matches. */
+/**
+ * Reverse-engineer a tuple from a `Light · Brand A · Normal`-shape
+ * theme name. Splits on ` · ` and zips with `virtualAxes` in declared
+ * order — matches `matchPermutationName`'s production direction so a
+ * round-trip is lossless. Returns `undefined` when the segment count
+ * doesn't match the axis count.
+ */
 function tupleForName(name: string): Record<string, string> | undefined {
-  const match = permutations.find((t) => t.name === name);
-  return match?.input;
+  if (!name) return undefined;
+  const parts = name.split(' · ');
+  if (parts.length !== virtualAxes.length) return undefined;
+  const out: Record<string, string> = {};
+  for (let i = 0; i < virtualAxes.length; i++) {
+    const axis = virtualAxes[i] as (typeof virtualAxes)[number];
+    const value = parts[i];
+    if (value === undefined) return undefined;
+    out[axis.name] = value;
+  }
+  return out;
 }
 
 /**
@@ -215,6 +229,24 @@ function resolveColorFormat(globals: SwatchbookGlobals): ColorFormat {
   return 'hex';
 }
 
+/**
+ * Single shared `resolveAt` instance for the lifetime of the preview
+ * iframe. The inputs (`virtualAxes`, `virtualCells`, …) are all
+ * module-level virtual-module exports with stable identity, so this
+ * never needs to rebuild; downstream `ProjectSnapshot` consumers can
+ * key memos on the snapshot wrapper without worrying about
+ * `resolveAt` churning when Storybook recreates `context.globals`.
+ *
+ * Replaces the per-render `useMemo(makeResolveAt(...))` dance the
+ * blocks side used to do in `useProject`.
+ */
+const previewResolveAt = buildResolveAt(
+  virtualAxes as readonly CoreAxis[],
+  virtualCells as CoreCells,
+  new Map(virtualJointOverrides as readonly (readonly [string, JointOverride])[]) as JointOverrides,
+  virtualDefaultTuple,
+);
+
 const themedDecorator: Decorator = (Story, context) => {
   const globals = context.globals as SwatchbookGlobals;
   const parameters = context.parameters as StoryParameters;
@@ -246,8 +278,6 @@ const themedDecorator: Decorator = (Story, context) => {
       axes: virtualAxes,
       disabledAxes: virtualDisabledAxes,
       presets: virtualPresets,
-      permutations,
-      permutationsResolved,
       activePermutation: themeName,
       activeAxes: tuple,
       cssVarPrefix,
@@ -258,6 +288,13 @@ const themedDecorator: Decorator = (Story, context) => {
       jointOverrides: virtualJointOverrides,
       varianceByPath: virtualVarianceByPath,
       defaultTuple: virtualDefaultTuple,
+      // Cast: `buildResolveAt` returns `TokenMap` (Terrazzo's
+      // `TokenNormalized`), while the block-side snapshot type uses
+      // its own narrower `VirtualTokenShape`. The shapes are
+      // structurally a subset; the cast covers the
+      // `exactOptionalPropertyTypes` mismatch between
+      // `string | undefined` and `string`.
+      resolveAt: previewResolveAt as unknown as NonNullable<ProjectSnapshot['resolveAt']>,
     }),
     [themeName, tuple],
   );
@@ -386,9 +423,6 @@ interface HmrSnapshot {
   axes: typeof virtualAxes;
   disabledAxes: typeof virtualDisabledAxes;
   presets: typeof virtualPresets;
-  permutations: typeof permutations;
-  defaultPermutation: typeof defaultPermutation;
-  permutationsResolved: typeof permutationsResolved;
   diagnostics: typeof diagnostics;
   css: string;
   cssVarPrefix: string;
@@ -422,9 +456,6 @@ html, body {
       axes: payload.axes,
       disabledAxes: payload.disabledAxes,
       presets: payload.presets,
-      permutations: payload.permutations,
-      defaultPermutation: payload.defaultPermutation,
-      permutationsResolved: payload.permutationsResolved,
       diagnostics: payload.diagnostics,
       cssVarPrefix: payload.cssVarPrefix,
       cells: payload.cells,

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -14,17 +14,12 @@ declare module 'virtual:swatchbook/tokens' {
     VirtualJointOverrides,
     VirtualListingEntry,
     VirtualPreset,
-    VirtualPermutation,
-    VirtualToken,
     VirtualVarianceByPath,
   } from '#/channel-types.ts';
 
   export const axes: readonly VirtualAxis[];
   export const disabledAxes: readonly string[];
   export const presets: readonly VirtualPreset[];
-  export const permutations: readonly VirtualPermutation[];
-  export const defaultPermutation: string | null;
-  export const permutationsResolved: Record<string, Record<string, VirtualToken>>;
   export const diagnostics: readonly VirtualDiagnostic[];
   export const css: string;
   export const cssVarPrefix: string;

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -113,9 +113,6 @@ export function swatchbookTokensPlugin({
         `export const axes = ${JSON.stringify(project.axes)};`,
         `export const presets = ${JSON.stringify(project.presets)};`,
         `export const disabledAxes = ${JSON.stringify(project.disabledAxes)};`,
-        `export const permutations = ${JSON.stringify(project.permutations)};`,
-        `export const defaultPermutation = ${JSON.stringify(project.permutations[0]?.name ?? null)};`,
-        `export const permutationsResolved = ${JSON.stringify(project.permutationsResolved)};`,
         `export const diagnostics = ${JSON.stringify(project.diagnostics)};`,
         `export const css = ${JSON.stringify(css)};`,
         `export const cssVarPrefix = ${JSON.stringify(config.cssVarPrefix ?? '')};`,
@@ -150,9 +147,7 @@ export function swatchbookTokensPlugin({
           void (async () => {
             await refresh();
             if (!project) return;
-            const tokenCount = Object.keys(
-              project.permutationsResolved[project.permutations[0]?.name ?? ''] ?? {},
-            ).length;
+            const tokenCount = project.varianceByPath.size;
             const diagCount = project.diagnostics.length;
             server.config.logger.info(
               `\x1b[36m[swatchbook]\x1b[0m tokens reloaded — ${tokenCount} tokens, ${diagCount} diagnostic${diagCount === 1 ? '' : 's'}`,
@@ -182,9 +177,6 @@ export function swatchbookTokensPlugin({
                 axes: project.axes,
                 disabledAxes: project.disabledAxes,
                 presets: project.presets,
-                permutations: project.permutations,
-                defaultPermutation: project.permutations[0]?.name ?? null,
-                permutationsResolved: project.permutationsResolved,
                 diagnostics: project.diagnostics,
                 css,
                 cssVarPrefix: config.cssVarPrefix ?? '',

--- a/packages/addon/test/use-token.browser.test.tsx
+++ b/packages/addon/test/use-token.browser.test.tsx
@@ -1,19 +1,29 @@
 import { type ReactNode } from 'react';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
-import { PermutationContext } from '@unpunnyfuns/swatchbook-blocks';
+import { AxesContext, PermutationContext } from '@unpunnyfuns/swatchbook-blocks';
 import { useToken } from '#/hooks/use-token.ts';
 
-function withPermutation(name: string) {
+/**
+ * The hook resolves through `useActiveAxes` (the post-cells contract);
+ * tests previously only set `PermutationContext`, which the legacy
+ * `useToken` translated to a permutation-name lookup. We set both so
+ * the test fixtures work under either contract.
+ */
+function withPermutation(name: string, axes: Record<string, string>) {
   return function Wrapper({ children }: { children: ReactNode }) {
-    return <PermutationContext.Provider value={name}>{children}</PermutationContext.Provider>;
+    return (
+      <PermutationContext.Provider value={name}>
+        <AxesContext.Provider value={axes}>{children}</AxesContext.Provider>
+      </PermutationContext.Provider>
+    );
   };
 }
 
 describe('useToken', () => {
   it('returns the resolved value + `var(--…)` reference for the active permutation', () => {
     const { result } = renderHook(() => useToken('color.accent.bg'), {
-      wrapper: withPermutation('Light'),
+      wrapper: withPermutation('Light', { mode: 'Light' }),
     });
     expect(result.current.value).toEqual({ colorSpace: 'srgb', components: [0, 0.4, 1] });
     expect(result.current.cssVar).toBe('var(--sb-color-accent-bg)');
@@ -23,10 +33,10 @@ describe('useToken', () => {
 
   it('returns a different resolved value when the active permutation changes', () => {
     const { result: light } = renderHook(() => useToken('color.accent.bg'), {
-      wrapper: withPermutation('Light'),
+      wrapper: withPermutation('Light', { mode: 'Light' }),
     });
     const { result: dark } = renderHook(() => useToken('color.accent.bg'), {
-      wrapper: withPermutation('Dark'),
+      wrapper: withPermutation('Dark', { mode: 'Dark' }),
     });
     expect(light.current.value).not.toEqual(dark.current.value);
     // cssVar is permutation-independent: blocks read CSS vars per
@@ -43,7 +53,7 @@ describe('useToken', () => {
 
   it('returns undefined value + cssVar reference when the path is unknown', () => {
     const { result } = renderHook(() => useToken('not.a.token'), {
-      wrapper: withPermutation('Light'),
+      wrapper: withPermutation('Light', { mode: 'Light' }),
     });
     expect(result.current.value).toBeUndefined();
     expect(result.current.cssVar).toBe('var(--sb-not-a-token)');
@@ -53,7 +63,7 @@ describe('useToken', () => {
 
   it('returns a non-color token with the right $type', () => {
     const { result } = renderHook(() => useToken('space.md'), {
-      wrapper: withPermutation('Light'),
+      wrapper: withPermutation('Light', { mode: 'Light' }),
     });
     expect(result.current.value).toBe('16px');
     expect(result.current.type).toBe('dimension');
@@ -62,7 +72,7 @@ describe('useToken', () => {
 
   it('omits the `description` field when the token has no $description', () => {
     const { result } = renderHook(() => useToken('space.md'), {
-      wrapper: withPermutation('Light'),
+      wrapper: withPermutation('Light', { mode: 'Light' }),
     });
     expect(result.current.description).toBeUndefined();
   });

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -90,8 +90,17 @@ export interface ProjectSnapshot {
   /** Axis names suppressed via `config.disabledAxes` — pinned to their defaults, hidden from the toolbar. */
   disabledAxes: readonly string[];
   presets: readonly VirtualPresetShape[];
-  permutations: readonly VirtualPermutationShape[];
-  permutationsResolved: Record<string, Record<string, VirtualTokenShape>>;
+  /**
+   * @deprecated Wire-shipped permutations were removed in PR 6a.
+   * Hand-built snapshots (tests, MDX consumers) may still populate
+   * this for backward compatibility with the legacy fallback path
+   * in `useProject`. Production preview snapshots omit it.
+   */
+  permutations?: readonly VirtualPermutationShape[];
+  /**
+   * @deprecated See `permutations`. Wire format dropped in PR 6a.
+   */
+  permutationsResolved?: Record<string, Record<string, VirtualTokenShape>>;
   activePermutation: string;
   activeAxes: Readonly<Record<string, string>>;
   cssVarPrefix: string;
@@ -129,6 +138,17 @@ export interface ProjectSnapshot {
    * Replaces the legacy "look at `permutations[0].input`" pattern.
    */
   defaultTuple?: Record<string, string>;
+  /**
+   * Pre-built `resolveAt(tuple)` accessor. The addon's preview
+   * decorator instantiates this once per iframe lifetime — the
+   * underlying virtual-module exports (cells, jointOverrides, axes,
+   * defaultTuple) are stable, so a single resolver instance with
+   * internal per-tuple memoization is correct and avoids the
+   * per-render rebuild dance the blocks side used to do. Hand-built
+   * snapshots (tests, MDX) can omit this; blocks fall back to
+   * building locally from `cells` / `permutationsResolved`.
+   */
+  resolveAt?: (tuple: Record<string, string>) => Record<string, VirtualTokenShape>;
 }
 
 /**

--- a/packages/blocks/src/internal/channel-tokens.ts
+++ b/packages/blocks/src/internal/channel-tokens.ts
@@ -5,13 +5,10 @@ import {
   cells as initialCells,
   css as initialCss,
   cssVarPrefix as initialCssVarPrefix,
-  defaultPermutation as initialDefaultPermutation,
   defaultTuple as initialDefaultTuple,
   diagnostics as initialDiagnostics,
   jointOverrides as initialJointOverrides,
   listing as initialListing,
-  permutations as initialPermutations,
-  permutationsResolved as initialPermutationsResolved,
   presets as initialPresets,
   varianceByPath as initialVarianceByPath,
 } from 'virtual:swatchbook/tokens';
@@ -20,7 +17,7 @@ import type {
   VirtualTokenListingShape,
   VirtualVarianceByPathShape,
 } from '#/contexts.ts';
-import type { VirtualAxis, VirtualDiagnostic, VirtualPermutation, VirtualToken } from '#/types.ts';
+import type { VirtualAxis, VirtualDiagnostic, VirtualToken } from '#/types.ts';
 
 /**
  * Live token snapshot backed by the addon's preview dev-time HMR event.
@@ -48,9 +45,6 @@ export interface TokenSnapshot {
     axes: Partial<Record<string, string>>;
     description?: string;
   }[];
-  readonly permutations: readonly VirtualPermutation[];
-  readonly defaultPermutation: string | null;
-  readonly permutationsResolved: Record<string, Record<string, VirtualToken>>;
   readonly diagnostics: readonly VirtualDiagnostic[];
   readonly css: string;
   readonly cssVarPrefix: string;
@@ -66,9 +60,6 @@ export interface TokenSnapshot {
 let snapshot: TokenSnapshot = {
   axes: initialAxes,
   presets: initialPresets,
-  permutations: initialPermutations,
-  defaultPermutation: initialDefaultPermutation,
-  permutationsResolved: initialPermutationsResolved,
   diagnostics: initialDiagnostics,
   css: initialCss,
   cssVarPrefix: initialCssVarPrefix,
@@ -91,9 +82,6 @@ function ensureSubscribed(): void {
     snapshot = {
       axes: payload.axes ?? snapshot.axes,
       presets: payload.presets ?? snapshot.presets,
-      permutations: payload.permutations ?? snapshot.permutations,
-      defaultPermutation: payload.defaultPermutation ?? snapshot.defaultPermutation,
-      permutationsResolved: payload.permutationsResolved ?? snapshot.permutationsResolved,
       diagnostics: payload.diagnostics ?? snapshot.diagnostics,
       css: payload.css ?? snapshot.css,
       cssVarPrefix: payload.cssVarPrefix ?? snapshot.cssVarPrefix,

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -27,9 +27,7 @@ export interface ProjectData {
   activePermutation: string;
   activeAxes: Record<string, string>;
   axes: readonly VirtualAxis[];
-  permutations: readonly VirtualPermutation[];
   resolved: ResolvedTokens;
-  permutationsResolved: Record<string, ResolvedTokens>;
   diagnostics: readonly VirtualDiagnostic[];
   cssVarPrefix: string;
   /**
@@ -111,6 +109,8 @@ function buildPermutationNameByTuple(
   return out;
 }
 
+const noPermutationName = (): string | undefined => undefined;
+
 function tuplesEqual(a: Record<string, string>, b: Record<string, string>): boolean {
   const keys = new Set([...Object.keys(a), ...Object.keys(b)]);
   for (const k of keys) {
@@ -156,18 +156,28 @@ function makeResolveAt(snapshot: {
 }
 
 /**
- * Build the `resolveAt` accessor for a snapshot, falling back to
- * indexing `permutationsResolved` by tuple name when the snapshot
- * pre-dates the wire format change and doesn't carry `cells`.
+ * Build the `resolveAt` accessor for a snapshot. Prefers the
+ * snapshot's own `resolveAt` (the addon's preview decorator
+ * pre-builds one at module load — see `previewResolveAt` in
+ * `packages/addon/src/preview.tsx`), falling back to constructing
+ * one from `cells` + `jointOverrides` when present (covers
+ * hand-built test snapshots and the no-provider path) and finally to
+ * the legacy per-permutation lookup for snapshots that only carry
+ * `permutationsResolved` + `permutations` (MDX consumers that
+ * pre-date the wire format change).
  */
 function snapshotResolveAt(
   snapshot: ProjectSnapshot,
 ): (tuple: Record<string, string>) => ResolvedTokens {
+  if (snapshot.resolveAt)
+    return snapshot.resolveAt as (tuple: Record<string, string>) => ResolvedTokens;
   const hasCells = Object.keys(snapshot.cells ?? {}).length > 0;
   if (hasCells) return makeResolveAt(snapshot);
   return (tuple) => {
-    const name = nameForTuple(snapshot.permutations, tuple) ?? snapshot.activePermutation;
-    return snapshot.permutationsResolved[name] ?? {};
+    const perms = snapshot.permutations ?? [];
+    const resolved = snapshot.permutationsResolved ?? {};
+    const name = nameForTuple(perms, tuple) ?? snapshot.activePermutation;
+    return resolved[name] ?? {};
   };
 }
 
@@ -203,8 +213,6 @@ export function useProject(): ProjectData {
   const cells = snapshot?.cells;
   const jointOverrides = snapshot?.jointOverrides;
   const dataDefaultTuple = snapshot?.defaultTuple;
-  const permutations = snapshot?.permutations;
-  const permutationsResolved = snapshot?.permutationsResolved;
   const activePermutation = snapshot?.activePermutation;
   const resolveAt = useMemo(() => {
     if (!snapshot) return null;
@@ -212,18 +220,10 @@ export function useProject(): ProjectData {
     // The deps below are deliberately the stable inner fields rather
     // than `snapshot` itself; see the long block comment above.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    axes,
-    cells,
-    jointOverrides,
-    dataDefaultTuple,
-    permutations,
-    permutationsResolved,
-    activePermutation,
-  ]);
+  }, [axes, cells, jointOverrides, dataDefaultTuple, activePermutation]);
   const permutationNameByTuple = useMemo(
-    () => buildPermutationNameByTuple(permutations ?? []),
-    [permutations],
+    () => buildPermutationNameByTuple(snapshot?.permutations ?? []),
+    [snapshot?.permutations],
   );
   const fallback = useVirtualModuleFallback(snapshot === null);
   if (snapshot !== null && resolveAt !== null) {
@@ -245,8 +245,6 @@ function snapshotToData(
     // the same memo-stability bug `resolveAt` had.
     activeAxes: snapshot.activeAxes as Record<string, string>,
     axes: snapshot.axes,
-    permutations: snapshot.permutations,
-    permutationsResolved: snapshot.permutationsResolved,
     resolved: resolveAt(snapshot.activeAxes),
     diagnostics: snapshot.diagnostics,
     cssVarPrefix: snapshot.cssVarPrefix,
@@ -280,13 +278,13 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     ? { ...contextAxes }
     : (channelGlobals.axes ?? defaultTuple(tokens.axes));
 
-  const derivedName = nameForTuple(tokens.permutations, activeAxes);
+  // No more `permutations` / `permutationsResolved` on the wire —
+  // synthesize an active-permutation name from the tuple instead
+  // (same form `permutationID` produced server-side: axis values
+  // joined by ` · `). Used only for the legacy
+  // `data-<prefix>-theme` attribute on swatches.
   const activePermutation =
-    contextPermutation ||
-    derivedName ||
-    tokens.defaultPermutation ||
-    tokens.permutations[0]?.name ||
-    '';
+    contextPermutation || tokens.axes.map((a) => activeAxes[a.name] ?? a.default).join(' · ') || '';
 
   // `buildResolveAt` returns a closure that memoizes on the canonical
   // tuple key, so wrapping the call in another `useMemo` would be
@@ -304,24 +302,22 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     [tokens.axes, tokens.cells, tokens.jointOverrides, tokens.defaultTuple],
   );
   const resolved = resolveAt(activeAxes);
-  const permutationNameByTuple = useMemo(
-    () => buildPermutationNameByTuple(tokens.permutations),
-    [tokens.permutations],
-  );
+  // No permutations list to index against — consumers
+  // (`AxisVariance`'s grid) treat `undefined` as "no theme name"
+  // and fall through to rendering without the data-theme attribute.
+  const permutationNameForTuple = noPermutationName;
 
   return {
     activePermutation,
     activeAxes,
     axes: tokens.axes,
-    permutations: tokens.permutations,
-    permutationsResolved: tokens.permutationsResolved,
     resolved,
     diagnostics: tokens.diagnostics,
     cssVarPrefix: tokens.cssVarPrefix,
     listing: tokens.listing,
     varianceByPath: tokens.varianceByPath,
     resolveAt,
-    permutationNameForTuple: (tuple) => permutationNameByTuple.get(canonicalTupleKey(tuple)),
+    permutationNameForTuple,
   };
 }
 

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -22,7 +22,6 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
     token,
     cssVar,
     axes,
-    permutations,
     activeAxes,
     cssVarPrefix,
     varianceByPath,
@@ -52,7 +51,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
     return { kind, varyingAxes: result.varyingAxes };
   }, [path, varianceByPath]);
 
-  if (permutations.length === 0) {
+  if (axes.length === 0) {
     return <></>;
   }
 
@@ -73,9 +72,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
                   />
                 )}
                 {value}
-                <span style={{ opacity: 0.6, marginLeft: 8 }}>
-                  same across all {permutations.length} tuples
-                </span>
+                <span style={{ opacity: 0.6, marginLeft: 8 }}>same across every axis</span>
               </td>
             </tr>
           </tbody>

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -1,4 +1,4 @@
-import type { Axis, Permutation } from '@unpunnyfuns/swatchbook-core';
+import type { Axis } from '@unpunnyfuns/swatchbook-core';
 import type { VirtualVarianceByPathShape } from '#/contexts.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 
@@ -26,8 +26,6 @@ export interface TokenDetailData {
   activePermutation: string;
   activeAxes: Record<string, string>;
   axes: readonly Axis[];
-  permutations: readonly Permutation[];
-  permutationsResolved: Record<string, Record<string, DetailToken>>;
   resolved: Record<string, DetailToken>;
   cssVarPrefix: string;
   varianceByPath: VirtualVarianceByPathShape;
@@ -53,8 +51,6 @@ export function useTokenDetailData(path: string): TokenDetailData {
     activePermutation,
     activeAxes,
     axes,
-    permutations,
-    permutationsResolved,
     resolved,
     cssVarPrefix,
     varianceByPath,
@@ -68,8 +64,6 @@ export function useTokenDetailData(path: string): TokenDetailData {
     activePermutation,
     activeAxes,
     axes,
-    permutations,
-    permutationsResolved: permutationsResolved as Record<string, Record<string, DetailToken>>,
     resolved: typedResolved,
     cssVarPrefix,
     varianceByPath,

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -71,9 +71,6 @@ declare module 'virtual:swatchbook/tokens' {
 
   export const axes: readonly VirtualAxis[];
   export const presets: readonly VirtualPreset[];
-  export const permutations: readonly VirtualPermutation[];
-  export const defaultPermutation: string | null;
-  export const permutationsResolved: Record<string, Record<string, VirtualToken>>;
   export const diagnostics: readonly VirtualDiagnostic[];
   export const css: string;
   export const cssVarPrefix: string;

--- a/packages/blocks/test/_color-table-helpers.tsx
+++ b/packages/blocks/test/_color-table-helpers.tsx
@@ -1,6 +1,17 @@
-import type { ProjectSnapshot } from '#/index.ts';
+import type { ProjectSnapshot, VirtualTokenShape } from '#/index.ts';
 
-export function makeColorTableSnapshot(): ProjectSnapshot {
+/**
+ * Test snapshot using the legacy `permutationsResolved` shape — the
+ * `snapshotResolveAt` fallback path in `use-project` covers this for
+ * hand-built snapshots. `permutationsResolved` is typed as the wider
+ * `Record<…>` rather than inferred from the literal so tests can
+ * extend the map with extra paths after construction.
+ */
+export interface ColorTableSnapshot extends ProjectSnapshot {
+  permutationsResolved: Record<string, Record<string, VirtualTokenShape>>;
+}
+
+export function makeColorTableSnapshot(): ColorTableSnapshot {
   return {
     axes: [{ name: 'mode', contexts: ['light'], default: 'light', source: 'resolver' }],
     disabledAxes: [],


### PR DESCRIPTION
First half of the cartesian-shape-drop chain's PR 6 (split for review clarity; the \`loadProject\` rewrite is PR 6b). Consumer-side cleanup only — no algorithmic changes in \`loadProject\` yet.

Closes #793 (lift \`resolveAt\` to the provider) and the wire-format drop of \`permutations\` / \`permutationsResolved\` / \`defaultPermutation\` from PR 6.

## Summary

- **Lift**: The addon's preview decorator builds a single \`previewResolveAt\` at module load over the stable virtual-module exports and ships it as \`snapshot.resolveAt\` through \`SwatchbookContext\`. Blocks' \`useProject\` reads it directly — no per-render rebuild, no memo gymnastics.
- **Wire drop**: \`virtual:swatchbook/tokens\` no longer exports \`permutations\`, \`permutationsResolved\`, or \`defaultPermutation\`. Same fields dropped from the HMR \`INIT_EVENT\` payload + the per-package \`virtual.d.ts\`.
- **Remaining addon-side consumers migrated**:
  - \`packages/addon/src/preset.ts\` codegen → iterates \`project.varianceByPath.keys()\` for token paths.
  - \`packages/addon/src/virtual/plugin.ts\` HMR-reload log → \`project.varianceByPath.size\`.
  - \`packages/addon/src/hooks/use-token.ts\` → reads \`snapshot.resolveAt\` when a provider is mounted, or a module-level \`fallbackResolveAt\` built from the virtual exports otherwise.
- **Block-side cleanup**:
  - \`ProjectData\` drops the now-unused \`permutations\` / \`permutationsResolved\` fields.
  - \`AxisVariance\` early-exits on \`axes.length === 0\` and drops the \"all N tuples\" count from the constant-token caption (the count is misleading at scale and the data going away).
  - \`useVirtualModuleFallback\` synthesizes the active permutation name from the tuple (\`axisValues.join(' · ')\`) instead of looking it up.
- **Preview decorator** synthesizes the legacy \`data-<prefix>-theme\` attribute by joining tuple values — same form \`permutationID\` produced server-side. \`tupleForName\` parses it back by zipping with \`virtualAxes\` order.
- **\`ProjectSnapshot\`** keeps \`permutations\` and \`permutationsResolved\` as optional fields so hand-built test snapshots (the \`_color-table-helpers\` fixture, MDX consumers) keep working through the \`snapshotResolveAt\` fallback path.

## Doesn't change

- \`Project.permutations\` and \`Project.permutationsResolved\` still exist on the core type. \`loadProject\` still materializes them. \`projectCss\` (cartesian emit) still works. **PR 6b is the algorithmic rewrite that drops the materialization.**
- MCP tool surface unchanged.

## Verification

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 tasks
- [x] \`pnpm --filter swatchbook-storybook test:storybook\` — 149/149 stories, 0 \"Maximum update depth\" errors
- [x] Fixed one storybook assertion that was matching the old \"same across all N tuples\" string; now matches \"same across every axis\".

Milestone: Maintenance
Closes #797
Plan impact: First half of the original PR 6 split. The actual cartesian materialization drops in PR 6b — the consumer surface (this PR) is the easier half; the loadProject rewrite is the harder algorithmic half.