### PR TITLE
refactor(core,blocks,addon): discriminate AxisVarianceResult on kind

### DIFF
--- a/.changeset/axis-variance-discriminated.md
+++ b/.changeset/axis-variance-discriminated.md
@@ -1,0 +1,17 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-addon": minor
+---
+
+Closes #825. `AxisVarianceResult` is now a discriminated union on `kind`:
+
+- `constant` — `varyingAxes: readonly []`
+- `single` — adds `axis: string` shortcut + `varyingAxes: readonly [string]`
+- `multi` — `varyingAxes: readonly [string, string, ...string[]]`
+
+Consumers get exhaustive `switch (result.kind)` narrowing, and the `single` variant exposes `axis: string` directly so blocks no longer need to defensively check `varyingAxes[0]` for undefined. Same applied to the addon-side `VirtualVarianceEntry` wire shape and the virtual module's ambient `VirtualAxisVarianceEntry` declaration.
+
+JSON wire shape is identical to the previous flat interface — MCP `get_axis_variance` and snapshot payloads keep working unchanged. New helper type `AxisVariancePerAxis` exported for consumers that want to reference the shared `perAxis` sub-shape without reaching into the union.
+
+`#866` and `#865` carry the remaining `JointOverrides` and `Config` discriminated-union refactors from the same audit — each higher-churn and earning a standalone PR.

