### PR TITLE
refactor(core): buildCells + validateChrome shed permutationsResolved dependency

### DIFF
--- a/.changeset/cells-chrome-off-permutations-resolved.md
+++ b/.changeset/cells-chrome-off-permutations-resolved.md
@@ -1,0 +1,16 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+"@unpunnyfuns/swatchbook-mcp": patch
+"@unpunnyfuns/swatchbook-integrations": patch
+---
+
+Internal migration. Core's own consumers of `Project.permutations` / `permutationsResolved` now route through abstractions that are upstream of the singleton enumeration:
+
+- **`buildCells`** takes a `resolveTuple: (tuple) => TokenMap` callback. Resolver-backed projects pass `resolver.apply` directly (no scan of the singleton enumeration); layered / plain-parse projects pass a lookup over the loader's per-tuple parse output. Drops the `findPermByTuple` helper and the dependence on `Permutation[]` + `Record<string, TokenMap>` inputs.
+- **`validateChrome`** takes a `ReadonlySet<string>` of token IDs instead of iterating `permutationsResolved` itself. `loadProject` computes the set from `varianceByPath.keys()` (same union of every path that appears in any theme, by construction).
+- **`load.ts`** wires both new signatures; `validateChrome` now runs after `varianceByPath` is built so the token-ID set is ready. Order-only change; chrome diagnostics still land in the same `Project.diagnostics` order.
+
+Part 2 of 3 for #815. With this PR, the only remaining `permutationsResolved` reads in core live in `load.ts` itself (the legacy `Project.permutationsResolved` field is still populated for `Project.graph` and the snapshot fallback in `blocks/use-project.ts`). Field removals + public-API exits land in Part 3, blocked on #842 (migrating blocks test snapshots off the legacy fallback).

