### PR TITLE
chore: strip stranded archaeology comments

### DIFF
--- a/.changeset/archaeology-sweep.md
+++ b/.changeset/archaeology-sweep.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-mcp": patch
+---
+
+Closes #827. Internal-only — strips remaining stale JSDoc / inline comments that referenced the cartesian-drop chain, "PR 6a" / "wire format change" phases, "see commit 893331f", and "Replaces the legacy …" patterns. The bulk of these were already cleaned up in #816 / #841 / #846 as those PRs deleted the code they pointed at; this PR catches the few that survived as stranded references.
+
+No behavior changes.

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -104,11 +104,9 @@ export function renderTokenTypes(project: Project): string {
 }
 
 /**
- * Same set the resolver loader's singleton enumeration produces:
- * default tuple + one per non-default cell on each axis + each
- * preset. Built from `project.axes` + `project.presets` + `project.defaultTuple`
- * so it survives the cartesian-drop chain's removal of
- * `project.permutations`.
+ * Default tuple + one per non-default cell on each axis + each
+ * preset — same set the resolver loader's singleton enumeration
+ * produces.
  */
 function enumerateThemeNames(project: Project): string[] {
   if (project.axes.length === 0) return [];

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -236,9 +236,6 @@ function resolveColorFormat(globals: SwatchbookGlobals): ColorFormat {
  * never needs to rebuild; downstream `ProjectSnapshot` consumers can
  * key memos on the snapshot wrapper without worrying about
  * `resolveAt` churning when Storybook recreates `context.globals`.
- *
- * Replaces the per-render `useMemo(makeResolveAt(...))` dance the
- * blocks side used to do in `useProject`.
  */
 const previewResolveAt = buildResolveAt(
   virtualAxes as readonly CoreAxis[],

--- a/packages/blocks/src/internal/prefers-reduced-motion.ts
+++ b/packages/blocks/src/internal/prefers-reduced-motion.ts
@@ -4,9 +4,9 @@ import { useEffect, useState } from 'react';
  * True when rendering inside Chromatic's snapshot runner. Chromatic's
  * browser ships a recognisable user-agent string; checked here so
  * motion-looping components can fall back to their static state for
- * deterministic snapshots without needing a global Chromatic parameter
- * (globally forcing `prefersReducedMotion: true` broke Chromatic's
- * verification parser in our setup — see commit 893331f).
+ * deterministic snapshots. Per-component detection rather than the
+ * global `chromatic.prefersReducedMotion: true` parameter — that
+ * parameter is incompatible with Chromatic's verification parser.
  */
 function isChromatic(): boolean {
   if (typeof navigator === 'undefined') return false;

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -33,25 +33,20 @@ export interface ProjectData {
   listing: Readonly<Record<string, VirtualTokenListingShape>>;
   /**
    * Cached per-path `AxisVarianceResult` — blocks use this for O(1)
-   * variance lookup instead of re-running the bucket analysis. Empty
-   * for snapshots that pre-date the wire format change.
+   * variance lookup instead of re-running the analysis on every
+   * render.
    */
   varianceByPath: VirtualVarianceByPathShape;
   /**
    * Compose the resolved `TokenMap` for any tuple of axis selections.
    * Built browser-side from `cells + jointOverrides` shipped over the
-   * wire — no resolver needed. Replaces direct
-   * `permutationsResolved[name]` reads for tuple-keyed lookups
-   * (`AxisVariance` grid cells, future per-tuple block displays).
+   * wire — no resolver needed.
    */
   resolveAt: (tuple: Record<string, string>) => ResolvedTokens;
   /**
-   * Look up the permutation name for a full tuple — `O(1)` against a
-   * `Map<canonicalKey, name>` built once per snapshot. Returns
-   * `undefined` when no permutation matches. Consumers that previously
-   * did `permutations.find(...)` per grid cell should use this
-   * instead to avoid quadratic-in-cell work as permutation counts
-   * grow.
+   * Synthesize a display name for a full tuple — `axisValues.join(' · ')`,
+   * matching the form `permutationID` produces server-side. Used by
+   * the AxisVariance grid for `data-<prefix>-theme` attribution.
    */
   permutationNameForTuple: (tuple: Record<string, string>) => string | undefined;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -281,16 +281,14 @@ export interface Project {
   /**
    * Joint-variant partial-tuple overrides — token values that diverge
    * from cascade composition over `cells` and need to be patched in
-   * by {@link resolveAt}. Currently extracted from the pair-only joint
-   * cases identified by `analyzeProjectVariance`; extends to N-order
-   * in a follow-up.
+   * by {@link resolveAt}. Probed via `analyzeProjectVariance` at all
+   * arities ≥ 2 against the cartesian truth.
    */
   jointOverrides: JointOverrides;
   /**
    * The default tuple — `{ axisName: axis.default }` for every axis,
-   * after `disabledAxes` filtering and any `config.default` overrides
-   * applied. Replaces the legacy "look at `permutations[0].input`"
-   * pattern for downstream consumers.
+   * after `disabledAxes` filtering. The baseline that `cells` /
+   * `resolveAt` compose against.
    */
   defaultTuple: Record<string, string>;
   /**

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -604,10 +604,9 @@ function buildTupleByName(project: Project): Map<string, Record<string, string>>
 }
 
 /**
- * Same form `permutationID` produces server-side — axis values joined
- * by ` · ` in axis order. Inlined here so MCP doesn't depend on the
- * `permutationID` export staying in core's public API through the
- * cartesian-drop chain.
+ * Synthesize the tuple's stable name — axis values joined by ` · ` in
+ * axis order. Inlined here rather than imported so MCP doesn't depend
+ * on `permutationID` staying in core's public API.
  */
 function tupleToName(
   axes: readonly { name: string; default: string }[],


### PR DESCRIPTION
## Summary

Closes #827. Internal-only — removes remaining stale JSDoc / inline comments that referenced the cartesian-drop chain, "PR 6a" / "wire format change" phases, "see commit 893331f", and "Replaces the legacy …" patterns. The bulk were already cleaned up in #816 / #841 / #846 as those PRs deleted the code they pointed at; this PR catches the few that survived as stranded references.

No behavior changes.

Milestone: Maintenance

Closes #827

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally)
- [ ] CI green