### PR TITLE
chore: document core subpath intent + narrow addon barrel constants

### DIFF
--- a/.changeset/subpath-exports-cleanup.md
+++ b/.changeset/subpath-exports-cleanup.md
@@ -1,0 +1,12 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-addon": minor
+---
+
+Closes #834.
+
+**`@unpunnyfuns/swatchbook-core`** — documents why the `./resolve-at` and `./fuzzy` subpath exports exist (browser-safe, no Terrazzo parser transitively). They're load-bearing for the addon's preview bundle and any browser consumer, not just internal organization leaking through. Source-file JSDoc updated; no API changes.
+
+**`@unpunnyfuns/swatchbook-addon`** — drops four internal-only constants from the package barrel (`ADDON_ID`, `AXES_GLOBAL_KEY`, `PARAM_KEY`, `VIRTUAL_MODULE_ID`). None had external consumers in this workspace; the manager/preview/blocks codebase imports them via `#/constants.ts` directly. Pre-1.0 minor bump for the public-surface narrowing.
+
+Sibling `RESOLVED_*` constants and channel event names (`INIT_EVENT`, `HMR_EVENT`, etc.) remain unexported; they're Vite-internal markers (`\0`-prefixed virtual module IDs) or addon-private channel names that consumers shouldn't wire against.

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -1,7 +1,6 @@
 import { definePreviewAddon } from 'storybook/internal/csf';
 import * as previewExports from '#/preview.tsx';
 
-export { ADDON_ID, AXES_GLOBAL_KEY, PARAM_KEY, VIRTUAL_MODULE_ID } from '#/constants.ts';
 export type { AddonOptions } from '#/options.ts';
 
 /**

--- a/packages/core/src/fuzzy.ts
+++ b/packages/core/src/fuzzy.ts
@@ -1,3 +1,10 @@
+/**
+ * Browser-safe fuzzy search helper. Exported through the
+ * `@unpunnyfuns/swatchbook-core/fuzzy` subpath so the MCP server
+ * + future browser consumers can use it without pulling in the
+ * Terrazzo parser. Single transitive dep (`@leeoniya/ufuzzy`),
+ * zero Node API usage.
+ */
 import uFuzzy from '@leeoniya/ufuzzy';
 
 export interface FuzzyOptions {

--- a/packages/core/src/resolve-at.ts
+++ b/packages/core/src/resolve-at.ts
@@ -1,3 +1,13 @@
+/**
+ * Browser-safe `resolveAt` builder. Exported through the
+ * `@unpunnyfuns/swatchbook-core/resolve-at` subpath so the preview
+ * + blocks can import it without pulling in the Terrazzo parser
+ * (which the main `@unpunnyfuns/swatchbook-core` barrel transitively
+ * depends on and which is Node-only). The subpath split is
+ * load-bearing for the addon's preview bundle and any browser
+ * consumer that needs to compose tokens at any tuple without
+ * shipping `@terrazzo/parser` to the client.
+ */
 import type { Axis, Cells, JointOverrides, ResolveAt, TokenMap } from '#/types.ts';
 
 /**


### PR DESCRIPTION
## Summary

Closes #834.

- **`@unpunnyfuns/swatchbook-core`** — documents why the `./resolve-at` and `./fuzzy` subpath exports exist (browser-safe, no Terrazzo parser transitively). They're load-bearing for the addon's preview bundle and any browser consumer, not just internal organization leaking through. Source-file JSDoc updated; no API changes.
- **`@unpunnyfuns/swatchbook-addon`** — drops four internal-only constants from the package barrel (`ADDON_ID`, `AXES_GLOBAL_KEY`, `PARAM_KEY`, `VIRTUAL_MODULE_ID`). None had external consumers in this workspace; the manager/preview/blocks codebase imports them via `#/constants.ts` directly. Pre-1.0 minor bump for the public-surface narrowing.

Sibling `RESOLVED_*` constants and channel event names (`INIT_EVENT`, `HMR_EVENT`, etc.) remain unexported — they're Vite-internal markers or addon-private channel names that consumers shouldn't wire against.

Milestone: Maintenance

Closes #834

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally)
- [ ] CI green