--- a/packages/core/src/cells.ts
+++ b/packages/core/src/cells.ts
@@ -1,72 +1,54 @@
-import type { Axis, Cells, Permutation, TokenMap } from '#/types.ts';
+import type { Axis, Cells, TokenMap } from '#/types.ts';
 
 /**
- * Derive `Project.cells` from the singleton permutation map. Each
- * non-default `(axis, context)` cell is stored as a **delta** —
- * only tokens whose `$value` differs from the default-cell baseline.
- * The default cell stays as a full TokenMap and serves as the
- * baseline reference for `resolveAt`.
+ * Build `Project.cells` by calling `resolveTuple` once per
+ * `(axis, context)` singleton. Each non-default cell is stored as a
+ * **delta** — only tokens whose `$value` differs from the default-cell
+ * baseline. The default cell stays as a full TokenMap and serves as
+ * the baseline reference for `resolveAt`.
  *
  * Delta cells make `composeAt` correct under sparse composition:
  * `Object.assign(result, cell)` for a later axis can't accidentally
  * overwrite an earlier axis's overlay on a token the later axis
  * doesn't actually touch, because the later axis's delta cell
- * doesn't contain that token. The previous full-TokenMap form
- * relied on "smart-dedup re-emit" in CSS cascade order to recover
- * the right value at multi-axis tuples; with delta cells the
- * composition is straightforwardly correct, and joint overrides
- * handle the few cases where the cartesian truth genuinely
- * diverges from delta composition (recorded by `probeJointOverrides`).
+ * doesn't contain that token. Joint overrides handle the few cases
+ * where the cartesian truth genuinely diverges from delta composition
+ * (recorded by `probeJointOverrides`).
+ *
+ * Caller-supplied `resolveTuple` is the data source: resolver-backed
+ * projects pass `resolver.apply`; layered / plain-parse projects pass
+ * a lookup over the loader's per-tuple parse output. Either way,
+ * `buildCells` doesn't read `Project.permutations` /
+ * `permutationsResolved` — the singleton enumeration is the data
+ * shape it produces, not the data shape it consumes.
  */
 export function buildCells(
   axes: readonly Axis[],
-  permutations: readonly Permutation[],
-  permutationsResolved: Readonly<Record<string, TokenMap>>,
+  resolveTuple: (tuple: Readonly<Record<string, string>>) => TokenMap,
   defaultTuple: Readonly<Record<string, string>>,
 ): Cells {
   const cells: Cells = {};
-  // Locate the default (baseline) TokenMap from the default permutation.
-  const defaultPerm = findPermByTuple(permutations, defaultTuple);
-  const baseline = defaultPerm ? permutationsResolved[defaultPerm.name] : undefined;
-
+  const baseline = resolveTuple(defaultTuple);
   for (const axis of axes) {
     const axisCells: Record<string, TokenMap> = {};
     for (const ctx of axis.contexts) {
-      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
-      const perm = findPermByTuple(permutations, cellTuple);
-      if (!perm) continue;
-      const resolved = permutationsResolved[perm.name];
-      if (!resolved) continue;
-      if (ctx === axis.default || !baseline) {
-        // Default cell — keep the full TokenMap; serves as baseline.
-        axisCells[ctx] = resolved;
-      } else {
-        // Non-default cell — store only tokens that differ from baseline.
-        const delta: TokenMap = {};
-        for (const path of Object.keys(resolved)) {
-          const cellValue = resolved[path];
-          if (!cellValue) continue;
-          if (!sameValue(cellValue, baseline[path])) delta[path] = cellValue;
-        }
-        axisCells[ctx] = delta;
+      if (ctx === axis.default) {
+        axisCells[ctx] = baseline;
+        continue;
       }
+      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
+      const resolved = resolveTuple(cellTuple);
+      const delta: TokenMap = {};
+      for (const path of Object.keys(resolved)) {
+        const cellValue = resolved[path];
+        if (!cellValue) continue;
+        if (!sameValue(cellValue, baseline[path])) delta[path] = cellValue;
+      }
+      axisCells[ctx] = delta;
     }
     cells[axis.name] = axisCells;
   }
   return cells;
-}
-
-function findPermByTuple(
-  permutations: readonly Permutation[],
-  tuple: Readonly<Record<string, string>>,
-): Permutation | undefined {
-  const keys = Object.keys(tuple);
-  return permutations.find((perm) => {
-    for (const key of keys) {
-      if (perm.input[key] !== tuple[key]) return false;
-    }
-    return Object.keys(perm.input).length === keys.length;
-  });
 }
 
 function sameValue(a: unknown, b: unknown): boolean {

--- a/packages/core/src/chrome.ts
+++ b/packages/core/src/chrome.ts
@@ -1,4 +1,4 @@
-import type { Diagnostic, TokenMap } from '#/types.ts';
+import type { Diagnostic } from '#/types.ts';
 
 /**
  * Closed set of roles that swatchbook's block chrome reads. Each role emits
@@ -67,24 +67,24 @@ export interface ChromeValidationResult {
 }
 
 /**
- * Validate `config.chrome` against the project's resolved tokens. Unknown
- * roles (outside `CHROME_ROLES`) and target paths that don't resolve in any
- * theme produce `warn` diagnostics and are dropped. Surviving entries land
- * on `Project.chrome` and override the hard-coded `DEFAULT_CHROME_MAP`
- * literals during CSS emission.
+ * Validate `config.chrome` against the project's known token paths.
+ * Unknown roles (outside `CHROME_ROLES`) and target paths that don't
+ * appear in any theme produce `warn` diagnostics and are dropped.
+ * Surviving entries land on `Project.chrome` and override the
+ * hard-coded `DEFAULT_CHROME_MAP` literals during CSS emission.
+ *
+ * Caller pre-computes `tokenIDs` (typically the union of every path
+ * in `Project.cells` or `Project.varianceByPath.keys()`) so this
+ * function doesn't reach into `permutationsResolved`.
  */
 export function validateChrome(
   raw: Record<string, string> | undefined,
-  permutationsResolved: Record<string, TokenMap>,
+  tokenIDs: ReadonlySet<string>,
 ): ChromeValidationResult {
   const diagnostics: Diagnostic[] = [];
   if (!raw) return { entries: {}, diagnostics };
 
   const known = new Set<string>(CHROME_ROLES);
-  const tokenIDs = new Set<string>();
-  for (const tokens of Object.values(permutationsResolved)) {
-    for (const id of Object.keys(tokens)) tokenIDs.add(id);
-  }
 
   const entries: Record<string, string> = {};
   for (const [role, target] of Object.entries(raw)) {
@@ -116,7 +116,7 @@ export function validateChrome(
  * `typography.body`). Composite tokens emit one CSS var per sub-field,
  * so either form is a valid alias target.
  */
-function targetResolves(target: string, tokenIDs: Set<string>): boolean {
+function targetResolves(target: string, tokenIDs: ReadonlySet<string>): boolean {
   if (tokenIDs.has(target)) return true;
   const lastDot = target.lastIndexOf('.');
   if (lastDot < 0) return false;

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -98,11 +98,6 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     }
   }
 
-  const { entries: chrome, diagnostics: chromeDiagnostics } = validateChrome(
-    config.chrome,
-    filteredResolved,
-  );
-
   const { diagnostics: cssOptionsDiagnostics } = validateCssOptions(config.cssOptions);
 
   // A misconfigured `disabledAxes` (e.g. pinning an axis whose default
@@ -133,21 +128,23 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
         )
       : { listing: {}, diagnostics: [] };
 
-  // Build the cells / jointOverrides / resolveAt surface alongside the
-  // existing cartesian shape. Additive only — downstream consumers can
-  // migrate to the new fields without breaking until a follow-up PR
-  // drops the cartesian materialization. `defaultTuple` here is the
-  // post-disabledAxes-filter version, matching what `cells` is keyed
-  // against.
+  // `defaultTuple` here is the post-disabledAxes-filter version,
+  // matching what `cells` is keyed against.
   const projectDefaultTuple: Record<string, string> = {};
   for (const axis of filteredAxes) projectDefaultTuple[axis.name] = axis.default;
 
-  const cells = buildCells(
-    filteredAxes,
-    filteredPermutations,
-    filteredResolved,
-    projectDefaultTuple,
-  );
+  // `buildCells` calls `resolveTuple` once per `(axis, context)`
+  // singleton. Resolver-backed projects route through `resolver.apply`
+  // directly (no scan of the singleton-enumeration shape); layered /
+  // plain-parse projects look up the loader's per-tuple parse output
+  // by `permutationID(tuple)`. Either way the data source is
+  // upstream of `Project.permutations` / `permutationsResolved`.
+  const resolveTuple = normalized.parserInput?.resolver
+    ? (tuple: Readonly<Record<string, string>>): TokenMap =>
+        normalized.parserInput!.resolver!.apply(tuple as Record<string, string>)
+    : (tuple: Readonly<Record<string, string>>): TokenMap =>
+        filteredResolved[permutationID(tuple)] ?? {};
+  const cells = buildCells(filteredAxes, resolveTuple, projectDefaultTuple);
 
   // Pair-only joint-divergence probe via `resolver.apply` — bounded
   // by `Σ pairs (contexts_a - 1) × (contexts_b - 1)` calls,
@@ -173,6 +170,16 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     cells,
     jointTouching,
     baselineForVariance,
+  );
+
+  // `validateChrome` checks targets against the project's path
+  // universe. `varianceByPath.keys()` is the union of every path
+  // that appears in any theme by construction — same set the prior
+  // `permutationsResolved`-scan produced, computed once at load time.
+  const tokenIDs = new Set<string>(varianceByPath.keys());
+  const { entries: chrome, diagnostics: chromeDiagnostics } = validateChrome(
+    config.chrome,
+    tokenIDs,
   );
 
   return {

--- a/packages/core/test/chrome.test.ts
+++ b/packages/core/test/chrome.test.ts
@@ -4,17 +4,14 @@ import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
 import { CHROME_ROLES, DEFAULT_CHROME_MAP, validateChrome } from '#/chrome';
 import { emitAxisProjectedCss } from '#/css-axis-projected';
 import { loadProject } from '#/load';
-import type { Project, TokenMap } from '#/types';
+import type { Project } from '#/types';
 
 const fixtureCwd = dirname(tokensDir);
 
-const tokensFixture: TokenMap = {
-  'color.palette.blue.500': {} as TokenMap[string],
-  'color.palette.neutral.0': {} as TokenMap[string],
-};
+const tokenIDs = new Set<string>(['color.palette.blue.500', 'color.palette.neutral.0']);
 
 it('validateChrome returns empty when input is undefined', () => {
-  const { entries, diagnostics } = validateChrome(undefined, { Light: tokensFixture });
+  const { entries, diagnostics } = validateChrome(undefined, tokenIDs);
   expect(entries).toEqual({});
   expect(diagnostics).toEqual([]);
 });
@@ -22,7 +19,7 @@ it('validateChrome returns empty when input is undefined', () => {
 it('validateChrome keeps entries whose role is known and target resolves', () => {
   const { entries, diagnostics } = validateChrome(
     { surfaceDefault: 'color.palette.blue.500' },
-    { Light: tokensFixture },
+    tokenIDs,
   );
   expect(entries).toEqual({ surfaceDefault: 'color.palette.blue.500' });
   expect(diagnostics).toEqual([]);
@@ -31,7 +28,7 @@ it('validateChrome keeps entries whose role is known and target resolves', () =>
 it('validateChrome drops unknown roles with a warn diagnostic', () => {
   const { entries, diagnostics } = validateChrome(
     { bogusRole: 'color.palette.blue.500' },
-    { Light: tokensFixture },
+    tokenIDs,
   );
   expect(entries).toEqual({});
   expect(diagnostics).toHaveLength(1);
@@ -41,20 +38,16 @@ it('validateChrome drops unknown roles with a warn diagnostic', () => {
 });
 
 it('validateChrome accepts composite sub-field targets (parent token exists)', () => {
-  const composite: TokenMap = { 'typography.body': {} as TokenMap[string] };
   const { entries, diagnostics } = validateChrome(
     { bodyFontFamily: 'typography.body.font-family' },
-    { Light: composite },
+    new Set(['typography.body']),
   );
   expect(entries).toEqual({ bodyFontFamily: 'typography.body.font-family' });
   expect(diagnostics).toEqual([]);
 });
 
 it('validateChrome drops entries whose target resolves in no theme', () => {
-  const { entries, diagnostics } = validateChrome(
-    { surfaceDefault: 'color.nowhere' },
-    { Light: tokensFixture },
-  );
+  const { entries, diagnostics } = validateChrome({ surfaceDefault: 'color.nowhere' }, tokenIDs);
   expect(entries).toEqual({});
   expect(diagnostics).toHaveLength(1);
   expect(diagnostics[0]?.severity).toBe('warn');


### PR DESCRIPTION
## Summary

Part 2 of 3 for #815. Core's own consumers of `Project.permutations` / `permutationsResolved` now route through abstractions upstream of the singleton enumeration:

- **`buildCells`** takes a `resolveTuple: (tuple) => TokenMap` callback. Resolver-backed projects pass `resolver.apply` directly (no scan of the singleton enumeration); layered / plain-parse projects pass a lookup over the loader's per-tuple parse output. Drops the `findPermByTuple` helper and the dependence on `Permutation[]` + `Record<string, TokenMap>` inputs.
- **`validateChrome`** takes a `ReadonlySet<string>` of token IDs instead of iterating `permutationsResolved` itself. `loadProject` computes the set from `varianceByPath.keys()` — same union of every path across themes, by construction.
- **`load.ts`** wires both new signatures; `validateChrome` now runs after `varianceByPath` is built so the token-ID set is ready. Order-only change in the diagnostics surface; chrome diagnostics still land in the same `Project.diagnostics` order.

With this PR the only remaining `permutationsResolved` reads in core live in `load.ts` itself (`Project.permutationsResolved` is still populated for `Project.graph` + the snapshot fallback in `blocks/use-project.ts`).

Milestone: Maintenance

Part of #815. Part 3 (field removals + public-API exits) is blocked on #842 (migrating blocks test snapshots off the legacy fallback).

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally, first try)
- [ ] `pnpm --filter swatchbook-storybook test:storybook` (149 interaction tests green locally)
- [ ] CI green