### PR TITLE
refactor(core): smart emitter + analyzeProjectVariance Phase 1 reads project.cells

### DIFF
--- a/.changeset/smart-emitter-variance-cells-phase-1.md
+++ b/.changeset/smart-emitter-variance-cells-phase-1.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+"@unpunnyfuns/swatchbook-mcp": patch
+"@unpunnyfuns/swatchbook-integrations": patch
+---
+
+`@unpunnyfuns/swatchbook-core`: smart emitter (`emitAxisProjectedCss`) and `analyzeProjectVariance` switch their Phase 1 cell construction from `findPermByTuple(permutations, …) → permutationsResolved[name]` to reading `project.cells` directly. Internal refactor only — same output for every fixture, just sourced from the bounded per-axis surface instead of the cartesian map. Phase 3 (joint case probing + lookup) still uses the resolver + `permutationsResolved`; that moves in the next PR alongside the loadProject rewrite. No public API changes.

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -2,7 +2,7 @@ import type { TokenNormalized } from '@terrazzo/parser';
 import { generateShorthand, makeCSSVar, transformCSSValue } from '@terrazzo/token-tools/css';
 import { CHROME_ROLES, CHROME_VAR_PREFIX, DEFAULT_CHROME_MAP } from '#/chrome.ts';
 import { dataAttr } from '#/css.ts';
-import type { Axis, Permutation, Project, TokenMap } from '#/types.ts';
+import type { Project, TokenMap } from '#/types.ts';
 import { analyzeProjectVariance, type JointCase, type VarianceInfo } from '#/variance-analysis.ts';
 
 /** @internal Addon-internal smart-emitter options. Not part of the public API. */
