### PR TITLE
test(blocks): migrate test fixtures to cells shape + drop legacy snapshot fallback

### DIFF
--- a/.changeset/blocks-test-snapshots-cells-shape.md
+++ b/.changeset/blocks-test-snapshots-cells-shape.md
@@ -1,0 +1,9 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Internal. Blocks test fixtures now provide `cells` / `jointOverrides` / `defaultTuple` via a new `withCellsShape` test helper (`packages/blocks/test/_snapshot-utils.ts`), derived from the existing `axes` + `permutationsResolved` ergonomics so individual fixture authoring stays unchanged.
+
+`snapshotResolveAt` in `packages/blocks/src/internal/use-project.ts` drops the legacy `permutationsResolved`-only fallback that existed for pre-migration hand-built snapshots. Snapshots now must provide `cells` (or a `resolveAt` accessor) — `withCellsShape` covers the common test case; production preview snapshots already provide both via the addon's wire format.
+
+Unblocks #815 Part 3 (the actual `Project.permutationsResolved` field removal).

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -120,24 +120,17 @@ function makeResolveAt(snapshot: {
  * Build the `resolveAt` accessor for a snapshot. Prefers the
  * snapshot's own `resolveAt` (the addon's preview decorator
  * pre-builds one at module load — see `previewResolveAt` in
- * `packages/addon/src/preview.tsx`), then `cells` + `jointOverrides`
- * via `makeResolveAt`, finally a hand-built-snapshot fallback that
- * resolves only the active-permutation TokenMap (sufficient for the
- * `resolveAt(activeAxes)` path blocks take; multi-tuple lookups
- * — `AxisVariance` grid cells — require `cells`). The fallback's
- * `permutationsResolved` read goes away in PR 3 of #815 when the
- * field exits `Project` entirely.
+ * `packages/addon/src/preview.tsx`), otherwise composes one from
+ * `cells` + `jointOverrides` via `makeResolveAt`. Hand-built
+ * snapshots should provide both via the test `withCellsShape`
+ * helper or by populating the fields directly.
  */
 function snapshotResolveAt(
   snapshot: ProjectSnapshot,
 ): (tuple: Record<string, string>) => ResolvedTokens {
   if (snapshot.resolveAt)
     return snapshot.resolveAt as (tuple: Record<string, string>) => ResolvedTokens;
-  const hasCells = Object.keys(snapshot.cells ?? {}).length > 0;
-  if (hasCells) return makeResolveAt(snapshot);
-  const resolved = (snapshot.permutationsResolved ?? {}) as Record<string, ResolvedTokens>;
-  const active = resolved[snapshot.activePermutation] ?? {};
-  return () => active;
+  return makeResolveAt(snapshot);
 }
 
 /**

--- a/packages/blocks/test/_color-table-helpers.tsx
+++ b/packages/blocks/test/_color-table-helpers.tsx
@@ -1,18 +1,18 @@
 import type { ProjectSnapshot, VirtualTokenShape } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 /**
- * Test snapshot using the legacy `permutationsResolved` shape — the
- * `snapshotResolveAt` fallback path in `use-project` covers this for
- * hand-built snapshots. `permutationsResolved` is typed as the wider
- * `Record<…>` rather than inferred from the literal so tests can
- * extend the map with extra paths after construction.
+ * Test snapshot carrying the legacy `permutationsResolved` map alongside
+ * the cells shape so existing assertions can keep extending it with
+ * extra paths after construction. `permutationsResolved` is typed as
+ * the wider `Record<…>` rather than inferred from the literal.
  */
 export interface ColorTableSnapshot extends ProjectSnapshot {
   permutationsResolved: Record<string, Record<string, VirtualTokenShape>>;
 }
 
 export function makeColorTableSnapshot(): ColorTableSnapshot {
-  return {
+  return withCellsShape({
     axes: [{ name: 'mode', contexts: ['light'], default: 'light', source: 'resolver' }],
     disabledAxes: [],
     presets: [],
@@ -45,5 +45,5 @@ export function makeColorTableSnapshot(): ColorTableSnapshot {
     cssVarPrefix: 'sb',
     diagnostics: [],
     css: '',
-  };
+  });
 }

--- a/packages/blocks/test/_snapshot-utils.ts
+++ b/packages/blocks/test/_snapshot-utils.ts
@@ -1,0 +1,73 @@
+import type { ProjectSnapshot, VirtualTokenShape } from '#/contexts.ts';
+
+/**
+ * Hand-built test snapshots historically populated `permutations` +
+ * `permutationsResolved` directly. The wire format moved to `cells` +
+ * `jointOverrides` + `defaultTuple` in PR 6a; `useProject`'s
+ * `snapshotResolveAt` retained a fallback that resolved only the
+ * active-permutation TokenMap so those fixtures kept passing.
+ *
+ * This helper derives the new shape from the old, so tests can keep
+ * their existing `makeSnapshot()` ergonomics and the production
+ * fallback can be deleted with #815 Part 3. Single-axis fixtures
+ * resolve trivially (one cell entry, no joint overrides);
+ * multi-context fixtures derive deltas vs the active baseline.
+ */
+export function withCellsShape<T extends ProjectSnapshot>(snapshot: T): T {
+  const defaultTuple: Record<string, string> = {};
+  for (const axis of snapshot.axes) {
+    defaultTuple[axis.name] = snapshot.activeAxes[axis.name] ?? axis.default;
+  }
+
+  const baseline = snapshot.permutationsResolved?.[snapshot.activePermutation] ?? {};
+
+  const cells: NonNullable<ProjectSnapshot['cells']> = {};
+  for (const axis of snapshot.axes) {
+    const axisCells: Record<string, Record<string, VirtualTokenShape>> = {};
+    for (const ctx of axis.contexts) {
+      const cellTuple = { ...defaultTuple, [axis.name]: ctx };
+      const tokens = findPermResolved(snapshot, cellTuple);
+      if (ctx === axis.default || ctx === defaultTuple[axis.name]) {
+        axisCells[ctx] = tokens ?? baseline;
+      } else if (tokens) {
+        const delta: Record<string, VirtualTokenShape> = {};
+        for (const [path, token] of Object.entries(tokens)) {
+          const b = baseline[path];
+          if (!b || JSON.stringify(b.$value) !== JSON.stringify(token.$value)) {
+            delta[path] = token;
+          }
+        }
+        axisCells[ctx] = delta;
+      } else {
+        axisCells[ctx] = {};
+      }
+    }
+    cells[axis.name] = axisCells;
+  }
+
+  return {
+    ...snapshot,
+    cells,
+    jointOverrides: snapshot.jointOverrides ?? [],
+    defaultTuple,
+  } as T;
+}
+
+function findPermResolved(
+  snapshot: ProjectSnapshot,
+  tuple: Readonly<Record<string, string>>,
+): Record<string, VirtualTokenShape> | undefined {
+  const perms = snapshot.permutations ?? [];
+  const resolved = snapshot.permutationsResolved ?? {};
+  for (const perm of perms) {
+    let match = true;
+    for (const k of Object.keys(tuple)) {
+      if ((perm.input as Record<string, string>)[k] !== tuple[k]) {
+        match = false;
+        break;
+      }
+    }
+    if (match) return resolved[perm.name];
+  }
+  return undefined;
+}

--- a/packages/blocks/test/color-palette.test.tsx
+++ b/packages/blocks/test/color-palette.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { type ProjectSnapshot, SwatchbookProvider, ColorPalette } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 function makeSnapshot(): ProjectSnapshot {
-  return {
+  return withCellsShape({
     axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
     disabledAxes: [],
     presets: [],
@@ -22,7 +23,7 @@ function makeSnapshot(): ProjectSnapshot {
     cssVarPrefix: 'sb',
     diagnostics: [],
     css: '',
-  };
+  });
 }
 
 describe('ColorPalette', () => {

--- a/packages/blocks/test/color-table-expansion.test.tsx
+++ b/packages/blocks/test/color-table-expansion.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, fireEvent, render, screen, within } from '@testing-librar
 import { afterEach, describe, expect, it } from 'vitest';
 import { ColorTable, SwatchbookProvider } from '#/index.ts';
 import { makeColorTableSnapshot } from './_color-table-helpers.tsx';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 describe('ColorTable — expansion', () => {
   afterEach(() => {
@@ -52,7 +53,7 @@ describe('ColorTable — expansion', () => {
       'color.bg.hi-d': { $type: 'color', $value: { hex: '#333333' } },
     };
     render(
-      <SwatchbookProvider value={snap}>
+      <SwatchbookProvider value={withCellsShape(snap)}>
         <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
       </SwatchbookProvider>,
     );
@@ -90,7 +91,7 @@ describe('ColorTable — expansion', () => {
       'color.bg.hi-h': { $type: 'color', $value: { hex: '#222222' } },
     };
     render(
-      <SwatchbookProvider value={snap}>
+      <SwatchbookProvider value={withCellsShape(snap)}>
         <ColorTable filter="color.bg.*" variants={{ hover: 'h' }} />
       </SwatchbookProvider>,
     );

--- a/packages/blocks/test/color-table-grouping.test.tsx
+++ b/packages/blocks/test/color-table-grouping.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, fireEvent, render, screen, within } from '@testing-librar
 import { afterEach, describe, expect, it } from 'vitest';
 import { ColorTable, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
 import { makeColorTableSnapshot } from './_color-table-helpers.tsx';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 function makeVariantSnapshot(): ProjectSnapshot {
   const base = makeColorTableSnapshot();
@@ -11,7 +12,10 @@ function makeVariantSnapshot(): ProjectSnapshot {
     'color.bg.hi-h': { $type: 'color', $value: { hex: '#222222' } },
     'color.bg.hi-d': { $type: 'color', $value: { hex: '#333333' } },
   };
-  return base;
+  // Rebuild cells against the mutated permutationsResolved — the
+  // initial `withCellsShape` call inside `makeColorTableSnapshot`
+  // captured the pre-mutation shape.
+  return withCellsShape(base);
 }
 
 describe('ColorTable — grouping', () => {
@@ -89,7 +93,7 @@ describe('ColorTable — grouping', () => {
       'color.bg.hi.hover': { $type: 'color', $value: { hex: '#333333' } },
     };
     render(
-      <SwatchbookProvider value={snap}>
+      <SwatchbookProvider value={withCellsShape(snap)}>
         <ColorTable filter="color.bg.*" variants={{ hover: 'hover', disabled: 'disabled' }} />
       </SwatchbookProvider>,
     );

--- a/packages/blocks/test/composite-breakdown.test.tsx
+++ b/packages/blocks/test/composite-breakdown.test.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { CompositeBreakdown, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 function makeSnapshot(): ProjectSnapshot {
   const permutationsResolved = {
@@ -27,7 +28,7 @@ function makeSnapshot(): ProjectSnapshot {
       },
     },
   };
-  return {
+  return withCellsShape({
     axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
     disabledAxes: [],
     presets: [],
@@ -38,7 +39,7 @@ function makeSnapshot(): ProjectSnapshot {
     cssVarPrefix: 'sb',
     diagnostics: [],
     css: '',
-  };
+  });
 }
 
 describe('CompositeBreakdown', () => {

--- a/packages/blocks/test/consumer-output.test.tsx
+++ b/packages/blocks/test/consumer-output.test.tsx
@@ -6,11 +6,12 @@ import {
   SwatchbookProvider,
   type VirtualTokenListingShape,
 } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 function makeSnapshot(
   listing?: Readonly<Record<string, VirtualTokenListingShape>>,
 ): ProjectSnapshot {
-  return {
+  return withCellsShape({
     axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
     disabledAxes: [],
     presets: [],
@@ -26,7 +27,7 @@ function makeSnapshot(
     diagnostics: [],
     css: '',
     ...(listing !== undefined && { listing }),
-  };
+  });
 }
 
 describe('ConsumerOutput', () => {

--- a/packages/blocks/test/detail-overlay.test.tsx
+++ b/packages/blocks/test/detail-overlay.test.tsx
@@ -10,11 +10,12 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { SwatchbookProvider } from '#/provider.tsx';
 import type { ProjectSnapshot } from '#/contexts.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 afterEach(cleanup);
 
 function emptySnapshot(): ProjectSnapshot {
-  return {
+  return withCellsShape({
     axes: [],
     disabledAxes: [],
     presets: [],
@@ -25,7 +26,7 @@ function emptySnapshot(): ProjectSnapshot {
     cssVarPrefix: '',
     diagnostics: [],
     css: '',
-  };
+  });
 }
 
 function renderOverlay(onClose = vi.fn()): { onClose: ReturnType<typeof vi.fn> } {

--- a/packages/blocks/test/diagnostics.test.tsx
+++ b/packages/blocks/test/diagnostics.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { Diagnostics, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 function makeSnapshot(diagnostics: ProjectSnapshot['diagnostics'] = []): ProjectSnapshot {
-  return {
+  return withCellsShape({
     axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
     disabledAxes: [],
     presets: [],
@@ -14,7 +15,7 @@ function makeSnapshot(diagnostics: ProjectSnapshot['diagnostics'] = []): Project
     cssVarPrefix: 'sb',
     diagnostics,
     css: '',
-  };
+  });
 }
 
 describe('Diagnostics', () => {

--- a/packages/blocks/test/token-navigator-keyboard.test.tsx
+++ b/packages/blocks/test/token-navigator-keyboard.test.tsx
@@ -9,11 +9,12 @@ import { userEvent } from '@vitest/browser/context';
 import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type ProjectSnapshot, SwatchbookProvider, TokenNavigator } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 afterEach(cleanup);
 
 function snapshot(): ProjectSnapshot {
-  return {
+  return withCellsShape({
     axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
     disabledAxes: [],
     presets: [],
@@ -31,7 +32,7 @@ function snapshot(): ProjectSnapshot {
     cssVarPrefix: 'sb',
     diagnostics: [],
     css: '',
-  };
+  });
 }
 
 function renderNav(props: { initiallyExpanded?: number; onSelect?: (p: string) => void } = {}) {

--- a/packages/blocks/test/token-navigator.test.tsx
+++ b/packages/blocks/test/token-navigator.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { type ProjectSnapshot, SwatchbookProvider, TokenNavigator } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 function makeSnapshot(): ProjectSnapshot {
-  return {
+  return withCellsShape({
     axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
     disabledAxes: [],
     presets: [],
@@ -21,7 +22,7 @@ function makeSnapshot(): ProjectSnapshot {
     cssVarPrefix: 'sb',
     diagnostics: [],
     css: '',
-  };
+  });
 }
 
 describe('TokenNavigator', () => {

--- a/packages/blocks/test/token-table.test.tsx
+++ b/packages/blocks/test/token-table.test.tsx
@@ -1,9 +1,10 @@
 import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { type ProjectSnapshot, SwatchbookProvider, TokenTable } from '#/index.ts';
+import { withCellsShape } from './_snapshot-utils.ts';
 
 function makeSnapshot(): ProjectSnapshot {
-  return {
+  return withCellsShape({
     axes: [
       {
         name: 'mode',
@@ -42,7 +43,7 @@ function makeSnapshot(): ProjectSnapshot {
     cssVarPrefix: 'sb',
     diagnostics: [],
     css: '',
-  };
+  });
 }
 
 describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => {


### PR DESCRIPTION
## Summary

Unblocks #815 Part 3 (the actual `Project.permutationsResolved` field removal).

- Adds `packages/blocks/test/_snapshot-utils.ts` with a `withCellsShape` helper that derives `cells` / `jointOverrides` / `defaultTuple` from the existing `axes` + `permutationsResolved` fixture shape. Single-axis fixtures resolve trivially (one cell entry, no joint overrides); multi-context fixtures derive deltas vs the active baseline.
- Every factory in `packages/blocks/test/*` (12 factories across 11 files) wraps its return through `withCellsShape`. Two mutate-after-construct sites in `color-table-{expansion,grouping}` re-wrap after mutating `permutationsResolved` so the cells reflect the addition.
- `snapshotResolveAt` in `packages/blocks/src/internal/use-project.ts` drops the legacy `permutationsResolved`-only fallback that existed for pre-migration hand-built snapshots. Snapshots now must provide `cells` (or a `resolveAt` accessor) — `withCellsShape` covers the test case; production preview snapshots already provide both via the addon's wire format.

Milestone: Maintenance

Closes #842

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally)
- [ ] `pnpm --filter swatchbook-storybook test:storybook` (149 interaction tests green locally)
- [ ] CI green