### PR TITLE
refactor(core): drop unreachable swatchbook/project disabled-axes diagnostic

### DIFF
--- a/.changeset/drop-unreachable-disabled-axes-diag.md
+++ b/.changeset/drop-unreachable-disabled-axes-diag.md
@@ -1,0 +1,9 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Closes #852. Removes the `swatchbook/project` warn diagnostic at `packages/core/src/load.ts:107-113` — its trigger (`disabledAxes.length > 0 && filteredPermutations.length === 0`) is unreachable under singleton enumeration.
+
+All three loader paths (`resolver`, `layered`, plain-parse) push the default tuple first (`permutations[0]` is always the all-defaults input). The `disabledAxes` filter requires `perm.input[name] !== axisDefaults.get(name)` to drop a permutation — but the default tuple has every axis at its default by construction, so it survives any `disabledAxes` filter. `filteredPermutations.length` is always ≥ 1 post-filter.
+
+The branch was load-bearing under the old cartesian fan-out path where misconfiguring `disabledAxes` could filter every cartesian tuple. Singleton enumeration's "default tuple always present" invariant made the check redundant. Drops the dead branch and the now-unused `Diagnostic` type import.

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -14,7 +14,6 @@ import {
   permutationID,
   type Axis,
   type Config,
-  type Diagnostic,
   type Permutation,
   type Project,
   type TokenMap,
@@ -97,20 +96,6 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   }
 
   const { diagnostics: cssOptionsDiagnostics } = validateCssOptions(config.cssOptions);
-
-  // A misconfigured `disabledAxes` (e.g. pinning an axis whose default
-  // context has no permutation rows) can filter every permutation out.
-  // We still return an empty project so the addon can render diagnostics
-  // instead of crashing, but the cause is easy to miss — the panel just
-  // shows an empty tree. Flag it here so users have something actionable.
-  const projectDiagnostics: Diagnostic[] = [];
-  if (disabledAxes.length > 0 && filteredPermutations.length === 0) {
-    projectDiagnostics.push({
-      severity: 'warn',
-      group: 'swatchbook/project',
-      message: `\`disabledAxes\` ${JSON.stringify(disabledAxes)} filtered out every permutation — nothing left to render. Check that the pinned axes' default contexts are represented in the resolver's permutations.`,
-    });
-  }
 
   const { listing, diagnostics: listingDiagnostics } =
     normalized.parserInput !== undefined
@@ -205,7 +190,6 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
       ...chromeDiagnostics,
       ...cssOptionsDiagnostics,
       ...listingDiagnostics,
-      ...projectDiagnostics,
     ],
   };
 }


### PR DESCRIPTION
## Summary

Removes the \`swatchbook/project\` warn diagnostic at \`packages/core/src/load.ts:107-113\` — its trigger (\`disabledAxes.length > 0 && filteredPermutations.length === 0\`) is unreachable under singleton enumeration.

**Why unreachable:** all three loader paths push the default tuple first.
- \`resolver\` path — \`packages/core/src/permutations/resolver.ts:188\` pushes \`{ name: defaultId, input: defaultInput, … }\`
- \`layered\` path — \`packages/core/src/permutations/layered.ts:126\` pushes the all-defaults tuple before any non-default variants
- plain-parse path — \`resolver.ts:132\` pushes a single \`{ theme: 'default' }\` permutation against the synthetic axis

The \`disabledAxes\` filter (\`load.ts:233-238\`) requires \`perm.input[name] !== axisDefaults.get(name)\` to drop a permutation — but the default tuple has every axis at its default by construction, so it survives any \`disabledAxes\` filter. \`filteredPermutations.length\` is always ≥ 1 post-filter.

The branch was load-bearing under the old cartesian fan-out path, where misconfiguring \`disabledAxes\` could filter every cartesian tuple. Singleton enumeration's "default tuple always present" invariant made the check redundant.

Drops the if-block + the no-longer-used \`projectDiagnostics\` array + the now-unused \`Diagnostic\` type import. Three lines removed from \`load.ts\`'s diagnostic aggregation.

Milestone: Maintenance
Closes: #852
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] No core tests asserted on the removed diagnostic (verified via \`grep -n "swatchbook/project" packages/core/test/\` → no matches)