### PR TITLE
test(blocks): drop trivial .toBeDefined() assertions on getByX results

### DIFF
--- a/.changeset/drop-trivial-tobedefined-assertions.md
+++ b/.changeset/drop-trivial-tobedefined-assertions.md
@@ -1,0 +1,9 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Partial close of #829. Drops trivial `.toBeDefined()` assertions on `getByText` / `getByTestId` / `findByTestId` results across the blocks test suite (38 sites in 10 files). Testing Library's `getByX` throws on absence, so `.toBeDefined()` was a no-op — the throw already enforced the invariant. The presence check now reads as `screen.getByText('…')` (or `screen.getByTestId('…')`) without the redundant assertion wrapper.
+
+Three remaining `.toBeDefined()` call sites that were also no-ops (against variables already returned by a throwing finder + then narrowed via `as`) are similarly cleaned up.
+
+The "one describe per file" half of #829 — splitting 4 multi-describe test files — is deferred to #858 for review-burden separation. No behavior change in this PR.

--- a/packages/blocks/test/color-palette.test.tsx
+++ b/packages/blocks/test/color-palette.test.tsx
@@ -52,9 +52,9 @@ describe('ColorPalette', () => {
     // `color.*` has fixed length 1. Auto groupBy clamps so every swatch
     // keeps a leaf label — depth-2 tokens get `color.<leaf>` groups,
     // depth-4 palette tokens collapse under the shared `color.palette` group.
-    expect(screen.getByText('color.bg')).toBeDefined();
-    expect(screen.getByText('color.fg')).toBeDefined();
-    expect(screen.getByText('color.palette')).toBeDefined();
+    screen.getByText('color.bg');
+    screen.getByText('color.fg');
+    screen.getByText('color.palette');
   });
 
   it('clamps auto-groupBy so each swatch keeps a leaf label', () => {
@@ -66,8 +66,8 @@ describe('ColorPalette', () => {
         <ColorPalette filter="color.palette.blue.*" />
       </SwatchbookProvider>,
     );
-    expect(screen.getByText('color.palette.blue')).toBeDefined();
-    expect(screen.getByText('500')).toBeDefined();
+    screen.getByText('color.palette.blue');
+    screen.getByText('500');
   });
 
   it('shows the empty state when the filter matches no color tokens', () => {
@@ -76,6 +76,6 @@ describe('ColorPalette', () => {
         <ColorPalette filter="typography.*" />
       </SwatchbookProvider>,
     );
-    expect(screen.getByText('No color tokens match this filter.')).toBeDefined();
+    screen.getByText('No color tokens match this filter.');
   });
 });