--- a/packages/addon/src/channel-types.ts
+++ b/packages/addon/src/channel-types.ts
@@ -100,15 +100,38 @@ export interface VirtualJointOverride {
 export type VirtualJointOverrides = readonly (readonly [string, VirtualJointOverride])[];
 
 /**
- * Wire shape of one cached `AxisVarianceResult` entry. Mirrors the
- * core type but uses the local `VirtualToken`-style references.
+ * Wire shape of one cached `AxisVarianceResult` entry — discriminated
+ * on `kind` so consumers narrow `varyingAxes`'s cardinality and (for
+ * the single-axis variant) reach `axis: string` directly. Mirrors
+ * core's discriminated union; JSON-shape-identical so the wire
+ * payload doesn't carry a translation step.
  */
-export interface VirtualVarianceEntry {
-  path: string;
-  kind: 'constant' | 'single' | 'multi';
-  varyingAxes: string[];
-  constantAcrossAxes: string[];
-  perAxis: Record<string, { varying: boolean; contexts: Record<string, string> }>;
-}
+export type VirtualVariancePerAxis = Record<
+  string,
+  { varying: boolean; contexts: Record<string, string> }
+>;
+export type VirtualVarianceEntry =
+  | {
+      path: string;
+      kind: 'constant';
+      varyingAxes: readonly [];
+      constantAcrossAxes: readonly string[];
+      perAxis: VirtualVariancePerAxis;
+    }
+  | {
+      path: string;
+      kind: 'single';
+      axis: string;
+      varyingAxes: readonly [string];
+      constantAcrossAxes: readonly string[];
+      perAxis: VirtualVariancePerAxis;
+    }
+  | {
+      path: string;
+      kind: 'multi';
+      varyingAxes: readonly [string, string, ...string[]];
+      constantAcrossAxes: readonly string[];
+      perAxis: VirtualVariancePerAxis;
+    };
 
 export type VirtualVarianceByPath = Record<string, VirtualVarianceEntry>;

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -12,10 +12,10 @@ export interface AxisVarianceProps {
   path: string;
 }
 
-interface Variance {
-  kind: 'constant' | 'one-axis' | 'multi-axis';
-  varyingAxes: readonly string[];
-}
+type Variance =
+  | { kind: 'constant' }
+  | { kind: 'one-axis'; axis: string; varyingAxes: readonly [string] }
+  | { kind: 'multi-axis'; varyingAxes: readonly [string, string, ...string[]] };
 
 export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
   const {
@@ -39,16 +39,15 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
     // map over the wire — O(1) lookup per render instead of an O(paths
     // × permutations) re-derivation here.
     const result = varianceByPath[path];
-    if (!result) {
-      return { kind: 'constant', varyingAxes: [] };
+    if (!result) return { kind: 'constant' };
+    switch (result.kind) {
+      case 'constant':
+        return { kind: 'constant' };
+      case 'single':
+        return { kind: 'one-axis', axis: result.axis, varyingAxes: result.varyingAxes };
+      case 'multi':
+        return { kind: 'multi-axis', varyingAxes: result.varyingAxes };
     }
-    const kind =
-      result.kind === 'constant'
-        ? 'constant'
-        : result.kind === 'single'
-          ? 'one-axis'
-          : 'multi-axis';
-    return { kind, varyingAxes: result.varyingAxes };
   }, [path, varianceByPath]);
 
   if (axes.length === 0) {
@@ -82,8 +81,7 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
   }
 
   if (variance.kind === 'one-axis') {
-    const axisName = variance.varyingAxes[0];
-    if (!axisName) return <></>;
+    const axisName = variance.axis;
     const axis = axes.find((a) => a.name === axisName);
     if (!axis) return <></>;
     const contextValues = axis.contexts.map((ctx) => {

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -55,13 +55,33 @@ declare module 'virtual:swatchbook/tokens' {
     tokens: Record<string, VirtualToken>;
   }
 
-  interface VirtualAxisVarianceEntry {
-    path: string;
-    kind: 'constant' | 'single' | 'multi';
-    varyingAxes: string[];
-    constantAcrossAxes: string[];
-    perAxis: Record<string, { varying: boolean; contexts: Record<string, string> }>;
-  }
+  type VirtualAxisVariancePerAxis = Record<
+    string,
+    { varying: boolean; contexts: Record<string, string> }
+  >;
+  type VirtualAxisVarianceEntry =
+    | {
+        path: string;
+        kind: 'constant';
+        varyingAxes: readonly [];
+        constantAcrossAxes: readonly string[];
+        perAxis: VirtualAxisVariancePerAxis;
+      }
+    | {
+        path: string;
+        kind: 'single';
+        axis: string;
+        varyingAxes: readonly [string];
+        constantAcrossAxes: readonly string[];
+        perAxis: VirtualAxisVariancePerAxis;
+      }
+    | {
+        path: string;
+        kind: 'multi';
+        varyingAxes: readonly [string, string, ...string[]];
+        constantAcrossAxes: readonly string[];
+        perAxis: VirtualAxisVariancePerAxis;
+      };
 
   export const axes: readonly VirtualAxis[];
   export const presets: readonly VirtualPreset[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export { type ListedToken, type TokenListingByPath } from '#/token-listing.ts';
 export type {
   Axis,
   AxisConfig,
+  AxisVariancePerAxis,
   AxisVarianceResult,
   Cells,
   Config,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -20,26 +20,50 @@ export type TokenMap = Record<string, TokenNormalized>;
  */
 export type VarianceKind = 'constant' | 'single' | 'multi';
 
-export interface AxisVarianceResult {
-  path: string;
-  kind: VarianceKind;
-  /** Axes whose contexts change this token's resolved value. */
-  varyingAxes: string[];
-  /** Axes whose contexts do not change the resolved value. */
-  constantAcrossAxes: string[];
-  /**
-   * Per-axis breakdown. For each axis, whether it affects this token,
-   * and the stringified value seen in each of its contexts (holding
-   * other axes at their defaults).
-   */
-  perAxis: Record<
-    string,
-    {
-      varying: boolean;
-      contexts: Record<string, string>;
+/**
+ * Per-axis breakdown carried on every variance result — whether each
+ * axis affects this token, and the stringified value seen in each of
+ * its contexts (holding other axes at their defaults).
+ */
+export type AxisVariancePerAxis = Record<
+  string,
+  {
+    varying: boolean;
+    contexts: Record<string, string>;
+  }
+>;
+
+/**
+ * Discriminated on `kind` so a `switch (result.kind)` narrows
+ * `varyingAxes`'s cardinality and exposes the `axis: string` shortcut
+ * on the single-axis variant. The wire shape is unchanged (the same
+ * JSON the flat interface serialized to), so MCP consumers and
+ * snapshot wire payloads keep working without translation.
+ */
+export type AxisVarianceResult =
+  | {
+      path: string;
+      kind: 'constant';
+      varyingAxes: readonly [];
+      constantAcrossAxes: readonly string[];
+      perAxis: AxisVariancePerAxis;
     }
-  >;
-}
+  | {
+      path: string;
+      kind: 'single';
+      /** Convenience accessor — the sole varying axis, also at `varyingAxes[0]`. */
+      axis: string;
+      varyingAxes: readonly [string];
+      constantAcrossAxes: readonly string[];
+      perAxis: AxisVariancePerAxis;
+    }
+  | {
+      path: string;
+      kind: 'multi';
+      varyingAxes: readonly [string, string, ...string[]];
+      constantAcrossAxes: readonly string[];
+      perAxis: AxisVariancePerAxis;
+    };
 
 /**
  * Per-axis cell maps. `cells[axisName][contextName]` is the resolved

--- a/packages/core/src/variance-by-path.ts
+++ b/packages/core/src/variance-by-path.ts
@@ -1,4 +1,4 @@
-import type { Axis, AxisVarianceResult, Cells, TokenMap, VarianceKind } from '#/types.ts';
+import type { Axis, AxisVariancePerAxis, AxisVarianceResult, Cells, TokenMap } from '#/types.ts';
 
 /**
  * Pre-compute per-path variance at load time so consumers don't have
@@ -42,7 +42,7 @@ export function buildVarianceByPath(
   const out = new Map<string, AxisVarianceResult>();
   for (const path of allPaths) {
     const baselineKey = valueKey(baseline[path]);
-    const perAxis: AxisVarianceResult['perAxis'] = {};
+    const perAxis: AxisVariancePerAxis = {};
     const varyingAxes: string[] = [];
     const constantAcrossAxes: string[] = [];
     const jointTouchSet = jointTouching.get(path) ?? new Set<string>();
@@ -60,11 +60,39 @@ export function buildVarianceByPath(
       (varying ? varyingAxes : constantAcrossAxes).push(axis.name);
     }
 
-    const kind: VarianceKind =
-      varyingAxes.length === 0 ? 'constant' : varyingAxes.length === 1 ? 'single' : 'multi';
-    out.set(path, { path, kind, varyingAxes, constantAcrossAxes, perAxis });
+    out.set(path, buildResult(path, varyingAxes, constantAcrossAxes, perAxis));
   }
   return out;
+}
+
+function buildResult(
+  path: string,
+  varyingAxes: string[],
+  constantAcrossAxes: string[],
+  perAxis: AxisVariancePerAxis,
+): AxisVarianceResult {
+  if (varyingAxes.length === 0) {
+    return { path, kind: 'constant', varyingAxes: [], constantAcrossAxes, perAxis };
+  }
+  if (varyingAxes.length === 1) {
+    const [axis] = varyingAxes as [string];
+    return {
+      path,
+      kind: 'single',
+      axis,
+      varyingAxes: [axis],
+      constantAcrossAxes,
+      perAxis,
+    };
+  }
+  const [first, second, ...rest] = varyingAxes as [string, string, ...string[]];
+  return {
+    path,
+    kind: 'multi',
+    varyingAxes: [first, second, ...rest],
+    constantAcrossAxes,
+    perAxis,
+  };
 }
 
 function valueKey(token: TokenMap[string] | undefined): string {


### PR DESCRIPTION
## Summary

- `AxisVarianceResult` is now a discriminated union on \`kind\` (\`constant\` / \`single\` / \`multi\`) with cardinality-typed \`varyingAxes\` tuples — \`readonly []\` / \`readonly [string]\` / \`readonly [string, string, ...string[]]\` respectively. The \`single\` variant also exposes \`axis: string\` directly.
- Same applied to the addon-side \`VirtualVarianceEntry\` wire shape (\`packages/addon/src/channel-types.ts\`) and the virtual module's ambient \`VirtualAxisVarianceEntry\` declaration so the entire variance path is exhaustively narrowable end-to-end.
- The \`AxisVariance\` block's local \`Variance\` type is also discriminated — its 'one-axis' arm no longer needs a defensive \`if (!axisName)\` check, since the source \`single\` variant guarantees \`axis: string\`.
- New helper type \`AxisVariancePerAxis\` exported from core for consumers that want to reference the shared \`perAxis\` sub-shape without reaching into the union.
- JSON wire shape is identical to the previous flat interface — MCP \`get_axis_variance\` and snapshot payloads keep working unchanged (no consumer translation needed). Pre-1.0 minor bump per project semver.

The remaining \`JointOverrides\` (#866) and \`Config\` (#865) discriminated-union refactors from #825 are higher-churn and earn standalone PRs.

Milestone: Maintenance
Closes: #825
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] Exhaustive narrowing verified in AxisVariance.tsx (constant / one-axis / multi-axis arms compile without optional-chaining or defensive guards)