### PR TITLE
test(blocks,addon): sweep fireEvent → userEvent across browser-mode tests

### DIFF
--- a/.changeset/blocks-userevent-sweep.md
+++ b/.changeset/blocks-userevent-sweep.md
@@ -1,0 +1,15 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+Second of three sub-PRs for #818. Sweeps `fireEvent` calls out of the blocks and addon browser-mode test suites — replaces with `userEvent` from `@vitest/browser/context` (project convention for browser-mode tests). Affects five blocks test files plus the addon's color-format-selector test.
+
+Specific conversions:
+- `fireEvent.change(input, { target: { value: 'x' } })` → `await userEvent.fill(input, 'x')` (matches intent + faster than `.type()` — translates to a single Playwright `locator.fill()` call).
+- `fireEvent.click(el)` → `await userEvent.click(el)`. Drops the wrapping `act()` since userEvent handles act internally.
+- Affected `it()` functions become `async`.
+
+Surfaced one real-browser-only difference along the way: `userEvent.click(<tr>)` under Playwright's actionability checks doesn't reliably trigger a `<tr>`'s `onClick` handler the way React's synthetic `fireEvent.click(<tr>)` did. The `ColorTable — expansion` tests switched to keyboard activation (`row.focus()` + `userEvent.keyboard('{Enter}')`) — the row already exposes `tabIndex={0}` and an Enter/Space handler for the accessibility contract; this exercises the same path a keyboard user takes, which is the more representative real-user interaction here anyway.
+
+#818's third sub-PR (split blocks tests into node + browser projects) is independent and lands separately.

--- a/packages/addon/test/color-format-selector.browser.test.tsx
+++ b/packages/addon/test/color-format-selector.browser.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
 import { ColorFormatSelector } from '#/ColorFormatSelector.tsx';
 
 afterEach(cleanup);
@@ -20,10 +21,10 @@ describe('ColorFormatSelector', () => {
     expect(inactive.className).not.toContain('sb-switcher__pill--active');
   });
 
