### PR TITLE
chore(core): add explicit .ts extensions to #/ imports in core/test

### DIFF
--- a/.changeset/core-test-ts-extensions.md
+++ b/.changeset/core-test-ts-extensions.md
@@ -1,0 +1,7 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Closes #828. Internal-only — every `#/`-prefixed import in `packages/core/test/*.ts` now carries an explicit `.ts` extension, matching the project convention (CLAUDE.md: "explicit extensions always"). Every other package's tests already followed the rule; core/test was the outlier with 22 missing-extension imports across 17 files.
+
+No runtime or API impact — the imports resolve to the same modules either way (`package.json#imports` extension-agnostic), but TypeScript + tsdown + node strip-types all prefer the explicit form.

--- a/packages/core/test/_helpers.ts
+++ b/packages/core/test/_helpers.ts
@@ -1,7 +1,7 @@
 import { dirname } from 'node:path';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { loadProject } from '#/load';
-import type { Project } from '#/types';
+import { loadProject } from '#/load.ts';
+import type { Project } from '#/types.ts';
 
 export const fixtureCwd = dirname(tokensDir);
 

--- a/packages/core/test/cells.test.ts
+++ b/packages/core/test/cells.test.ts
@@ -6,7 +6,7 @@
 // later axis's cell can't accidentally overwrite an earlier axis's
 // overlay on a token it doesn't touch.
 import { beforeAll, expect, it } from 'vitest';
-import type { Project } from '#/types';
+import type { Project } from '#/types.ts';
 import { loadWithPrefix } from './_helpers';
 
 let project: Project;

--- a/packages/core/test/chrome.test.ts
+++ b/packages/core/test/chrome.test.ts
@@ -1,10 +1,10 @@
 import { beforeAll, expect, it } from 'vitest';
 import { dirname } from 'node:path';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { CHROME_ROLES, DEFAULT_CHROME_MAP, validateChrome } from '#/chrome';
-import { emitAxisProjectedCss } from '#/css-axis-projected';
-import { loadProject } from '#/load';
-import type { Project } from '#/types';
+import { CHROME_ROLES, DEFAULT_CHROME_MAP, validateChrome } from '#/chrome.ts';
+import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
+import { loadProject } from '#/load.ts';
+import type { Project } from '#/types.ts';
 
 const fixtureCwd = dirname(tokensDir);
 

