### PR TITLE
test(storybook): add play() coverage to all seven token-detail stories

### DIFF
--- a/.changeset/token-detail-play-coverage.md
+++ b/.changeset/token-detail-play-coverage.md
@@ -1,0 +1,9 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Closes #831. Adds `play()` coverage to the seven previously-uncovered token-detail story files in `apps/storybook` (`AliasChain`, `AliasedBy`, `AxisVariance`, `CompositeBreakdown`, `CompositePreview`, `TokenHeader`, `TokenUsageSnippet`); only `ConsumerOutput.stories.tsx` had interaction coverage before.
+
+Each play asserts the block's user-facing render against the active fixture token — type pills and CSS-var text for `TokenHeader`, the alias-chain DOM for `AliasChain`, the aliased-by tree presence for `AliasedBy`, the values-table layout for both multi-axis and constant tokens in `AxisVariance`, the typography / shadow key/value grid in `CompositeBreakdown`, the color-swatch and typography pangram samples in `CompositePreview`, and the snippet text plus clipboard copy in `TokenUsageSnippet`. Also adds negative-path coverage where the block legitimately returns null (e.g. `AliasChain` for a primitive, `AliasedBy` for a leaf alias) — guards against accidental "always renders" regressions.
+
+No source changes; pure storybook test coverage.

--- a/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
@@ -1,4 +1,5 @@
 import { AliasChain } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -13,3 +14,33 @@ export default meta;
 
 export const AccentBg = meta.story({ args: { path: 'color.accent.bg' } });
 export const SpaceMd = meta.story({ args: { path: 'space.md' } });
+
+export const RendersChainHeaderAndAtLeastOneHop = meta.story({
+  args: { path: 'color.accent.bg' },
+  play: async ({ canvasElement }) => {
+    const header = await waitFor(() => {
+      const headers = canvasElement.querySelectorAll('.sb-token-detail__section-header');
+      const aliasHeader = [...headers].find((h) => h.textContent === 'Alias chain');
+      if (!aliasHeader) throw new Error('alias chain header not rendered');
+      return aliasHeader;
+    });
+    expect(header).toBeTruthy();
+    const nodes = canvasElement.querySelectorAll('.sb-token-detail__chain-node');
+    // Chain renders [source, ...hops]; an aliased token has ≥ 2 nodes.
+    expect(nodes.length).toBeGreaterThanOrEqual(2);
+    expect(nodes[0]?.textContent).toBe('color.accent.bg');
+  },
+});
+
+export const RendersNothingForPrimitive = meta.story({
+  args: { path: 'color.palette.blue.500' },
+  play: async ({ canvasElement }) => {
+    // Primitive tokens have no aliasChain / aliasOf — the block returns
+    // null. Wait one frame to let React commit, then assert absence.
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    const header = [...canvasElement.querySelectorAll('.sb-token-detail__section-header')].find(
+      (h) => h.textContent === 'Alias chain',
+    );
+    expect(header).toBeUndefined();
+  },
+});

--- a/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
@@ -1,4 +1,5 @@
 import { AliasedBy } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -13,3 +14,33 @@ export default meta;
 
 export const RefNeutralZero = meta.story({ args: { path: 'color.palette.neutral.0' } });
 export const RefBlue500 = meta.story({ args: { path: 'color.palette.blue.500' } });
