### PR TITLE
docs: fix-forward references to removed projectCss / permutationsResolved / maxPermutations

### DIFF
--- a/.changeset/docs-fix-forward-removed-apis.md
+++ b/.changeset/docs-fix-forward-removed-apis.md
@@ -1,0 +1,12 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Closes #821. Docs fix-forward — the reference and architecture pages no longer describe APIs that no longer exist.
+
+- `apps/docs/docs/reference/core.mdx` — drops the `projectCss()` and `resolvePermutation()` sections (both removed in earlier v0.55 PRs); drops the `permutationsResolved` field from the `Project` shape; documents `project.resolveAt(tuple)` + `project.defaultTokens` + `project.varianceByPath` + the cells/jointOverrides primitives + `emitAxisProjectedCss` in their place.
+- `apps/docs/docs/reference/axes.mdx` — drops the `maxPermutations` historical-guard mention.
+- `apps/docs/docs/reference/token-pipeline.mdx` — example import now reads `cells, jointOverrides, defaultTuple, axes, diagnostics, css` (the actual virtual-module exports).
+- `apps/docs/docs/developers/architecture.mdx` — `Project` shape updated; static-build data-flow diagram swaps `projectCss` for `emitAxisProjectedCss` and mentions the compound joint blocks.
+
+Patch changeset per project policy so the docs snapshot rebuilds on next release — without the bump, the fix only reaches `/next/`, not `/`.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -43,12 +43,15 @@ Everything flows through one shape: `Project` in `packages/core/src/types.ts`.
 interface Project {
   config: Config;              // the resolved user config
   axes: Axis[];                // axes driving composition (mode, brand, contrast…)
-  disabledAxes: DisabledAxis[];// axes the consumer explicitly suppressed
-  presets: Preset[];           // named quick-select axis tuples
+  disabledAxes: readonly string[]; // axes the consumer explicitly suppressed
+  presets: readonly Preset[];  // named quick-select axis tuples
   chrome: Record<string, string>; // block-chrome → consumer-token alias map
-  permutations: Permutation[]; // cartesian product of axis contexts
-  permutationsResolved: Record<string, TokenMap>; // permutation.name → resolved tokens
-  graph: TokenMap;             // default permutation's resolved tokens
+  defaultTokens: TokenMap;     // resolved tokens at the default tuple
+  cells: Cells;                // per-axis (context → TokenMap) cells, bounded by Σ(axes × contexts)
+  jointOverrides: JointOverrides; // partial-tuple divergences cells composition can't reproduce
+  defaultTuple: Record<string, string>; // axis defaults
+  resolveAt: (tuple: Record<string, string>) => TokenMap; // compose any tuple
+  varianceByPath: ReadonlyMap<string, AxisVarianceResult>; // O(1) per-token variance lookup
   sourceFiles: string[];       // every file that fed the build (for watchers)
   cwd: string;                 // loader cwd — config-relative paths resolve here
   diagnostics: Diagnostic[];   // parser / validator / resolver findings
@@ -57,7 +60,7 @@ interface Project {
 
 Properties:
 
-- **Permutations are eagerly resolved.** `project.permutationsResolved[name]` is ready at load time — no lazy I/O.
+- **Tokens are bounded by axis cardinality, not cartesian size.** `cells` carries `Σ(axes × contexts)` resolved TokenMaps; `jointOverrides` carries only the partial-tuple divergences cells composition can't reproduce. `resolveAt(tuple)` composes any tuple on demand — no resolver calls at read time.
 - **`sourceFiles` is the canonical watch set.** The addon's Vite plugin and the MCP server both use it to decide what to watch for HMR / live-reload.
 - **Diagnostics flow as data, not exceptions.** Parse errors, unresolved aliases, invalid preset axis values — all land in `project.diagnostics` with a severity. The `<Diagnostics />` block renders them.
 - **One axis type.** `Axis.source` is `'resolver'` (DTCG resolver modifier), `'layered'` (authored per-axis layer globs), or `'synthetic'` (single-axis fallback for projects without a resolver or layers). Everything downstream treats them uniformly.
@@ -80,7 +83,7 @@ interface SwatchbookIntegration {
 
 The addon's Vite plugin iterates `integrations[]`, resolves each `virtualId`, serves whatever `render(project)` produces, and invalidates every integration-contributed module on HMR alongside `virtual:swatchbook/tokens`. The addon itself learns nothing about Tailwind, emotion, or anything else — integrations own their library-specific logic.
 
-The `Project` snapshot passed to `render` carries everything: axes, permutations, presets, resolved maps, `cssVarPrefix`. See the [Integrations guide](../guides/integrations/index.mdx) for factory usage.
+The `Project` snapshot passed to `render` carries everything: axes, cells, joint overrides, presets, `defaultTokens`, `resolveAt`, `cssVarPrefix`. See the [Integrations guide](../guides/integrations/index.mdx) for factory usage.
 
 ## Data flow — static build path
 
@@ -93,15 +96,18 @@ tokens/resolver.json
        ↓
      Project                       ← the one shape
        ↓
-   projectCss(project)             ← packages/core/src/css.ts
+   emitAxisProjectedCss(project)   ← packages/core/src/css-axis-projected.ts
        ↓
  :root { --prefix-color-…: … }
  [data-prefix-mode="Dark"] { … }
+ [data-prefix-mode="Dark"][data-prefix-brand="Brand A"] { … }
 ```
 
 The same `Project` also feeds:
 
-- `resolvePermutation(project, name)` — look up a single theme's resolved tokens
+- `project.resolveAt(tuple)` — compose the resolved TokenMap for any axis tuple
+- `project.defaultTokens` — the default-tuple snapshot for global views
+- `project.varianceByPath` — O(1) per-token variance classification
 - `project.diagnostics` — the `<Diagnostics />` block reads this
 - the MCP server's tool handlers (all twelve read straight from the project)
 - TypeScript type emission (via Terrazzo's token-tools; not currently exposed as a CLI)

--- a/apps/docs/docs/reference/axes.mdx
+++ b/apps/docs/docs/reference/axes.mdx
@@ -91,7 +91,7 @@ A resolver may declare more modifiers than a given Storybook wants to surface. L
 
 `loadProject` enumerates `1 + Σ(axes × (contexts - 1))` singleton tuples per project — the default tuple plus one per non-default cell on each axis. Bounded by axis cardinality, independent of the cartesian product, so a resolver with 20 axes × 5 contexts loads ~80 tuples regardless of whether the underlying cartesian is hundreds or 15 million. The toolbar surfaces every axis, the smart CSS emitter writes per-axis cell blocks plus compound blocks only for tokens with genuine joint divergence, and runtime CSS composition lands the right value at any multi-axis selector.
 
-That makes the historical `maxPermutations` guard unnecessary — the loader can't blow up on a large cartesian because it doesn't materialize the cartesian in the first place. Two scoping levers remain, both presentational:
+The loader can't blow up on a large cartesian because it doesn't materialize the cartesian in the first place. Two scoping levers remain, both presentational:
 
 - **`presets`** — author named tuples for the handful of permutations that matter (`Default Light`, `Brand A Dark`, `A11y High Contrast`). Toolbar surfaces them as quick-select pills; emit pipelines can fan out on `'presets'` instead of every axis-attribute combination. The right answer when only a handful of tuples are presentational.
 - **`disabledAxes`** — pin state-space modifiers (locale, density, motion-pref, …) to their defaults. They vanish from the toolbar, drop from the project's axis list, and don't contribute to emitted CSS. The right answer when an axis exists in the resolver but doesn't represent presentational variation.

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -32,32 +32,33 @@ export default defineSwatchbookConfig({
 
 ### `loadProject(config, cwd?)`
 
-Parse + resolve a project. Eagerly resolves every permutation, so downstream consumers can read `permutationsResolved[name]` directly without further I/O.
+Parse + resolve a project. Returns a `Project` carrying per-axis cells, joint overrides, and a `resolveAt(tuple)` accessor — no resolver calls happen at consumer-read time.
 
 ```ts
 import { loadProject } from '@unpunnyfuns/swatchbook-core';
 
 const project = await loadProject(config, process.cwd());
-// project: { config, axes, presets, permutations, permutationsResolved, graph, diagnostics }
+// project: { config, axes, presets, cells, jointOverrides, defaultTuple,
+//            defaultTokens, resolveAt, varianceByPath, diagnostics, … }
 ```
 
-### `resolvePermutation(project, name)`
+### `project.resolveAt(tuple)`
 
-Pick a single composed permutation out of a project.
+Compose the resolved `TokenMap` for any axis tuple. Pure function over `cells + jointOverrides + axes + defaultTuple`; accepts partial tuples (omitted axes fall back to their defaults). Memoized on the tuple key.
 
 ```ts
-const { tokens } = resolvePermutation(project, 'Light · Default');
+const dark = project.resolveAt({ mode: 'Dark' });
+const darkBrand = project.resolveAt({ mode: 'Dark', brand: 'Brand A' });
 ```
 
-Throws with a helpful "known permutations" message if the name is unknown.
+### `project.defaultTokens`
 
-### `permutationID(input)`
-
-Stringify a tuple to the form used as `Permutation.name` and CSS data-attribute values:
+The resolved `TokenMap` at the project's default tuple. Convenience for global views.
 
 ```ts
-permutationID({ mode: 'Dark', brand: 'Brand A' }); // → "Dark · Brand A"
-permutationID({ theme: 'Light' }); // → "Light"
+for (const [path, token] of Object.entries(project.defaultTokens)) {
+  // …
+}
 ```
 
 ### `project.varianceByPath`
@@ -73,20 +74,20 @@ const info = project.varianceByPath.get('color.accent.bg');
 
 See [`AxisVarianceResult`](#axisvarianceresult) for the entry shape.
 
-### `projectCss(project)`
+### `emitAxisProjectedCss(project, options?)`
 
-Emit the project's resolved CSS as a string — the same output the addon publishes into `virtual:swatchbook/tokens` at preview time. Each permutation gets its own `[data-sb-<axis>="<context>"]` selector block; the default permutation's tokens are also written to `:root`.
+Emit the project's resolved CSS as a string — the same output the addon publishes into `virtual:swatchbook/tokens` at preview time. Each per-axis non-default cell gets its own `[data-<prefix>-<axis>="<context>"]` selector block; the default cell's tokens are written to `:root`; joint-divergent tokens get compound `[data-axis-A][data-axis-B]` blocks. Size bounded by `Σ(axes × contexts)` regardless of cartesian product size.
 
 ```ts
-import { loadProject, projectCss } from '@unpunnyfuns/swatchbook-core';
+import { loadProject, emitAxisProjectedCss } from '@unpunnyfuns/swatchbook-core';
 
 const project = await loadProject(config, process.cwd());
-const css = projectCss(project);
+const css = emitAxisProjectedCss(project);
 // :root { --sb-color-accent-bg: …; … }
 // [data-sb-mode="Dark"] { --sb-color-accent-bg: …; }
 ```
 
-For consumers building docs sites, the docs apps under `apps/docs/` use this same call to feed Docusaurus's Infima theme. For production builds, prefer Terrazzo's CLI — `projectCss` exists primarily for tooling that wants the same emission the addon does.
+For production builds, prefer Terrazzo's CLI — `emitAxisProjectedCss` exists primarily for tooling that wants the same emission the addon does.
 
 ## Constants
 
@@ -187,9 +188,18 @@ interface Project {
   presets: Preset[];
   /** Validated chrome-alias entries from `config.chrome`. Invalid entries are dropped and reported as diagnostics. */
   chrome: Record<string, string>;
-  permutations: Permutation[];
-  permutationsResolved: Record<string, TokenMap>;
-  graph: TokenMap; // default permutation's resolved tokens
+  /** Resolved TokenMap at the default tuple. Convenience for global views. */
+  defaultTokens: TokenMap;
+  /** Per-axis cell maps: `cells[axisName][contextName]` is the resolved TokenMap for `{ ...defaults, [axisName]: contextName }`. */
+  cells: Cells;
+  /** Joint-variant partial-tuple overrides — values that diverge from cells composition. */
+  jointOverrides: JointOverrides;
+  /** Axis defaults — `{ axisName: axis.default }` for every axis. */
+  defaultTuple: Record<string, string>;
+  /** Compose the resolved TokenMap for any tuple of axis selections. */
+  resolveAt: (tuple: Record<string, string>) => TokenMap;
+  /** Pre-computed per-path variance classification (O(1) lookup). */
+  varianceByPath: ReadonlyMap<string, AxisVarianceResult>;
   /** Absolute paths of every file loaded while building the project (resolver + `$ref` targets, overlay files, or globbed plain-parse files). */
   sourceFiles: string[];
   /** Loader cwd — what all config-relative paths resolved against. */
@@ -331,4 +341,4 @@ interface ParserInput {
 
 - ✅ Use this package at build time — Node scripts, SSR, Storybook presets. It has no DOM dependency.
 - ❌ Don't import from `@terrazzo/parser` directly unless you need features core doesn't expose.
-- ❌ Don't ship `Project` objects to the browser — they carry full raw-AST references. Use `permutationsResolved` projections instead.
+- ❌ Don't ship `Project` objects to the browser — they carry full raw-AST references on `parserInput`. Ship the cells / `defaultTokens` projections instead (the addon's virtual module does exactly this).

--- a/apps/docs/docs/reference/token-pipeline.mdx
+++ b/apps/docs/docs/reference/token-pipeline.mdx
@@ -13,7 +13,7 @@ Swatchbook doesn't require a separate token build step. Tokens flow into the pre
 The addon's Vite plugin publishes a virtual ESM module named `virtual:swatchbook/tokens`. The Storybook preview imports from it like any other module:
 
 ```ts
-import { permutationsResolved, axes, diagnostics, css } from 'virtual:swatchbook/tokens';
+import { cells, jointOverrides, defaultTuple, axes, diagnostics, css } from 'virtual:swatchbook/tokens';
 ```
 
 "Virtual" means there's no file on disk. Vite asks the plugin to materialize the module on each preview build, and the plugin does this by calling `loadProject(config, cwd)` from `@unpunnyfuns/swatchbook-core` and serializing the result into ESM exports:
@@ -29,7 +29,9 @@ swatchbook.config.ts               ← your config
        ↓
  Vite plugin load('virtual:swatchbook/tokens')
        ↓
- export const permutationsResolved = { … }
+ export const cells = { … }
+ export const jointOverrides = [ … ]
+ export const defaultTuple = { … }
  export const axes = [ … ]
  export const css = '…'            ← preview decorator injects as <style>
 ```


### PR DESCRIPTION
## Summary

Closes #821. Docs fix-forward — the reference and architecture pages no longer describe APIs that no longer exist.

- `apps/docs/docs/reference/core.mdx` — drops `projectCss()` + `resolvePermutation()` sections; drops `permutationsResolved` from the `Project` shape; documents `project.resolveAt(tuple)` + `project.defaultTokens` + `project.varianceByPath` + cells / jointOverrides + `emitAxisProjectedCss` in their place.
- `apps/docs/docs/reference/axes.mdx` — drops the `maxPermutations` historical-guard mention.
- `apps/docs/docs/reference/token-pipeline.mdx` — example import lists the actual virtual-module exports.
- `apps/docs/docs/developers/architecture.mdx` — `Project` shape updated; static-build data-flow diagram swaps `projectCss` for `emitAxisProjectedCss` and mentions the compound joint blocks.

Patch changeset per project policy so the docs snapshot rebuilds on next release — without the bump, the fix only reaches `/next/`, not `/`.

Milestone: Maintenance

Closes #821

## Test plan
- [ ] `pnpm turbo run typecheck` (docs MDX type-checks clean)
- [ ] CI green