### PR TITLE
refactor(core,addon): extract snapshotForWire helper to core subpath

### DIFF
--- a/.changeset/snapshot-for-wire.md
+++ b/.changeset/snapshot-for-wire.md
@@ -1,0 +1,21 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+First half of #819. Extracts the wire-format snapshot helper that the addon's virtual-module plugin was duplicating across its two emit sites (module-body emission + HMR custom event) into a single browser-safe core subpath: `@unpunnyfuns/swatchbook-core/snapshot-for-wire`.
+
+**New exports** (subpath: `/snapshot-for-wire`):
+- `SnapshotForWire` interface — names the 11 fields the wire payload carries (axes, disabledAxes, presets, diagnostics, cssVarPrefix, css, listing, cells, jointOverrides, varianceByPath, defaultTuple) with JSON-friendly types (`Record` instead of `Map` for varianceByPath, slimmed `SlimListedToken` instead of the full `ListedToken`).
+- `SnapshotForWire`'s sub-types `SlimListedToken` — the three fields blocks actually read from each listing entry.
+- `snapshotForWire(project, css)` — builds a `SnapshotForWire` from a loaded `Project`. Does the Map-to-Object conversion for `varianceByPath` and the `slimListing` reduction in one place. The `css` arg is the `emitAxisProjectedCss(project)` output the plugin computes alongside the project load — not on `Project` itself.
+
+**Refactor:**
+- `packages/addon/src/virtual/plugin.ts` — both emit sites now call `snapshotForWire(project, css)`:
+  - Module-body emit destructures and JSON-stringifies each field for ESM exports.
+  - HMR `server.ws.send` passes the snapshot as the event `data` directly.
+- The duplicated `slimListing` helper + `SlimListedToken` type are removed from the plugin (they live in core now).
+
+**Still open for follow-up #819 work:** type-shape duplication across `packages/blocks/src/contexts.ts`, `packages/blocks/src/virtual.d.ts`, `packages/addon/src/channel-types.ts`, and `packages/addon/src/virtual.d.ts` (VirtualToken declared 3×, disabledAxes absent from blocks/virtual.d.ts, etc.). This PR consolidates the builders; the type-consolidation half follows separately because it cascades through ambient-module declarations + the manager-bundle import constraint.
+
+Minor bump on core (new public subpath); patch on addon (no public API change, internal cleanup).

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -1,11 +1,6 @@
-import type {
-  Config,
-  ListedToken,
-  Project,
-  SwatchbookIntegration,
-  TokenListingByPath,
-} from '@unpunnyfuns/swatchbook-core';
+import type { Config, Project, SwatchbookIntegration } from '@unpunnyfuns/swatchbook-core';
 import { emitAxisProjectedCss, loadProject } from '@unpunnyfuns/swatchbook-core';
+import { snapshotForWire } from '@unpunnyfuns/swatchbook-core/snapshot-for-wire';
 import { type FSWatcher, watch as fsWatch } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import picomatch from 'picomatch';
@@ -107,23 +102,23 @@ export function swatchbookTokensPlugin({
       }
       if (id !== RESOLVED_VIRTUAL_MODULE_ID) return null;
       if (!project) return 'export default null;';
-      // Emit a typed ESM module. Values are JSON-stringified for stability.
-      // `jointOverrides` is already an array of `[key, entry]` pairs on
-      // the server side — same shape consumers read on the wire.
-      const varianceByPathObj = Object.fromEntries(project.varianceByPath.entries());
+      // Emit a typed ESM module. `snapshotForWire` does the field set +
+      // Map-to-Object conversion in one place; we destructure here and
+      // JSON-stringify each field for ESM export.
+      const snap = snapshotForWire(project, css);
       return [
         `/* swatchbook virtual module — generated */`,
-        `export const axes = ${JSON.stringify(project.axes)};`,
-        `export const presets = ${JSON.stringify(project.presets)};`,
-        `export const disabledAxes = ${JSON.stringify(project.disabledAxes)};`,
-        `export const diagnostics = ${JSON.stringify(project.diagnostics)};`,
-        `export const css = ${JSON.stringify(css)};`,
-        `export const cssVarPrefix = ${JSON.stringify(config.cssVarPrefix ?? '')};`,
-        `export const listing = ${JSON.stringify(slimListing(project.listing))};`,
-        `export const cells = ${JSON.stringify(project.cells)};`,
-        `export const jointOverrides = ${JSON.stringify(project.jointOverrides)};`,
-        `export const varianceByPath = ${JSON.stringify(varianceByPathObj)};`,
-        `export const defaultTuple = ${JSON.stringify(project.defaultTuple)};`,
+        `export const axes = ${JSON.stringify(snap.axes)};`,
+        `export const presets = ${JSON.stringify(snap.presets)};`,
+        `export const disabledAxes = ${JSON.stringify(snap.disabledAxes)};`,
+        `export const diagnostics = ${JSON.stringify(snap.diagnostics)};`,
+        `export const css = ${JSON.stringify(snap.css)};`,
+        `export const cssVarPrefix = ${JSON.stringify(snap.cssVarPrefix)};`,
+        `export const listing = ${JSON.stringify(snap.listing)};`,
+        `export const cells = ${JSON.stringify(snap.cells)};`,
+        `export const jointOverrides = ${JSON.stringify(snap.jointOverrides)};`,
+        `export const varianceByPath = ${JSON.stringify(snap.varianceByPath)};`,
+        `export const defaultTuple = ${JSON.stringify(snap.defaultTuple)};`,
       ].join('\n');
     },
 
