### PR TITLE
docs: refresh apps/docs + core README against post-cartesian-drop public API

### DIFF
--- a/.changeset/docs-refresh-post-cartesian-drop.md
+++ b/.changeset/docs-refresh-post-cartesian-drop.md
@@ -1,0 +1,16 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+"@unpunnyfuns/swatchbook-switcher": patch
+---
+
+Closes #888. Refreshes the npm landing page + apps/docs reference against the current post-cartesian-drop public API. The single biggest user-visible debt heading into 0.60.
+
+**`packages/core/README.md`** — rewritten Usage example (removed `permutationsResolved` access; shows `defaultTokens` + `resolveAt`), added Browser-safe subpaths section (5 subpaths), updated Boundaries to reference `snapshot-for-wire` instead of removed `permutationsResolved` projections.
+
+**`apps/docs/docs/reference/core.mdx`** — removed sections for `Permutation` / `ResolvedPermutation` / `resolvePermutation` (none exported anymore); rewrote `AxisVarianceResult` as the discriminated union it actually is (`kind: 'constant' | 'single' | 'multi'` with cardinality-typed `varyingAxes` tuples + the `axis: string` shortcut on the `single` variant); rewrote `Config` section as the new discriminated union (`ResolverConfig | LayeredConfig | PlainConfig`); added Browser-safe subpaths table; added `Cells` / `JointOverride` / `JointOverrides` / `ResolveAt` type docs; replaced "per-permutation token snapshots" framing with "per-axis cells."
+
+**`apps/docs/docs/reference/switcher.mdx`** — removed the nonexistent `themes?:` prop documentation and the `SwitcherPermutation` type (neither has ever been in the switcher's actual exports — `packages/switcher/src/index.ts` only exports `ThemeSwitcher` / `ThemeSwitcherProps` / `SwitcherAxis` / `SwitcherPreset`). Updated the closing paragraph to drop the `Project.permutations` reference.
+
+**`apps/docs/docs/reference/config.mdx`** — added discriminated-union framing to "Picking a theming input" (`Config = ResolverConfig | LayeredConfig | PlainConfig`; invalid combos are compile errors); replaced cartesian framing on `axes` docs with singleton-tuple framing (`Σ(axes × (contexts - 1))`, joint divergences via `Project.jointOverrides`).
+
+Patch bump because the docs ship via the docs-site snapshot — without a changeset, the fix only reaches `/next/` instead of `/`.

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -58,13 +58,15 @@ The separate file path (`configPath`) is useful when the same config is consumed
 
 ## Picking a theming input
 
+`Config` is a discriminated union — `ResolverConfig | LayeredConfig | PlainConfig`. TypeScript narrows on which load-strategy field is present, and invalid combinations (like `{ resolver, axes }` or `{ axes }` without `tokens`) are compile-time errors. The runtime loader still checks the same invariants as defense-in-depth for JS callers.
+
 Exactly three shapes are legal:
 
-- **Resolver** — `resolver: 'path/to/resolver.json'`. The DTCG-spec-native path; the file declares sets, modifiers, and resolutionOrder, and the modifiers become your axes. Recommended.
-- **Layered** — `axes: [...]` + `tokens: [...]`. For projects without a resolver document. You declare axes inline; each context names overlay files that layer onto the base `tokens`.
-- **Plain parse** — `tokens: [...]` alone. Single synthetic `theme` axis; every token loaded as one tuple. Useful for smoke-testing a token set before adopting a resolver.
+- **Resolver** (`ResolverConfig`) — `resolver: 'path/to/resolver.json'`. The DTCG-spec-native path; the file declares sets, modifiers, and resolutionOrder, and the modifiers become your axes. Recommended.
+- **Layered** (`LayeredConfig`) — `axes: [...]` + `tokens: [...]`. For projects without a resolver document. You declare axes inline; each context names overlay files that layer onto the base `tokens`.
+- **Plain parse** (`PlainConfig`) — `tokens: [...]` alone. Single synthetic `theme` axis; every token loaded as one tuple. Useful for smoke-testing a token set before adopting a resolver.
 
-Setting `resolver` and `axes` at the same time is an error. Setting none of the three (no `resolver`, no `axes`, no `tokens`) throws at load time.
+All three variants extend a shared base (`cssVarPrefix`, `presets`, `disabledAxes`, `chrome`, `cssOptions`, `listingOptions`, `terrazzoPlugins`, `default`, `outDir`). The discriminant is which load-strategy field is present.
 
 ## Fields
 
@@ -97,7 +99,7 @@ interface AxisConfig {
 
 `contexts` is a map from context name to an ordered list of overlay files (paths or globs, relative to the config's cwd). An empty array is legal — it means "no override," which is the baseline for an axis that introduces nothing by default (`Default: []`).
 
-Themes are every combination of contexts across all axes. Last write wins on duplicate token paths across base + overlays; overlay files listed later in `axes` win over earlier ones.
+The loader materializes a singleton tuple per `(axis, context)` cell — bounded by `Σ(axes × (contexts - 1))`, not the cartesian product. Joint divergences across multiple axes are detected via a targeted probe and patched in via `Project.jointOverrides`. Last write wins on duplicate token paths across base + overlays; overlay files listed later in `axes` win over earlier ones.
 
 ### `default?: Partial<Record<string, string>>`
 

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 
 # Core
 
-Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses token files via Terrazzo, resolves aliases, composes per-permutation token snapshots through a resolver or layered-axes config. No React, no Storybook dependency.
+Published as `@unpunnyfuns/swatchbook-core`. Framework-free DTCG loader. Parses token files via Terrazzo, resolves aliases, composes per-axis cells through a DTCG resolver or authored layered axes. No React, no Storybook dependency.
 
 ## Install
 
@@ -67,12 +67,15 @@ Cached per-token variance classification, built at load time and stored on `Proj
 
 ```ts
 const info = project.varianceByPath.get('color.accent.bg');
-// info?.kind: 'constant' | 'single' | 'multi'
-// info?.varyingAxes: axes whose contexts change this token
-// info?.perAxis: per-axis contexts → stringified resolved values
+if (info?.kind === 'single') {
+  // info.axis : string  (the single varying axis)
+  // info.varyingAxes : readonly [string]
+} else if (info?.kind === 'multi') {
+  // info.varyingAxes : readonly [string, string, ...string[]]
+}
 ```
 
-See [`AxisVarianceResult`](#axisvarianceresult) for the entry shape.
+See [`AxisVarianceResult`](#axisvarianceresult) for the discriminated-union shape.
 
 ### `emitAxisProjectedCss(project, options?)`
 
@@ -88,6 +91,23 @@ const css = emitAxisProjectedCss(project);
 ```
 
 For production builds, prefer Terrazzo's CLI — `emitAxisProjectedCss` exists primarily for tooling that wants the same emission the addon does.
+
+## Browser-safe subpaths
+
+Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths. Each is tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports — safe to import from preview-side bundles, the Storybook manager, or any browser consumer.
+
+| Subpath | Export | Purpose |
+| --- | --- | --- |
+| `/resolve-at` | `buildResolveAt(axes, cells, jointOverrides, defaultTuple)` | Compose tokens for any tuple without the loader. |
+| `/snapshot-for-wire` | `snapshotForWire(project, css)` + `SnapshotForWire` type | JSON-friendly subset of `Project` for cross-boundary transport. |
+| `/fuzzy` | `fuzzyFilter` + `fuzzyMatches` | uFuzzy-backed token search; powers the MCP `search_tokens` tool. |
+| `/css-var` | `makeCssVar(path, prefix)` | Compose `var(--prefix-path)` strings — same shape Terrazzo's plugin-css emits. |
+| `/data-attr` | `dataAttr(prefix, key)` | Compose `data-prefix-key` attribute names — namespaced to `cssVarPrefix`. |
+
+```ts
+import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
+import { snapshotForWire } from '@unpunnyfuns/swatchbook-core/snapshot-for-wire';
+```
 
 ## Constants
 
@@ -126,21 +146,45 @@ type ChromeRole = (typeof CHROME_ROLES)[number];
 
 ### `Config`
 
+Discriminated union of `ResolverConfig | LayeredConfig | PlainConfig`. Each variant has a different load strategy; field-presence narrowing enforces the mutually-exclusive trio at compile time (invalid combos like `{ resolver, axes }` are TS errors). See [Config reference](./config.mdx) for the full per-field semantics.
+
 ```ts
-interface Config {
-  /** Required for plain-parse and layered; optional when `resolver` is set. */
+type Config = ResolverConfig | LayeredConfig | PlainConfig;
+```
+
+### `ResolverConfig`
+
+Resolver-driven: axes derived from a DTCG 2025.10 resolver file's modifiers. `tokens` is optional (the resolver's `$ref` targets determine which files load).
+
+```ts
+interface ResolverConfig extends CommonConfig {
+  resolver: string;
   tokens?: string[];
-  resolver?: string; // mutually exclusive with `axes`
-  axes?: AxisConfig[]; // mutually exclusive with `resolver`
-  presets?: Preset[];
-  /** Partial tuple keyed by axis name — e.g. `{ mode: 'Dark', brand: 'Brand A' }`. Omitted axes fall back to each axis's own `default`. */
-  default?: Partial<Record<string, string>>;
-  /** Axis names to suppress from the toolbar and CSS emission; each is pinned to its default context. */
-  disabledAxes?: string[];
-  /** Map from block chrome roles (CHROME_ROLES) to target token paths — emits :root aliases redirecting --swatchbook-* chrome reads to consumer tokens. */
-  chrome?: Record<string, string>;
-  cssVarPrefix?: string;
-  outDir?: string;
+  axes?: never;
+}
+```
+
+### `LayeredConfig`
+
+Authored layered axes — per-context overlay globs that layer onto the base `tokens`. The base `tokens` is required.
+
+```ts
+interface LayeredConfig extends CommonConfig {
+  axes: AxisConfig[];
+  tokens: string[];
+  resolver?: never;
+}
+```
+
+### `PlainConfig`
+
+Plain-parse: single synthetic axis (`theme`), no resolver, no overlays. The simplest "I just have token files" case.
+
+```ts
+interface PlainConfig extends CommonConfig {
+  tokens: string[];
+  resolver?: never;
+  axes?: never;
 }
 ```
 
@@ -170,7 +214,7 @@ interface Preset {
 ```ts
 interface Axis {
   name: string;
-  contexts: string[];
+  contexts: readonly string[];
   default: string;
   description?: string;
   source: 'resolver' | 'layered' | 'synthetic';
@@ -182,17 +226,17 @@ interface Axis {
 ```ts
 interface Project {
   config: Config;
-  axes: Axis[];
+  axes: readonly Axis[];
   /** Axis names suppressed via `config.disabledAxes` and validated against the resolver. */
-  disabledAxes: string[];
-  presets: Preset[];
+  disabledAxes: readonly string[];
+  presets: readonly Preset[];
   /** Validated chrome-alias entries from `config.chrome`. Invalid entries are dropped and reported as diagnostics. */
   chrome: Record<string, string>;
   /** Resolved TokenMap at the default tuple. Convenience for global views. */
   defaultTokens: TokenMap;
   /** Per-axis cell maps: `cells[axisName][contextName]` is the resolved TokenMap for `{ ...defaults, [axisName]: contextName }`. */
   cells: Cells;
-  /** Joint-variant partial-tuple overrides — values that diverge from cells composition. */
+  /** Joint-variant partial-tuple overrides — values that diverge from cells composition. Array of `[canonicalKey, override]` pairs in ascending arity order. */
   jointOverrides: JointOverrides;
   /** Axis defaults — `{ axisName: axis.default }` for every axis. */
   defaultTuple: Record<string, string>;
@@ -216,6 +260,29 @@ interface Project {
   diagnostics: Diagnostic[];
 }
 ```
+
+### `Cells`
+
+```ts
+type Cells = Record<string, Record<string, TokenMap>>;
+```
+
+Per-axis resolved maps: `cells[axisName][contextName]` is the resolved `TokenMap` for `{ ...defaults, [axisName]: contextName }`. Non-default cells store only tokens whose value differs from the default-cell baseline (delta cells). Bounded by `Σ(axes × contexts)`, independent of the cartesian product size.
+
+### `JointOverride` / `JointOverrides`
+
+```ts
+interface JointOverride {
+  /** axisName → contextName for the divergent combination (arity ≥ 2). */
+  axes: Record<string, string>;
+  /** Only the tokens whose resolved value at this tuple diverges from cells composition. */
+  tokens: TokenMap;
+}
+
+type JointOverrides = ReadonlyArray<readonly [string, JointOverride]>;
+```
+
+Array of `[canonicalKey, override]` pairs in ascending arity order — higher-order divergences win over lower-order ones when applied in sequence. Same shape consumers read on the wire (no Map ↔ array marshaling).
 
 ### `TokenListingByPath`
 
@@ -243,16 +310,6 @@ interface SwatchbookIntegration {
 
 See the [Integrations guide](../guides/integrations/index.mdx) for factories that build these for Tailwind and CSS-in-JS.
 
-### `Permutation`
-
-```ts
-interface Permutation {
-  name: string;
-  input: Record<string, string>; // the axis tuple
-  sources: string[];
-}
-```
-
 ### `Diagnostic`
 
 ```ts
@@ -274,41 +331,43 @@ type DiagnosticSeverity = 'error' | 'warn' | 'info';
 
 ### `AxisVarianceResult`
 
-Each entry of [`project.varianceByPath`](#projectvariancebypath). `kind` classifies the overall variance shape; `perAxis` records the resolved value seen in each context with other axes held at their defaults.
+Each entry of [`project.varianceByPath`](#projectvariancebypath). Discriminated on `kind`; the cardinality of `varyingAxes` is reflected in the tuple type so consumers narrow exhaustively. The `single` variant adds a convenience `axis: string` accessor.
 
 ```ts
-interface AxisVarianceResult {
-  path: string;
-  kind: VarianceKind;
-  /** Axes whose contexts change this token's resolved value. */
-  varyingAxes: string[];
-  /** Axes whose contexts do not change the resolved value. */
-  constantAcrossAxes: string[];
-  perAxis: Record<
-    string,
-    {
-      varying: boolean;
-      contexts: Record<string, string>;
+type AxisVarianceResult =
+  | {
+      path: string;
+      kind: 'constant';
+      varyingAxes: readonly [];
+      constantAcrossAxes: readonly string[];
+      perAxis: AxisVariancePerAxis;
     }
-  >;
-}
+  | {
+      path: string;
+      kind: 'single';
+      axis: string;
+      varyingAxes: readonly [string];
+      constantAcrossAxes: readonly string[];
+      perAxis: AxisVariancePerAxis;
+    }
+  | {
+      path: string;
+      kind: 'multi';
+      varyingAxes: readonly [string, string, ...string[]];
+      constantAcrossAxes: readonly string[];
+      perAxis: AxisVariancePerAxis;
+    };
+
+type AxisVariancePerAxis = Record<
+  string,
+  { varying: boolean; contexts: Record<string, string> }
+>;
 ```
 
 ### `VarianceKind`
 
 ```ts
 type VarianceKind = 'constant' | 'single' | 'multi';
-```
-
-### `ResolvedPermutation`
-
-Pair of `(name, tokens)` returned by [`resolvePermutation`](#resolvepermutationproject-name).
-
-```ts
-interface ResolvedPermutation {
-  name: string;
-  tokens: TokenMap;
-}
 ```
 
 ### `TokenMap`
@@ -323,22 +382,17 @@ type TokenMap = Record<string, TokenNormalized>;
 
 The per-token shape from `@terrazzo/plugin-token-listing`, re-exported for typing convenience. Each entry carries the authoritative plugin-css-emitted CSS variable names, a CSS-ready `previewValue`, the pre-resolution `originalValue`, and a `source.loc` pointer to the authoring file + line. Composed map: [`TokenListingByPath`](#tokenlistingbypath).
 
-### `ParserInput`
-
-Retained Terrazzo parse output threaded through the project for downstream plugin emission. Consumers should treat this as opaque; reach for it only when wiring custom Terrazzo plugins.
+### `ResolveAt`
 
 ```ts
-interface ParserInput {
-  tokens: Record<string, TokenNormalized>;
-  sources: InputSourceWithDocument[];
-  resolver: Resolver;
-}
+type ResolveAt = (tuple: Record<string, string>) => TokenMap;
 ```
 
-`InputSourceWithDocument` and `Resolver` come from `@terrazzo/parser`.
+The shape of `project.resolveAt` — also returned by `buildResolveAt()` from the [`/resolve-at`](#browser-safe-subpaths) subpath.
 
 ## Do / don't
 
 - ✅ Use this package at build time — Node scripts, SSR, Storybook presets. It has no DOM dependency.
+- ✅ Ship `project.cells` / `project.jointOverrides` / `project.defaultTokens` to the browser via the [`/snapshot-for-wire`](#browser-safe-subpaths) subpath — that's exactly what the addon's preview does.
 - ❌ Don't import from `@terrazzo/parser` directly unless you need features core doesn't expose.
-- ❌ Don't ship `Project` objects to the browser — they carry full raw-AST references on `parserInput`. Ship the cells / `defaultTokens` projections instead (the addon's virtual module does exactly this).
+- ❌ Don't ship the full `Project` object to the browser — `parserInput` carries the raw Terrazzo AST. Use `snapshotForWire(project, css)` to get a JSON-friendly subset.

--- a/apps/docs/docs/reference/switcher.mdx
+++ b/apps/docs/docs/reference/switcher.mdx
@@ -77,7 +77,6 @@ For a working example, the docs site you're reading mounts `<ThemeSwitcher>` ins
 interface ThemeSwitcherProps {
   axes: readonly SwitcherAxis[];
   presets?: readonly SwitcherPreset[];
-  themes?: readonly SwitcherPermutation[];
   activeTuple: Readonly<Record<string, string>>;
   defaults: Readonly<Record<string, string>>;
   lastApplied: string | null;
@@ -92,7 +91,6 @@ interface ThemeSwitcherProps {
 | --- | --- | --- |
 | `axes` | yes | Axes the project ships. The component renders one row per entry. Omit this to draw a presets-only menu. |
 | `presets` | no | Saved tuple snapshots rendered above the axes. Empty / omitted = no presets section. |
-| `themes` | no | The full resolved theme list. Used only to determine whether the active tuple has drifted from the most recent applied preset (the "modified" dot on the preset pill). |
 | `activeTuple` | yes | Active axis selections, keyed by axis name. Drives which pill in each axis row is `--active`. |
 | `defaults` | yes | Fallback values used to fill in axes a preset doesn't explicitly set. |
 | `lastApplied` | yes | Name of the most recently applied preset, or `null`. Drives the "modified since applied" dot. |
@@ -117,14 +115,9 @@ interface SwitcherPreset {
   axes: Partial<Record<string, string>>;
   description?: string;
 }
-
-interface SwitcherPermutation {
-  name: string;
-  input: Record<string, string>;
-}
 ```
 
-`SwitcherAxis` / `SwitcherPreset` / `SwitcherPermutation` are structurally compatible with `Project.axes` / `Project.presets` / `Project.permutations` from `@unpunnyfuns/swatchbook-core` — pass them through unchanged. The shapes are re-declared in the switcher package so it stays framework-agnostic and doesn't pull `core` as a runtime dependency.
+`SwitcherAxis` and `SwitcherPreset` are structurally compatible with `Project.axes` / `Project.presets` from `@unpunnyfuns/swatchbook-core` — pass them through unchanged. The shapes are re-declared in the switcher package so it stays framework-agnostic and doesn't pull `core` as a runtime dependency.
 
 ## Axis-state propagation
 

--- a/apps/docs/docs/reference/switcher.mdx
+++ b/apps/docs/docs/reference/switcher.mdx
@@ -26,14 +26,14 @@ The component is a *menu*, not a *button*. It draws no trigger of its own — yo
 
 ## Mount example
 
-Minimal React usage. Pull `axes` / `presets` / `themes` / `defaults` from `@unpunnyfuns/swatchbook-core`'s `loadProject` output (or any other source that produces matching shapes); track the active tuple yourself.
+Minimal React usage. Pull `axes` / `presets` / `defaults` from `@unpunnyfuns/swatchbook-core`'s `loadProject` output (or any other source that produces matching shapes); track the active tuple yourself.
 
 ```tsx title="src/components/MySwitcher.tsx"
 import { ThemeSwitcher, type SwitcherPreset } from '@unpunnyfuns/swatchbook-switcher';
 import '@unpunnyfuns/swatchbook-switcher/style.css';
 import { useState, useCallback } from 'react';
 
-export function MySwitcher({ axes, presets, themes, defaults }) {
+export function MySwitcher({ axes, presets, defaults }) {
   const [activeTuple, setActiveTuple] = useState(defaults);
   const [lastApplied, setLastApplied] = useState<string | null>(null);
 
@@ -56,7 +56,6 @@ export function MySwitcher({ axes, presets, themes, defaults }) {
     <ThemeSwitcher
       axes={axes}
       presets={presets}
-      themes={themes}
       activeTuple={activeTuple}
       defaults={defaults}
       lastApplied={lastApplied}

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,16 +23,33 @@ const config = defineSwatchbookConfig({
 });
 
 const project = await loadProject(config, process.cwd());
-// project.permutationsResolved[permutationName] — ready to read, no further I/O.
+
+// Read the default-tuple snapshot directly.
+const defaults = project.defaultTokens;
+
+// Read any tuple via the composer — bounded over per-axis cells +
+// joint overrides, no resolver round-trip.
+const darkBrandA = project.resolveAt({ mode: 'Dark', brand: 'Brand A' });
 ```
 
-The [config reference](https://unpunnyfuns.github.io/swatchbook/reference/config) covers every field; the [core reference](https://unpunnyfuns.github.io/swatchbook/reference/core) covers the `Project` shape and exported helpers (`resolvePermutation`, `permutationID`, typed `Axis` / `Permutation` / `Diagnostic`).
+The [config reference](https://unpunnyfuns.github.io/swatchbook/reference/config) covers every field; the [core reference](https://unpunnyfuns.github.io/swatchbook/reference/core) covers the `Project` shape and exported helpers (`emitAxisProjectedCss`, `jointOverrideKey`, typed `Axis` / `Config` / `Diagnostic` / `Project`).
+
+## Browser-safe subpaths
+
+Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths — each tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports:
+
+- `@unpunnyfuns/swatchbook-core/resolve-at` — `buildResolveAt(axes, cells, jointOverrides, defaultTuple)`
+- `@unpunnyfuns/swatchbook-core/snapshot-for-wire` — `snapshotForWire(project, css)` + `SnapshotForWire` type
+- `@unpunnyfuns/swatchbook-core/fuzzy` — uFuzzy-backed token search
+- `@unpunnyfuns/swatchbook-core/css-var` — `makeCssVar(path, prefix)`
+- `@unpunnyfuns/swatchbook-core/data-attr` — `dataAttr(prefix, key)`
 
 ## Boundaries
 
 - ✅ Build-time use — Node, scripts, SSR, Storybook presets.
 - ✅ Pair with [Terrazzo](https://terrazzo.app/)'s CLI for production artifact emission (CSS / JS / Tailwind / Swift / Sass / …).
-- ❌ Don't ship the `Project` object to the browser — it carries full raw-AST references. Use `permutationsResolved` projections instead.
+- ✅ Ship `project.cells` / `project.jointOverrides` / `project.defaultTokens` to the browser via the `snapshot-for-wire` subpath — that's exactly what the addon's preview does.
+- ❌ Don't ship the full `Project` object to the browser. `parserInput` carries the raw Terrazzo AST; use `snapshotForWire(project, css)` to get a JSON-friendly subset.
 - ❌ Don't reach into `@terrazzo/parser` directly. Stay on the core surface so upgrades don't churn your code.
 
 ## Credits


### PR DESCRIPTION
## Summary

Closes #888. Refreshes the npm landing page + apps/docs reference against the current post-cartesian-drop public API — the single biggest user-visible debt heading into 0.60.

**\`packages/core/README.md\` (the npm landing page)** — rewrote Usage example (removed \`permutationsResolved\` access; shows \`defaultTokens\` + \`resolveAt\`), added Browser-safe subpaths section listing all five (\`/resolve-at\`, \`/snapshot-for-wire\`, \`/fuzzy\`, \`/css-var\`, \`/data-attr\`), updated Boundaries to reference \`snapshot-for-wire\` instead of removed \`permutationsResolved\` projections.

**\`apps/docs/docs/reference/core.mdx\`** — substantial rewrite:
- Removed dead sections for \`Permutation\` / \`ResolvedPermutation\` / \`resolvePermutation\` (none exported)
- Rewrote \`AxisVarianceResult\` as the discriminated union it is (\`kind: 'constant' | 'single' | 'multi'\` with cardinality-typed \`varyingAxes\` tuples + the \`axis: string\` shortcut on the \`single\` variant)
- Rewrote \`Config\` section as the new discriminated union (\`ResolverConfig | LayeredConfig | PlainConfig\`); added \`ResolverConfig\` / \`LayeredConfig\` / \`PlainConfig\` subtype docs
- Added Browser-safe subpaths table
- Added missing type docs for \`Cells\` / \`JointOverride\` / \`JointOverrides\` (with the array-of-pairs shape post-#871) / \`ResolveAt\`
- Replaced "per-permutation token snapshots" framing with "per-axis cells"
- Updated \`varianceByPath\` example to show exhaustive narrowing

**\`apps/docs/docs/reference/switcher.mdx\`** — removed the nonexistent \`themes?:\` prop documentation and the \`SwitcherPermutation\` type from the docs. Neither has ever been in switcher's actual exports (\`packages/switcher/src/index.ts\` only exports \`ThemeSwitcher\` / \`ThemeSwitcherProps\` / \`SwitcherAxis\` / \`SwitcherPreset\`). Cleaned up the closing paragraph that referenced \`Project.permutations\`.

**\`apps/docs/docs/reference/config.mdx\`** — added discriminated-union framing to "Picking a theming input" (\`Config = ResolverConfig | LayeredConfig | PlainConfig\`; invalid combos like \`{ resolver, axes }\` are compile errors); replaced cartesian framing on \`axes\` docs (\"Themes are every combination of contexts across all axes\") with singleton-tuple framing (\`Σ(axes × (contexts - 1))\`, joint divergences via \`Project.jointOverrides\`).

**Scope note:** the remaining \"permutation\" mentions across other docs files (sharing-terrazzo-options.mdx, addon.mdx, axes.mdx, architecture.mdx, blocks/hooks.mdx) are largely accurate — they refer to Terrazzo's own \`cssOptions.permutations\` field (real, still used), the composed theme ID (\"Light · Brand A\"), or the loader's conceptual operation. Holding the \"Permutation → Theme\" rename until #894 (the public-API rename) so docs and code change together.

Patch bump because the snapshot script ships docs into versioned_docs; without the changeset, the fix only reaches \`/next/\` instead of \`/\`.

Milestone: Maintenance
Closes: #888
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] No removed-API names remain in primary reference docs (\`grep -E 'permutationsResolved|ResolvedPermutation|resolvePermutation' apps/docs/docs/reference/core.mdx apps/docs/docs/reference/switcher.mdx packages/core/README.md\` → no matches)
- [x] \`Config\` discriminated union shape matches \`packages/core/src/types.ts\`
- [x] \`AxisVarianceResult\` shape matches the source-of-truth in \`packages/core/src/types.ts:43-66\`