--- a/packages/core/test/config.test.ts
+++ b/packages/core/test/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { defineSwatchbookConfig } from '#/config';
+import { defineSwatchbookConfig } from '#/config.ts';
 
 describe('defineSwatchbookConfig', () => {
   it('returns the config unchanged (identity helper)', () => {

--- a/packages/core/test/css-axis-projected.test.ts
+++ b/packages/core/test/css-axis-projected.test.ts
@@ -23,8 +23,8 @@
  *   - the chrome alias block is emitted unchanged at the tail.
  */
 import { beforeAll, expect, it } from 'vitest';
-import { emitAxisProjectedCss } from '#/css-axis-projected';
-import type { Project } from '#/types';
+import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
+import type { Project } from '#/types.ts';
 import { extractBlock, loadWithPrefix } from './_helpers';
 
 let project: Project;

--- a/packages/core/test/default-tuple.test.ts
+++ b/packages/core/test/default-tuple.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
-import { loadProject } from '#/load';
+import { loadProject } from '#/load.ts';
 import { fixtureCwd } from './_helpers';
 
 // `Project.defaultTuple` is the axis-defaults baseline that `cells` /

--- a/packages/core/test/disabled-axes.test.ts
+++ b/packages/core/test/disabled-axes.test.ts
@@ -1,10 +1,10 @@
 import { dirname } from 'node:path';
 import { beforeAll, expect, it } from 'vitest';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { emitAxisProjectedCss } from '#/css-axis-projected';
-import { loadProject } from '#/load';
-import { validateDisabledAxes } from '#/disabled-axes';
-import type { Axis, Project } from '#/types';
+import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
+import { loadProject } from '#/load.ts';
+import { validateDisabledAxes } from '#/disabled-axes.ts';
+import type { Axis, Project } from '#/types.ts';
 
 const fixtureCwd = dirname(tokensDir);
 

--- a/packages/core/test/joint-overrides.test.ts
+++ b/packages/core/test/joint-overrides.test.ts
@@ -4,7 +4,7 @@
 // accessible-accent chain; this test pins that we identify those
 // entries without overcollecting.
 import { beforeAll, expect, it } from 'vitest';
-import type { Project } from '#/types';
+import type { Project } from '#/types.ts';
 import { loadWithPrefix } from './_helpers';
 
 let project: Project;

--- a/packages/core/test/load-presets.test.ts
+++ b/packages/core/test/load-presets.test.ts
@@ -1,8 +1,8 @@
 import { dirname } from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { loadProject } from '#/load';
-import type { Project } from '#/types';
+import { loadProject } from '#/load.ts';
+import type { Project } from '#/types.ts';
 
 const fixtureCwd = dirname(tokensDir);
 

--- a/packages/core/test/load-validation.test.ts
+++ b/packages/core/test/load-validation.test.ts
@@ -1,7 +1,7 @@
 import { dirname } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { loadProject } from '#/load';
+import { loadProject } from '#/load.ts';
 
 const fixtureCwd = dirname(tokensDir);
 

--- a/packages/core/test/load.test.ts
+++ b/packages/core/test/load.test.ts
@@ -1,8 +1,8 @@
 import { dirname } from 'node:path';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { loadProject } from '#/load';
-import type { Project } from '#/types';
+import { loadProject } from '#/load.ts';
+import type { Project } from '#/types.ts';
 
 const fixtureCwd = dirname(tokensDir);
 

--- a/packages/core/test/presets.test.ts
+++ b/packages/core/test/presets.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { validatePresets } from '#/presets';
-import type { Axis, Preset } from '#/types';
+import { validatePresets } from '#/presets.ts';
+import type { Axis, Preset } from '#/types.ts';
 
 const axes: Axis[] = [
   {

--- a/packages/core/test/resolve-at.test.ts
+++ b/packages/core/test/resolve-at.test.ts
@@ -7,7 +7,7 @@
 // (`color.accent.fg` under mode=Dark + brand=Brand A) without invoking
 // the resolver again at runtime.
 import { beforeAll, expect, it } from 'vitest';
-import type { Project } from '#/types';
+import type { Project } from '#/types.ts';
 import { loadWithPrefix } from './_helpers';
 
 let project: Project;

--- a/packages/core/test/resolver-edge-cases.test.ts
+++ b/packages/core/test/resolver-edge-cases.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, expect, it } from 'vitest';
-import { loadProject } from '#/load';
+import { loadProject } from '#/load.ts';
 
 let workspace: string;
 

--- a/packages/core/test/source-files.test.ts
+++ b/packages/core/test/source-files.test.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve as resolvePath } from 'node:path';
 import { expect, it } from 'vitest';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { loadProject } from '#/load';
+import { loadProject } from '#/load.ts';
 import { fixtureCwd } from './_helpers';
 
 it('populates sourceFiles with every $ref target when config.tokens is omitted', async () => {

--- a/packages/core/test/terrazzo-options.test.ts
+++ b/packages/core/test/terrazzo-options.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest';
-import { validateCssOptions } from '#/terrazzo-options';
+import { validateCssOptions } from '#/terrazzo-options.ts';
 
 it('validateCssOptions returns no diagnostics for an empty object', () => {
   const { diagnostics } = validateCssOptions({});

--- a/packages/core/test/token-listing.test.ts
+++ b/packages/core/test/token-listing.test.ts
@@ -1,6 +1,6 @@
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 import { describe, expect, it } from 'vitest';
-import { loadProject } from '#/load';
+import { loadProject } from '#/load.ts';
 import { fixtureCwd, loadWithPrefix } from './_helpers';
 
 describe('Token Listing integration', () => {


### PR DESCRIPTION
## Summary

Closes #828. Every `#/`-prefixed import in `packages/core/test/*.ts` now carries an explicit `.ts` extension. Convention adherence (CLAUDE.md: "explicit extensions always"); every other package's tests already followed the rule; core/test was the outlier with 22 missing-extension imports across 17 files.

No runtime or API impact — imports resolve to the same modules either way (`package.json#imports` is extension-agnostic), but TypeScript + tsdown + node strip-types all prefer the explicit form.

Milestone: Maintenance

Closes #828

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally)
- [ ] CI green