### PR TITLE
refactor(core,blocks,addon): consolidate makeCssVar onto core/css-var subpath

### DIFF
--- a/.changeset/consolidate-makecssvar.md
+++ b/.changeset/consolidate-makecssvar.md
@@ -1,0 +1,13 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+Second of three `#824` halves. Consolidates the two `makeCssVar` impls onto a single source — `packages/addon/src/hooks/use-token.ts:55`'s hand-rolled `path.replaceAll('.', '-')` version was a confirmed drift risk (no Terrazzo casing / unicode pass), while `packages/blocks/src/internal/use-project.ts:287`'s correct wrapper around `@terrazzo/token-tools/css`'s `makeCSSVar` was internal-only.
+
+Adds `@unpunnyfuns/swatchbook-core/css-var` subpath exporting `makeCssVar(path, prefix)` — same browser-safe-subpath pattern as `/resolve-at` and `/fuzzy`. Both blocks and addon now import from there; the local impls are deleted. Future Terrazzo naming-policy shifts reach both surfaces in lockstep.
+
+Minor bump on core because the subpath is a new public surface area; patch on blocks + addon (no public API change, just consumer-side cleanup).
+
+The remaining `#824` half (`dataAttr` consolidation across 3 sites in core / addon / blocks) follows the same subpath shape and lands separately.

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -6,6 +6,7 @@ import {
   jointOverrides as virtualJointOverrides,
 } from 'virtual:swatchbook/tokens';
 import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
+import { makeCssVar } from '@unpunnyfuns/swatchbook-core/css-var';
 import type {
   Axis as CoreAxis,
   Cells as CoreCells,
@@ -49,11 +50,6 @@ export interface TokenInfo {
   type?: string;
   /** Optional DTCG `$description`. */
   description?: string;
-}
-
-function makeCssVar(path: string, prefix: string): string {
-  const tail = path.replaceAll('.', '-');
-  return prefix ? `var(--${prefix}-${tail})` : `var(--${tail})`;
 }
 
 /**

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,6 +1,6 @@
 import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
+import { makeCssVar } from '@unpunnyfuns/swatchbook-core/css-var';
 import type { Axis, Cells, JointOverrides, TokenMap } from '@unpunnyfuns/swatchbook-core';
-import { makeCSSVar } from '@terrazzo/token-tools/css';
 import { useEffect, useMemo } from 'react';
 import type { VirtualTokenListingShape, VirtualVarianceByPathShape } from '#/contexts.ts';
 import { useActiveAxes, useActivePermutation, useOptionalSwatchbookData } from '#/contexts.ts';
@@ -276,16 +276,6 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
       resolveAt,
     ],
   );
-}
-
-/**
- * Thin wrapper around Terrazzo's `makeCSSVar` so the block-display surface
- * and `packages/core/src/css.ts`'s emitter share one implementation. Any
- * future naming-policy shift in Terrazzo (casing, unicode, prefix handling)
- * reaches both surfaces at once instead of needing a parallel update here.
- */
-export function makeCssVar(path: string, prefix: string): string {
-  return prefix ? makeCSSVar(path, { prefix, wrapVar: true }) : makeCSSVar(path, { wrapVar: true });
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,10 @@
     "./resolve-at": {
       "types": "./dist/resolve-at.d.mts",
       "import": "./dist/resolve-at.mjs"
+    },
+    "./css-var": {
+      "types": "./dist/css-var.d.mts",
+      "import": "./dist/css-var.mjs"
     }
   },
   "imports": {
@@ -48,7 +52,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts src/css-var.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/src/css-var.ts
+++ b/packages/core/src/css-var.ts
@@ -1,0 +1,18 @@
+/**
+ * Browser-safe `makeCssVar(path, prefix)` helper. Exported through the
+ * `@unpunnyfuns/swatchbook-core/css-var` subpath so the addon's hooks
+ * and the blocks-side display surface share one implementation — any
+ * future naming-policy shift in Terrazzo (casing, unicode, prefix
+ * handling) reaches both at once instead of needing parallel updates.
+ *
+ * Wraps `@terrazzo/token-tools/css`'s `makeCSSVar` because its `prefix`
+ * option is a function-argument-position concern (per call) while
+ * `wrapVar: true` is a here-always concern (every caller wants the
+ * `var(--…)` wrapper). The two-argument shape `(path, prefix)` is the
+ * ergonomic minimum.
+ */
+import { makeCSSVar } from '@terrazzo/token-tools/css';
+
+export function makeCssVar(path: string, prefix: string): string {
+  return prefix ? makeCSSVar(path, { prefix, wrapVar: true }) : makeCSSVar(path, { wrapVar: true });
+}


### PR DESCRIPTION
## Summary

Second of three \`#824\` halves. Consolidates the two \`makeCssVar\` impls onto a single source.

**The drift risk this fixes:** \`packages/addon/src/hooks/use-token.ts:55\` had a hand-rolled \`path.replaceAll('.', '-')\` formatter, while \`packages/blocks/src/internal/use-project.ts:287\` correctly wrapped \`@terrazzo/token-tools/css\`'s \`makeCSSVar\`. The hand-rolled version skipped Terrazzo's casing / unicode-normalisation pass, so any token path Terrazzo would have munged differently produced divergent CSS-var names between the two consumers.

**Fix:** new \`@unpunnyfuns/swatchbook-core/css-var\` subpath exporting \`makeCssVar(path, prefix)\`. Same browser-safe-subpath shape as the existing \`/resolve-at\` and \`/fuzzy\` exports. Both blocks and addon now import from there; the two local impls are deleted. Future Terrazzo naming-policy shifts (casing, unicode normalisation, prefix handling) reach both surfaces in lockstep.

**Subpath shape:**
- \`packages/core/src/css-var.ts\` (new) — 4-line module wrapping \`makeCSSVar\` to flatten the awkward \`{prefix, wrapVar: true}\` vs \`{wrapVar: true}\` Terrazzo signature into a 2-arg \`(path, prefix)\` shape.
- \`packages/core/package.json\` — adds \`./css-var\` to \`exports\` map and \`src/css-var.ts\` to the tsdown build entries.

Minor bump on core (new public subpath); patch on blocks + addon (no public API change).

The remaining #824 half (\`dataAttr\` consolidation across 3 sites in core / addon / blocks) follows the same subpath shape and lands separately.

Milestone: Maintenance
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] No remaining \`makeCssVar\` hand-rolled or wrapper sites in blocks/src or addon/src (\`grep -rn "function makeCssVar\\\\|function makeCSSVar" packages/{blocks,addon}/src\` → no matches)
- [x] Both consumers' tests green (blocks browser harness + addon unit tests)