### PR TITLE
refactor(blocks): centralize virtual-module type declarations + fix disabledAxes drift

### DIFF
--- a/.changeset/centralize-wire-types.md
+++ b/.changeset/centralize-wire-types.md
@@ -1,0 +1,19 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Closes #819. Second-half follow-up to PR #883 (which extracted the `snapshotForWire` builder helper). This PR consolidates the duplicated wire-shape type declarations on the blocks side:
+
+**Before:**
+- `packages/blocks/src/contexts.ts` exported `VirtualTokenShape`, `VirtualTokenListingShape`, etc.
+- `packages/blocks/src/virtual.d.ts` re-declared the same shapes inline inside the `declare module 'virtual:swatchbook/tokens'` block.
+- That virtual.d.ts was missing the `disabledAxes` export (silent drift from the addon's emitter, which has shipped `disabledAxes` over the wire since v0.55).
+
+**After:**
+- `VirtualTokenListingShape` now aliases `SlimListedToken` from `@unpunnyfuns/swatchbook-core/snapshot-for-wire` — cross-package alignment, same definition both addon-server-side and blocks-consumer-side.
+- `packages/blocks/src/virtual.d.ts` imports its types from `#/contexts.ts` (mirroring the cleaner pattern `packages/addon/src/virtual.d.ts` already uses with its `#/channel-types.ts`). The inline declarations are gone.
+- `disabledAxes` is now declared in `blocks/virtual.d.ts` — wire shape matches what the addon's emit + the existing `blocks/test/virtual-stub.ts` already provided.
+
+Net duplication: the `VirtualToken`/`Virtual*` interfaces dropped from 3× (contexts.ts + 2 virtual.d.ts variants) to 2× (one per package — blocks' `contexts.ts` and addon's `channel-types.ts`). Cross-package single-sourcing isn't feasible without violating the manager-bundle's Node-free import constraint; per-package single-sourcing is the achievable end state.
+
+No source changes; pure type-shape consolidation.

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -1,4 +1,5 @@
 import type { Axis, AxisVarianceResult, Diagnostic, Preset } from '@unpunnyfuns/swatchbook-core';
+import type { SlimListedToken } from '@unpunnyfuns/swatchbook-core/snapshot-for-wire';
 import { createContext, useContext } from 'react';
 import { useChannelGlobals } from '#/internal/channel-globals.ts';
 import type { ColorFormat } from '#/format-color.ts';
@@ -51,20 +52,11 @@ export interface VirtualTokenShape {
  * variable name and `previewValue` for the display-ready CSS string.
  * `source.loc` enables "jump to authoring source" affordances.
  *
- * Only the fields blocks consume are typed here; the plugin's full shape
- * lives in `@unpunnyfuns/swatchbook-core`.
+ * Aliases `SlimListedToken` from core's `/snapshot-for-wire` subpath —
+ * the single canonical wire shape; both the addon's plugin (server-side
+ * emit) and blocks (consumer-side read) reference the same definition.
  */
-export interface VirtualTokenListingShape {
-  names: Record<string, string>;
-  previewValue?: string | number;
-  source?: {
-    resource: string;
-    loc?: {
-      start: { line: number; column: number; offset: number };
-      end: { line: number; column: number; offset: number };
-    };
-  };
-}
+export type VirtualTokenListingShape = SlimListedToken;
 
 export type VirtualPresetShape = Preset;
 

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -2,96 +2,32 @@
  * Typed shape of the addon's `virtual:swatchbook/tokens` module. The runtime
  * payload is produced by the addon's Vite plugin (`swatchbookTokensPlugin`)
  * and JSON-serialized, so this declaration describes the plain-data shape
- * consumers read back — a narrow subset of Terrazzo's `TokenNormalized`
- * plus core's `Axis` / `Diagnostic` / `Preset` shapes.
+ * consumers read back. Shapes are imported from `#/contexts.ts` so the
+ * virtual module, the React contexts, and every blocks consumer can't
+ * drift from each other — single source within the package, mirroring
+ * the `addon/src/virtual.d.ts` → `addon/src/channel-types.ts` pattern.
  */
 declare module 'virtual:swatchbook/tokens' {
-  interface VirtualAxis {
-    name: string;
-    contexts: readonly string[];
-    default: string;
-    description?: string;
-    source: 'resolver' | 'layered' | 'synthetic';
-  }
+  import type {
+    VirtualAxisShape,
+    VirtualDiagnosticShape,
+    VirtualJointOverrideShape,
+    VirtualPresetShape,
+    VirtualTokenListingShape,
+    VirtualTokenShape,
+    VirtualVarianceByPathShape,
+  } from '#/contexts.ts';
 
-  interface VirtualDiagnostic {
-    severity: 'error' | 'warn' | 'info';
-    group: string;
-    message: string;
-    filename?: string;
-    line?: number;
-    column?: number;
-  }
-
-  interface VirtualToken {
-    $type?: string;
-    $value?: unknown;
-    $description?: string;
-    aliasOf?: string;
-    aliasChain?: readonly string[];
-    aliasedBy?: readonly string[];
-  }
-
-  interface VirtualPreset {
-    name: string;
-    axes: Partial<Record<string, string>>;
-    description?: string;
-  }
-
-  interface VirtualListingEntry {
-    names: Record<string, string>;
-    previewValue?: string | number;
-    source?: {
-      resource: string;
-      loc?: {
-        start: { line: number; column: number; offset: number };
-        end: { line: number; column: number; offset: number };
-      };
-    };
-  }
-
-  interface VirtualJointOverrideEntry {
-    axes: Record<string, string>;
-    tokens: Record<string, VirtualToken>;
-  }
-
-  type VirtualAxisVariancePerAxis = Record<
-    string,
-    { varying: boolean; contexts: Record<string, string> }
-  >;
-  type VirtualAxisVarianceEntry =
-    | {
-        path: string;
-        kind: 'constant';
-        varyingAxes: readonly [];
-        constantAcrossAxes: readonly string[];
-        perAxis: VirtualAxisVariancePerAxis;
-      }
-    | {
-        path: string;
-        kind: 'single';
-        axis: string;
-        varyingAxes: readonly [string];
-        constantAcrossAxes: readonly string[];
-        perAxis: VirtualAxisVariancePerAxis;
-      }
-    | {
-        path: string;
-        kind: 'multi';
-        varyingAxes: readonly [string, string, ...string[]];
-        constantAcrossAxes: readonly string[];
-        perAxis: VirtualAxisVariancePerAxis;
-      };
-
-  export const axes: readonly VirtualAxis[];
-  export const presets: readonly VirtualPreset[];
-  export const diagnostics: readonly VirtualDiagnostic[];
+  export const axes: readonly VirtualAxisShape[];
+  export const disabledAxes: readonly string[];
+  export const presets: readonly VirtualPresetShape[];
+  export const diagnostics: readonly VirtualDiagnosticShape[];
   export const css: string;
   export const cssVarPrefix: string;
-  export const listing: Readonly<Record<string, VirtualListingEntry>>;
-  export const cells: Record<string, Record<string, Record<string, VirtualToken>>>;
-  export const jointOverrides: readonly (readonly [string, VirtualJointOverrideEntry])[];
-  export const varianceByPath: Record<string, VirtualAxisVarianceEntry>;
+  export const listing: Readonly<Record<string, VirtualTokenListingShape>>;
+  export const cells: Record<string, Record<string, Record<string, VirtualTokenShape>>>;
+  export const jointOverrides: readonly (readonly [string, VirtualJointOverrideShape])[];
+  export const varianceByPath: VirtualVarianceByPathShape;
   export const defaultTuple: Record<string, string>;
 }
 


### PR DESCRIPTION
## Summary

Closes #819. Second-half follow-up to PR #883 (which extracted the \`snapshotForWire\` builder helper). This PR consolidates the blocks-side wire-shape type declarations and fixes the one real drift the audit flagged.

**Before:**
- \`packages/blocks/src/contexts.ts\` exported \`VirtualTokenShape\` / \`VirtualTokenListingShape\` / \`VirtualPresetShape\` etc.
- \`packages/blocks/src/virtual.d.ts\` re-declared the same shapes inline inside the \`declare module 'virtual:swatchbook/tokens'\` block.
- That virtual.d.ts was **missing the \`disabledAxes\` export** — silent drift from the addon's emitter, which has shipped \`disabledAxes\` over the wire since v0.55. The runtime works because TS doesn't enforce ambient-module exhaustiveness, but typed consumers had no signal.

**After:**
- \`packages/blocks/src/virtual.d.ts\` imports its types from \`#/contexts.ts\` — mirrors the cleaner pattern \`packages/addon/src/virtual.d.ts\` already uses with its \`#/channel-types.ts\` import. The inline interface declarations are gone (33 lines → 0).
- \`disabledAxes: readonly string[]\` is now declared in \`blocks/virtual.d.ts\` — the wire shape matches what the addon's emit and the existing \`blocks/test/virtual-stub.ts\` already provide.
- \`VirtualTokenListingShape\` in \`blocks/contexts.ts\` now aliases \`SlimListedToken\` from \`@unpunnyfuns/swatchbook-core/snapshot-for-wire\` — cross-package single-sourcing, same definition both addon-server-side (emit) and blocks-consumer-side (read).

**Net duplication change:** \`VirtualToken\` / \`Virtual*\` interfaces drop from 3× (blocks/contexts.ts + blocks/virtual.d.ts + addon/channel-types.ts) to 2× (one per package). Cross-package single-source isn't feasible without violating the manager-bundle's Node-free import constraint (the manager bundle can't take a runtime dep on core); per-package single-sourcing is the achievable end state.

No source changes; pure type-shape consolidation. The audit's "Critical" tier is fully closed with this PR (\`#822\` done in #868, \`#818\` done across #873/#875/#877, \`#819\` done across #883/this PR).

Milestone: Maintenance
Closes: #819
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] No inline \`Virtual*\` interface declarations remain in \`blocks/virtual.d.ts\` (\`grep -n "interface Virtual" packages/blocks/src/virtual.d.ts\` → no matches)
- [x] \`disabledAxes\` declared in \`blocks/virtual.d.ts\` (matches the existing addon's emit + blocks' test stub)