+
+export const RendersAliasedByTreeForPrimitive = meta.story({
+  args: { path: 'color.palette.neutral.0' },
+  play: async ({ canvasElement }) => {
+    const header = await waitFor(() => {
+      const headers = canvasElement.querySelectorAll('.sb-token-detail__section-header');
+      const ab = [...headers].find((h) => h.textContent === 'Aliased by');
+      if (!ab) throw new Error('aliased by header not rendered');
+      return ab;
+    });
+    expect(header).toBeTruthy();
+    // At least one row in the tree — primitives in the reference fixture
+    // are referenced by surface / text role tokens.
+    const rows = canvasElement.querySelectorAll('.sb-token-detail__aliased-by-row');
+    expect(rows.length).toBeGreaterThan(0);
+  },
+});
+
+export const RendersNothingForLeafAlias = meta.story({
+  args: { path: 'color.surface.default' },
+  play: async ({ canvasElement }) => {
+    // `color.surface.default` is itself an alias — nothing aliases it.
+    // Block returns null.
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+    const header = [...canvasElement.querySelectorAll('.sb-token-detail__section-header')].find(
+      (h) => h.textContent === 'Aliased by',
+    );
+    expect(header).toBeUndefined();
+  },
+});

--- a/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
@@ -1,4 +1,5 @@
 import { AxisVariance } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -13,3 +14,32 @@ export default meta;
 
 export const AccentBg = meta.story({ args: { path: 'color.accent.bg' } });
 export const SurfaceDefault = meta.story({ args: { path: 'color.surface.default' } });
+
+export const RendersValuesTableForMultiAxisToken = meta.story({
+  args: { path: 'color.accent.bg' },
+  play: async ({ canvasElement }) => {
+    const table = await waitFor(() => {
+      const el = canvasElement.querySelector('[data-testid="token-detail-values"]');
+      if (!el) throw new Error('values table not rendered');
+      return el;
+    });
+    // accent.bg is multi-axis varying in the reference fixture; the
+    // multi-axis layout uses one-row-per-context. At least two body rows.
+    const rows = table.querySelectorAll('.sb-token-detail__theme-row');
+    expect(rows.length).toBeGreaterThanOrEqual(2);
+  },
+});
+
+export const RendersConstantCellForBaselineOnlyToken = meta.story({
+  args: { path: 'color.palette.blue.500' },
+  play: async ({ canvasElement }) => {
+    // Palette primitives don't vary across any axis — block renders the
+    // "constant" branch (single cell with `data-testid="token-detail-constant"`).
+    const cell = await waitFor(() => {
+      const el = canvasElement.querySelector('[data-testid="token-detail-constant"]');
+      if (!el) throw new Error('constant cell not rendered');
+      return el;
+    });
+    expect(cell.textContent).toContain('same across every axis');
+  },
+});

--- a/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
@@ -1,4 +1,5 @@
 import { CompositeBreakdown } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -16,3 +17,39 @@ export const Shadow = meta.story({ args: { path: 'shadow.md' } });
 export const Border = meta.story({ args: { path: 'border.default' } });
 export const Transition = meta.story({ args: { path: 'transition.enter' } });
 export const Gradient = meta.story({ args: { path: 'gradient.sunrise' } });
+
+export const TypographyRendersKeyValueGrid = meta.story({
+  args: { path: 'typography.heading' },
+  play: async ({ canvasElement }) => {
+    const section = await waitFor(() => {
+      const el = canvasElement.querySelector('.sb-token-detail__breakdown-section');
+      if (!el) throw new Error('breakdown section not rendered');
+      return el;
+    });
+    // Typography breakdown renders one row per composite field; expect
+    // at least font-family and font-size keys.
+    const keys = section.querySelectorAll('.sb-token-detail__breakdown-key');
+    const keyTexts = [...keys].map((k) => k.textContent);
+    expect(keyTexts).toContain('fontFamily');
+    expect(keyTexts).toContain('fontSize');
+  },
+});
+
+export const ShadowRendersOffsetAndBlurKeys = meta.story({
+  args: { path: 'shadow.md' },
+  play: async ({ canvasElement }) => {
+    // Single-layer shadow renders one key/value grid (no "Layer N" header
+    // — that only appears for multi-layer values like shadow.lg).
+    const section = await waitFor(() => {
+      const el = canvasElement.querySelector('.sb-token-detail__breakdown-section');
+      if (!el) throw new Error('breakdown section not rendered');
+      return el;
+    });
+    const keyTexts = [...section.querySelectorAll('.sb-token-detail__breakdown-key')].map(
+      (k) => k.textContent,
+    );
+    expect(keyTexts).toContain('color');
+    expect(keyTexts).toContain('offsetY');
+    expect(keyTexts).toContain('blur');
+  },
+});

