### PR TITLE
test(core): cover probeJointOverrides branches with direct unit tests + fixture invariants

### DIFF
--- a/.changeset/probe-joint-overrides-coverage.md
+++ b/.changeset/probe-joint-overrides-coverage.md
@@ -1,0 +1,7 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Closes #822. Adds direct unit tests for `probeJointOverrides` in `packages/core/test/probe-joint-overrides.test.ts` covering every algorithmic branch with synthetic minimal `axes / cells / resolver` inputs: the `axes.length < 2` early-return, the resolver-undefined early-return, arity-2 override capture, the `cellB[path] ?? baseline[path]` baseline-fallback (touching detection through a delta cell that omits a path), arity-3+ conservative touching marking, and canonical-key dedupe (axes lexicographically sorted regardless of declared order).
+
+Also extends `packages/core/test/joint-overrides.test.ts` (the fixture-based suite) with two new invariants: the reference fixture produces at least one arity-3 override entry (pins that the arity-3 loop has real-data coverage — the audit's "dead in tests" claim was actually wrong, the fixture's `{Brand A, High, Dark}` triple exists), and an axis appears in `varianceByPath.varyingAxes` even when its singleton cell matches baseline (variance surfaces via the joint probe). No source changes.

--- a/packages/core/test/joint-overrides.test.ts
+++ b/packages/core/test/joint-overrides.test.ts
@@ -37,3 +37,38 @@ it("iteration order is ascending arity (so composition can apply lower-order ove
     prevArity = arity;
   }
 });
+
+it('exercises the arity-3 branch — the fixture produces at least one triple-axis override entry', () => {
+  // probeJointOverrides walks arity 2..N. The arity-3+ branch
+  // marks every participating axis touching conservatively (vs
+  // arity-2's per-axis leave-one-out check) and dedupes via
+  // canonicalKey across arity passes. The fixture's
+  // {brand:'Brand A', contrast:High, mode:Dark} entry exists because
+  // pair-composition can't reproduce the triple-joint accessible-accent
+  // values; pin that the branch is reachable so future fixture changes
+  // don't silently drop the only real-data coverage of the arity-3 loop.
+  const triples = [...project.jointOverrides.values()].filter(
+    (o) => Object.keys(o.axes).length === 3,
+  );
+  expect(triples.length).toBeGreaterThan(0);
+  for (const triple of triples) {
+    expect(Object.keys(triple.tokens).length).toBeGreaterThan(0);
+  }
+});
+
+it('marks an axis as joint-touching even when its singleton cell matches baseline (variance surfaces via the joint probe, not the per-axis cell)', () => {
+  // `color.accent.fg`: brand at default mode produces white, matching
+  // baseline white — brand's singleton cell records no divergence. Yet
+  // brand still appears in varianceByPath.varyingAxes because the joint
+  // probe at {mode:Dark, brand:'Brand A'} marks brand touching
+  // (Brand A's resolver overrides accent.fg=white where Dark's cell
+  // alone gives dark). Pins that the two signals — singleton + joint —
+  // both flow into varyingAxes.
+  const variance = project.varianceByPath.get('color.accent.fg');
+  expect(variance?.kind).toBe('multi');
+  expect(variance?.varyingAxes).toContain('brand');
+  // Brand's per-axis singleton contexts match (no singleton effect).
+  const brandContexts = variance?.perAxis['brand']?.contexts ?? {};
+  const brandValues = new Set(Object.values(brandContexts));
+  expect(brandValues.size).toBe(1);
+});

