### PR TITLE
refactor(core): smart emitter + analyzeProjectVariance Phase 3 reads project.jointOverrides

### DIFF
--- a/.changeset/smart-emitter-variance-phase3-joint-overrides.md
+++ b/.changeset/smart-emitter-variance-phase3-joint-overrides.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+"@unpunnyfuns/swatchbook-mcp": patch
+"@unpunnyfuns/swatchbook-integrations": patch
+---
+
+`@unpunnyfuns/swatchbook-core`: smart emitter (`emitAxisProjectedCss`) compound-block emission and `analyzeProjectVariance` Phase 3 read from `project.jointOverrides` directly. The smart emitter iterates overrides for N-arity compound selectors (pairs / triples / etc. uniformly); the variance analysis derives the legacy pair-shape `JointCase` array from the same overrides for back-compat. No more `findPermByTuple` + `permutationsResolved[jointCase.permutationName]` lookup in either path. Internal refactor; same output for every fixture. `loadProject` still materializes the cartesian map; that goes in the next PR.

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -3,7 +3,7 @@ import { generateShorthand, makeCSSVar, transformCSSValue } from '@terrazzo/toke
 import { CHROME_ROLES, CHROME_VAR_PREFIX, DEFAULT_CHROME_MAP } from '#/chrome.ts';
 import { dataAttr } from '#/css.ts';
 import type { Project, TokenMap } from '#/types.ts';
