### PR TITLE
refactor(mcp): rename response field permutations → themes

### DIFF
--- a/.changeset/mcp-vocabulary-themes.md
+++ b/.changeset/mcp-vocabulary-themes.md
@@ -1,0 +1,7 @@
+---
+"@unpunnyfuns/swatchbook-mcp": minor
+---
+
+Closes #826. Renames `permutations` → `themes` and `defaultPermutation` → `defaultTheme` in MCP tool response shapes (`describe_project`, `list_axes`). Aligns the AI-tool wire surface with the rest of the public vocabulary post-cartesian-drop — internally the server already worked in terms of themes; only the response field names trailed. Tool descriptions and help-text prose updated to match.
+
+Breaking for MCP clients that key off the old field names; the underlying values (default tuple name + singleton enumeration) are unchanged. The `theme` argument on tool inputs stays as-is — it's a string identifier (e.g. `"Dark · Brand A"`), not a tuple object, and the audit's `tuple` rename was rejected on that basis.

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -45,7 +45,7 @@ Usage:
   swatchbook-mcp --config <path> --no-watch   Disable live-reload on token / config edits.
 
 Tools exposed:
-  describe_project    Orientation — counts, axes, permutations, presets, diagnostics.
+  describe_project    Orientation — counts, axes, themes, presets, diagnostics.
   list_tokens         List tokens by path glob / \`$type\`.
   search_tokens       Fuzzy search across paths, descriptions, values.
   resolve_theme       Full resolved token map for an axis tuple.
@@ -56,7 +56,7 @@ Tools exposed:
   get_color_formats   hex / rgb / hsl / oklch / raw for a color token.
   get_color_contrast  Pair-wise contrast (WCAG 2.1 ratio or APCA Lc) + pass flags.
   get_axis_variance   Classify token variance (constant / single / multi) per axis.
-  list_axes           Axes + contexts + permutations + presets.
+  list_axes           Axes + contexts + themes + presets.
   get_diagnostics     Project diagnostics (optional severity filter).
   emit_css            Full project stylesheet.`);
       process.exit(0);

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -23,9 +23,7 @@ export function createServer(initial: Project): McpServer & {
   // parameter use this to map it to a tuple in O(1) before calling
   // `project.resolveAt(tuple)`. The set carries the default tuple +
   // every singleton (one per non-default cell on each axis) + every
-  // preset — enumerated from `axes` + `presets` + `defaultTuple`
-  // independently of the soon-to-be-removed `Project.permutations`
-  // field.
+  // preset — enumerated from `axes` + `presets` + `defaultTuple`.
   let tupleByName = buildTupleByName(initial);
   let defaultThemeName = tupleToName(initial.axes, initial.defaultTuple);
   const server = new McpServer(
@@ -57,9 +55,8 @@ export function createServer(initial: Project): McpServer & {
 
   /**
    * Iterate every `(themeName, tuple)` pair the project surfaces —
-   * default + singletons + presets — without going through
-   * `project.permutations`. Order is insertion order of `tupleByName`
-   * (default first, then singletons per axis, then presets).
+   * default + singletons + presets. Order is insertion order of
+   * `tupleByName` (default first, then singletons per axis, then presets).
    */
   const eachTheme = function* (): Generator<{ name: string; tuple: Record<string, string> }> {
     for (const [name, tuple] of tupleByName) yield { name, tuple };
@@ -89,8 +86,8 @@ export function createServer(initial: Project): McpServer & {
       return jsonResult({
         cssVarPrefix: project.config.cssVarPrefix ?? '',
         axes: project.axes.map((a) => ({ name: a.name, contexts: a.contexts, default: a.default })),
-        permutations: [...tupleByName.keys()],
-        defaultPermutation: defaultThemeName,
+        themes: [...tupleByName.keys()],
+        defaultTheme: defaultThemeName,
         presets: project.presets.map((p) => p.name),
         tokensPerTheme,
         types: typeCounts,
@@ -129,7 +126,7 @@ export function createServer(initial: Project): McpServer & {
         theme: z
           .string()
           .optional()
-          .describe('Permutation name to read values from. Defaults to the project default theme.'),
+          .describe('Theme name to read values from. Defaults to the project default theme.'),
       },
     },
     ({ filter, type, theme }) => {
@@ -203,7 +200,7 @@ export function createServer(initial: Project): McpServer & {
     'list_axes',
     {
       description:
-        'List the project axes — each axis has a name, its contexts (discrete values like `Light` / `Dark`), a default, and a source (`resolver` for DTCG-resolver-driven, `layered` for authored layered axes, `synthetic` for single-theme projects). Also returns the named permutations (every axis tuple combination) and any presets defined in the project config.',
+        'List the project axes — each axis has a name, its contexts (discrete values like `Light` / `Dark`), a default, and a source (`resolver` for DTCG-resolver-driven, `layered` for authored layered axes, `synthetic` for single-theme projects). Also returns the named themes (one per default tuple + per-axis non-default singleton + preset) and any presets defined in the project config.',
       inputSchema: {},
     },
     () =>
@@ -216,7 +213,7 @@ export function createServer(initial: Project): McpServer & {
           source: axis.source,
         })),
         disabledAxes: project.disabledAxes,
-        permutations: [...eachTheme()].map(({ name, tuple }) => ({ name, input: tuple })),
+        themes: [...eachTheme()].map(({ name, tuple }) => ({ name, input: tuple })),
         presets: project.presets.map((p) => ({
           name: p.name,
           axes: p.axes,
@@ -309,9 +306,7 @@ export function createServer(initial: Project): McpServer & {
         theme: z
           .string()
           .optional()
-          .describe(
-            'Permutation name to read the value from. Defaults to the project default theme.',
-          ),
+          .describe('Theme name to read the value from. Defaults to the project default theme.'),
       },
     },
     ({ path, theme }) => {
@@ -341,10 +336,7 @@ export function createServer(initial: Project): McpServer & {
         background: z
           .string()
           .describe('Dot-path of the background color token, e.g. `color.surface.default`.'),
-        theme: z
-          .string()
-          .optional()
-          .describe('Permutation name. Defaults to the project default theme.'),
+        theme: z.string().optional().describe('Theme name. Defaults to the project default theme.'),
         algorithm: z
           .enum(['wcag21', 'apca'])
           .optional()
@@ -411,7 +403,7 @@ export function createServer(initial: Project): McpServer & {
         theme: z
           .string()
           .optional()
-          .describe('Permutation name to search within. Defaults to the project default.'),
+          .describe('Theme name to search within. Defaults to the project default.'),
         limit: z.number().int().positive().optional().describe('Cap the result count. Default 50.'),
       },
     },

--- a/packages/mcp/test/computed-and-emit.test.ts
+++ b/packages/mcp/test/computed-and-emit.test.ts
@@ -182,7 +182,7 @@ it('resolve_theme: scopes the returned map via filter and $type', async () => {
 it('emit_css: returns a stylesheet with :root + per-tuple selectors', async () => {
   const css = await mcp.callText('emit_css');
   expect(css).toContain(':root');
-  // The non-default permutations get attribute selectors with the data-sb-* prefix.
+  // The non-default themes get attribute selectors with the data-sb-* prefix.
   expect(css).toMatch(/data-sb-mode/);
   // CSS vars use the project prefix.
   expect(css).toMatch(/--sb-color-/);

--- a/packages/mcp/test/project-metadata.test.ts
+++ b/packages/mcp/test/project-metadata.test.ts
@@ -21,32 +21,32 @@ afterAll(async () => {
 interface DescribeProjectResult {
   cssVarPrefix: string;
   axes: { name: string; contexts: string[]; default: string }[];
-  permutations: string[];
-  defaultPermutation: string | null;
+  themes: string[];
+  defaultTheme: string | null;
   presets: string[];
   tokensPerTheme: Record<string, number>;
   types: Record<string, number>;
   diagnostics: { counts: Record<string, number>; total: number };
 }
 
-it('describe_project: returns axis summary, permutation list, token counts, and diagnostic counts', async () => {
+it('describe_project: returns axis summary, theme list, token counts, and diagnostic counts', async () => {
   const result = await mcp.callJson<DescribeProjectResult>('describe_project');
   expect(result.cssVarPrefix).toBe('sb');
   expect(result.axes.length).toBeGreaterThan(0);
   const modeAxis = result.axes.find((a) => a.name === 'mode');
   expect(modeAxis?.contexts).toContain('Light');
   expect(modeAxis?.contexts).toContain('Dark');
-  expect(result.permutations.length).toBeGreaterThan(1);
-  expect(result.defaultPermutation).toBe(result.permutations[0]);
-  expect(result.tokensPerTheme[result.defaultPermutation!]).toBeGreaterThan(0);
+  expect(result.themes.length).toBeGreaterThan(1);
+  expect(result.defaultTheme).toBe(result.themes[0]);
+  expect(result.tokensPerTheme[result.defaultTheme!]).toBeGreaterThan(0);
   expect(result.types['color']).toBeGreaterThan(0);
   expect(result.diagnostics.total).toBeGreaterThanOrEqual(0);
 });
 
 it('describe_project: types histogram covers every DTCG type present', async () => {
   const result = await mcp.callJson<DescribeProjectResult>('describe_project');
-  // Sum across types should equal the total token count across permutations
-  // — sanity that the histogram came from the same walk as tokensPerTheme.
+  // Sum across types should equal the total token count across themes —
+  // sanity that the histogram came from the same walk as tokensPerTheme.
   const totalFromTypes = Object.values(result.types).reduce((a, b) => a + b, 0);
   const totalFromThemes = Object.values(result.tokensPerTheme).reduce((a, b) => a + b, 0);
   expect(totalFromTypes).toBeGreaterThan(0);
@@ -56,11 +56,11 @@ it('describe_project: types histogram covers every DTCG type present', async () 
 interface ListAxesResult {
   axes: { name: string; contexts: string[]; default: string; source: string }[];
   disabledAxes: string[];
-  permutations: { name: string; input: Record<string, string> }[];
+  themes: { name: string; input: Record<string, string> }[];
   presets: { name: string; axes: Record<string, string>; description?: string }[];
 }
 
-it('list_axes: returns axes with `source: resolver` for resolver-driven projects, plus the materialized singleton permutations', async () => {
+it('list_axes: returns axes with `source: resolver` for resolver-driven projects, plus the materialized singleton themes', async () => {
   const result = await mcp.callJson<ListAxesResult>('list_axes');
   expect(result.axes.every((a) => a.source === 'resolver')).toBe(true);
   expect(result.disabledAxes).toEqual([]);
@@ -68,9 +68,9 @@ it('list_axes: returns axes with `source: resolver` for resolver-driven projects
   // each axis = 1 + Σ(contexts - 1). Bounded by Σ(axes × contexts),
   // not by the cartesian product.
   const expected = 1 + result.axes.reduce((acc, a) => acc + (a.contexts.length - 1), 0);
-  expect(result.permutations.length).toBe(expected);
-  // Every permutation should have an entry per axis.
-  for (const tuple of result.permutations) {
+  expect(result.themes.length).toBe(expected);
+  // Every theme should have an entry per axis.
+  for (const tuple of result.themes) {
     expect(Object.keys(tuple.input).toSorted()).toEqual(result.axes.map((a) => a.name).toSorted());
   }
 });
@@ -111,7 +111,7 @@ it('list_tokens: scopes results to a DTCG `$type`', async () => {
   expect(result.tokens.every((t) => t.type === 'color')).toBe(true);
 });
 
-it('list_tokens: reads from a non-default permutation when `theme` is supplied', async () => {
+it('list_tokens: reads from a non-default theme when `theme` is supplied', async () => {
   // Synthesize a Dark-mode singleton name the same way the server does.
   const modeAxis = project.axes.find((a) => a.name === 'mode');
   if (!modeAxis) throw new Error('expected fixture to include a mode axis');

--- a/packages/mcp/test/token-introspection.test.ts
+++ b/packages/mcp/test/token-introspection.test.ts
@@ -47,14 +47,14 @@ interface GetTokenResult {
   perTheme: Record<string, { value: string; aliasOf?: string; aliasChain?: readonly string[] }>;
 }
 
-it('get_token: returns the alias chain and resolved value per permutation', async () => {
+it('get_token: returns the alias chain and resolved value per theme', async () => {
   const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });
   expect(result.path).toBe(ALIAS_TOKEN);
   expect(result.type).toBe('color');
   // cssVar uses the project prefix and dot→dash substitution.
   expect(result.cssVar).toBe(`var(--sb-${ALIAS_TOKEN.replaceAll('.', '-')})`);
   expect(Object.keys(result.perTheme).length).toBe(singletonCount(project));
-  // Every permutation entry carries a value; aliased ones name their target.
+  // Every theme entry carries a value; aliased ones name their target.
   for (const entry of Object.values(result.perTheme)) {
     expect(entry.value).toBeTruthy();
     if (entry.aliasOf) {
@@ -84,7 +84,7 @@ interface GetAliasChainResult {
   perTheme: Record<string, { aliasOf?: string; chain: readonly string[] }>;
 }
 
-it('get_alias_chain: returns the forward chain per permutation for an alias token', async () => {
+it('get_alias_chain: returns the forward chain per theme for an alias token', async () => {
   const result = await mcp.callJson<GetAliasChainResult>('get_alias_chain', { path: ALIAS_TOKEN });
   expect(result.path).toBe(ALIAS_TOKEN);
   expect(Object.keys(result.perTheme).length).toBe(singletonCount(project));
@@ -170,7 +170,7 @@ interface SearchTokensResult {
   }[];
 }
 
-it('search_tokens: returns ranked fuzzy hits scoped to the default permutation', async () => {
+it('search_tokens: returns ranked fuzzy hits scoped to the default theme', async () => {
   const result = await mcp.callJson<SearchTokensResult>('search_tokens', { query: 'surface' });
   expect(result.theme).toBe(defaultThemeName(project));
   expect(result.count).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- Renames `permutations` → `themes` and `defaultPermutation` → `defaultTheme` in MCP `describe_project` and `list_axes` response shapes.
- Aligns the AI-tool wire surface with the post-cartesian-drop vocabulary — internally the server already worked in terms of themes (`tupleByName`, `tokensPerTheme`, `eachTheme()`); only the response field names trailed.
- `theme` argument on tool inputs stays as-is. It's a stringified tuple identifier (e.g. `"Dark · Brand A"`), not an object tuple, so the audit's `tuple` rename was rejected on that basis.
- Tool descriptions and help-text prose swept for residual "permutation" references; comments updated to match.

Milestone: Maintenance
Closes: #826
Plan impact: None.

## Test plan

- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — all 37 tasks green
- [x] MCP suite (73 tests across 7 files) green after the rename