### PR TITLE
perf(addon,blocks): dedupe Storybook channel listener barrage

### DIFF
--- a/.changeset/dedup-channel-listener-barrage.md
+++ b/.changeset/dedup-channel-listener-barrage.md
@@ -1,0 +1,10 @@
+---
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Closes #837. The addon preview's global-axis applier and the blocks channel-globals subscriber both subscribe to all three of Storybook's `globalsUpdated` / `setGlobals` / `updateGlobals` events. Subscribing to all three is intentional (each carries the payload at a different point in the preview lifecycle — init, toolbar tick, cross-frame echo) but the handlers previously ran their full update path on every fire, so a single toolbar change fan-out to 3× DOM writes / 3× snapshot updates / 3× consumer re-renders.
+
+Both handlers now content-dedupe on a stringified fingerprint (`axes` JSON + `format`). The first fire of each tick applies; the second and third no-op. No behavior change beyond fewer redundant updates.
+
+The blocks-side previous identity-equality guard (`if (next !== snapshot)`) didn't dedupe because the spread (`{ ...next, axes: nextAxes }`) produced a fresh object identity on every fire even when content was unchanged.

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -380,8 +380,23 @@ function installGlobalAxisApplier(): void {
     const tuple = resolveTuple(globals, {});
     setRootAxes(matchPermutationName(tuple), tuple);
   };
+  // Storybook fires `globalsUpdated`, `setGlobals`, and `updateGlobals`
+  // for the same logical change (preview init + every toolbar tick).
+  // Subscribing to all three is intentional — `setGlobals` carries the
+  // initial URL-persisted globals; `updateGlobals` is the toolbar
+  // signal; `globalsUpdated` is the cross-frame echo. Apply the same
+  // handler to all three but dedupe via a stringified-tuple guard so
+  // downstream `setRootAxes` + `useSyncExternalStore` consumers
+  // re-render at most once per real change instead of three times per
+  // tick.
+  let lastApplied = '';
   const onGlobals = (payload: { globals?: SwatchbookGlobals }): void => {
-    if (payload.globals) apply(payload.globals);
+    if (!payload.globals) return;
+    const tuple = resolveTuple(payload.globals, {});
+    const fingerprint = matchPermutationName(tuple);
+    if (fingerprint === lastApplied) return;
+    lastApplied = fingerprint;
+    apply(payload.globals);
   };
   channel.on('globalsUpdated', onGlobals);
   channel.on('setGlobals', onGlobals);

--- a/packages/blocks/src/internal/channel-globals.ts
+++ b/packages/blocks/src/internal/channel-globals.ts
@@ -41,31 +41,30 @@ function ensureSubscribed(): void {
   if (subscribed || typeof window === 'undefined') return;
   subscribed = true;
   const channel = addons.getChannel();
+  // Storybook fires `globalsUpdated`, `setGlobals`, and `updateGlobals`
+  // for the same logical change (preview init + every toolbar tick).
+  // Subscribing to all three is intentional — `setGlobals` carries the
+  // initial URL-persisted globals; `updateGlobals` is the toolbar
+  // signal; `globalsUpdated` is the cross-frame echo. The handler runs
+  // for each but content-deduplicates: we only update the shared
+  // snapshot when axes or format actually shifted (the previous
+  // identity-based spread guard fired three times per tick because each
+  // spread produced a new object identity even with unchanged content).
+  let lastFingerprint = '';
   const onGlobals = (payload: { globals?: SwatchbookGlobalsPayload }): void => {
     const globals = payload.globals;
     if (!globals) return;
-    let next = snapshot;
-    const nextAxes = globals[AXES_GLOBAL_KEY];
-    if (nextAxes && typeof nextAxes === 'object') {
-      next = { ...next, axes: nextAxes };
-    }
-    const nextFormat = globals[COLOR_FORMAT_GLOBAL_KEY];
-    if (isColorFormat(nextFormat)) {
-      next = { ...next, format: nextFormat };
-    }
-    if (next !== snapshot) {
-      snapshot = next;
-      for (const cb of listeners) cb();
-    }
+    const incomingAxes = globals[AXES_GLOBAL_KEY];
+    const incomingFormat = globals[COLOR_FORMAT_GLOBAL_KEY];
+    const nextAxes =
+      incomingAxes && typeof incomingAxes === 'object' ? incomingAxes : snapshot.axes;
+    const nextFormat = isColorFormat(incomingFormat) ? incomingFormat : snapshot.format;
+    const fingerprint = `${nextFormat ?? ''}|${nextAxes ? JSON.stringify(nextAxes) : ''}`;
+    if (fingerprint === lastFingerprint) return;
+    lastFingerprint = fingerprint;
+    snapshot = { axes: nextAxes, format: nextFormat };
+    for (const cb of listeners) cb();
   };
-  /**
-   * `setGlobals` fires once on preview init carrying the URL-persisted user
-   * globals (Storybook stores toolbar selections in `?globals=…`). Without
-   * this listener, deeplinking to an MDX page with a non-default axis tuple
-   * or color format renders defaults for one frame before the first
-   * `updateGlobals` arrives. `emitGlobals()` reads from `userGlobals.get()`
-   * (current state), so the payload is never stale — safe to handle.
-   */
   channel.on('globalsUpdated', onGlobals);
   channel.on('updateGlobals', onGlobals);
   channel.on('setGlobals', onGlobals);


### PR DESCRIPTION
## Summary

Closes #837. The addon preview's `installGlobalAxisApplier` and the blocks `channel-globals` `onGlobals` both subscribe to all three of Storybook's `globalsUpdated` / `setGlobals` / `updateGlobals` events. Subscribing to all three is intentional (each carries the payload at a different point in the preview lifecycle), but the handlers previously ran their full update path on every fire. A single toolbar change → 3× DOM writes (preview) and 3× snapshot updates + listener notifications (blocks).

Both handlers now content-dedupe on a stringified fingerprint (`axes` JSON + `format`). The first fire of each tick applies; the second and third no-op.

The blocks-side previous identity-equality guard (`if (next !== snapshot)`) didn't dedupe because the spread (`{ ...next, axes: nextAxes }`) produced a fresh object identity on every fire even when content was unchanged.

No behavior change beyond fewer redundant updates.

Milestone: Maintenance

Closes #837

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally)
- [ ] `pnpm --filter swatchbook-storybook test:storybook` (149 interaction tests green locally)
- [ ] CI green