### PR TITLE
refactor(core): consolidate canonicalKey, valueKey, cssEscape into shared helpers

### DIFF
--- a/.changeset/consolidate-core-helpers.md
+++ b/.changeset/consolidate-core-helpers.md
@@ -1,0 +1,13 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+First half of #824. Extracts three helpers that were duplicated across core modules into dedicated files:
+
+- `canonicalKey(tuple)` → `packages/core/src/tuple-key.ts`. Was inlined in both `resolve-at.ts` and `joint-overrides.ts`. Pure string ops; no runtime deps so the browser-safe `@unpunnyfuns/swatchbook-core/resolve-at` subpath stays Terrazzo-free.
+- `valueKey(token)` → `packages/core/src/value-key.ts`. Was inlined in `variance-analysis.ts`, `joint-overrides.ts`, and `variance-by-path.ts` under three different signatures (`TokenNormalized | undefined`, `unknown`, `TokenMap[string] | undefined`) with identical bodies. Unified on a structural input type `{$value?: unknown} | undefined` so the helper doesn't pull `@terrazzo/parser` into its import graph.
+- `cssEscape(value)` → `packages/core/src/css-escape.ts`. Was inlined as `cssEscape` in `css-axis-projected.ts` and `cssEscapeAttr` in `emit-via-terrazzo.ts` — same body, different name; collapsed to a single export. `cssEscapeAttr` callers renamed to `cssEscape`.
+
+`jointOverrideKey` (public API) still re-exports through `joint-overrides.ts` and now just delegates to `canonicalKey`. No behavioural change; identical CSS output, identical snapshot keys.
+
+`dataAttr` (3 sites across core/addon/blocks) and `makeCssVar` (2 sites with confirmed Terrazzo-vs-hand-rolled drift) need a subpath-export decision; left for follow-up PRs.

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -1,6 +1,7 @@
 import type { TokenNormalized } from '@terrazzo/parser';
 import { generateShorthand, makeCSSVar, transformCSSValue } from '@terrazzo/token-tools/css';
 import { CHROME_ROLES, CHROME_VAR_PREFIX, DEFAULT_CHROME_MAP } from '#/chrome.ts';
+import { cssEscape } from '#/css-escape.ts';
 import type { Project, TokenMap } from '#/types.ts';
 import { analyzeProjectVariance, type VarianceInfo } from '#/variance-analysis.ts';
 
@@ -298,8 +299,4 @@ function* collectTokenDeclarations(
   }
   const shorthand = generateShorthand({ token, localID });
   if (shorthand) yield { varName, value: shorthand };
-}
-
-function cssEscape(name: string): string {
-  return name.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }

--- a/packages/core/src/css-escape.ts
+++ b/packages/core/src/css-escape.ts
@@ -1,0 +1,8 @@
+/**
+ * Escape backslash + double-quote in a CSS string literal — used for
+ * `data-*` attribute selector values and other places where token /
+ * context names may contain characters that need quoting.
+ */
+export function cssEscape(value: string): string {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+}

--- a/packages/core/src/emit-via-terrazzo.ts
+++ b/packages/core/src/emit-via-terrazzo.ts
@@ -2,6 +2,7 @@ import { pathToFileURL } from 'node:url';
 import { build, defineConfig, Logger, type Plugin } from '@terrazzo/parser';
 import cssPlugin, { type CSSPluginOptions } from '@terrazzo/plugin-css';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
+import { cssEscape } from '#/css-escape.ts';
 import { fillPresetTuple } from '#/presets.ts';
 import { permutationID, type Axis, type Project } from '#/types.ts';
 
