### PR TITLE
perf(addon): share single loadProject between preset codegen + virtual plugin

### DIFF
--- a/.changeset/share-loaded-project-startup.md
+++ b/.changeset/share-loaded-project-startup.md
@@ -1,0 +1,9 @@
+---
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+Closes #838. The addon's preset now calls `loadProject` once at Storybook startup and shares the result with both the typed-token codegen and the Vite plugin's first virtual-module render. Previously each ran its own independent `loadProject` call, parsing the same DTCG sources twice in sequence at startup.
+
+`swatchbookTokensPlugin` gains an optional `initialProject` field; when supplied, the plugin's first `buildStart` skips its `loadProject` call and uses the pre-loaded project directly. HMR-triggered reloads still call `loadProject` as before (no behavior change for live reloads).
+
+Storybook startup is now a single `loadProject` pass for the addon. Order of operations and emitted outputs unchanged.

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -25,16 +25,20 @@ export async function viteFinal(
 ): Promise<InlineConfig> {
   const { config, cwd } = await resolveConfig(options);
 
-  // Codegen runs once at Vite startup. The virtual module plugin still
-  // owns the live reload path via its HMR watcher; this file just gives
-  // TS autocomplete for `useToken('…')` in consumer stories.
-  await writeTokenCodegen(config, cwd, options);
+  // One `loadProject` call shared between codegen (needs the resolved
+  // shape to render typed token paths) and the Vite plugin (uses it
+  // for its first virtual-module render). Without sharing, the addon
+  // calls `loadProject` twice at Storybook startup — once here for
+  // codegen, once again inside the plugin's `buildStart`.
+  const project = await loadProject(config, cwd);
+  await writeTokenCodegen(project, options);
 
   const plugins = Array.isArray(viteConfig.plugins) ? [...viteConfig.plugins] : [];
   plugins.push(
     swatchbookTokensPlugin({
       config,
       cwd,
+      initialProject: project,
       ...(options.integrations !== undefined && { integrations: options.integrations }),
     }),
   );
@@ -69,14 +73,9 @@ async function resolveConfig(options: PresetOptions): Promise<{ config: Config; 
   return { config: loaded, cwd };
 }
 
-async function writeTokenCodegen(
-  config: Config,
-  cwd: string,
-  options: PresetOptions,
-): Promise<void> {
-  const project = await loadProject(config, cwd);
+async function writeTokenCodegen(project: Project, options: PresetOptions): Promise<void> {
   const projectRoot = resolve(options.configDir, '..');
-  const outDir = resolve(projectRoot, config.outDir ?? '.swatchbook');
+  const outDir = resolve(projectRoot, project.config.outDir ?? '.swatchbook');
   await mkdir(outDir, { recursive: true });
   const content = renderTokenTypes(project);
   await writeFile(resolve(outDir, 'tokens.d.ts'), content);

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -23,6 +23,14 @@ export interface SwatchbookPluginOptions {
   cwd: string;
   /** Display-side integrations — each may contribute a virtual module the preview imports. */
   integrations?: readonly SwatchbookIntegration[];
+  /**
+   * Pre-loaded project to use for the first `buildStart` instead of
+   * calling `loadProject` again. Lets `preset.viteFinal` share its
+   * single `loadProject` call (originally needed for codegen) with the
+   * plugin, eliminating a redundant parse pass at Storybook startup.
+   * HMR-triggered reloads still call `loadProject` directly.
+   */
+  initialProject?: Project;
 }
 
 /** `\0<virtualId>` — Vite convention for resolved virtual module IDs. */
@@ -40,9 +48,10 @@ export function swatchbookTokensPlugin({
   config,
   cwd,
   integrations = [],
+  initialProject,
 }: SwatchbookPluginOptions): Plugin {
-  let project: Project | undefined;
-  let css = '';
+  let project: Project | undefined = initialProject;
+  let css = project ? emitAxisProjectedCss(project) : '';
 
   async function refresh(): Promise<void> {
     project = await loadProject(config, cwd);
@@ -65,6 +74,10 @@ export function swatchbookTokensPlugin({
     enforce: 'pre',
 
     async buildStart() {
+      // Skip the redundant load when preset.viteFinal already supplied
+      // a freshly-loaded project via `initialProject`. The first HMR
+      // reload (or a manual `refresh()`) calls `loadProject` as usual.
+      if (project) return;
       await refresh();
     },
 


### PR DESCRIPTION
## Summary

Closes #838. The addon's preset now calls `loadProject` once at Storybook startup and shares the result with both the typed-token codegen and the Vite plugin's first virtual-module render. Previously each ran its own independent `loadProject` call, parsing the same DTCG sources twice in sequence at startup.

`swatchbookTokensPlugin` gains an optional `initialProject` field; when supplied, the plugin's first `buildStart` skips its `loadProject` call and uses the pre-loaded project directly. HMR-triggered reloads still call `loadProject` as before (no behavior change for live reloads).

Storybook startup is now a single `loadProject` pass for the addon. Order of operations and emitted outputs unchanged.

Milestone: Maintenance

Closes #838

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally)
- [ ] CI green