### PR TITLE
refactor(core,addon,blocks): collapse JointOverrides Map to wire-shape array

### DIFF
--- a/.changeset/joint-overrides-array-shape.md
+++ b/.changeset/joint-overrides-array-shape.md
@@ -1,0 +1,13 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+Closes #866. Collapses `JointOverrides` from `ReadonlyMap<string, JointOverride>` to `ReadonlyArray<readonly [string, JointOverride]>` — the same shape consumers already saw on the wire (virtual module, Storybook channel) and what blocks-side `makeResolveAt` already reconstructed Maps from on every snapshot read.
+
+No consumer uses keyed lookup. The three downstream callers (`buildResolveAt` in `resolve-at.ts`, `analyzeProjectVariance` in `variance-analysis.ts`, the smart emitter's `collectJointBlocks` in `css-axis-projected.ts`) all do `for (const … of …values())` iteration; switching to `for (const [, override] of …)` array destructuring is the only call-site change. Tests using `.size` switch to `.length`.
+
+`probeJointOverrides` still uses an internal `Map<string, JointOverride>` for canonical-key dedupe across arity passes; the public return is materialized to the array shape on emit. The Map-↔-array marshaling on the wire boundary disappears: `addon/virtual/plugin.ts` (both module body and HMR re-broadcast) stops calling `[...project.jointOverrides.entries()]`, and `blocks/internal/use-project.ts` stops `new Map(...)` reconstructing on every render.
+
+Pre-1.0 minor bump (`JointOverrides` is a public type export from core).

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -9,7 +9,6 @@ import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
 import type {
   Axis as CoreAxis,
   Cells as CoreCells,
-  JointOverride,
   JointOverrides,
 } from '@unpunnyfuns/swatchbook-core';
 import { useActiveAxes, useOptionalSwatchbookData } from '@unpunnyfuns/swatchbook-blocks';
@@ -24,7 +23,7 @@ import { useActiveAxes, useOptionalSwatchbookData } from '@unpunnyfuns/swatchboo
 const fallbackResolveAt = buildResolveAt(
   virtualAxes as readonly CoreAxis[],
   virtualCells as CoreCells,
-  new Map(virtualJointOverrides as readonly (readonly [string, JointOverride])[]) as JointOverrides,
+  virtualJointOverrides as JointOverrides,
   virtualDefaultTuple,
 );
 

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -3,7 +3,6 @@ import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
 import type {
   Axis as CoreAxis,
   Cells as CoreCells,
-  JointOverride,
   JointOverrides,
 } from '@unpunnyfuns/swatchbook-core';
 import type { Decorator, Preview } from '@storybook/react-vite';
@@ -240,7 +239,7 @@ function resolveColorFormat(globals: SwatchbookGlobals): ColorFormat {
 const previewResolveAt = buildResolveAt(
   virtualAxes as readonly CoreAxis[],
   virtualCells as CoreCells,
-  new Map(virtualJointOverrides as readonly (readonly [string, JointOverride])[]) as JointOverrides,
+  virtualJointOverrides as JointOverrides,
   virtualDefaultTuple,
 );
 

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -108,10 +108,8 @@ export function swatchbookTokensPlugin({
       if (id !== RESOLVED_VIRTUAL_MODULE_ID) return null;
       if (!project) return 'export default null;';
       // Emit a typed ESM module. Values are JSON-stringified for stability.
-      // `jointOverrides` ships as an array of `[key, entry]` pairs because
-      // `Map` doesn't survive `JSON.stringify`; the block side reconstructs
-      // the Map (or just reads the array, depending on the consumer).
-      const jointOverridesArr = [...project.jointOverrides.entries()];
+      // `jointOverrides` is already an array of `[key, entry]` pairs on
+      // the server side — same shape consumers read on the wire.
       const varianceByPathObj = Object.fromEntries(project.varianceByPath.entries());
       return [
         `/* swatchbook virtual module — generated */`,
@@ -123,7 +121,7 @@ export function swatchbookTokensPlugin({
         `export const cssVarPrefix = ${JSON.stringify(config.cssVarPrefix ?? '')};`,
         `export const listing = ${JSON.stringify(slimListing(project.listing))};`,
         `export const cells = ${JSON.stringify(project.cells)};`,
-        `export const jointOverrides = ${JSON.stringify(jointOverridesArr)};`,
+        `export const jointOverrides = ${JSON.stringify(project.jointOverrides)};`,
         `export const varianceByPath = ${JSON.stringify(varianceByPathObj)};`,
         `export const defaultTuple = ${JSON.stringify(project.defaultTuple)};`,
       ].join('\n');
@@ -187,7 +185,7 @@ export function swatchbookTokensPlugin({
                 cssVarPrefix: config.cssVarPrefix ?? '',
                 listing: slimListing(project.listing),
                 cells: project.cells,
-                jointOverrides: [...project.jointOverrides.entries()],
+                jointOverrides: project.jointOverrides,
                 varianceByPath: Object.fromEntries(project.varianceByPath.entries()),
                 defaultTuple: project.defaultTuple,
               },

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,11 +1,5 @@
 import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
-import type {
-  Axis,
-  Cells,
-  JointOverride,
-  JointOverrides,
-  TokenMap,
-} from '@unpunnyfuns/swatchbook-core';
+import type { Axis, Cells, JointOverrides, TokenMap } from '@unpunnyfuns/swatchbook-core';
 import { makeCSSVar } from '@terrazzo/token-tools/css';
 import { useEffect, useMemo } from 'react';
 import type { VirtualTokenListingShape, VirtualVarianceByPathShape } from '#/contexts.ts';
@@ -84,12 +78,11 @@ function tupleToName(
 }
 
 /**
- * Reconstruct a `resolveAt` accessor from snapshot data. The wire
- * format ships `cells` as plain JSON and `jointOverrides` as an
- * array of `[key, entry]` pairs (Map doesn't survive JSON.stringify);
- * this hydrates them and wraps `buildResolveAt` from core. Stable
- * identity across calls with the same snapshot — `useMemo` keyed on
- * the snapshot fields produces a referentially stable function.
+ * Reconstruct a `resolveAt` accessor from snapshot data. Both `cells`
+ * and `jointOverrides` ship as plain JSON in the same shape core uses
+ * internally — no Map reconstruction at the boundary. Stable identity
+ * across calls with the same snapshot — `useMemo` keyed on the
+ * snapshot fields produces a referentially stable function.
  */
 function makeResolveAt(snapshot: {
   axes: readonly VirtualAxis[];
@@ -98,9 +91,7 @@ function makeResolveAt(snapshot: {
   defaultTuple?: ProjectSnapshot['defaultTuple'];
 }): (tuple: Record<string, string>) => ResolvedTokens {
   const cells = (snapshot.cells ?? {}) as Cells;
-  const jointOverrides: JointOverrides = new Map<string, JointOverride>(
-    (snapshot.jointOverrides ?? []) as readonly (readonly [string, JointOverride])[],
-  );
+  const jointOverrides = (snapshot.jointOverrides ?? []) as JointOverrides;
   const defaults = snapshot.defaultTuple ?? defaultTuple(snapshot.axes);
   const resolver = buildResolveAt(
     snapshot.axes as readonly Axis[],

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -211,7 +211,7 @@ function collectJointBlocks(
   transformAlias: (token: TokenNormalized) => string,
 ): string[] {
   const blocks: string[] = [];
-  for (const override of project.jointOverrides.values()) {
+  for (const [, override] of project.jointOverrides) {
     const fullTuple = { ...project.defaultTuple, ...override.axes };
     const fullTokens = project.resolveAt(fullTuple);
     const axisEntries = Object.entries(override.axes);

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -47,8 +47,8 @@ export interface JointProbeResult {
  * Pair-only at this stage. Triple-and-higher joint variance is a
  * documented limitation; the algorithm extends naturally to arity N.
  *
- * Resolver-less projects (layered / plain-parse) return empty maps
- * — no resolver to probe with.
+ * Resolver-less projects (layered / plain-parse) return empty
+ * collections — no resolver to probe with.
  */
 export function probeJointOverrides(
   axes: readonly Axis[],
@@ -57,9 +57,12 @@ export function probeJointOverrides(
   resolver: Resolver | undefined,
 ): JointProbeResult {
   if (!resolver || axes.length < 2) {
-    return { overrides: new Map(), jointTouching: new Map() };
+    return { overrides: [], jointTouching: new Map() };
   }
 
+  // Internal Map keyed on canonicalKey for dedupe across arity passes.
+  // Materialized to the public array shape on return so the wire
+  // boundary doesn't have to marshal a Map.
   const overrides = new Map<string, JointOverride>();
   const jointTouching = new Map<string, Set<string>>();
   // Baseline carries the values for paths that delta cells omit;
@@ -83,7 +86,7 @@ export function probeJointOverrides(
   // divergences get recorded only when they're not already implied
   // by a lower-arity override.
   for (let arity = 2; arity <= axes.length; arity++) {
-    const composer = buildResolveAt(axes, cells, overrides, defaultTuple);
+    const composer = buildResolveAt(axes, cells, [...overrides.entries()], defaultTuple);
 
     for (const axisCombo of axisCombinations(axes, arity)) {
       for (const partialTuple of contextProducts(axisCombo)) {
@@ -140,7 +143,7 @@ export function probeJointOverrides(
     }
   }
 
-  return { overrides, jointTouching };
+  return { overrides: [...overrides.entries()], jointTouching };
 }
 
 function* axisCombinations(axes: readonly Axis[], k: number): Generator<readonly Axis[]> {

--- a/packages/core/src/resolve-at.ts
+++ b/packages/core/src/resolve-at.ts
@@ -65,9 +65,9 @@ export function buildResolveAt(
       const cell = cells[axis.name]?.[ctx];
       if (cell) Object.assign(result, cell);
     }
-    // Step 3: joint overrides. Map iteration is insertion order =
-    // ascending arity, so larger overrides naturally win.
-    for (const override of jointOverrides.values()) {
+    // Step 3: joint overrides. Array iteration order is ascending
+    // arity by construction, so larger overrides naturally win.
+    for (const [, override] of jointOverrides) {
       if (!isSubset(override.axes, full)) continue;
       Object.assign(result, override.tokens);
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -88,12 +88,19 @@ export interface JointOverride {
 }
 
 /**
- * All joint-variant overrides for a project, keyed by canonical
- * stringification of `JointOverride.axes`. Iteration order is
- * ascending arity so higher-order divergences win over lower-order
- * ones when applied in sequence.
+ * All joint-variant overrides for a project — an array of
+ * `[canonicalKey, override]` pairs (canonical stringification of
+ * `override.axes`). Iteration order is ascending arity so higher-order
+ * divergences win over lower-order ones when applied in sequence.
+ *
+ * Shape mirrors the wire format the addon's virtual module ships to the
+ * preview — no Map↔array marshaling at the boundary. No consumer needs
+ * keyed lookup; all reads are `for (const [, override] of ...)`
+ * iteration. Internal dedupe during construction (`probeJointOverrides`)
+ * uses a temporary Map keyed on canonical tuple, materialized to this
+ * array shape on return.
  */
-export type JointOverrides = ReadonlyMap<string, JointOverride>;
+export type JointOverrides = ReadonlyArray<readonly [string, JointOverride]>;
 
 /**
  * Compute the resolved `TokenMap` for any tuple of axis selections

--- a/packages/core/src/variance-analysis.ts
+++ b/packages/core/src/variance-analysis.ts
@@ -162,7 +162,7 @@ export function analyzeProjectVariance(project: Project): Map<string, VarianceIn
   // information; reading from them avoids a duplicate probe pass on
   // every emit.
   const jointCasesByPath = new Map<string, JointCase[]>();
-  for (const override of project.jointOverrides.values()) {
+  for (const [, override] of project.jointOverrides) {
     const axisEntries = Object.entries(override.axes);
     if (axisEntries.length < 2) continue;
     // Flatten N-arity overrides into all pair sub-combinations so the

--- a/packages/core/test/joint-overrides.test.ts
+++ b/packages/core/test/joint-overrides.test.ts
@@ -14,24 +14,24 @@ beforeAll(async () => {
 }, 30_000);
 
 it('produces at least one entry for the reference fixture (which has a known joint-variance case on color.accent.fg)', () => {
-  expect(project.jointOverrides.size).toBeGreaterThan(0);
+  expect(project.jointOverrides.length).toBeGreaterThan(0);
 });
 
 it("every entry covers a partial tuple of size ≥ 2 (joint by definition; singleton variance is single-axis, captured in cells)", () => {
-  for (const override of project.jointOverrides.values()) {
+  for (const [, override] of project.jointOverrides) {
     expect(Object.keys(override.axes).length).toBeGreaterThanOrEqual(2);
   }
 });
 
 it('every entry holds at least one token whose value at the partial tuple diverges from cascade composition', () => {
-  for (const override of project.jointOverrides.values()) {
+  for (const [, override] of project.jointOverrides) {
     expect(Object.keys(override.tokens).length).toBeGreaterThan(0);
   }
 });
 
 it("iteration order is ascending arity (so composition can apply lower-order overrides before higher-order ones)", () => {
   let prevArity = 0;
-  for (const override of project.jointOverrides.values()) {
+  for (const [, override] of project.jointOverrides) {
     const arity = Object.keys(override.axes).length;
     expect(arity).toBeGreaterThanOrEqual(prevArity);
     prevArity = arity;
@@ -47,9 +47,9 @@ it('exercises the arity-3 branch — the fixture produces at least one triple-ax
   // pair-composition can't reproduce the triple-joint accessible-accent
   // values; pin that the branch is reachable so future fixture changes
   // don't silently drop the only real-data coverage of the arity-3 loop.
-  const triples = [...project.jointOverrides.values()].filter(
-    (o) => Object.keys(o.axes).length === 3,
-  );
+  const triples = project.jointOverrides
+    .map(([, override]) => override)
+    .filter((o) => Object.keys(o.axes).length === 3);
   expect(triples.length).toBeGreaterThan(0);
   for (const triple of triples) {
     expect(Object.keys(triple.tokens).length).toBeGreaterThan(0);

--- a/packages/core/test/probe-joint-overrides.test.ts
+++ b/packages/core/test/probe-joint-overrides.test.ts
@@ -45,7 +45,7 @@ it('returns empty maps when axes.length < 2 (no joint combinations to probe)', (
     { mode: 'Light' },
     resolver,
   );
-  expect(overrides.size).toBe(0);
+  expect(overrides.length).toBe(0);
   expect(jointTouching.size).toBe(0);
 });
 
@@ -61,7 +61,7 @@ it('returns empty maps when resolver is undefined (layered / plain-parse project
     { mode: 'Light', brand: 'Default' },
     undefined,
   );
-  expect(overrides.size).toBe(0);
+  expect(overrides.length).toBe(0);
   expect(jointTouching.size).toBe(0);
 });
 
@@ -89,8 +89,8 @@ it('records an arity-2 override when cells composition cannot reproduce the cart
     { mode: 'Light', brand: 'Default' },
     resolver,
   );
-  expect(overrides.size).toBe(1);
-  const entry = [...overrides.values()][0];
+  expect(overrides.length).toBe(1);
+  const entry = overrides[0]?.[1];
   expect(entry?.axes).toEqual({ mode: 'Dark', brand: 'A' });
   expect(entry?.tokens['color.fg']?.$value).toBe('red');
   // Both axes contribute (cartesian red differs from cellA black AND from cellB baseline white).
@@ -163,9 +163,9 @@ it('marks every participating axis touching when an arity-3+ divergence is found
     { mode: 'Light', brand: 'Default', contrast: 'Normal' },
     resolver,
   );
-  const tripleEntries = [...overrides.values()].filter(
-    (o) => Object.keys(o.axes).length === 3,
-  );
+  const tripleEntries = overrides
+    .map(([, o]) => o)
+    .filter((o) => Object.keys(o.axes).length === 3);
   expect(tripleEntries).toHaveLength(1);
   expect(tripleEntries[0]?.tokens['color.fg']?.$value).toBe('red');
   // Arity-3 conservative marking: every participating axis flagged.
@@ -199,6 +199,6 @@ it('dedupes overrides on canonical key — the same partial tuple under differen
   );
   // Exactly one arity-2 entry; canonicalKey is `brand:A|mode:Dark`
   // (axis names lexicographically sorted), not `mode:Dark|brand:A`.
-  expect(overrides.size).toBe(1);
-  expect([...overrides.keys()]).toEqual(['brand:A|mode:Dark']);
+  expect(overrides.length).toBe(1);
+  expect(overrides.map(([k]) => k)).toEqual(['brand:A|mode:Dark']);
 });

--- a/packages/core/test/resolve-at.test.ts
+++ b/packages/core/test/resolve-at.test.ts
@@ -86,6 +86,6 @@ it('materializes a bounded set of joint override entries (one per divergent part
   // Bounded by `Σ_n C(axes, n) × Π_i (contexts_i - 1)` across all
   // arities that probed up a divergence — much smaller than the
   // cartesian product for typical fixtures.
-  expect(project.jointOverrides.size).toBeGreaterThan(0);
-  expect(project.jointOverrides.size).toBeLessThan(50);
+  expect(project.jointOverrides.length).toBeGreaterThan(0);
+  expect(project.jointOverrides.length).toBeLessThan(50);
 });


### PR DESCRIPTION
## Summary

Collapses \`JointOverrides\` from \`ReadonlyMap<string, JointOverride>\` to \`ReadonlyArray<readonly [string, JointOverride]>\` — the shape consumers already saw on the wire (virtual module + Storybook channel) and what blocks-side \`makeResolveAt\` already reconstructed Maps from on every snapshot read.

**Why this is safe:** No consumer uses keyed lookup. The three downstream callers all do \`.values()\` iteration:
- \`buildResolveAt\` in \`resolve-at.ts\`
- \`analyzeProjectVariance\` in \`variance-analysis.ts\`
- the smart emitter's \`collectJointBlocks\` in \`css-axis-projected.ts\`

Switching to \`for (const [, override] of jointOverrides)\` array destructuring is the only call-site change. Tests using \`.size\` switch to \`.length\`.

**Internal dedupe still works:** \`probeJointOverrides\` keeps a \`Map<string, JointOverride>\` internally for canonical-key dedupe across arity passes (the load-bearing reason the type was a Map originally). The public return materializes to the array shape on emit via \`[...overrides.entries()]\` — one O(N) conversion at the end of probe vs ongoing wire-boundary marshaling.

**Wire-boundary marshaling disappears:**
- \`addon/virtual/plugin.ts\` (both module body emit at L114 and HMR re-broadcast at L188) stops calling \`[...project.jointOverrides.entries()]\` — \`project.jointOverrides\` is already the array.
- \`blocks/internal/use-project.ts:makeResolveAt\` stops \`new Map(...)\` reconstructing on every snapshot read.
- \`addon/src/preview.tsx:previewResolveAt\` and \`addon/src/hooks/use-token.ts:fallbackResolveAt\` stop their \`new Map(... as readonly (readonly [string, JointOverride])[]) as JointOverrides\` cast dance — the virtual module exports the array shape directly.

Pre-1.0 minor bump on core (\`JointOverrides\` is a public type export); patch on addon + blocks (no public API change, just consumer-side cleanup).

Milestone: Maintenance
Closes: #866
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] Existing fixture tests (joint-overrides + resolve-at) green with \`.length\` substitutions
- [x] Direct probe unit tests green with \`[, override]\` array destructuring