--- a/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
@@ -1,4 +1,5 @@
 import { CompositePreview } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -18,3 +19,41 @@ export const Transition = meta.story({ args: { path: 'transition.enter' } });
 export const Typography = meta.story({ args: { path: 'typography.body' } });
 export const Gradient = meta.story({ args: { path: 'gradient.sunrise' } });
 export const StrokeStyle = meta.story({ args: { path: 'stroke.style.custom-dash' } });
+
+export const ColorRendersSwatchRow = meta.story({
+  args: { path: 'color.accent.bg' },
+  play: async ({ canvasElement }) => {
+    const row = await waitFor(() => {
+      const el = canvasElement.querySelector('.sb-token-detail__color-swatch-row');
+      if (!el) throw new Error('color swatch row not rendered');
+      return el;
+    });
+    // Light + dark swatches both rendered for the same color cssVar.
+    expect(row.querySelector('.sb-token-detail__color-swatch-light')).toBeTruthy();
+    expect(row.querySelector('.sb-token-detail__color-swatch-dark')).toBeTruthy();
+  },
+});
+
+export const TypographyRendersPangramSample = meta.story({
+  args: { path: 'typography.body' },
+  play: async ({ canvasElement }) => {
+    const sample = await waitFor(() => {
+      const el = canvasElement.querySelector<HTMLElement>('.sb-token-detail__typography-sample');
+      if (!el) throw new Error('typography sample not rendered');
+      return el;
+    });
+    // Sample has the pangram text; its font-family resolves through the
+    // composite's sub-vars (renders even if the cssVar resolution is empty).
+    expect(sample.textContent?.length ?? 0).toBeGreaterThan(0);
+  },
+});
+
+export const ShadowRendersSample = meta.story({
+  args: { path: 'shadow.md' },
+  play: async ({ canvasElement }) => {
+    await waitFor(() => {
+      const el = canvasElement.querySelector('.sb-token-detail__shadow-sample');
+      if (!el) throw new Error('shadow sample not rendered');
+    });
+  },
+});

--- a/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
@@ -1,4 +1,5 @@
 import { TokenHeader } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -15,4 +16,43 @@ export default meta;
 export const Default = meta.story({ args: { path: 'color.accent.bg' } });
 export const WithHeading = meta.story({
   args: { path: 'typography.heading', heading: 'Heading typography' },
+});
+
+export const RendersPathTypePillAndCssVar = meta.story({
+  args: { path: 'color.accent.bg' },
+  play: async ({ canvasElement }) => {
+    const heading = await waitFor(() => {
+      const el = canvasElement.querySelector<HTMLHeadingElement>('.sb-token-detail__heading');
+      if (!el) throw new Error('heading not rendered');
+      return el;
+    });
+    expect(heading.textContent).toBe('color.accent.bg');
+    const pill = canvasElement.querySelector('.sb-token-detail__type-pill');
+    expect(pill?.textContent).toBe('color');
+    expect(canvasElement.textContent).toContain('var(--sb-color-accent-bg)');
+  },
+});
+
+export const HeadingPropOverridesPath = meta.story({
+  args: { path: 'typography.heading', heading: 'Custom Heading' },
+  play: async ({ canvasElement }) => {
+    const heading = await waitFor(() => {
+      const el = canvasElement.querySelector<HTMLHeadingElement>('.sb-token-detail__heading');
+      if (!el) throw new Error('heading not rendered');
+      return el;
+    });
+    expect(heading.textContent).toBe('Custom Heading');
+  },
+});
+
+export const RendersMissingFallbackForUnknownPath = meta.story({
+  args: { path: 'color.does.not.exist' },
+  play: async ({ canvasElement }) => {
+    const missing = await waitFor(() => {
+      const el = canvasElement.querySelector('.sb-token-detail__missing');
+      if (!el) throw new Error('missing fallback not rendered');
+      return el;
+    });
+    expect(missing.textContent).toContain('color.does.not.exist');
+  },
 });

