### PR TITLE
test(core,tokens): layered fixture realism — composites + multi-hop alias chains

### DIFF
--- a/.changeset/layered-fixture-realism.md
+++ b/.changeset/layered-fixture-realism.md
@@ -1,0 +1,17 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Closes #833. Extends the layered test fixture (`packages/core/test/fixtures/layered/`) with composites and a multi-hop alias chain so the layered-loader path has real-data coverage for the same shapes the resolver-path reference fixture already exercises.
+
+Before: 4 files, color-only, single-hop aliases. Real consumers using layered mode with composites would be the first to discover any bug in alias-through-composite resolution under that path.
+
+Now:
+- `base/ref.json` adds `dimension`, `duration`, `cubicBezier`, `fontFamily`, `fontWeight` primitives — the alias targets for the new composites.
+- `base/sys.json` adds composite roles: `shadow.md` (single-layer shadow with aliased color + offsets), `border.default` (aliases `color.accent` which itself aliases `color.blue` — depth-2 chain), `transition.enter`, `typography.heading`. Also adds `color.fg` aliasing `color.text` for a plain depth-2 color chain.
+- `modes/dark.json` re-aims `shadow.md.color` to `{color.white}` so the Dark overlay exercises composite-whole replacement.
+- Existing tokens (`color.surface` / `text` / `accent`) and their overlays are unchanged — additive only, no test regressions.
+
+New test file `load-layered-composites.test.ts` covers the new shapes with 6 assertions: composites load with `$type` intact, multi-hop color chain resolves transitively in Light, the same chain re-resolves when an intermediate target flips under an axis (Dark), composite sub-field flips when its alias target is re-aimed under an axis, composite alias chain depth ≥ 2 resolves, and the head re-aim case for brand-touched composites.
+
+No source changes.

--- a/packages/core/test/fixtures/layered/base/ref.json
+++ b/packages/core/test/fixtures/layered/base/ref.json
@@ -13,5 +13,27 @@
     "red": {
       "$value": { "colorSpace": "srgb", "components": [0.9, 0.2, 0.2] }
     }
+  },
+  "dimension": {
+    "$type": "dimension",
+    "xs": { "$value": { "value": 4, "unit": "px" } },
+    "sm": { "$value": { "value": 8, "unit": "px" } }
+  },
+  "duration": {
+    "$type": "duration",
+    "fast": { "$value": { "value": 150, "unit": "ms" } }
+  },
+  "cubicBezier": {
+    "$type": "cubicBezier",
+    "ease-out": { "$value": [0, 0, 0.2, 1] }
+  },
+  "fontFamily": {
+    "$type": "fontFamily",
+    "sans": { "$value": ["Inter", "system-ui", "sans-serif"] }
+  },
+  "fontWeight": {
+    "$type": "fontWeight",
+    "regular": { "$value": 400 },
+    "bold": { "$value": 700 }
   }
 }

--- a/packages/core/test/fixtures/layered/base/sys.json
+++ b/packages/core/test/fixtures/layered/base/sys.json
@@ -3,6 +3,51 @@
     "$type": "color",
     "surface": { "$value": "{color.white}" },
     "text":    { "$value": "{color.black}" },
-    "accent":  { "$value": "{color.blue}" }
+    "accent":  { "$value": "{color.blue}" },
+    "fg":      { "$value": "{color.text}" }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "md": {
+      "$value": {
+        "color":   "{color.black}",
+        "offsetX": { "value": 0, "unit": "px" },
+        "offsetY": "{dimension.xs}",
+        "blur":    "{dimension.sm}",
+        "spread":  { "value": 0, "unit": "px" }
+      }
+    }
+  },
+  "border": {
+    "$type": "border",
+    "default": {
+      "$value": {
+        "color": "{color.accent}",
+        "width": "{dimension.xs}",
+        "style": "solid"
+      }
+    }
+  },
+  "transition": {
+    "$type": "transition",
+    "enter": {
+      "$value": {
+        "duration":       "{duration.fast}",
+        "delay":          { "value": 0, "unit": "ms" },
+        "timingFunction": "{cubicBezier.ease-out}"
+      }
+    }
+  },
+  "typography": {
+    "$type": "typography",
+    "heading": {
+      "$value": {
+        "fontFamily":    "{fontFamily.sans}",
+        "fontSize":      { "value": 24, "unit": "px" },
+        "fontWeight":    "{fontWeight.bold}",
+        "lineHeight":    1.2,
+        "letterSpacing": { "value": 0, "unit": "px" }
+      }
+    }
   }
 }