--- a/packages/core/test/probe-joint-overrides.test.ts
+++ b/packages/core/test/probe-joint-overrides.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Direct unit tests for `probeJointOverrides` — minimal synthetic
+ * `axes / cells / resolver` inputs that exercise each algorithmic
+ * branch without depending on the reference fixture. The fixture
+ * test (`joint-overrides.test.ts`) covers end-to-end behaviour against
+ * real data; these tests pin individual branches so a future fixture
+ * shape change can't accidentally drop coverage of the early-returns,
+ * the baseline-fallback, or the arity dedupe.
+ */
+import type { Resolver, TokenNormalized } from '@terrazzo/parser';
+import { expect, it } from 'vitest';
+import { probeJointOverrides } from '#/joint-overrides.ts';
+import type { Axis, Cells, TokenMap } from '#/types.ts';
+
+// Minimal `TokenNormalized`-shaped value for synthetic cells. Only the
+// `$value` field participates in the probe's comparison (via
+// `JSON.stringify($value)`), so the rest can stay sparse.
+function tok(value: unknown): TokenNormalized {
+  return { $value: value, $type: 'color' } as TokenNormalized;
+}
+
+// Mock Resolver: only `apply` is consulted by probeJointOverrides.
+// Cast through unknown because the production Resolver interface has
+// five fields (apply / listPermutations / getPermutationID / source /
+// isValidInput); none of the others are reached, so a typed mock would
+// be dead weight.
+function mockResolver(
+  apply: (input: Record<string, string>) => TokenMap,
+): Resolver | undefined {
+  return { apply } as unknown as Resolver;
+}
+
+it('returns empty maps when axes.length < 2 (no joint combinations to probe)', () => {
+  const axes: Axis[] = [
+    { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'resolver' },
+  ];
+  const cells: Cells = {
+    mode: { Light: { 'color.fg': tok('white') }, Dark: { 'color.fg': tok('black') } },
+  };
+  const resolver = mockResolver(() => ({ 'color.fg': tok('white') }));
+
+  const { overrides, jointTouching } = probeJointOverrides(
+    axes,
+    cells,
+    { mode: 'Light' },
+    resolver,
+  );
+  expect(overrides.size).toBe(0);
+  expect(jointTouching.size).toBe(0);
+});
+
+it('returns empty maps when resolver is undefined (layered / plain-parse projects have no resolver to probe)', () => {
+  const axes: Axis[] = [
+    { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'layered' },
+    { name: 'brand', contexts: ['Default', 'A'], default: 'Default', source: 'layered' },
+  ];
+  const cells: Cells = {};
+  const { overrides, jointTouching } = probeJointOverrides(
+    axes,
+    cells,
+    { mode: 'Light', brand: 'Default' },
+    undefined,
+  );
+  expect(overrides.size).toBe(0);
+  expect(jointTouching.size).toBe(0);
+});
+
+it('records an arity-2 override when cells composition cannot reproduce the cartesian value', () => {
+  // Cells composition for {Dark, A}: baseline white → cellA(Dark)=black
+  // → cellB(A) doesn't touch color.fg (matches baseline) → composed=black.
+  // Resolver at {Dark, A} returns red — divergent. Override expected.
+  const axes: Axis[] = [
+    { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'resolver' },
+    { name: 'brand', contexts: ['Default', 'A'], default: 'Default', source: 'resolver' },
+  ];
+  const cells: Cells = {
+    mode: { Light: { 'color.fg': tok('white') }, Dark: { 'color.fg': tok('black') } },
+    brand: { Default: { 'color.fg': tok('white') }, A: {} },
+  };
+  const resolver = mockResolver((input) => {
+    if (input.mode === 'Dark' && input.brand === 'A') return { 'color.fg': tok('red') };
+    if (input.mode === 'Dark') return { 'color.fg': tok('black') };
+    return { 'color.fg': tok('white') };
+  });
+
+  const { overrides, jointTouching } = probeJointOverrides(
+    axes,
+    cells,
+    { mode: 'Light', brand: 'Default' },
+    resolver,
+  );
+  expect(overrides.size).toBe(1);
+  const entry = [...overrides.values()][0];
+  expect(entry?.axes).toEqual({ mode: 'Dark', brand: 'A' });
+  expect(entry?.tokens['color.fg']?.$value).toBe('red');
+  // Both axes contribute (cartesian red differs from cellA black AND from cellB baseline white).
+  expect(jointTouching.get('color.fg')).toEqual(new Set(['mode', 'brand']));
+});
+
+it('marks an axis as joint-touching even when the cells path falls back to baseline (delta cell omits the path)', () => {
+  // cellA(Dark) has color.fg=black; cellB(A) doesn't carry color.fg
+  // (matches baseline white, so dropped from the delta cell). Resolver
+  // at {Dark, A} returns white. Cells composition: white → black (cellA)
+  // → still black (cellB omits the path) → composed=black ≠ cartesian
+  // white, so an override is recorded. But the touching check compares
+  // cartesian to (cellB[path] ?? baseline[path]) — falling back to
+  // baseline white matches cartesian white, so axis A (mode) is NOT
+  // marked touching; only axis B (brand) is.
+  const axes: Axis[] = [
+    { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'resolver' },
+    { name: 'brand', contexts: ['Default', 'A'], default: 'Default', source: 'resolver' },
+  ];
+  const cells: Cells = {
+    mode: {
+      Light: { 'color.fg': tok('white') },
+      Dark: { 'color.fg': tok('black') },
+    },
+    brand: { Default: { 'color.fg': tok('white') }, A: {} },
+  };
+  const resolver = mockResolver((input) => {
+    if (input.mode === 'Dark' && input.brand === 'A') return { 'color.fg': tok('white') };
+    if (input.mode === 'Dark') return { 'color.fg': tok('black') };
+    return { 'color.fg': tok('white') };
+  });
+
+  const { jointTouching } = probeJointOverrides(
+    axes,
+    cells,
+    { mode: 'Light', brand: 'Default' },
+    resolver,
+  );
+  // brand is marked (cartesian white differs from cellA black);
+  // mode is NOT marked (cartesian white === cellB-or-baseline white).
+  expect(jointTouching.get('color.fg')).toEqual(new Set(['brand']));
+});
+
+it('marks every participating axis touching when an arity-3+ divergence is found (conservative marking, vs arity-2 leave-one-out)', () => {
+  // Build a triple-joint case: pairwise resolver values match cell
+  // composition (no arity-2 override), but the triple does not.
+  const axes: Axis[] = [
+    { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'resolver' },
+    { name: 'brand', contexts: ['Default', 'A'], default: 'Default', source: 'resolver' },
+    { name: 'contrast', contexts: ['Normal', 'High'], default: 'Normal', source: 'resolver' },
+  ];
+  const cells: Cells = {
+    mode: { Light: { 'color.fg': tok('white') }, Dark: { 'color.fg': tok('black') } },
+    brand: { Default: { 'color.fg': tok('white') }, A: {} },
+    contrast: { Normal: { 'color.fg': tok('white') }, High: {} },
+  };
+  const resolver = mockResolver((input) => {
+    // Singletons / pairs all match cells composition; only the full
+    // triple diverges. (Resolver returns 'red' only at the triple.)
+    if (input.mode === 'Dark' && input.brand === 'A' && input.contrast === 'High') {
+      return { 'color.fg': tok('red') };
+    }
+    if (input.mode === 'Dark') return { 'color.fg': tok('black') };
+    return { 'color.fg': tok('white') };
+  });
+
+  const { overrides, jointTouching } = probeJointOverrides(
+    axes,
+    cells,
+    { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+    resolver,
+  );
+  const tripleEntries = [...overrides.values()].filter(
+    (o) => Object.keys(o.axes).length === 3,
+  );
+  expect(tripleEntries).toHaveLength(1);
+  expect(tripleEntries[0]?.tokens['color.fg']?.$value).toBe('red');
+  // Arity-3 conservative marking: every participating axis flagged.
+  expect(jointTouching.get('color.fg')).toEqual(new Set(['mode', 'brand', 'contrast']));
+});
+
+it('dedupes overrides on canonical key — the same partial tuple under different iteration orders maps to one entry', () => {
+  // canonicalKey sorts axis names, so {mode:Dark, brand:A} and
+  // {brand:A, mode:Dark} collapse to one entry. axisCombinations
+  // emits combos in declared axis order, but verify the key is
+  // order-invariant by inspecting the recorded entry's key shape.
+  const axes: Axis[] = [
+    { name: 'brand', contexts: ['Default', 'A'], default: 'Default', source: 'resolver' },
+    { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'resolver' },
+  ];
+  const cells: Cells = {
+    brand: { Default: { 'color.fg': tok('white') }, A: {} },
+    mode: { Light: { 'color.fg': tok('white') }, Dark: { 'color.fg': tok('black') } },
+  };
+  const resolver = mockResolver((input) => {
+    if (input.mode === 'Dark' && input.brand === 'A') return { 'color.fg': tok('red') };
+    if (input.mode === 'Dark') return { 'color.fg': tok('black') };
+    return { 'color.fg': tok('white') };
+  });
+
+  const { overrides } = probeJointOverrides(
+    axes,
+    cells,
+    { brand: 'Default', mode: 'Light' },
+    resolver,
+  );
+  // Exactly one arity-2 entry; canonicalKey is `brand:A|mode:Dark`
+  // (axis names lexicographically sorted), not `mode:Dark|brand:A`.
+  expect(overrides.size).toBe(1);
+  expect([...overrides.keys()]).toEqual(['brand:A|mode:Dark']);
+});


### PR DESCRIPTION
## Summary

- Adds `packages/core/test/probe-joint-overrides.test.ts` — direct unit tests with a synthetic Resolver mock (only `apply` is reached; cast through `unknown` rather than stub the other four interface fields). Six tests, one per branch: `axes.length < 2` early-return, resolver-undefined early-return, arity-2 override capture, baseline-fallback for delta cells that omit a path (touching detection), arity-3+ conservative touching marking, and canonical-key dedupe (axes lexicographically sorted regardless of declared axis order).
- Extends `packages/core/test/joint-overrides.test.ts` with two fixture-side invariants: at least one arity-3 override entry exists (the reference fixture's `{Brand A, High, Dark}` triple — turns out the audit's "arity-3 dead in tests" claim was wrong; the branch DOES have real-data coverage today, this pins it against future fixture drift), and an axis appears in `varianceByPath.varyingAxes` even when its singleton cell matches baseline (variance can flow through the joint probe, not just per-axis cells).
- No source changes; pure test-coverage extension.

Discovered during the work: my initial pass assumed `color.accent.fg` would be the joint-touching-without-override case. Diagnostic output showed it's actually the opposite — accent.fg IS in an override at `{Dark, Brand A}`, and the singleton-equal-to-baseline case is brand (whose contexts both produce white). The corrected assertion is the one above.

Milestone: Maintenance
Closes: #822
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] New \`probe-joint-overrides.test.ts\` — 6/6 green on first run, runs in ~3 ms (no resolver, no fixture load)
- [x] Existing \`joint-overrides.test.ts\` — 6/6 green (4 original + 2 new fixture invariants)