--- a/packages/blocks/test/color-table-expansion.test.tsx
+++ b/packages/blocks/test/color-table-expansion.test.tsx
@@ -20,7 +20,7 @@ describe('ColorTable — expansion', () => {
     act(() => {
       fireEvent.click(row);
     });
-    expect(screen.getByTestId('color-table-detail')).toBeDefined();
+    screen.getByTestId('color-table-detail');
     expect(row.getAttribute('aria-label')).toBe('Collapse color.text.default');
 
     act(() => {
@@ -39,7 +39,7 @@ describe('ColorTable — expansion', () => {
       fireEvent.click(screen.getByTestId('color-table-row'));
     });
     const detail = screen.getByTestId('color-table-detail');
-    expect(within(detail).getByText('Primary text on default surfaces.')).toBeDefined();
+    within(detail).getByText('Primary text on default surfaces.');
     expect(detail.textContent).toContain('color.palette.neutral.900');
   });
 

--- a/packages/blocks/test/color-table-grouping.test.tsx
+++ b/packages/blocks/test/color-table-grouping.test.tsx
@@ -49,7 +49,7 @@ describe('ColorTable — grouping', () => {
       .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
     if (!hiRow) throw new Error('group row not found');
     expect(hiRow.getAttribute('data-path')).toBe('color.bg.hi');
-    expect(within(hiRow).getByText('#111111')).toBeDefined();
+    within(hiRow).getByText('#111111');
   });
 
   it('clicking a pill swaps the active variant and the displayed values', () => {
@@ -76,7 +76,7 @@ describe('ColorTable — grouping', () => {
       .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
     if (!hiRow) throw new Error('group row after click not found');
     expect(hiRow.getAttribute('data-path')).toBe('color.bg.hi-d');
-    expect(within(hiRow).getByText('#333333')).toBeDefined();
+    within(hiRow).getByText('#333333');
   });
 
   it('renders DTCG dot-segment variants (hi.disabled) the same as hyphen tails', () => {

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -32,9 +32,9 @@ describe('ColorTable — base rendering', () => {
     );
 
     const row = screen.getByTestId('color-table-row');
-    expect(within(row).getByText('#111111')).toBeDefined();
-    expect(within(row).getByText(/var\(--sb-color-text-default\)/)).toBeDefined();
-    expect(within(row).getByText('color.palette.neutral.900')).toBeDefined();
+    within(row).getByText('#111111');
+    within(row).getByText(/var\(--sb-color-text-default\)/);
+    within(row).getByText('color.palette.neutral.900');
     // Per-format HSL / OKLCH copy buttons shouldn't exist on the collapsed row.
     expect(within(row).queryByLabelText(/Copy HSL/)).toBeNull();
     expect(within(row).queryByLabelText(/Copy OKLCH/)).toBeNull();
@@ -73,7 +73,7 @@ describe('ColorTable — base rendering', () => {
       </SwatchbookProvider>,
     );
     expect(screen.queryByRole('table')).toBeNull();
-    expect(screen.getByText('No color tokens match this filter.')).toBeDefined();
+    screen.getByText('No color tokens match this filter.');
   });
 
   it('renders no variant pills when the variants prop is omitted', () => {

--- a/packages/blocks/test/composite-breakdown.test.tsx
+++ b/packages/blocks/test/composite-breakdown.test.tsx
@@ -58,10 +58,9 @@ describe('CompositeBreakdown', () => {
     const aliasAnnotations = screen.getAllByTestId('breakdown-alias');
     expect(aliasAnnotations.length).toBe(1);
 
-    const chain = aliasAnnotations[0];
-    expect(chain).toBeDefined();
-    expect(within(chain as HTMLElement).getByText('color.border.default')).toBeDefined();
-    expect(within(chain as HTMLElement).getByText('color.palette.blue.500')).toBeDefined();
+    const chain = aliasAnnotations[0] as HTMLElement;
+    within(chain).getByText('color.border.default');
+    within(chain).getByText('color.palette.blue.500');
   });
 
   it('omits the alias annotation on sub-values that are literal (not aliases)', () => {

--- a/packages/blocks/test/diagnostics.test.tsx
+++ b/packages/blocks/test/diagnostics.test.tsx
@@ -29,7 +29,7 @@ describe('Diagnostics', () => {
         <Diagnostics />
       </SwatchbookProvider>,
     );
-    expect(screen.getByText(/✔ OK · no diagnostics/)).toBeDefined();
+    screen.getByText(/✔ OK · no diagnostics/);
   });
 
   it('auto-expands when there are errors and lists each row', () => {
@@ -51,15 +51,15 @@ describe('Diagnostics', () => {
     );
 
     // Summary shows the aggregated count.
-    expect(screen.getByText(/✖ 1 error · ⚠ 1 warning/)).toBeDefined();
+    screen.getByText(/✖ 1 error · ⚠ 1 warning/);
 
     // <details> auto-opens when errors exist — rows visible.
     const details = screen.getByText(/✖ 1 error · ⚠ 1 warning/).closest('details');
     expect(details?.hasAttribute('open')).toBe(true);
 
-    expect(screen.getByText('Missing $value on color.bg')).toBeDefined();
-    expect(screen.getByText('modifier unusable')).toBeDefined();
-    expect(screen.getByText(/parser · \/proj\/tokens.json · :4/)).toBeDefined();
+    screen.getByText('Missing $value on color.bg');
+    screen.getByText('modifier unusable');
+    screen.getByText(/parser · \/proj\/tokens.json · :4/);
   });
 
   it('stays collapsed when only info-level diagnostics are present', () => {
@@ -80,6 +80,6 @@ describe('Diagnostics', () => {
         <Diagnostics caption="Project health" />
       </SwatchbookProvider>,
     );
-    expect(screen.getByText('Project health')).toBeDefined();
+    screen.getByText('Project health');
   });
 });

--- a/packages/blocks/test/token-navigator.test.tsx
+++ b/packages/blocks/test/token-navigator.test.tsx
@@ -55,8 +55,8 @@ describe('TokenNavigator', () => {
     );
     expect(screen.queryByText('radius')).toBeNull();
     // Leaves `bg` and `fg` visible under the scoped root.
-    expect(screen.getByText('bg')).toBeDefined();
-    expect(screen.getByText('fg')).toBeDefined();
+    screen.getByText('bg');
+    screen.getByText('fg');
   });
 
   it('shows an empty-state message when the root matches no tokens', () => {
@@ -65,7 +65,7 @@ describe('TokenNavigator', () => {
         <TokenNavigator root="does-not-exist" />
       </SwatchbookProvider>,
     );
-    expect(screen.getByText(/No tokens under "does-not-exist"/)).toBeDefined();
+    screen.getByText(/No tokens under "does-not-exist"/);
   });
 
   it('filters by DTCG $type with a single string', () => {
@@ -103,7 +103,7 @@ describe('TokenNavigator', () => {
         <TokenNavigator root="color" type="dimension" />
       </SwatchbookProvider>,
     );
-    expect(screen.getByText(/No tokens under "color"/)).toBeDefined();
+    screen.getByText(/No tokens under "color"/);
   });
 
   it('shows a type-aware empty-state when no tokens match', () => {
@@ -112,7 +112,7 @@ describe('TokenNavigator', () => {
         <TokenNavigator type="fontWeight" />
       </SwatchbookProvider>,
     );
-    expect(screen.getByText(/No tokens matching \$type=fontWeight/)).toBeDefined();
+    screen.getByText(/No tokens matching \$type=fontWeight/);
   });
 
   it('renders a search input by default that prunes the tree to matching leaves', () => {
@@ -123,8 +123,6 @@ describe('TokenNavigator', () => {
     );
 
     const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
-    expect(input).toBeDefined();
-
     fireEvent.change(input, { target: { value: 'bg' } });
 
     // `color.bg` is the single leaf matching 'bg'; `radius` and `color.fg` /
@@ -165,7 +163,7 @@ describe('TokenNavigator', () => {
     const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'xyz-no-match' } });
 
-    expect(screen.getByText(/No tokens match "xyz-no-match"/)).toBeDefined();
+    screen.getByText(/No tokens match "xyz-no-match"/);
     expect(screen.queryByRole('tree')).toBeNull();
   });
 

--- a/packages/blocks/test/token-table.test.tsx
+++ b/packages/blocks/test/token-table.test.tsx
@@ -63,9 +63,9 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     const rows = within(table).getAllByRole('row');
     expect(rows.length).toBe(4);
 
-    expect(within(table).getByText('color.text')).toBeDefined();
-    expect(within(table).getByText('color.surface')).toBeDefined();
-    expect(within(table).getByText('space.md')).toBeDefined();
+    within(table).getByText('color.text');
+    within(table).getByText('color.surface');
+    within(table).getByText('space.md');
   });
 
   it('clicking a row opens the TokenDetail overlay by default', async () => {
@@ -81,8 +81,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     if (!target) throw new Error('row not found');
     target.click();
 
-    const overlay = await findByTestId('token-table-overlay');
-    expect(overlay).toBeDefined();
+    await findByTestId('token-table-overlay');
   });
 
   it('onSelect suppresses the overlay and hands the path to the consumer', () => {
@@ -124,8 +123,6 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     );
 
     const input = screen.getByTestId('token-table-search') as HTMLInputElement;
-    expect(input).toBeDefined();
-
     const before = within(screen.getByRole('table')).getAllByRole('row').length;
     expect(before).toBeGreaterThan(2);
 
@@ -153,7 +150,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     const input = screen.getByTestId('token-table-search') as HTMLInputElement;
     fireEvent.change(input, { target: { value: 'xyz-no-match' } });
 
-    expect(screen.getByText(/No tokens match "xyz-no-match"/)).toBeDefined();
+    screen.getByText(/No tokens match "xyz-no-match"/);
   });
 
   it('hides the search input when searchable={false}', () => {
@@ -177,7 +174,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     );
 
     expect(screen.queryByRole('table')).toBeNull();
-    expect(screen.getByText('No tokens match this filter.')).toBeDefined();
+    screen.getByText('No tokens match this filter.');
   });
 
   it('does not carry any chrome-aliasing inline style on the wrapper', () => {


### PR DESCRIPTION
## Summary

Partial close of #829. Drops trivial `.toBeDefined()` assertions on `getByText` / `getByTestId` / `findByTestId` results across the blocks test suite (38 sites in 10 files). Testing Library's `getByX` throws on absence, so `.toBeDefined()` was a no-op — the throw already enforced the invariant. The presence check now reads as `screen.getByText('…')` (or `screen.getByTestId('…')`) without the redundant assertion wrapper.

Three remaining `.toBeDefined()` call sites that were also no-ops (against variables already returned by a throwing finder + narrowed via `as`) are similarly cleaned up.

The "one describe per file" half of #829 — splitting 4 multi-describe test files — is deferred to #858 for review-burden separation.

Milestone: Maintenance

Closes #829 (alongside #858)

## Test plan
- [ ] `pnpm turbo run format:check lint typecheck test` (37 tasks green locally; blocks 220 tests still pass)
- [ ] CI green