@@ -80,30 +80,21 @@ export function emitAxisProjectedCss(
   const transformAlias = (token: TokenNormalized): string =>
     makeCSSVar(token.id, { ...varOpts, wrapVar: true });
 
-  const { axes, permutations, permutationsResolved } = project;
+  const { axes, permutationsResolved } = project;
   const variance = options.variance ?? analyzeProjectVariance(project);
 
-  const defaultTuple = buildDefaultTuple(axes);
-  const baselinePerm =
-    axes.length > 0 ? findPermutationByTuple(permutations, defaultTuple) : permutations[0];
+  const defaultTuple = project.defaultTuple;
+  const firstAxis = axes[0];
+  const baselineTokens = firstAxis ? project.cells[firstAxis.name]?.[firstAxis.default] : undefined;
 
   const blocks: string[] = [];
 
   // 1. Baseline `:root` — every token's baseline value lives here.
   //    Baseline-only tokens never appear elsewhere; all other variance
   //    kinds also need a baseline value to start the cascade from.
-  if (baselinePerm) {
-    const baselineTokens = permutationsResolved[baselinePerm.name];
-    if (baselineTokens) {
-      const lines = collectLines(
-        baselineTokens,
-        () => true,
-        baselinePerm.input,
-        varOpts,
-        transformAlias,
-      );
-      if (lines.length > 0) blocks.push(`:root {\n${lines.join('\n')}\n}`);
-    }
+  if (baselineTokens) {
+    const lines = collectLines(baselineTokens, () => true, defaultTuple, varOpts, transformAlias);
+    if (lines.length > 0) blocks.push(`:root {\n${lines.join('\n')}\n}`);
   }
 
   // 2. Per-axis singleton cells — emit every token this axis touches.
@@ -115,16 +106,14 @@ export function emitAxisProjectedCss(
   for (const axis of axes) {
     for (const ctx of axis.contexts) {
       if (ctx === axis.default) continue;
-      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
-      const cellPerm = findPermutationByTuple(permutations, cellTuple);
-      if (!cellPerm) continue;
-      const cellTokens = permutationsResolved[cellPerm.name];
+      const cellTokens = project.cells[axis.name]?.[ctx];
       if (!cellTokens) continue;
+      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
 
       const lines = collectLines(
         cellTokens,
         (path) => axisTouchesToken(axis.name, variance.get(path)),
-        cellPerm.input,
+        cellTuple,
         varOpts,
         transformAlias,
       );
@@ -317,25 +306,6 @@ function* collectTokenDeclarations(
   }
   const shorthand = generateShorthand({ token, localID });
   if (shorthand) yield { varName, value: shorthand };
-}
-
-function buildDefaultTuple(axes: readonly Axis[]): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const axis of axes) out[axis.name] = axis.default;
-  return out;
-}
-
-function findPermutationByTuple(
-  permutations: readonly Permutation[],
-  tuple: Readonly<Record<string, string>>,
-): Permutation | undefined {
-  const keys = Object.keys(tuple);
-  return permutations.find((perm) => {
-    for (const key of keys) {
-      if (perm.input[key] !== tuple[key]) return false;
-    }
-    return Object.keys(perm.input).length === keys.length;
-  });
 }
 
 function cssEscape(name: string): string {

--- a/packages/core/src/variance-analysis.ts
+++ b/packages/core/src/variance-analysis.ts
@@ -116,24 +116,22 @@ export function analyzeProjectVariance(project: Project): Map<string, VarianceIn
   }
 
   // Phase 1 — locate the baseline tuple + per-axis non-default cells.
-  const defaultTuple: Record<string, string> = {};
-  for (const axis of axes) defaultTuple[axis.name] = axis.default;
-  const baselinePerm = findPermByTuple(permutations, defaultTuple);
-  const baseline: TokenMap = baselinePerm
-    ? (permutationsResolved[baselinePerm.name] ?? {})
+  // Reads directly from `project.cells` rather than reconstructing
+  // from `permutationsResolved`. `Project.cells` is the bounded
+  // per-axis surface; cartesian materialization is on its way out.
+  const defaultTuple = project.defaultTuple;
+  const firstAxis = axes[0];
+  const baseline: TokenMap = firstAxis
+    ? (project.cells[firstAxis.name]?.[firstAxis.default] ?? project.graph)
     : project.graph;
 
-  // cells[axis.name][ctx] = TokenMap for { ...defaults, [axis.name]: ctx }.
-  // Missing cells (resolver pruned a tuple, disabledAxes filtered it) are
-  // treated as "no overlay" — the token's value at that cell equals baseline.
   const cells: Record<string, Record<string, TokenMap>> = {};
   for (const axis of axes) {
     const axisCells: Record<string, TokenMap> = {};
     for (const ctx of axis.contexts) {
       if (ctx === axis.default) continue;
-      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
-      const cellPerm = findPermByTuple(permutations, cellTuple);
-      if (cellPerm) axisCells[ctx] = permutationsResolved[cellPerm.name] ?? {};
+      const cell = project.cells[axis.name]?.[ctx];
+      if (cell) axisCells[ctx] = cell;
     }
     cells[axis.name] = axisCells;
   }


### PR DESCRIPTION
First sub-PR of PR 6b's split (review-clarity split #2; the loadProject rewrite + public API drops are the next PR). Internal refactor only — no public API changes, no behavior changes, no fixture updates.

## Summary

\`emitAxisProjectedCss\` (smart emitter) and \`analyzeProjectVariance\` switch their Phase 1 cell construction from \`findPermByTuple(project.permutations, …) → project.permutationsResolved[name]\` to reading \`project.cells\` directly. Same per-cell TokenMap; bounded surface; no cartesian dependency for this phase.

- \`packages/core/src/css-axis-projected.ts\`: baseline tokens come from \`project.cells[firstAxis.name]?.[firstAxis.default]\`; per-axis singleton cells from \`project.cells[axis.name]?.[ctx]\`. Drops the dead \`buildDefaultTuple\` + \`findPermutationByTuple\` helpers and the \`Permutation\` import.
- \`packages/core/src/variance-analysis.ts\`: Phase 1 reads \`project.cells\` (with the corresponding default-cell fallback for baseline). Phase 3 (joint probe via \`resolver.apply\` + lookup into \`permutationsResolved[jointPerm.name]\` for JointCase \`permutationName\`) is **unchanged** — moves in the next PR alongside the \`buildJointOverrides\` rewrite.

## Doesn't change

- \`loadProject\` still materializes \`Project.permutations\` + \`Project.permutationsResolved\`.
- \`projectCss\` (cartesian emitter) still works.
- All public API surfaces unchanged.
- Test fixtures unchanged.

## Verification

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 tasks
- [x] \`pnpm --filter swatchbook-storybook test:storybook\` — 149/149 stories, 0 \"Maximum update depth\" errors
- [x] Smart emitter output for the reference fixture is byte-identical to current main

Milestone: Maintenance
Closes #800
Plan impact: PR 6b-i of the cartesian-shape-drop chain (split from #799 for review clarity). One more PR (the loadProject rewrite + public API drops) closes out the chain.