@@ -176,19 +171,7 @@ export function swatchbookTokensPlugin({
             server.ws.send({
               type: 'custom',
               event: HMR_EVENT,
-              data: {
-                axes: project.axes,
-                disabledAxes: project.disabledAxes,
-                presets: project.presets,
-                diagnostics: project.diagnostics,
-                css,
-                cssVarPrefix: config.cssVarPrefix ?? '',
-                listing: slimListing(project.listing),
-                cells: project.cells,
-                jointOverrides: project.jointOverrides,
-                varianceByPath: Object.fromEntries(project.varianceByPath.entries()),
-                defaultTuple: project.defaultTuple,
-              },
+              data: snapshotForWire(project, css),
             });
           })();
         }, 100);
@@ -267,28 +250,4 @@ export function collectWatchPaths(
 function resolveFromCwd(p: string, cwd: string): string {
   if (isAbsolute(p)) return p;
   return resolvePath(cwd, p);
-}
-
-type SlimListedToken = Pick<
-  ListedToken['$extensions']['app.terrazzo.listing'],
-  'names' | 'previewValue' | 'source'
->;
-
-/**
- * Reduce the full Token Listing surface down to the fields blocks read.
- * Drops `originalValue` (large, not needed for display), `$value`, `$type`,
- * `mode`, `subtype` for now — the blocks don't consume them yet. Keeps the
- * virtual module payload lean, especially for large projects where each
- * token's raw listing entry can weigh a few KB.
- */
-function slimListing(listing: TokenListingByPath): Record<string, SlimListedToken> {
-  const out: Record<string, SlimListedToken> = {};
-  for (const [path, entry] of Object.entries(listing)) {
-    const ext = entry.$extensions['app.terrazzo.listing'];
-    const slim: SlimListedToken = { names: ext.names };
-    if (ext.previewValue !== undefined) slim.previewValue = ext.previewValue;
-    if (ext.source !== undefined) slim.source = ext.source;
-    out[path] = slim;
-  }
-  return out;
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,10 @@
     "./data-attr": {
       "types": "./dist/data-attr.d.mts",
       "import": "./dist/data-attr.mjs"
+    },
+    "./snapshot-for-wire": {
+      "types": "./dist/snapshot-for-wire.d.mts",
+      "import": "./dist/snapshot-for-wire.mjs"
     }
   },
   "imports": {
@@ -56,7 +60,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts src/css-var.ts src/data-attr.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts src/css-var.ts src/data-attr.ts src/snapshot-for-wire.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/src/snapshot-for-wire.ts
+++ b/packages/core/src/snapshot-for-wire.ts
@@ -1,0 +1,98 @@
+/**
+ * Browser-safe wire-format helper. Exported through the
+ * `@unpunnyfuns/swatchbook-core/snapshot-for-wire` subpath so the
+ * addon's virtual-module emitter and HMR re-broadcast share one
+ * implementation — the field list and the Map-to-Object conversions
+ * live in one place rather than three.
+ *
+ * Builds a JSON-friendly subset of `Project` plus the emitter's CSS
+ * string. Drops fields that don't survive `JSON.stringify` and would
+ * either crash the wire (`parserInput`'s resolver, `resolveAt`'s
+ * function) or be useless after deserialisation. Converts the
+ * `varianceByPath` Map to a plain Record at the boundary; slims
+ * `listing` entries down to the three fields blocks actually read
+ * (`names`, `previewValue`, `source`).
+ *
+ * Consumers:
+ * - addon's Vite plugin emits the virtual ESM module body from this
+ * - addon's Vite plugin sends it as the HMR custom event payload
+ * - blocks' channel-tokens listener reads the same shape from
+ *   `TOKENS_UPDATED_EVENT`
+ *
+ * The `InitPayload` shape in `packages/addon/src/channel-types.ts` is
+ * a subset of this (manager-side doesn't need CSS or listing); kept
+ * separately for now because the manager bundle has its own
+ * import-resolution constraints.
+ */
+import type { ListedToken } from '#/token-listing.ts';
+import type { JointOverrides, Project } from '#/types.ts';
+
+/**
+ * Slimmed `ListedToken` — the three fields blocks actually consume.
+ * Drops `originalValue` (large; not needed for display), the wrapping
+ * `$extensions` envelope, and per-platform listings the blocks don't
+ * render yet.
+ */
+export interface SlimListedToken {
+  names: Record<string, string>;
+  previewValue?: ListedToken['$extensions']['app.terrazzo.listing']['previewValue'];
+  source?: ListedToken['$extensions']['app.terrazzo.listing']['source'];
+}
+
+/**
+ * JSON-friendly snapshot of `Project` for wire transport (virtual
+ * module body, HMR custom event, Storybook channel TOKENS_UPDATED_EVENT).
+ * Field set is the union every blocks-side consumer reads; the
+ * manager-side INIT_EVENT shape is a subset (no `css` / `listing`).
+ *
+ * Note `varianceByPath` is `Record`, not `Map` — `JSON.stringify` drops
+ * Map entries. Browser consumers read it as a plain object via O(1)
+ * key lookup; the original Map identity stays server-side on `Project`.
+ */
+export interface SnapshotForWire {
+  axes: Project['axes'];
+  disabledAxes: Project['disabledAxes'];
+  presets: Project['presets'];
+  diagnostics: Project['diagnostics'];
+  cssVarPrefix: string;
+  css: string;
+  listing: Readonly<Record<string, SlimListedToken>>;
+  cells: Project['cells'];
+  jointOverrides: JointOverrides;
+  varianceByPath: Record<string, ReturnType<Project['varianceByPath']['get']>>;
+  defaultTuple: Project['defaultTuple'];
+}
+
+/**
+ * Build the wire snapshot from a `Project` plus the emitter's CSS
+ * string. The CSS isn't on `Project` itself — it's the
+ * `emitAxisProjectedCss(project)` output that the addon's plugin
+ * computes alongside the project load.
+ */
+export function snapshotForWire(project: Project, css: string): SnapshotForWire {
+  return {
+    axes: project.axes,
+    disabledAxes: project.disabledAxes,
+    presets: project.presets,
+    diagnostics: project.diagnostics,
+    cssVarPrefix: project.config.cssVarPrefix ?? '',
+    css,
+    listing: slimListing(project.listing),
+    cells: project.cells,
+    jointOverrides: project.jointOverrides,
+    varianceByPath: Object.fromEntries(project.varianceByPath.entries()),
+    defaultTuple: project.defaultTuple,
+  };
+}
+
+function slimListing(listing: Project['listing']): Record<string, SlimListedToken> {
+  const out: Record<string, SlimListedToken> = {};
+  for (const [path, entry] of Object.entries(listing)) {
+    const ext = entry.$extensions['app.terrazzo.listing'];
+    const slim: SlimListedToken = { names: ext.names };
+    if (ext.previewValue !== undefined) slim.previewValue = ext.previewValue;
+    if (ext.source !== undefined) slim.source = ext.source;
+    out[path] = slim;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary

First half of #819. Extracts the wire-format snapshot helper that the addon's virtual-module plugin was duplicating across its two emit sites into a single browser-safe core subpath: \`@unpunnyfuns/swatchbook-core/snapshot-for-wire\`.

**Before** — two emit sites in \`packages/addon/src/virtual/plugin.ts\`, plus a private \`slimListing\` helper, each manually re-listing the same 11 fields:
- Module-body emit (line 113-127 prior): one \`export const … = JSON.stringify(…)\` per field.
- HMR \`server.ws.send\` (line 179-191 prior): same field set, same Map-to-Object conversion for \`varianceByPath\`, same \`slimListing\` call on \`project.listing\`.

**After:** one helper, two destructures.

**New core exports** (subpath \`/snapshot-for-wire\`):
- \`SnapshotForWire\` interface — the 11 fields the wire carries (axes, disabledAxes, presets, diagnostics, cssVarPrefix, css, listing, cells, jointOverrides, varianceByPath, defaultTuple) with JSON-friendly types: \`Record\` instead of \`Map\` for \`varianceByPath\`, slimmed \`SlimListedToken\` instead of the full Terrazzo \`ListedToken\`.
- \`SlimListedToken\` sub-type — the three fields (\`names\`, \`previewValue\`, \`source\`) blocks actually read.
- \`snapshotForWire(project, css)\` — builds the snapshot. Does Map-to-Object on \`varianceByPath\` and the listing reduction in one place.

**Refactor:**
- Plugin's module-body emit: \`const snap = snapshotForWire(project, css); return [...emit each snap.<field>...].join('\\n');\`
- Plugin's HMR send: \`server.ws.send({ type: 'custom', event: HMR_EVENT, data: snapshotForWire(project, css) })\`
- Duplicated \`slimListing\` helper + \`SlimListedToken\` type removed from the plugin.

**The rest of #819 — type-shape duplication consolidation** (VirtualToken declared 3× across \`blocks/contexts.ts\` / \`blocks/virtual.d.ts\` / \`addon/channel-types.ts\` / \`addon/virtual.d.ts\`) — is its own follow-up. It cascades through ambient module declarations and the manager-bundle import constraint; better as a separate PR. This PR addresses the duplicated-builder half cleanly.

Minor bump on core (new public subpath); patch on addon (no public API change).

Milestone: Maintenance
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] No \`Object.fromEntries(project.varianceByPath\` calls or hand-rolled \`slimListing\` remain in addon (\`grep -rn "varianceByPath.entries\\\\|slimListing" packages/addon\` → no matches)
- [x] Virtual-plugin tests still pass (4/4 in addon's node project)