--- a/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
@@ -1,4 +1,5 @@
 import { TokenUsageSnippet } from '@unpunnyfuns/swatchbook-blocks';
+import { expect, userEvent, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -13,3 +14,49 @@ export default meta;
 
 export const Color = meta.story({ args: { path: 'color.accent.bg' } });
 export const Space = meta.story({ args: { path: 'space.md' } });
+
+export const RendersSnippetAndCssVar = meta.story({
+  args: { path: 'color.accent.bg' },
+  play: async ({ canvasElement }) => {
+    const snippet = await waitFor(() => {
+      const el = canvasElement.querySelector<HTMLElement>('.sb-token-detail__snippet');
+      if (!el) throw new Error('snippet not rendered');
+      return el;
+    });
+    expect(snippet.textContent).toBe('color: var(--sb-color-accent-bg);');
+  },
+});
+
+export const CopySnippetWritesToClipboard = meta.story({
+  args: { path: 'color.accent.bg' },
+  play: async ({ canvasElement }) => {
+    const writes: string[] = [];
+    const originalClipboard = navigator.clipboard;
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: (text: string) => {
+          writes.push(text);
+          return Promise.resolve();
+        },
+      },
+    });
+    try {
+      const btn = await waitFor(() => {
+        const el = canvasElement.querySelector<HTMLElement>('.sb-token-detail__snippet-row button');
+        if (!el) throw new Error('copy button not rendered');
+        return el;
+      });
+      await userEvent.click(btn);
+      await waitFor(() => {
+        if (writes.length === 0) throw new Error('clipboard not written');
+      });
+      expect(writes).toEqual(['color: var(--sb-color-accent-bg);']);
+    } finally {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard,
+      });
+    }
+  },
+});


### PR DESCRIPTION
## Summary

Before this PR, only \`ConsumerOutput.stories.tsx\` had \`play()\` interaction coverage in \`apps/storybook/src/stories/token-detail/\` — the other seven (\`AliasChain\`, \`AliasedBy\`, \`AxisVariance\`, \`CompositeBreakdown\`, \`CompositePreview\`, \`TokenHeader\`, \`TokenUsageSnippet\`) rendered without any user-facing assertion, so DOM-shape regressions in those blocks would only surface in Chromatic.

Each play asserts what the block actually renders for the active fixture token:

- \`TokenHeader\` — \`<h3>\` text equals path; \`.type-pill\` text equals \`$type\`; \`cssVar\` string appears in subline. Negative: missing path fallback for unknown tokens.
- \`AliasChain\` — header + ≥ 2 chain-node rows for aliased token; negative: returns null for primitives.
- \`AliasedBy\` — header + ≥ 1 row for primitives; negative: returns null for leaf aliases.
- \`AxisVariance\` — multi-axis values-table for varying tokens; single \`token-detail-constant\` cell with \"same across every axis\" for baseline-only tokens.
- \`CompositeBreakdown\` — typography renders \`fontFamily\` / \`fontSize\` keys; single-layer shadow renders \`color\` / \`offsetY\` / \`blur\` keys (multi-layer shadow.lg's \"Layer N\" header isn't reachable from shadow.md).
- \`CompositePreview\` — color renders light + dark swatches; typography renders pangram sample; shadow renders sample div.
- \`TokenUsageSnippet\` — snippet text equals \`color: var(--sb-color-accent-bg);\`; clipboard write fires the same text on copy-button click.

No source changes; pure storybook test coverage.

Milestone: Maintenance
Closes: #831
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] \`pnpm test:storybook\` (apps/storybook) — 165 / 165 (was 149 before this PR)