-import { analyzeProjectVariance, type JointCase, type VarianceInfo } from '#/variance-analysis.ts';
+import { analyzeProjectVariance, type VarianceInfo } from '#/variance-analysis.ts';
 
 /** @internal Addon-internal smart-emitter options. Not part of the public API. */
 export interface EmitAxisProjectedCssOptions {
@@ -80,7 +80,7 @@ export function emitAxisProjectedCss(
   const transformAlias = (token: TokenNormalized): string =>
     makeCSSVar(token.id, { ...varOpts, wrapVar: true });
 
-  const { axes, permutationsResolved } = project;
+  const { axes } = project;
   const variance = options.variance ?? analyzeProjectVariance(project);
 
   const defaultTuple = project.defaultTuple;
@@ -123,19 +123,13 @@ export function emitAxisProjectedCss(
     }
   }
 
-  // 3. Compound joint cells — one block per unique `(axisA, ctxA, axisB,
-  //    ctxB)` combination across all joint-variant tokens. The block
-  //    carries the spec-correct cartesian values for each token that
-  //    diverges from projection composition at that joint tuple.
-  //    Compound selector specificity beats the singleton cells, so the
-  //    joint cell wins where it applies.
-  for (const block of collectJointBlocks(
-    variance,
-    permutationsResolved,
-    prefix,
-    varOpts,
-    transformAlias,
-  )) {
+  // 3. Compound joint cells — one block per `Project.jointOverrides`
+  //    entry. Each override carries the cartesian-correct values for
+  //    the divergent tokens at that partial tuple; the block selector
+  //    is built from the override's axes (N-arity supported — pairs,
+  //    triples, etc.). Compound-selector specificity beats the
+  //    singleton cells, so the joint cell wins where it applies.
+  for (const block of collectJointBlocks(project, prefix, varOpts, transformAlias)) {
     blocks.push(block);
   }
 
@@ -178,55 +172,44 @@ function axisTouchesToken(axisName: string, info: VarianceInfo | undefined): boo
 }
 
 /**
- * Group every joint-variant token's `jointCases` by their compound
- * selector key (`axisA|ctxA|axisB|ctxB`), then emit one block per
- * unique key containing the cartesian-correct values for each token's
- * joint case. Each token's joint value is pulled from the corresponding
- * permutation's resolved TokenMap (the `permutationName` recorded
- * during analysis), so it goes through the same Terrazzo-side resolution
- * as cartesian emit would.
+ * Iterate `Project.jointOverrides` and emit one compound-selector
+ * block per entry. Each override entry carries the spec-correct
+ * cartesian values for its divergent tokens at the entry's partial
+ * tuple, so the block content comes from the override's `tokens` map
+ * directly — no \`permutationsResolved[jointCase.permutationName]\`
+ * roundtrip.
+ *
+ * Selector arity matches the override's `axes` arity — pairs produce
+ * `[data-A="a"][data-B="b"]`, triples produce a 3-attribute compound
+ * selector, etc. Compound-selector specificity beats the singleton
+ * cells emitted in Phase 2.
+ *
+ * Composite tokens with alias references resolve against
+ * `project.resolveAt(fullTuple)` — the full TokenMap at the joint
+ * tuple, so cross-token aliases find their targets.
  */
 function collectJointBlocks(
-  variance: Map<string, VarianceInfo>,
-  permutationsResolved: Record<string, TokenMap>,
+  project: Project,
   prefix: string,
   varOpts: VarOpts,
   transformAlias: (token: TokenNormalized) => string,
 ): string[] {
-  const grouped = new Map<string, { path: string; jointCase: JointCase }[]>();
-  for (const [path, info] of variance) {
-    if (info.kind !== 'joint-variant') continue;
-    for (const jointCase of info.jointCases) {
-      const key = `${jointCase.axisA}|${jointCase.ctxA}|${jointCase.axisB}|${jointCase.ctxB}`;
-      const bucket = grouped.get(key) ?? [];
-      bucket.push({ path, jointCase });
-      grouped.set(key, bucket);
-    }
-  }
-
   const blocks: string[] = [];
-  for (const [key, entries] of grouped) {
-    const parts = key.split('|');
-    const axisA = parts[0] as string;
-    const ctxA = parts[1] as string;
-    const axisB = parts[2] as string;
-    const ctxB = parts[3] as string;
-    const selector = `[${dataAttr(prefix, axisA)}="${cssEscape(ctxA)}"][${dataAttr(prefix, axisB)}="${cssEscape(ctxB)}"]`;
+  for (const override of project.jointOverrides.values()) {
+    const fullTuple = { ...project.defaultTuple, ...override.axes };
+    const fullTokens = project.resolveAt(fullTuple);
+    const axisEntries = Object.entries(override.axes);
+    const selector = axisEntries
+      .map(([axisName, ctx]) => `[${dataAttr(prefix, axisName)}="${cssEscape(ctx)}"]`)
+      .join('');
 
     const lines: string[] = [];
-    for (const { path, jointCase } of entries) {
-      const cellTokens = permutationsResolved[jointCase.permutationName];
-      if (!cellTokens) continue;
-      const token = cellTokens[path];
-      if (!token) continue;
+    for (const [path, token] of Object.entries(override.tokens)) {
       for (const decl of collectTokenDeclarations(
         path,
         token,
-        cellTokens,
-        // Use the joint permutation's input as the resolution context —
-        // composite token sub-fields and alias references are resolved
-        // against the joint tuple, matching what cartesian emit would do.
-        jointInputFromCase(jointCase),
+        fullTokens,
+        fullTuple,
         varOpts,
         transformAlias,
       )) {
@@ -237,16 +220,6 @@ function collectJointBlocks(
   }
 
   return blocks;
-}
-
-/**
- * Reconstruct a partial `permutation.input` from a JointCase. Used as
- * the `permutation` context for `transformCSSValue` — composite tokens
- * and aliases resolve against the joint tuple. Other axes default
- * naturally during transform; the joint axes are the load-bearing ones.
- */
-function jointInputFromCase(jointCase: JointCase): Record<string, string> {
-  return { [jointCase.axisA]: jointCase.ctxA, [jointCase.axisB]: jointCase.ctxB };
 }
 
 /**

--- a/packages/core/src/variance-analysis.ts
+++ b/packages/core/src/variance-analysis.ts
@@ -1,5 +1,5 @@
 import type { TokenNormalized } from '@terrazzo/parser';
-import type { Axis, Project, TokenMap } from '#/types.ts';
+import { permutationID, type Project, type TokenMap } from '#/types.ts';
 
 /**
  * Per-token variance classification across a loaded project's axes.
@@ -105,7 +105,7 @@ export interface JointCase {
  */
 export function analyzeProjectVariance(project: Project): Map<string, VarianceInfo> {
   const result = new Map<string, VarianceInfo>();
-  const { axes, permutations, permutationsResolved, parserInput } = project;
+  const { axes } = project;
 
   if (axes.length === 0) {
     // No axes → every token is baseline-only. Skip the cell + probe work.
@@ -163,11 +163,40 @@ export function analyzeProjectVariance(project: Project): Map<string, VarianceIn
     touchingByPath.set(path, new Set(cached?.varyingAxes ?? []));
   }
 
-  // Partition + Phase 3 (joint probe for multi-touch only). Phase 3 needs
-  // resolver.apply, which only resolver-backed projects have; for layered
-  // / plain-parse we conservatively mark multi-touch as joint-variant
-  // (empty jointCases — emitter falls back to cartesian-style emit).
-  const resolver = parserInput?.resolver;
+  // Phase 3 — derive joint-variant kind from `project.jointOverrides`
+  // instead of running an ad-hoc resolver probe. The overrides were
+  // computed once at load time and carry the same divergence
+  // information; reading from them avoids a duplicate probe pass on
+  // every emit.
+  const jointCasesByPath = new Map<string, JointCase[]>();
+  for (const override of project.jointOverrides.values()) {
+    const axisEntries = Object.entries(override.axes);
+    if (axisEntries.length < 2) continue;
+    // Flatten N-arity overrides into all pair sub-combinations so the
+    // pair-shaped `JointCase` surface keeps working for consumers
+    // that depend on it (analyzeProjectVariance tests + any external
+    // tooling). The smart emitter itself iterates `jointOverrides`
+    // at full arity for compound-block emission.
+    for (let i = 0; i < axisEntries.length; i++) {
+      for (let j = i + 1; j < axisEntries.length; j++) {
+        const [axisA, ctxA] = axisEntries[i] as [string, string];
+        const [axisB, ctxB] = axisEntries[j] as [string, string];
+        for (const [path, token] of Object.entries(override.tokens)) {
+          const list = jointCasesByPath.get(path) ?? [];
+          const fullTuple = { ...defaultTuple, ...override.axes };
+          list.push({
+            axisA,
+            ctxA,
+            axisB,
+            ctxB,
+            cartesianValueKey: valueKey(token),
+            permutationName: permutationID(fullTuple),
+          });
+          jointCasesByPath.set(path, list);
+        }
+      }
+    }
+  }
 
   for (const [path, touching] of touchingByPath) {
     if (touching.size === 0) {
@@ -179,25 +208,7 @@ export function analyzeProjectVariance(project: Project): Map<string, VarianceIn
       result.set(path, { kind: 'single-axis', axis: axis as string });
       continue;
     }
-
-    if (!resolver) {
-      // Conservative: treat as joint-variant. Empty jointCases — the emitter
-      // signals "I can't determine joint correctness, emit cartesian-style."
-      result.set(path, { kind: 'joint-variant', touching, jointCases: [] });
-      continue;
-    }
-
-    const jointCases = probeJointPairs(
-      path,
-      touching,
-      axes,
-      defaultTuple,
-      cells,
-      baseline,
-      resolver,
-      permutations,
-      permutationsResolved,
-    );
+    const jointCases = jointCasesByPath.get(path) ?? [];
     if (jointCases.length === 0) {
       result.set(path, { kind: 'orthogonal-after-probe', touching });
     } else {
@@ -206,98 +217,6 @@ export function analyzeProjectVariance(project: Project): Map<string, VarianceIn
   }
 
   return result;
-}
-
-/**
- * For a multi-touch token, probe every pair of touching axes at every
- * non-default combination. Compare the cartesian-resolved value against
- * what projection composition would produce; record the divergences.
- *
- * Composition assumes the "smart dedup" rule: a cell re-emits its value
- * for any token touched by ANY cell (not just when this cell differs
- * from baseline). Under that rule, projection composition at a joint
- * `(A, B)` tuple equals the value of whichever of `cells[A][ctx_a]` /
- * `cells[B][ctx_b]` is emitted later in source order — by axis iteration
- * order. We match that by checking the B-cell value (B iterated after A).
- */
-function probeJointPairs(
-  path: string,
-  touching: ReadonlySet<string>,
-  axes: readonly Axis[],
-  defaultTuple: Record<string, string>,
-  cells: Record<string, Record<string, TokenMap>>,
-  baseline: TokenMap,
-  resolver: NonNullable<Project['parserInput']>['resolver'],
-  permutations: Project['permutations'],
-  permutationsResolved: Project['permutationsResolved'],
-): JointCase[] {
-  const cases: JointCase[] = [];
-  // Stable axis-pair iteration in project axis order — gives deterministic
-  // output and matches the cascade order the emitter will use.
-  const touchingAxes = axes.filter((a) => touching.has(a.name));
-
-  for (let i = 0; i < touchingAxes.length; i++) {
-    for (let j = i + 1; j < touchingAxes.length; j++) {
-      const axisA = touchingAxes[i] as Axis;
-      const axisB = touchingAxes[j] as Axis;
-      const cellsA = cells[axisA.name] ?? {};
-      const cellsB = cells[axisB.name] ?? {};
-
-      for (const ctxA of Object.keys(cellsA)) {
-        for (const ctxB of Object.keys(cellsB)) {
-          // Cartesian truth via resolver.apply.
-          const jointTuple = { ...defaultTuple, [axisA.name]: ctxA, [axisB.name]: ctxB };
-          const cartesianTokens = resolver.apply(jointTuple);
-          const cartesianValueKey = valueKey(cartesianTokens[path]);
-
-          // Projection composition under smart dedup: B is later in source
-          // order than A, so B's cell value wins when both touch the token.
-          // Falls back to A if only A's cell holds a value, else baseline.
-          const projectionValueKey =
-            valueKey(cellsB[ctxB]?.[path]) ||
-            valueKey(cellsA[ctxA]?.[path]) ||
-            valueKey(baseline[path]);
-
-          if (cartesianValueKey === projectionValueKey) continue;
-
-          // Divergence — record the joint case. Look up the permutation
-          // name so downstream emit can find the full TokenNormalized.
-          const jointPerm = findPermByTuple(permutations, jointTuple);
-          if (!jointPerm) continue;
-          if (permutationsResolved[jointPerm.name] === undefined) continue;
-          cases.push({
-            axisA: axisA.name,
-            ctxA,
-            axisB: axisB.name,
-            ctxB,
-            cartesianValueKey,
-            permutationName: jointPerm.name,
-          });
-        }
-      }
-    }
-  }
-
-  return cases;
-}
-
-/**
- * Locate the permutation whose `input` exactly matches the given tuple.
- * Returns `undefined` when no permutation matches — happens when
- * `disabledAxes` filtered the tuple out, or when the resolver's
- * cartesian was pruned. Callers handle this as "no overlay applies."
- */
-function findPermByTuple(
-  permutations: Project['permutations'],
-  tuple: Readonly<Record<string, string>>,
-): Project['permutations'][number] | undefined {
-  const keys = Object.keys(tuple);
-  return permutations.find((perm) => {
-    for (const key of keys) {
-      if (perm.input[key] !== tuple[key]) return false;
-    }
-    return Object.keys(perm.input).length === keys.length;
-  });
 }
 
 /**


### PR DESCRIPTION
Same shape as #801 but for Phase 3 — the joint-block emission + joint-case derivation now read from \`project.jointOverrides\` directly instead of \`findPermByTuple\` + \`project.permutationsResolved[jointCase.permutationName]\`. \`loadProject\` still materializes the cartesian map; this PR gets the last consumers off it. The actual cartesian drop is the next PR.

## Summary

- **\`collectJointBlocks\`** iterates \`project.jointOverrides.values()\` and emits one compound-selector block per entry. Selector arity matches override arity uniformly (pairs / triples / etc.). Composite token alias resolution runs against \`project.resolveAt(fullTuple)\` so cross-token references find their targets.
- **\`analyzeProjectVariance\` Phase 3** derives the legacy pair-shape \`JointCase\` array by walking \`project.jointOverrides\` — each override gets flattened to all pair sub-combinations. Same output for the reference fixture's pair-only overrides; back-compat with any consumer reading \`VarianceInfo['joint-variant'].jointCases\`.
- Drops \`probeJointPairs\` and \`findPermByTuple\` from \`variance-analysis.ts\` (both dead after the Phase 3 rewrite).

## Doesn't change

- \`loadProject\` still materializes \`Project.permutations\` and \`Project.permutationsResolved\`.
- \`buildJointOverrides\` still uses the cartesian-divergence probe.
- \`projectCss\` still works; MCP \`emit_css\` unchanged.
- Public API unchanged.
- Test fixtures unchanged.

## Verification

- [x] \`pnpm turbo run format:check lint typecheck test\` — 37/37 tasks
- [x] \`pnpm --filter swatchbook-storybook test:storybook\` — 149/149 stories, 0 \"Maximum update depth\" errors
- [x] Smart-emitter output for the reference fixture matches pre-PR-6b-i baseline

Milestone: Maintenance
Closes #802
Plan impact: PR 6b-ii of the cartesian-shape-drop chain. One more PR (the loadProject rewrite + public API drops) closes out the chain.