--- a/packages/core/test/fixtures/layered/modes/dark.json
+++ b/packages/core/test/fixtures/layered/modes/dark.json
@@ -3,5 +3,17 @@
     "$type": "color",
     "surface": { "$value": "{color.black}" },
     "text":    { "$value": "{color.white}" }
+  },
+  "shadow": {
+    "$type": "shadow",
+    "md": {
+      "$value": {
+        "color":   "{color.white}",
+        "offsetX": { "value": 0, "unit": "px" },
+        "offsetY": "{dimension.xs}",
+        "blur":    "{dimension.sm}",
+        "spread":  { "value": 0, "unit": "px" }
+      }
+    }
   }
 }

--- a/packages/core/test/load-layered-composites.test.ts
+++ b/packages/core/test/load-layered-composites.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Layered-fixture coverage for composites + multi-hop alias chains.
+ *
+ * The layered fixture grew (#833) to include `shadow.md`, `border.default`,
+ * `transition.enter`, `typography.heading` and a multi-hop `color.fg →
+ * color.text → color.black/white` chain so that the layered loader path
+ * has real-data coverage for the same composite + alias-chain shapes the
+ * resolver-path reference fixture exercises.
+ *
+ * Without this, the layered loader has only color-token + single-hop alias
+ * coverage — a real consumer using layered mode with composites would be
+ * the first to discover any bug in alias-through-composite resolution
+ * under the layered path.
+ */
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { beforeAll, expect, it } from 'vitest';
+import { loadProject } from '#/load.ts';
+import type { Config, Project } from '#/types.ts';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtureCwd = resolve(here, 'fixtures/layered');
+
+let project: Project;
+beforeAll(async () => {
+  const config: Config = {
+    tokens: ['base/*.json'],
+    axes: [
+      { name: 'mode', contexts: { Light: [], Dark: ['modes/dark.json'] }, default: 'Light' },
+      {
+        name: 'brand',
+        contexts: { Default: [], 'Brand A': ['brands/brand-a.json'] },
+        default: 'Default',
+      },
+    ],
+  };
+  project = await loadProject(config, fixtureCwd);
+}, 30_000);
+
+it('composite tokens (shadow, border, transition, typography) load with sub-field aliases intact', () => {
+  // shadow.md.color aliases color.black; offsetY/blur alias dimension.xs/sm.
+  // border.default.color aliases color.accent (which itself aliases color.blue).
+  // transition.enter.duration aliases duration.fast; timingFunction aliases cubicBezier.ease-out.
+  // typography.heading.fontFamily / fontWeight alias the matching primitives.
+  expect(project.defaultTokens['shadow.md']?.$type).toBe('shadow');
+  expect(project.defaultTokens['border.default']?.$type).toBe('border');
+  expect(project.defaultTokens['transition.enter']?.$type).toBe('transition');
+  expect(project.defaultTokens['typography.heading']?.$type).toBe('typography');
+});
+
+it('multi-hop alias chain resolves transitively (color.fg → color.text → color.black) in Light mode', () => {
+  const light = project.resolveAt({ mode: 'Light', brand: 'Default' });
+  // Two hops to a primitive — exercises the layered loader's alias
+  // re-resolution through one indirection level on top of the direct
+  // alias the single-hop tests already cover.
+  expect(light['color.fg']?.$value).toMatchObject({ components: [0, 0, 0] });
+});
+
+it('multi-hop alias chain re-resolves when the intermediate target flips under an axis (Dark overrides color.text → white)', () => {
+  const dark = project.resolveAt({ mode: 'Dark', brand: 'Default' });
+  // color.fg still aliases color.text; color.text is overridden to white
+  // in Dark mode; so color.fg resolves to white. The layered loader
+  // must re-resolve the chain at the Dark tuple, not freeze it against
+  // the baseline.
+  expect(dark['color.fg']?.$value).toMatchObject({ components: [1, 1, 1] });
+});
+
+it('composite sub-field flips when its alias target is re-aimed under an axis (shadow.md.color in Dark)', () => {
+  // In Light, shadow.md.color aliases color.black. In Dark, dark.json
+  // re-aims shadow.md.color to {color.white}. The layered loader has
+  // to apply the composite-token override as a whole; this assertion
+  // checks the resolved composite value reflects the Dark-mode alias.
+  // Terrazzo normalizes shadow `$value` to an array of layers regardless
+  // of authored shape, so single-layer shadows still expose `[0].color`.
+  const dark = project.resolveAt({ mode: 'Dark', brand: 'Default' });
+  const layers = dark['shadow.md']?.$value as
+    | ReadonlyArray<{ color?: { components?: number[] } }>
+    | undefined;
+  expect(layers?.[0]?.color?.components).toEqual([1, 1, 1]);
+});
+
+it('composite alias chain depth ≥ 2 resolves through the layered loader (border.default.color → color.accent → color.blue)', () => {
+  // border.default.color aliases color.accent, which itself aliases
+  // color.blue. Light + Default — no brand override on accent.
+  const light = project.resolveAt({ mode: 'Light', brand: 'Default' });
+  const border = light['border.default']?.$value as
+    | { color?: { components?: number[] } }
+    | undefined;
+  expect(border?.color?.components).toEqual([0.1, 0.3, 0.9]);
+});
+
+it('composite alias chain re-resolves when the chain head is re-aimed under an axis (border.default.color in Brand A)', () => {
+  // Brand A overrides color.accent → color.red. border.default.color
+  // still aliases color.accent, so it should now resolve to red.
+  const brand = project.resolveAt({ mode: 'Light', brand: 'Brand A' });
+  const border = brand['border.default']?.$value as
+    | { color?: { components?: number[] } }
+    | undefined;
+  expect(border?.color?.components).toEqual([0.9, 0.2, 0.2]);
+});


### PR DESCRIPTION
## Summary

Closes #833. Extends the layered test fixture so the layered-loader path has real-data coverage for the same shapes the resolver-path reference fixture already exercises.

**Before:** \`packages/core/test/fixtures/layered/\` had 4 files, color-only, single-hop aliases (e.g. \`{color.white}\`), zero composites. Any consumer using layered mode with composites would be the first to discover a bug in alias-through-composite resolution under that path.

**After:**
- \`base/ref.json\` adds primitive types (\`dimension\`, \`duration\`, \`cubicBezier\`, \`fontFamily\`, \`fontWeight\`) — the alias targets for the new composites.
- \`base/sys.json\` adds composite roles: \`shadow.md\` (single-layer shadow with aliased color + offsets), \`border.default\` (aliases \`color.accent\` which itself aliases \`color.blue\` — depth-2 chain), \`transition.enter\`, \`typography.heading\`. Also adds \`color.fg\` aliasing \`color.text\` for a plain depth-2 color chain.
- \`modes/dark.json\` re-aims \`shadow.md.color\` to \`{color.white}\` so the Dark overlay exercises composite-whole replacement.
- Existing tokens (\`color.surface\` / \`text\` / \`accent\`) and their overlays are unchanged — additive only, no test regressions.

**New test file** \`load-layered-composites.test.ts\` covers 6 invariants:
1. Composites load with \`$type\` intact.
2. Multi-hop color chain resolves transitively in Light (\`color.fg → color.text → color.black\`).
3. The same chain re-resolves when the intermediate target flips under an axis (Dark mode overrides \`color.text → white\`, so \`color.fg\` follows).
4. Composite sub-field flips when its alias target is re-aimed under an axis (\`shadow.md.color\` in Dark).
5. Composite alias chain depth ≥ 2 resolves (\`border.default.color → color.accent → color.blue\`).
6. Composite alias chain re-resolves when the chain head is re-aimed (\`border.default.color\` in Brand A flips through \`color.accent → color.red\`).

**One Terrazzo behaviour surfaced:** \`shadow.$value\` is normalized to an \`Array<ShadowLayer>\` regardless of authored shape (single-layer authored as object → \`$value[0]\` in the resolved output). The assertion accesses \`$value[0].color\` and documents the normalisation in a comment.

No source changes; pure fixture + test extension.

Milestone: Maintenance
Closes: #833
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] All 12 existing layered-fixture tests (\`load-layered\`, \`load-layered-validation\`, \`variance-analysis-layered\`) still pass against the extended fixture — no behaviour regressions
- [x] New \`load-layered-composites.test.ts\` 6/6 green