@@ -141,17 +142,13 @@ function compoundSelector(
   for (const axis of axes) {
     const value = input[axis.name];
     if (value === undefined) continue;
-    parts.push(`[${attrName(prefix, axis.name)}="${cssEscapeAttr(value)}"]`);
+    parts.push(`[${attrName(prefix, axis.name)}="${cssEscape(value)}"]`);
   }
   return parts.length > 0 ? parts.join('') : ':root';
 }
 
 function attrName(prefix: string, key: string): string {
   return prefix ? `data-${prefix}-${key}` : `data-${key}`;
-}
-
-function cssEscapeAttr(value: string): string {
-  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
 }
 
 function resolveSelection(

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -1,6 +1,8 @@
 import type { Resolver } from '@terrazzo/parser';
 import { buildResolveAt } from '#/resolve-at.ts';
+import { canonicalKey } from '#/tuple-key.ts';
 import type { Axis, Cells, JointOverride, JointOverrides, TokenMap } from '#/types.ts';
+import { valueKey } from '#/value-key.ts';
 
 /**
  * Two-pass joint-probe output:
@@ -176,18 +178,4 @@ function* contextProducts(axisCombo: readonly Axis[]): Generator<Record<string, 
  */
 export function jointOverrideKey(axes: Readonly<Record<string, string>>): string {
   return canonicalKey(axes);
-}
-
-function canonicalKey(axes: Readonly<Record<string, string>>): string {
-  return Object.keys(axes)
-    .toSorted()
-    .map((k) => `${k}:${axes[k]}`)
-    .join('|');
-}
-
-function valueKey(token: unknown): string {
-  if (token && typeof token === 'object' && '$value' in token) {
-    return JSON.stringify((token as { $value: unknown }).$value);
-  }
-  return '';
 }

--- a/packages/core/src/resolve-at.ts
+++ b/packages/core/src/resolve-at.ts
@@ -8,6 +8,7 @@
  * consumer that needs to compose tokens at any tuple without
  * shipping `@terrazzo/parser` to the client.
  */
+import { canonicalKey } from '#/tuple-key.ts';
 import type { Axis, Cells, JointOverrides, ResolveAt, TokenMap } from '#/types.ts';
 
 /**
@@ -84,11 +85,4 @@ function isSubset(
     if (full[key] !== sub[key]) return false;
   }
   return true;
-}
-
-function canonicalKey(tuple: Readonly<Record<string, string>>): string {
-  return Object.keys(tuple)
-    .toSorted()
-    .map((k) => `${k}:${tuple[k]}`)
-    .join('|');
 }

--- a/packages/core/src/tuple-key.ts
+++ b/packages/core/src/tuple-key.ts
@@ -1,0 +1,14 @@
+/**
+ * Canonical key for an axis tuple — axes sorted by name so `{A:a,B:b}`
+ * and `{B:b,A:a}` produce the same lookup key. Used as the Map key for
+ * `Project.jointOverrides` and the memoization key inside
+ * `buildResolveAt`. Pure string ops; no runtime deps so the
+ * browser-safe `resolve-at` subpath can use it without pulling the
+ * Terrazzo parser.
+ */
+export function canonicalKey(tuple: Readonly<Record<string, string>>): string {
+  return Object.keys(tuple)
+    .toSorted()
+    .map((k) => `${k}:${tuple[k]}`)
+    .join('|');
+}

--- a/packages/core/src/value-key.ts
+++ b/packages/core/src/value-key.ts
@@ -1,0 +1,14 @@
+/**
+ * Stable comparison key for a DTCG token's `$value`. Composite tokens
+ * (shadow, typography, …) compare on every sub-field; missing tokens
+ * compare equal to the empty string.
+ *
+ * Structural input type (`{$value?: unknown} | undefined`) so this
+ * helper doesn't pull `@terrazzo/parser`'s `TokenNormalized` into the
+ * import graph — keeps any consumer that wants only `valueKey`
+ * Terrazzo-free.
+ */
+export function valueKey(token: { $value?: unknown } | undefined): string {
+  if (!token) return '';
+  return JSON.stringify(token.$value);
+}

--- a/packages/core/src/variance-analysis.ts
+++ b/packages/core/src/variance-analysis.ts
@@ -1,5 +1,5 @@
-import type { TokenNormalized } from '@terrazzo/parser';
 import { permutationID, type Project, type TokenMap } from '#/types.ts';
+import { valueKey } from '#/value-key.ts';
 
 /**
  * Per-token variance classification across a loaded project's axes.
@@ -211,14 +211,4 @@ export function analyzeProjectVariance(project: Project): Map<string, VarianceIn
   }
 
   return result;
-}
-
-/**
- * Stable key for value comparison — `JSON.stringify($value)`.
- * Composite tokens (shadow, typography, …) compare on every sub-field;
- * missing tokens compare equal to the empty string.
- */
-function valueKey(token: TokenNormalized | undefined): string {
-  if (!token) return '';
-  return JSON.stringify(token.$value);
 }

--- a/packages/core/src/variance-by-path.ts
+++ b/packages/core/src/variance-by-path.ts
@@ -1,4 +1,5 @@
 import type { Axis, AxisVariancePerAxis, AxisVarianceResult, Cells, TokenMap } from '#/types.ts';
+import { valueKey } from '#/value-key.ts';
 
 /**
  * Pre-compute per-path variance at load time so consumers don't have
@@ -93,9 +94,4 @@ function buildResult(
     constantAcrossAxes,
     perAxis,
   };
-}
-
-function valueKey(token: TokenMap[string] | undefined): string {
-  if (!token) return '';
-  return JSON.stringify(token.$value);
 }


### PR DESCRIPTION
## Summary

First half of #824 — extracts three helpers that were duplicated across core modules with identical bodies:

- **\`canonicalKey(tuple)\`** → \`packages/core/src/tuple-key.ts\`. Was inlined in both \`resolve-at.ts\` and \`joint-overrides.ts\`. Pure string ops; no runtime deps so the browser-safe \`@unpunnyfuns/swatchbook-core/resolve-at\` subpath stays Terrazzo-free.
- **\`valueKey(token)\`** → \`packages/core/src/value-key.ts\`. Was inlined in \`variance-analysis.ts\`, \`joint-overrides.ts\`, and \`variance-by-path.ts\` under three different signatures (\`TokenNormalized | undefined\`, \`unknown\`, \`TokenMap[string] | undefined\`) but identical bodies. Unified on a structural input type \`{$value?: unknown} | undefined\` so the helper doesn't pull \`@terrazzo/parser\` into its import graph.
- **\`cssEscape(value)\`** → \`packages/core/src/css-escape.ts\`. Was inlined as \`cssEscape\` in \`css-axis-projected.ts\` and \`cssEscapeAttr\` in \`emit-via-terrazzo.ts\` — same body, different name. \`cssEscapeAttr\` callers renamed to \`cssEscape\`.

\`jointOverrideKey\` (the public API) still re-exports through \`joint-overrides.ts\` and now just delegates to \`canonicalKey\`. No behavioural change; identical CSS output, identical snapshot keys.

The remaining halves of #824 — \`dataAttr\` (3 sites across core/addon/blocks) and \`makeCssVar\` (2 sites with confirmed Terrazzo-vs-hand-rolled drift) — both need a subpath-export decision and are left for follow-up PRs.

Milestone: Maintenance
Closes: (none — leaves #824 partially open for the dataAttr + makeCssVar follow-ups)
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] Snapshot tests unchanged (css-axis-projected golden + emit-via-terrazzo selector spec)