### PR TITLE
refactor(addon,blocks): drop as-cast on preview.tsx resolveAt

### DIFF
--- a/.changeset/preview-resolveat-cast.md
+++ b/.changeset/preview-resolveat-cast.md
@@ -1,0 +1,6 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+Closes #863. Drops the last `as unknown as` cast in `packages/addon/src/preview.tsx` by structurally aligning `VirtualTokenShape` with what `buildResolveAt` actually returns: optional string fields widened to `?: T | undefined` so they accept Terrazzo's `string | undefined` shape under `exactOptionalPropertyTypes`, and `partialAliasOf` retyped as `unknown` since its per-composite-type structure is heterogeneous (color's `components: (string | undefined)[]` doesn't fit `Record<string, string | undefined>`; the `CompositeBreakdown` consumer already narrows at runtime).

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -285,13 +285,7 @@ const themedDecorator: Decorator = (Story, context) => {
       jointOverrides: virtualJointOverrides,
       varianceByPath: virtualVarianceByPath,
       defaultTuple: virtualDefaultTuple,
-      // Cast: `buildResolveAt` returns `TokenMap` (Terrazzo's
-      // `TokenNormalized`), while the block-side snapshot type uses
-      // its own narrower `VirtualTokenShape`. The shapes are
-      // structurally a subset; the cast covers the
-      // `exactOptionalPropertyTypes` mismatch between
-      // `string | undefined` and `string`.
-      resolveAt: previewResolveAt as unknown as NonNullable<ProjectSnapshot['resolveAt']>,
+      resolveAt: previewResolveAt,
     }),
     [themeName, tuple],
   );

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -24,21 +24,25 @@ export type VirtualAxisShape = Axis;
 export type VirtualDiagnosticShape = Diagnostic;
 
 export interface VirtualTokenShape {
-  $type?: string;
+  $type?: string | undefined;
   $value?: unknown;
-  $description?: string;
-  aliasOf?: string;
-  aliasChain?: readonly string[];
-  aliasedBy?: readonly string[];
+  $description?: string | undefined;
+  aliasOf?: string | undefined;
+  aliasChain?: readonly string[] | undefined;
+  aliasedBy?: readonly string[] | undefined;
   /**
    * Per-sub-field alias map for composite tokens whose value blends
    * primitives with aliased fragments — Terrazzo populates this when
    * one or more component fields of a composite ($type: 'border',
    * 'shadow', 'typography', 'gradient', 'transition') resolve through
    * an alias. The `CompositeBreakdown` block reads it to render the
-   * source path beside each component value.
+   * source path beside each component value. Typed as `unknown` because
+   * the shape varies per composite type (color carries a
+   * `{components: (string | undefined)[]}` sub-shape; typography/border
+   * carry a flat `Record<string, string | undefined>`); the block
+   * narrows it at the consumer.
    */
-  partialAliasOf?: Record<string, string | undefined>;
+  partialAliasOf?: unknown;
 }
 
 /**

--- a/packages/blocks/src/motion-preview/MotionSample.tsx
+++ b/packages/blocks/src/motion-preview/MotionSample.tsx
@@ -107,7 +107,7 @@ function asEasing(
 }
 
 export function resolveMotionSpec(
-  token: { $type?: string; $value?: unknown } | undefined,
+  token: { $type?: string | undefined; $value?: unknown } | undefined,
   themeTokens: Record<string, { $value?: unknown }>,
 ): Spec | null {
   if (!token) return null;


### PR DESCRIPTION
## Summary

- Drops the last `as unknown as` cast in `packages/addon/src/preview.tsx` (line 294, on `previewResolveAt`) by structurally aligning the snapshot type with what `buildResolveAt` returns.
- `VirtualTokenShape`'s optional string fields widened to `?: T | undefined` so they accept Terrazzo's `string | undefined` shape under `exactOptionalPropertyTypes`.
- `partialAliasOf` retyped as `unknown` — Terrazzo's per-composite-type structure is heterogeneous (color carries `components: (string | undefined)[]` which doesn't fit `Record<string, string | undefined>`); the `CompositeBreakdown` consumer already narrows at runtime via `pickObjectAliases` / `pickArrayAliases`, so `unknown` matches reality and removes the documented "the cast is wrong but covers it" friction.
- Same widening applied to the local helper signature in `MotionSample.resolveMotionSpec` so callers passing a `VirtualTokenShape` typecheck without a cast.

Milestone: Maintenance
Closes: #863
Plan impact: None.

## Test plan

- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — all 37 tasks green
- [x] No `as unknown as` casts remain in `packages/addon/src/`