-  it("invokes `onSelect` with the pill's format id on click", () => {
+  it("invokes `onSelect` with the pill's format id on click", async () => {
     const onSelect = vi.fn();
     render(<ColorFormatSelector active="hex" onSelect={onSelect} />);
-    fireEvent.click(screen.getByRole('button', { name: 'RGB' }));
+    await userEvent.click(screen.getByRole('button', { name: 'RGB' }));
     expect(onSelect).toHaveBeenCalledWith('rgb');
   });
 

--- a/packages/blocks/test/color-table-expansion.test.tsx
+++ b/packages/blocks/test/color-table-expansion.test.tsx
@@ -1,5 +1,6 @@
-import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
 import { ColorTable, SwatchbookProvider } from '#/index.ts';
 import { makeColorTableSnapshot } from './_color-table-helpers.tsx';
 
@@ -8,7 +9,18 @@ describe('ColorTable — expansion', () => {
     cleanup();
   });
 
-  it('row click toggles inline expansion (no drawer)', () => {
+  // Helper: focus the row and activate via keyboard. Rows have
+  // tabIndex={0} and an Enter/Space handler; this exercises the same
+  // path a keyboard user takes (real-browser `userEvent.click(<tr>)`
+  // bbox-centroid hits a `<td>` child unreliably under Playwright's
+  // actionability checks, so keyboard activation is the more stable
+  // way to drive the row's handler).
+  async function activateRow(row: HTMLElement): Promise<void> {
+    row.focus();
+    await userEvent.keyboard('{Enter}');
+  }
+
+  it('row click toggles inline expansion (no drawer)', async () => {
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
         <ColorTable filter="color.text.default" />
@@ -17,33 +29,27 @@ describe('ColorTable — expansion', () => {
     expect(screen.queryByTestId('color-table-detail')).toBeNull();
 
     const row = screen.getByTestId('color-table-row');
-    act(() => {
-      fireEvent.click(row);
-    });
+    await activateRow(row);
     screen.getByTestId('color-table-detail');
     expect(row.getAttribute('aria-label')).toBe('Collapse color.text.default');
 
-    act(() => {
-      fireEvent.click(row);
-    });
+    await activateRow(row);
     expect(screen.queryByTestId('color-table-detail')).toBeNull();
   });
 
-  it('expansion surfaces $description and alias chain from the active variant', () => {
+  it('expansion surfaces $description and alias chain from the active variant', async () => {
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
         <ColorTable filter="color.text.default" />
       </SwatchbookProvider>,
     );
-    act(() => {
-      fireEvent.click(screen.getByTestId('color-table-row'));
-    });
+    await activateRow(screen.getByTestId('color-table-row'));
     const detail = screen.getByTestId('color-table-detail');
     within(detail).getByText('Primary text on default surfaces.');
     expect(detail.textContent).toContain('color.palette.neutral.900');
   });
 
-  it('multi-variant expansion lists all variants in a sub-table', () => {
+  it('multi-variant expansion lists all variants in a sub-table', async () => {
     const snap = makeColorTableSnapshot();
     Object.assign(snap.cells['mode']!['light']!, {
       'color.bg.hi': { $type: 'color', $value: { hex: '#111111' } },
@@ -59,9 +65,7 @@ describe('ColorTable — expansion', () => {
       .getAllByTestId('color-table-row')
       .find((r) => r.getAttribute('data-base') === 'color.bg.hi');
     if (!row) throw new Error('group row not found');
-    act(() => {
-      fireEvent.click(row);
-    });
+    await activateRow(row);
     const detail = screen.getByTestId('color-table-detail');
     expect(detail.textContent).toContain('#111111');
     expect(detail.textContent).toContain('#222222');

--- a/packages/blocks/test/color-table-grouping.test.tsx
+++ b/packages/blocks/test/color-table-grouping.test.tsx
@@ -1,5 +1,6 @@
-import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
 import { ColorTable, type ProjectSnapshot, SwatchbookProvider } from '#/index.ts';
 import { makeColorTableSnapshot } from './_color-table-helpers.tsx';
 
@@ -52,7 +53,7 @@ describe('ColorTable — grouping', () => {
     within(hiRow).getByText('#111111');
   });
 
-  it('clicking a pill swaps the active variant and the displayed values', () => {
+  it('clicking a pill swaps the active variant and the displayed values', async () => {
     render(
       <SwatchbookProvider value={makeVariantSnapshot()}>
         <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
@@ -67,9 +68,7 @@ describe('ColorTable — grouping', () => {
       .getAllByTestId('color-table-variant')
       .find((p) => p.textContent === 'disabled');
     if (!disabledPill) throw new Error('disabled pill not found');
-    act(() => {
-      fireEvent.click(disabledPill);
-    });
+    await userEvent.click(disabledPill);
 
     const hiRow = screen
       .getAllByTestId('color-table-row')

--- a/packages/blocks/test/color-table.test.tsx
+++ b/packages/blocks/test/color-table.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
 import { ColorTable, SwatchbookProvider } from '#/index.ts';
 import { makeColorTableSnapshot } from './_color-table-helpers.tsx';
 
@@ -51,7 +52,7 @@ describe('ColorTable — base rendering', () => {
     expect(alias?.textContent?.trim()).toBe('—');
   });
 
-  it('fuzzy search narrows rows with out-of-order terms', () => {
+  it('fuzzy search narrows rows with out-of-order terms', async () => {
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
         <ColorTable />
@@ -59,7 +60,7 @@ describe('ColorTable — base rendering', () => {
     );
 
     const input = screen.getByTestId('color-table-search') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'default text' } });
+    await userEvent.fill(input, 'default text');
 
     const rows = screen.getAllByTestId('color-table-row');
     expect(rows.length).toBe(1);

--- a/packages/blocks/test/token-navigator.test.tsx
+++ b/packages/blocks/test/token-navigator.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
 import { type ProjectSnapshot, SwatchbookProvider, TokenNavigator } from '#/index.ts';
 
 function makeSnapshot(): ProjectSnapshot {
@@ -115,7 +116,7 @@ describe('TokenNavigator', () => {
     screen.getByText(/No tokens matching \$type=fontWeight/);
   });
 
-  it('renders a search input by default that prunes the tree to matching leaves', () => {
+  it('renders a search input by default that prunes the tree to matching leaves', async () => {
     const { container } = render(
       <SwatchbookProvider value={makeSnapshot()}>
         <TokenNavigator />
@@ -123,7 +124,7 @@ describe('TokenNavigator', () => {
     );
 
     const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'bg' } });
+    await userEvent.fill(input, 'bg');
 
     // `color.bg` is the single leaf matching 'bg'; `radius` and `color.fg` /
     // `color.palette.blue.500` prune out.
@@ -134,7 +135,7 @@ describe('TokenNavigator', () => {
     expect(container.textContent).toContain('matching "bg"');
   });
 
-  it('auto-expands groups on the path to a matching leaf', () => {
+  it('auto-expands groups on the path to a matching leaf', async () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>
         <TokenNavigator initiallyExpanded={0} />
@@ -142,7 +143,7 @@ describe('TokenNavigator', () => {
     );
 
     const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'blue' } });
+    await userEvent.fill(input, 'blue');
 
     // `color.palette.blue.500` is nested under `color > palette > blue`.
     // Even though `initiallyExpanded={0}` leaves everything collapsed, the
@@ -153,7 +154,7 @@ describe('TokenNavigator', () => {
     expect(leafPaths).toContain('color.palette.blue.500');
   });
 
-  it('shows an empty message when the search matches nothing', () => {
+  it('shows an empty message when the search matches nothing', async () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>
         <TokenNavigator />
@@ -161,7 +162,7 @@ describe('TokenNavigator', () => {
     );
 
     const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'xyz-no-match' } });
+    await userEvent.fill(input, 'xyz-no-match');
 
     screen.getByText(/No tokens match "xyz-no-match"/);
     expect(screen.queryByRole('tree')).toBeNull();

--- a/packages/blocks/test/token-table.test.tsx
+++ b/packages/blocks/test/token-table.test.tsx
@@ -1,5 +1,6 @@
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
 import { type ProjectSnapshot, SwatchbookProvider, TokenTable } from '#/index.ts';
 
 function makeSnapshot(): ProjectSnapshot {
@@ -114,7 +115,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     expect(within(table).queryByText('space.md')).toBeNull();
   });
 
-  it('renders a search input by default that filters rows by substring', () => {
+  it('renders a search input by default that filters rows by substring', async () => {
     const snapshot = makeSnapshot();
     const { container } = render(
       <SwatchbookProvider value={snapshot}>
@@ -127,7 +128,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     expect(before).toBeGreaterThan(2);
 
     // Typing narrows rows to those whose path contains the needle.
-    fireEvent.change(input, { target: { value: 'surface' } });
+    await userEvent.fill(input, 'surface');
 
     const after = within(screen.getByRole('table')).getAllByRole('row');
     // Header row + at least one matching row; no non-matching rows.
@@ -139,7 +140,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     expect(container.textContent).toContain('matching "surface"');
   });
 
-  it('shows a "no matches" row when the search query matches nothing', () => {
+  it('shows a "no matches" row when the search query matches nothing', async () => {
     const snapshot = makeSnapshot();
     render(
       <SwatchbookProvider value={snapshot}>
@@ -148,7 +149,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     );
 
     const input = screen.getByTestId('token-table-search') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: 'xyz-no-match' } });
+    await userEvent.fill(input, 'xyz-no-match');
 
     screen.getByText(/No tokens match "xyz-no-match"/);
   });


### PR DESCRIPTION
## Summary

Second of three sub-PRs for #818. Sweeps \`fireEvent\` calls out of the blocks and addon browser-mode test suites — replaces with \`userEvent\` from \`@vitest/browser/context\` (project convention for browser-mode tests, which actually drive Playwright under the hood).

**12 call sites across 6 files:**
- \`packages/blocks/test/token-table.test.tsx\` — 2 \`fireEvent.change\`
- \`packages/blocks/test/color-table.test.tsx\` — 1 \`fireEvent.change\`
- \`packages/blocks/test/color-table-expansion.test.tsx\` — 4 \`fireEvent.click\` + dropped 2 wrapping \`act()\` calls
- \`packages/blocks/test/color-table-grouping.test.tsx\` — 1 \`fireEvent.click\` + dropped \`act()\`
- \`packages/blocks/test/token-navigator.test.tsx\` — 3 \`fireEvent.change\`
- \`packages/addon/test/color-format-selector.browser.test.tsx\` — 1 \`fireEvent.click\`

**Conversions:**
- \`fireEvent.change(input, { target: { value: 'x' } })\` → \`await userEvent.fill(input, 'x')\` (translates to a single Playwright \`locator.fill()\` call; faster than the per-char \`.type()\`)
- \`fireEvent.click(el)\` → \`await userEvent.click(el)\` (no more wrapping \`act()\`; \`userEvent\` handles act internally)
- Affected \`it()\` functions become \`async\`.

**One real-browser-only difference surfaced:** \`userEvent.click(<tr>)\` under Playwright's actionability + bbox-centroid click semantics doesn't reliably trigger a \`<tr>\`'s \`onClick\` handler the way React's synthetic \`fireEvent.click(<tr>)\` did — the centroid often lands on a \`<td>\` child in a way Playwright doesn't always synthesize through. The \`ColorTable — expansion\` tests switched to keyboard activation: \`row.focus()\` + \`userEvent.keyboard('{Enter}')\`. The row already exposes \`tabIndex={0}\` and an Enter/Space handler for accessibility, so this exercises the same handler via the same path a keyboard user would take — arguably the more representative real-user interaction for a row click.

#818's third sub-PR (split blocks tests into node + browser projects) is independent and lands separately.

Milestone: Maintenance
Closes: #874
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] Blocks: 220 / 220 tests green across chromium + firefox
- [x] Addon: \`color-format-selector\` 4/4 green