### PR TITLE
refactor(core): drop ParserInput from public barrel; mark Project.parserInput @internal

### DIFF
--- a/.changeset/parser-input-internal.md
+++ b/.changeset/parser-input-internal.md
@@ -1,0 +1,11 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+---
+
+Closes #820. The `ParserInput` type is no longer exported from `@unpunnyfuns/swatchbook-core`'s barrel. The type still exists internally (the loader produces it, `emitViaTerrazzo` consumes it) but is no longer part of the public API surface — its old presence on the barrel surfaced Terrazzo's `Resolver` + `InputSourceWithDocument` types into consumer-visible TypeScript without intent.
+
+`Project.parserInput` itself remains as an optional field on `Project` (resolver-backed projects populate it, layered/plain-parse projects leave it `undefined`). JSDoc updated to mark it `@internal` — consumers should pass the `Project` to `emitViaTerrazzo` rather than reaching for the field directly. The shape may move under a different name in future releases.
+
+The `Project.parserInput?:` optional-with-omit form (rather than `T | undefined`) is unchanged — the audit finding called out a non-existent issue here; the file always used the correct `exactOptionalPropertyTypes`-compatible form.
+
+Pre-1.0 minor bump per the project's semver policy.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,7 +16,6 @@ export type {
   DiagnosticSeverity,
   JointOverride,
   JointOverrides,
-  ParserInput,
   Preset,
   Project,
   ResolveAt,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -324,11 +324,17 @@ export interface Project {
    */
   cwd: string;
   /**
-   * Raw Terrazzo parse output retained so downstream emitters can drive
-   * Terrazzo's plugin pipeline (`emitViaTerrazzo(project, [...plugins])`)
-   * without re-parsing from disk. Present for resolver-backed projects;
-   * currently `undefined` for layered + plain-parse paths — those would
-   * need a synthesized resolver before `build()` accepts them.
+   * @internal Raw Terrazzo parse output retained so downstream
+   * emitters can drive Terrazzo's plugin pipeline
+   * (`emitViaTerrazzo(project, [...plugins])`) without re-parsing
+   * from disk. Present for resolver-backed projects; currently
+   * `undefined` for layered + plain-parse paths — those would need
+   * a synthesized resolver before `build()` accepts them.
+   *
+   * Consumers should pass the `Project` itself to
+   * `emitViaTerrazzo` rather than reaching for this field directly —
+   * the `ParserInput` shape is not part of the public type surface
+   * and may move under a different name in future releases.
    */
   parserInput?: ParserInput;
   /**


### PR DESCRIPTION
## Summary

Closes #820. The `ParserInput` type is no longer exported from `@unpunnyfuns/swatchbook-core`'s barrel. Its presence there surfaced Terrazzo's `Resolver` + `InputSourceWithDocument` types into consumer-visible TypeScript without intent. The type still exists internally (the loader produces it, `emitViaTerrazzo` consumes it).

`Project.parserInput` remains as an optional field but gets an `@internal` JSDoc note — consumers should pass the `Project` to `emitViaTerrazzo` rather than reaching for the field directly.

The audit's "`parserInput: T | undefined` violates `exactOptionalPropertyTypes`" sub-finding was a false positive — the source has always used the correct `parserInput?: ParserInput` form. No change there.

Milestone: Maintenance

Closes #820

## Test plan
- [ ] `pnpm turbo run typecheck test` (21 tasks green locally)
- [ ] CI green