### PR TITLE
refactor(core,blocks,mcp): consolidate path matchers onto core/match-path subpath

### DIFF
--- a/.changeset/match-path-subpath.md
+++ b/.changeset/match-path-subpath.md
@@ -1,0 +1,22 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-mcp": patch
+---
+
+Closes #890. Consolidates the two divergent path-matchers onto a single `@unpunnyfuns/swatchbook-core/match-path` subpath:
+
+- `packages/blocks/src/internal/use-project.ts:globMatch` (5-line prefix matcher; treated `color.*` as "any descendants")
+- `packages/mcp/src/match.ts:matchPath` (full mid-string `*` / `**` matcher; treated `color.*` as strict single-segment per conventional glob spec)
+
+The blocks version was a documented narrow subset; the audit (#887 worth-a-PR #8) flagged them as "diverged despite a comment claiming parity." On closer inspection they're genuinely divergent — different semantic for `color.*`. Going with the **conventional glob spec** as the unified semantics (mcp's version): `*` matches a single segment, `**` matches any number of segments. This is a pre-1.0 minor break for blocks' `filter` prop.
+
+**Blocks-side migration:** any consumer passing `filter="color.*"` to a block (`<ColorPalette>`, `<ColorTable>`, `<TokenTable>`, `<TypographyScale>`, `<DimensionScale>`, etc.) expecting "all descendants of color" needs to update to `filter="color.**"`. The single `*` now means exactly one segment after the prefix. The doc-site MDX (`apps/storybook/src/docs/*`, `apps/docs/docs/quickstart.mdx`, `apps/docs/docs/guides/authoring-doc-stories.mdx`, `apps/docs/docs/reference/blocks/*.mdx`) and every blocks test fixture is migrated in this PR.
+
+**Touched files:**
+- New `packages/core/src/match-path.ts` + `./match-path` subpath in core's `package.json` exports + tsdown entry.
+- `packages/mcp/src/server.ts` — imports `matchPath` from the core subpath; deleted `packages/mcp/src/match.ts`.
+- `packages/blocks/src/internal/use-project.ts` — `globMatch` export removed; the 13 consuming blocks (`ColorTable`, `ColorPalette`, `TokenTable`, `TypographyScale`, `OpacityScale`, `FontWeightScale`, `FontFamilySample`, `DimensionScale`, `MotionPreview`, `ShadowPreview`, `BorderPreview`, `StrokeStyleSample`, `GradientPalette`) import `matchPath` from the core subpath directly.
+- Test moved: `packages/mcp/test/match.test.ts` → `packages/core/test/match-path.test.ts`. 5 blocks-test files updated to use `**` for descendant matches; same for ~10 MDX files in apps/storybook + apps/docs.
+
+The unified spec also gains mid-string globs (`color.**.500`) for blocks consumers that didn't have them before.

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/docs/reference/blocks/index.mdx
+++ b/apps/docs/docs/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.20/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.20/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.20/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.20/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.20/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.20/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.20/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.20/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.50/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.50/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.50/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.50/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.50/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.50/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.50/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.50/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.51/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.51/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.51/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.51/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.51/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.51/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.51/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.51/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.52/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.52/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.52/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.52/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.52/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.52/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.52/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.52/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.53/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.53/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.53/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.53/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.53/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.53/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.53/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.53/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.54/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.54/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.54/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.54/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.54/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.54/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.54/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.54/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.55/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.55/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.55/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.55/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.55/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.55/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.55/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.55/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/docs/versioned_docs/version-0.56/guides/authoring-doc-stories.mdx
+++ b/apps/docs/versioned_docs/version-0.56/guides/authoring-doc-stories.mdx
@@ -30,15 +30,15 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 
 ## Primitive palette
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic slots
 
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 
 ## Everything as a table
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 ```
 
 `ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
@@ -64,7 +64,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 <TokenTable />
 ```
 
-`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.*" />`.
+`Diagnostics` auto-collapses on clean loads, so it's safe at the top of every page without adding noise. Scope the tree or table with a prop: `<TokenNavigator root="color" />`, `<TokenTable filter="space.**" />`.
 
 ## Blocks at a glance
 

--- a/apps/docs/versioned_docs/version-0.56/quickstart.mdx
+++ b/apps/docs/versioned_docs/version-0.56/quickstart.mdx
@@ -107,10 +107,10 @@ import {
 <Diagnostics />
 
 ## Palette
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Semantic roles
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Everything
 <TokenNavigator initiallyExpanded={0} />

--- a/apps/docs/versioned_docs/version-0.56/reference/blocks/index.mdx
+++ b/apps/docs/versioned_docs/version-0.56/reference/blocks/index.mdx
@@ -25,9 +25,9 @@ Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these block
 ```tsx
 import { ColorPalette, ColorTable, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
-<ColorPalette filter="color.*" />
-<ColorTable filter="color.*" />
-<TokenTable filter="size.*" type="dimension" />
+<ColorPalette filter="color.**" />
+<ColorTable filter="color.**" />
+<TokenTable filter="size.**" type="dimension" />
 <TokenDetail path="color.accent.bg" />
 ```
 
@@ -72,6 +72,6 @@ All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for rich token references.
-- ✅ Filter aggressively — `<TokenTable filter="color.*" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
 - ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/versioned_docs/version-0.56/reference/blocks/overview.mdx
+++ b/apps/docs/versioned_docs/version-0.56/reference/blocks/overview.mdx
@@ -58,7 +58,7 @@ Every block in this group scopes to one DTCG `$type`, filters / sorts, and rende
 ### ColorPalette
 
 ```tsx
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 ```
 
 Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filter's fixed-prefix depth but can be overridden. Default sort is `'path'`; `'value'` orders colors perceptually via oklch **L → C → H** so ramps read light → dark and warm → cool.
@@ -66,7 +66,7 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 ### ColorTable
 
 ```tsx
-<ColorTable filter="color.*" />
+<ColorTable filter="color.**" />
 ```
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
@@ -77,7 +77,7 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 
 ```tsx
 <ColorTable
-  filter="color.bg.*"
+  filter="color.bg.**"
   variants={{ hover: 'hover', disabled: 'disabled' }}
 />
 ```
@@ -131,7 +131,7 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 ### OpacityScale
 
 ```tsx
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 ```
 
 One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.

--- a/apps/storybook/src/docs/Borders.mdx
+++ b/apps/storybook/src/docs/Borders.mdx
@@ -11,7 +11,7 @@ so mode changes repaint the stroke.
 
 ## System borders
 
-<BorderPreview filter="border.*" />
+<BorderPreview filter="border.**" />
 
 ## Inspect a single token
 

--- a/apps/storybook/src/docs/Colors.mdx
+++ b/apps/storybook/src/docs/Colors.mdx
@@ -24,7 +24,7 @@ Groups the role colors by sub-path (`color.surface.*`, `color.text.*`,
 `color.accent.*`, `color.border.*`, `color.status.*`). Switch the theme
 in the toolbar to see every swatch repaint.
 
-<ColorPalette filter="color.*" />
+<ColorPalette filter="color.**" />
 
 ## Semantic roles (variant-grouped)
 
@@ -34,7 +34,7 @@ side-by-side. The `status` row bundles its `-bg` / `-fg` hyphen pairs
 under each status name.
 
 <ColorTable
-  filter="color.surface.*"
+  filter="color.surface.**"
   variants={{
     default: 'default',
     muted: 'muted',
@@ -45,7 +45,7 @@ under each status name.
 />
 
 <ColorTable
-  filter="color.text.*"
+  filter="color.text.**"
   variants={{
     default: 'default',
     muted: 'muted',
@@ -55,28 +55,28 @@ under each status name.
   }}
 />
 
-<ColorTable filter="color.accent.*" variants={{ bg: 'bg', fg: 'fg', hover: '-hover' }} />
+<ColorTable filter="color.accent.**" variants={{ bg: 'bg', fg: 'fg', hover: '-hover' }} />
 
 <ColorTable
-  filter="color.border.*"
+  filter="color.border.**"
   variants={{ default: 'default', strong: 'strong', focus: 'focus' }}
 />
 
-<ColorTable filter="color.status.*" variants={{ bg: '-bg', fg: '-fg' }} />
+<ColorTable filter="color.status.**" variants={{ bg: '-bg', fg: '-fg' }} />
 
 ## Palette
 
 Every primitive hue. Use as the alias source when authoring new roles,
 not when styling components directly.
 
-<ColorPalette filter="color.palette.*" />
+<ColorPalette filter="color.palette.**" />
 
 ## Raw table
 
 The same tokens as rows with resolved values, types, and CSS var names —
 handy when you know the path you're looking for.
 
-<TokenTable filter="color.*" type="color" />
+<TokenTable filter="color.**" type="color" />
 
 ## Opacity
 
@@ -85,7 +85,7 @@ in `[0, 1]`. The bare number (`0.4`) tells you less than the visible
 effect; `<OpacityScale>` renders each token as the sample colour at that
 opacity over a checkerboard so the transparency reads.
 
-<OpacityScale filter="number.opacity.*" />
+<OpacityScale filter="number.opacity.**" />
 
 The swatch colour is `color.accent.bg` by default. Pass `sampleColor` to
 demo the token against whatever surface role matters — scrims against

--- a/apps/storybook/src/docs/Dimensions.mdx
+++ b/apps/storybook/src/docs/Dimensions.mdx
@@ -14,19 +14,19 @@ radii). Size primitives live under `size.*`.
 
 Width-driven bars, sorted numerically.
 
-<DimensionScale filter="space.*" />
+<DimensionScale filter="space.**" />
 
 ## Radius scale
 
 Rendered as rounded squares so you can eyeball the corner curve.
 
-<DimensionScale filter="radius.*" kind="radius" />
+<DimensionScale filter="radius.**" kind="radius" />
 
 ## Raw size primitives
 
 Square samples sized directly from the token's `$value`.
 
-<DimensionScale filter="size.*" kind="size" />
+<DimensionScale filter="size.**" kind="size" />
 
 ## Inspect a single token
 

--- a/apps/storybook/src/docs/Motion.mdx
+++ b/apps/storybook/src/docs/Motion.mdx
@@ -16,15 +16,15 @@ to a textual placeholder.
 Every `transition.*` token animated against a horizontal track. The
 speed control is global to this block.
 
-<MotionPreview filter="transition.*" />
+<MotionPreview filter="transition.**" />
 
 ## Durations
 
-<MotionPreview filter="duration.*" />
+<MotionPreview filter="duration.**" />
 
 ## Easings
 
-<MotionPreview filter="easing.*" />
+<MotionPreview filter="easing.**" />
 
 ## Inspect a single token
 

--- a/apps/storybook/src/docs/Shadows.mdx
+++ b/apps/storybook/src/docs/Shadows.mdx
@@ -15,7 +15,7 @@ optional `inset` flag. Emitted CSS concatenates the layers into a single
 Every `shadow.*` token applied to a surface rectangle. Switch the
 theme in the toolbar to see shadows redraw against dark surfaces.
 
-<ShadowPreview filter="shadow.*" />
+<ShadowPreview filter="shadow.**" />
 
 ## Inspect a single token
 

--- a/apps/storybook/src/docs/Typography.mdx
+++ b/apps/storybook/src/docs/Typography.mdx
@@ -14,7 +14,7 @@ Typography tokens are DTCG composites — each `$value` is an object with
 
 Every `typography.*` token rendered as a sample line using its own value.
 
-<TypographyScale filter="typography" />
+<TypographyScale filter="typography.**" />
 
 ## Inspect a single token
 

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -278,7 +278,7 @@ export const TokenDetailCompositeBreakdownGradient = meta.story({
  * sample text visible.
  */
 export const TypographyScaleRenders = meta.story({
-  render: () => <TypographyScale filter="typography" sample="Sphinx of black quartz" />,
+  render: () => <TypographyScale filter="typography.**" sample="Sphinx of black quartz" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'section, [role="table"], div');
     const samples = [...canvasElement.querySelectorAll('div')].filter((el) =>

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -50,7 +50,7 @@ async function waitForContent(root: ParentNode, selector: string): Promise<Eleme
  * swatch card whose background resolves to a non-transparent CSS value.
  */
 export const ColorPaletteRenders = meta.story({
-  render: () => <ColorPalette filter="color.surface.*" groupBy={2} />,
+  render: () => <ColorPalette filter="color.surface.**" groupBy={2} />,
   play: async ({ canvasElement }) => {
     const section = await waitForContent(canvasElement, 'section');
     const swatch = section.querySelector<HTMLElement>('[aria-hidden="true"]');
@@ -66,7 +66,7 @@ export const ColorPaletteRenders = meta.story({
  * `TokenTable` must render the expected headers and at least one data row.
  */
 export const TokenTableRenders = meta.story({
-  render: () => <TokenTable filter="color.*" type="color" />,
+  render: () => <TokenTable filter="color.**" type="color" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'tbody tr');
     const headerTexts = [...canvasElement.querySelectorAll('thead th')].map((th) =>
@@ -84,7 +84,7 @@ export const TokenTableRenders = meta.story({
  * tokens with a non-zero value — space.md is 12px).
  */
 export const DimensionScaleRenders = meta.story({
-  render: () => <DimensionScale filter="space.*" />,
+  render: () => <DimensionScale filter="space.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'div[aria-hidden="true"]');
     const bars = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
@@ -102,7 +102,7 @@ export const DimensionScaleRenders = meta.story({
  * computed style for at least one shadow token.
  */
 export const ShadowPreviewRenders = meta.story({
-  render: () => <ShadowPreview filter="shadow.*" />,
+  render: () => <ShadowPreview filter="shadow.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'div[aria-hidden="true"]');
     const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
@@ -123,7 +123,7 @@ export const ShadowPreviewRenders = meta.story({
  * that includes `gradient` (the computed shorthand).
  */
 export const GradientPaletteRenders = meta.story({
-  render: () => <GradientPalette filter="gradient.*" />,
+  render: () => <GradientPalette filter="gradient.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'div[aria-hidden="true"]');
     const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
@@ -143,7 +143,7 @@ export const GradientPaletteRenders = meta.story({
  * `none` for at least one border token.
  */
 export const BorderPreviewRenders = meta.story({
-  render: () => <BorderPreview filter="border.*" />,
+  render: () => <BorderPreview filter="border.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'div[aria-hidden="true"]');
     const samples = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
@@ -164,7 +164,7 @@ export const BorderPreviewRenders = meta.story({
  * is on — we don't assert behavior there, just that the block renders).
  */
 export const MotionPreviewRenders = meta.story({
-  render: () => <MotionPreview filter="transition.*" />,
+  render: () => <MotionPreview filter="transition.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'div[aria-hidden="true"]');
     const balls = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
@@ -350,7 +350,7 @@ export const TokenDetailShadowComposite = meta.story({
  * fallback, which is acceptable.
  */
 export const StrokeStyleSampleRenders = meta.story({
-  render: () => <StrokeStyleSample filter="stroke.style.*" />,
+  render: () => <StrokeStyleSample filter="stroke.style.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'section, div');
     const lines = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
@@ -372,7 +372,7 @@ export const StrokeStyleSampleRenders = meta.story({
  * sample's computed `font-family` must resolve to a non-empty stack.
  */
 export const FontFamilySampleRenders = meta.story({
-  render: () => <FontFamilySample filter="font.family.*" />,
+  render: () => <FontFamilySample filter="font.family.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'section, div');
     const paths = [...canvasElement.querySelectorAll('span')].filter((el) =>
@@ -395,7 +395,7 @@ export const FontFamilySampleRenders = meta.story({
  * computed `font-weight` reflecting each token's value.
  */
 export const FontWeightScaleRenders = meta.story({
-  render: () => <FontWeightScale filter="font.weight.*" />,
+  render: () => <FontWeightScale filter="font.weight.**" />,
   play: async ({ canvasElement }) => {
     await waitForContent(canvasElement, 'section, div');
     const samples = [...canvasElement.querySelectorAll<HTMLElement>('div')].filter(

--- a/apps/storybook/src/stories/BorderPreview.stories.tsx
+++ b/apps/storybook/src/stories/BorderPreview.stories.tsx
@@ -13,7 +13,7 @@ const meta = preview.meta({
 export default meta;
 
 export const SystemBorders = meta.story({
-  args: { filter: 'border.*' },
+  args: { filter: 'border.**' },
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       const samples = canvasElement.querySelectorAll('[aria-hidden="true"]');

--- a/apps/storybook/src/stories/ColorFormat.stories.tsx
+++ b/apps/storybook/src/stories/ColorFormat.stories.tsx
@@ -41,7 +41,7 @@ async function waitForMatch(
  * should display a `#rrggbb` string.
  */
 export const DefaultHex = meta.story({
-  render: () => <TokenTable filter="color.*" type="color" />,
+  render: () => <TokenTable filter="color.**" type="color" />,
   play: async ({ canvasElement }) => {
     const text = await waitForMatch(canvasElement, (t) => /#[0-9a-f]{6}/i.test(t), 'expected hex');
     expect(text).toMatch(/#[0-9a-f]{6}/i);
@@ -56,7 +56,7 @@ export const DefaultHex = meta.story({
  */
 export const RgbFormat = meta.story({
   globals: { swatchbookColorFormat: 'rgb' },
-  render: () => <TokenTable filter="color.*" type="color" />,
+  render: () => <TokenTable filter="color.**" type="color" />,
   play: async ({ canvasElement }) => {
     const text = await waitForMatch(
       canvasElement,
@@ -69,7 +69,7 @@ export const RgbFormat = meta.story({
 
 export const OklchFormat = meta.story({
   globals: { swatchbookColorFormat: 'oklch' },
-  render: () => <TokenTable filter="color.*" type="color" />,
+  render: () => <TokenTable filter="color.**" type="color" />,
   play: async ({ canvasElement }) => {
     const text = await waitForMatch(
       canvasElement,
@@ -82,7 +82,7 @@ export const OklchFormat = meta.story({
 
 export const RawFormat = meta.story({
   globals: { swatchbookColorFormat: 'raw' },
-  render: () => <TokenTable filter="color.*" type="color" />,
+  render: () => <TokenTable filter="color.**" type="color" />,
   play: async ({ canvasElement }) => {
     const text = await waitForMatch(
       canvasElement,

--- a/apps/storybook/src/stories/ColorPalette.stories.tsx
+++ b/apps/storybook/src/stories/ColorPalette.stories.tsx
@@ -24,11 +24,11 @@ export const All = meta.story({
   play: async ({ canvasElement }) => assertPaletteRenders(canvasElement),
 });
 export const SysOnly = meta.story({
-  args: { filter: 'color.*' },
+  args: { filter: 'color.**' },
   play: async ({ canvasElement }) => assertPaletteRenders(canvasElement),
 });
 export const RefBlue = meta.story({
-  args: { filter: 'color.palette.blue.*' },
+  args: { filter: 'color.palette.blue.**' },
   play: async ({ canvasElement }) => assertPaletteRenders(canvasElement),
 });
 export const Flat = meta.story({ args: { groupBy: 2 } });

--- a/apps/storybook/src/stories/ColorTable.stories.tsx
+++ b/apps/storybook/src/stories/ColorTable.stories.tsx
@@ -32,11 +32,11 @@ export const All = meta.story({
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });
 export const SysOnly = meta.story({
-  args: { filter: 'color.*' },
+  args: { filter: 'color.**' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });
 export const RefBlue = meta.story({
-  args: { filter: 'color.palette.blue.*' },
+  args: { filter: 'color.palette.blue.**' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });
 export const SortedPerceptually = meta.story({
@@ -45,7 +45,7 @@ export const SortedPerceptually = meta.story({
 });
 export const GroupedVariants = meta.story({
   args: {
-    filter: 'color.*',
+    filter: 'color.**',
     variants: { hover: 'hover' },
   },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
@@ -57,7 +57,7 @@ export const GroupedVariants = meta.story({
  * Closes the "ColorTable — no expansion play" gap from #704.
  */
 export const ExpandsOnRowClick = meta.story({
-  args: { filter: 'color.palette.blue.*' },
+  args: { filter: 'color.palette.blue.**' },
   parameters: { chromatic: { disableSnapshot: true } },
   play: async ({ canvasElement }) => {
     await assertTableRenders(canvasElement);

--- a/apps/storybook/src/stories/DimensionScale.stories.tsx
+++ b/apps/storybook/src/stories/DimensionScale.stories.tsx
@@ -21,12 +21,12 @@ async function assertScaleRenders(canvas: HTMLElement): Promise<void> {
 }
 
 export const SpaceSystem = meta.story({
-  args: { filter: 'space.*' },
+  args: { filter: 'space.**' },
   play: async ({ canvasElement }) => assertScaleRenders(canvasElement),
 });
-export const RadiusSystem = meta.story({ args: { filter: 'radius.*', kind: 'radius' } });
+export const RadiusSystem = meta.story({ args: { filter: 'radius.**', kind: 'radius' } });
 export const SizeReferencePx = meta.story({
-  args: { filter: 'size.*', kind: 'size' },
+  args: { filter: 'size.**', kind: 'size' },
   play: async ({ canvasElement }) => assertScaleRenders(canvasElement),
 });
 export const All = meta.story();

--- a/apps/storybook/src/stories/GradientPalette.stories.tsx
+++ b/apps/storybook/src/stories/GradientPalette.stories.tsx
@@ -20,4 +20,4 @@ export const AllGradients = meta.story({
     });
   },
 });
-export const RefGradients = meta.story({ args: { filter: 'gradient.*' } });
+export const RefGradients = meta.story({ args: { filter: 'gradient.**' } });

--- a/apps/storybook/src/stories/MotionPreview.stories.tsx
+++ b/apps/storybook/src/stories/MotionPreview.stories.tsx
@@ -13,7 +13,7 @@ const meta = preview.meta({
 export default meta;
 
 export const SystemTransitions = meta.story({
-  args: { filter: 'transition.*' },
+  args: { filter: 'transition.**' },
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       const wrapper = canvasElement.querySelector('[data-sb-theme]');
@@ -24,6 +24,6 @@ export const SystemTransitions = meta.story({
     });
   },
 });
-export const Durations = meta.story({ args: { filter: 'duration.*' } });
-export const Easings = meta.story({ args: { filter: 'cubicBezier.*' } });
+export const Durations = meta.story({ args: { filter: 'duration.**' } });
+export const Easings = meta.story({ args: { filter: 'cubicBezier.**' } });
 export const All = meta.story();

--- a/apps/storybook/src/stories/OpacityScale.stories.tsx
+++ b/apps/storybook/src/stories/OpacityScale.stories.tsx
@@ -14,7 +14,7 @@ const meta = preview.meta({
 export default meta;
 
 export const NumberOpacities = meta.story({
-  args: { filter: 'number.opacity.*' },
+  args: { filter: 'number.opacity.**' },
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       const cards = canvasElement.querySelectorAll('[aria-hidden="true"]');
@@ -24,11 +24,11 @@ export const NumberOpacities = meta.story({
 });
 
 export const TextSampleColor = meta.story({
-  args: { filter: 'number.opacity.*', sampleColor: 'color.text.default' },
+  args: { filter: 'number.opacity.**', sampleColor: 'color.text.default' },
 });
 
 export const EmptyFilter = meta.story({
-  args: { filter: 'nonexistent.*' },
+  args: { filter: 'nonexistent.**' },
   play: async ({ canvasElement }) => {
     expect(canvasElement.textContent).toContain('No opacity tokens match');
   },

--- a/apps/storybook/src/stories/ShadowPreview.stories.tsx
+++ b/apps/storybook/src/stories/ShadowPreview.stories.tsx
@@ -13,7 +13,7 @@ const meta = preview.meta({
 export default meta;
 
 export const SystemShadows = meta.story({
-  args: { filter: 'shadow.*' },
+  args: { filter: 'shadow.**' },
   play: async ({ canvasElement }) => {
     await waitFor(() => {
       const samples = canvasElement.querySelectorAll('[aria-hidden="true"]');

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -48,8 +48,8 @@ export const ColorsOnly = meta.story({
   args: { type: 'color' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });
-export const SysColors = meta.story({ args: { filter: 'color.*' } });
-export const SysTypography = meta.story({ args: { filter: 'typography.*' } });
+export const SysColors = meta.story({ args: { filter: 'color.**' } });
+export const SysTypography = meta.story({ args: { filter: 'typography.**' } });
 export const DimensionsOnly = meta.story({
   args: { type: 'dimension' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -766,7 +766,7 @@
 
 - 4fd054c: docs: strip remaining pitch residue from the intro's "What the addon includes" section
 
-  Follow-up to the prose conversion. A second read found eight smaller tells still reading as marketing framing: section heading ("gives you" → "includes"), action verbs ("brings in" → "includes"), tour-guide framing ("Most authoring happens in MDX"), a mid-prose `<ColorPalette filter="color.*" />` example that acted as a sales moment, an emphasised "A single Swatchbook icon" ("single" → dropped), a redundant gloss after the color-format selector's own name, and a three-parallel-clauses "nothing is written / no prebuild / HMR propagates" stack that worked as a strawman — consolidated to one descriptive clause. Section now reads as a reference entry.
+  Follow-up to the prose conversion. A second read found eight smaller tells still reading as marketing framing: section heading ("gives you" → "includes"), action verbs ("brings in" → "includes"), tour-guide framing ("Most authoring happens in MDX"), a mid-prose `<ColorPalette filter="color.**" />` example that acted as a sales moment, an emphasised "A single Swatchbook icon" ("single" → dropped), a redundant gloss after the color-format selector's own name, and a three-parallel-clauses "nothing is written / no prebuild / HMR propagates" stack that worked as a strawman — consolidated to one descriptive clause. Section now reads as a reference entry.
 
 - 3cff041: docs: rewrite the intro's "What the addon gives you" section as prose under subheadings
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -19,8 +19,8 @@ Inside Storybook the addon mounts a `SwatchbookProvider` for you:
 ```mdx
 import { ColorPalette, TokenTable, TokenDetail } from '@unpunnyfuns/swatchbook-addon';
 
-<ColorPalette filter="color.*" />
-<TokenTable filter="color.*" type="color" />
+<ColorPalette filter="color.**" />
+<TokenTable filter="color.**" type="color" />
 <TokenDetail path="color.accent.bg" />
 ```
 

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -6,7 +6,8 @@ import { useColorFormat } from '#/contexts.ts';
 import { type ColorFormat, formatColor } from '#/format-color.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface BorderPreviewProps {
   /**
@@ -69,7 +70,7 @@ export function BorderPreview({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'border') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -4,7 +4,8 @@ import './ColorPalette.css';
 import { useColorFormat } from '#/contexts.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface ColorPaletteProps {
   /**
@@ -76,7 +77,7 @@ export function ColorPalette({
   const groups = useMemo(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'color') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
 

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -8,7 +8,8 @@ import { type ColorFormat, formatColor, type NormalizedColor } from '#/format-co
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 const BASE_LABEL = 'base';
 const COLUMN_COUNT = 6;
@@ -108,7 +109,7 @@ export function ColorTable({
   const groups = useMemo<Group[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'color') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     const sorted = sortTokens(filtered, { by: sortBy, dir: sortDir });
 

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -5,7 +5,8 @@ import { DimensionBar, type DimensionKind } from '#/dimension-scale/DimensionBar
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export type { DimensionKind };
 
@@ -74,7 +75,7 @@ export function DimensionScale({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'dimension') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
       const pxValue = toPixels(token.$value);

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -2,7 +2,8 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './FontFamilySample.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 
 export interface FontFamilySampleProps {
@@ -50,7 +51,7 @@ export function FontFamilySample({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'fontFamily') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -4,7 +4,8 @@ import './FontWeightScale.css';
 import { cssVarAsNumber } from '#/internal/css-var-style.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface FontWeightScaleProps {
   /**
@@ -56,7 +57,7 @@ export function FontWeightScale({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'fontWeight') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -5,7 +5,8 @@ import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface GradientPaletteProps {
   /**
@@ -77,7 +78,7 @@ export function GradientPalette({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'gradient') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -4,7 +4,8 @@ import { useMemo, useState } from 'react';
 import './MotionPreview.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import {
   MotionSample,
   type MotionSpeed,
@@ -54,7 +55,7 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
   const rows = useMemo(() => {
     const collected: Row[] = [];
     for (const [path, token] of Object.entries(resolved)) {
-      if (filter && !globMatch(path, filter)) continue;
+      if (filter && !matchPath(path, filter)) continue;
       if (!filter && !['transition', 'duration', 'cubicBezier'].includes(token.$type ?? '')) {
         continue;
       }

--- a/packages/blocks/src/OpacityScale.tsx
+++ b/packages/blocks/src/OpacityScale.tsx
@@ -3,7 +3,8 @@ import { useMemo } from 'react';
 import './OpacityScale.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface OpacityScaleProps {
   /**
@@ -76,7 +77,7 @@ export function OpacityScale({
       if (token.$type !== type) return false;
       const v = toOpacity(token.$value);
       if (!Number.isFinite(v) || v < 0 || v > 1) return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
       const opacity = toOpacity(token.$value);

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -6,7 +6,8 @@ import { useColorFormat } from '#/contexts.ts';
 import { type ColorFormat, formatColor } from '#/format-color.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 
 export interface ShadowPreviewProps {
@@ -86,7 +87,7 @@ export function ShadowPreview({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'shadow') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -3,7 +3,8 @@ import { useMemo } from 'react';
 import './StrokeStyleSample.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
-import { globMatch, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 
 export interface StrokeStyleSampleProps {
@@ -59,7 +60,7 @@ export function StrokeStyleSample({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'strokeStyle') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -9,7 +9,8 @@ import { themeAttrs } from '#/internal/data-attr.ts';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
-import { globMatch, resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface TokenTableProps {
   /**
@@ -67,7 +68,7 @@ export function TokenTable({
 
   const rows = useMemo(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (!globMatch(path, filter)) return false;
+      if (!matchPath(path, filter)) return false;
       if (type && token.$type !== type) return false;
       return true;
     });

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -3,7 +3,8 @@ import { useMemo } from 'react';
 import './TypographyScale.css';
 import type { TypographyValue } from '#/internal/composite-types.ts';
 import { themeAttrs } from '#/internal/data-attr.ts';
-import { globMatch, useProject } from '#/internal/use-project.ts';
+import { useProject } from '#/internal/use-project.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { type SortBy, type SortDir, sortTokens } from '#/internal/sort-tokens.ts';
 
 /**
@@ -95,7 +96,7 @@ export function TypographyScale({
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'typography') return false;
-      return globMatch(path, filter);
+      return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
       const value = token.$value;

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -318,29 +318,3 @@ export function resolveColorValue(
   }
   return formatColor(raw, colorFormat);
 }
-
-/**
- * Match a dot-separated DTCG token path against a block `filter` prop.
- *
- * **Supported shapes** (the narrow subset we need — DTCG paths don't have
- * directories, brace expansion, or regex, so we skip a full glob engine):
- *
- * | Pattern            | Matches                                             |
- * | ------------------ | --------------------------------------------------- |
- * | `undefined` / `''` | everything                                          |
- * | `*` or `**`        | everything                                          |
- * | `color`            | exact path `color`, or any descendant `color.*`     |
- * | `color.*`      | any path whose fixed prefix is `color.`         |
- * | `color**`          | any path starting with `color`                      |
- *
- * Not supported (all pass through as literal segment matchers): brace
- * expansion (`{a,b}`), mid-path globs (`color.*.bg`), negation (`!foo`),
- * character classes (`[sys]`). If you hit those, pre-filter by hand.
- */
-export function globMatch(path: string, glob: string | undefined): boolean {
-  if (!glob) return true;
-  if (glob === '*' || glob === '**') return true;
-  if (glob.endsWith('.*')) return path.startsWith(`${glob.slice(0, -2)}.`);
-  if (glob.endsWith('**')) return path.startsWith(glob.slice(0, -2));
-  return path === glob || path.startsWith(`${glob}.`);
-}

--- a/packages/blocks/test/color-palette.browser.test.tsx
+++ b/packages/blocks/test/color-palette.browser.test.tsx
@@ -46,7 +46,7 @@ describe('ColorPalette', () => {
   it('narrows to the filter subtree and derives groupBy from it', () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>
-        <ColorPalette filter="color.*" />
+        <ColorPalette filter="color.**" />
       </SwatchbookProvider>,
     );
     // `color.*` has fixed length 1. Auto groupBy clamps so every swatch
@@ -63,7 +63,7 @@ describe('ColorPalette', () => {
     // their shade as the leaf.
     render(
       <SwatchbookProvider value={makeSnapshot()}>
-        <ColorPalette filter="color.palette.blue.*" />
+        <ColorPalette filter="color.palette.blue.**" />
       </SwatchbookProvider>,
     );
     screen.getByText('color.palette.blue');
@@ -73,7 +73,7 @@ describe('ColorPalette', () => {
   it('shows the empty state when the filter matches no color tokens', () => {
     render(
       <SwatchbookProvider value={makeSnapshot()}>
-        <ColorPalette filter="typography.*" />
+        <ColorPalette filter="typography.**" />
       </SwatchbookProvider>,
     );
     screen.getByText('No color tokens match this filter.');

--- a/packages/blocks/test/color-table-expansion.browser.test.tsx
+++ b/packages/blocks/test/color-table-expansion.browser.test.tsx
@@ -58,7 +58,7 @@ describe('ColorTable — expansion', () => {
     });
     render(
       <SwatchbookProvider value={snap}>
-        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+        <ColorTable filter="color.bg.**" variants={{ hover: 'h', disabled: 'd' }} />
       </SwatchbookProvider>,
     );
     const row = screen
@@ -93,7 +93,7 @@ describe('ColorTable — expansion', () => {
     });
     render(
       <SwatchbookProvider value={snap}>
-        <ColorTable filter="color.bg.*" variants={{ hover: 'h' }} />
+        <ColorTable filter="color.bg.**" variants={{ hover: 'h' }} />
       </SwatchbookProvider>,
     );
     const row = screen

--- a/packages/blocks/test/color-table-grouping.browser.test.tsx
+++ b/packages/blocks/test/color-table-grouping.browser.test.tsx
@@ -22,7 +22,7 @@ describe('ColorTable — grouping', () => {
   it('collapses sibling variants into one row with a pill per variant', () => {
     render(
       <SwatchbookProvider value={makeVariantSnapshot()}>
-        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+        <ColorTable filter="color.bg.**" variants={{ hover: 'h', disabled: 'd' }} />
       </SwatchbookProvider>,
     );
 
@@ -41,7 +41,7 @@ describe('ColorTable — grouping', () => {
   it('defaults to the "base" variant when one is present', () => {
     render(
       <SwatchbookProvider value={makeVariantSnapshot()}>
-        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+        <ColorTable filter="color.bg.**" variants={{ hover: 'h', disabled: 'd' }} />
       </SwatchbookProvider>,
     );
 
@@ -56,7 +56,7 @@ describe('ColorTable — grouping', () => {
   it('clicking a pill swaps the active variant and the displayed values', async () => {
     render(
       <SwatchbookProvider value={makeVariantSnapshot()}>
-        <ColorTable filter="color.bg.*" variants={{ hover: 'h', disabled: 'd' }} />
+        <ColorTable filter="color.bg.**" variants={{ hover: 'h', disabled: 'd' }} />
       </SwatchbookProvider>,
     );
 
@@ -87,7 +87,7 @@ describe('ColorTable — grouping', () => {
     });
     render(
       <SwatchbookProvider value={snap}>
-        <ColorTable filter="color.bg.*" variants={{ hover: 'hover', disabled: 'disabled' }} />
+        <ColorTable filter="color.bg.**" variants={{ hover: 'hover', disabled: 'disabled' }} />
       </SwatchbookProvider>,
     );
 
@@ -100,7 +100,7 @@ describe('ColorTable — grouping', () => {
   it('ignores variants that would match characters inside a segment (neutral-900 ≠ suffix 0)', () => {
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
-        <ColorTable filter="color.palette.*" variants={{ zero: '0' }} />
+        <ColorTable filter="color.palette.**" variants={{ zero: '0' }} />
       </SwatchbookProvider>,
     );
     expect(screen.queryAllByTestId('color-table-variant').length).toBe(0);

--- a/packages/blocks/test/color-table.browser.test.tsx
+++ b/packages/blocks/test/color-table.browser.test.tsx
@@ -44,7 +44,7 @@ describe('ColorTable — base rendering', () => {
   it('renders an em-dash in the alias column for non-aliased tokens', () => {
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
-        <ColorTable filter="color.surface.*" />
+        <ColorTable filter="color.surface.**" />
       </SwatchbookProvider>,
     );
     const row = screen.getByTestId('color-table-row');
@@ -70,7 +70,7 @@ describe('ColorTable — base rendering', () => {
   it('renders the empty state when the filter matches no colors', () => {
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
-        <ColorTable filter="typography.*" />
+        <ColorTable filter="typography.**" />
       </SwatchbookProvider>,
     );
     expect(screen.queryByRole('table')).toBeNull();
@@ -90,7 +90,7 @@ describe('ColorTable — base rendering', () => {
     const picks: string[] = [];
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
-        <ColorTable onSelect={(p) => picks.push(p)} filter="color.surface.*" />
+        <ColorTable onSelect={(p) => picks.push(p)} filter="color.surface.**" />
       </SwatchbookProvider>,
     );
     const copy = screen.getAllByLabelText(/Copy value/)[0];

--- a/packages/blocks/test/token-table.browser.test.tsx
+++ b/packages/blocks/test/token-table.browser.test.tsx
@@ -104,7 +104,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
 
     render(
       <SwatchbookProvider value={snapshot}>
-        <TokenTable filter="color.*" />
+        <TokenTable filter="color.**" />
       </SwatchbookProvider>,
     );
 
@@ -170,7 +170,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
 
     render(
       <SwatchbookProvider value={snapshot}>
-        <TokenTable filter="typography.*" />
+        <TokenTable filter="typography.**" />
       </SwatchbookProvider>,
     );
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,10 @@
     "./snapshot-for-wire": {
       "types": "./dist/snapshot-for-wire.d.mts",
       "import": "./dist/snapshot-for-wire.mjs"
+    },
+    "./match-path": {
+      "types": "./dist/match-path.d.mts",
+      "import": "./dist/match-path.mjs"
     }
   },
   "imports": {
@@ -60,7 +64,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts src/css-var.ts src/data-attr.ts src/snapshot-for-wire.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts src/css-var.ts src/data-attr.ts src/snapshot-for-wire.ts src/match-path.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/src/match-path.ts
+++ b/packages/core/src/match-path.ts
@@ -1,9 +1,19 @@
 /**
- * Minimal DTCG-flavoured path matcher. Accepts exact paths (`color.bg`), single-
- * segment globs (`color.*`), multi-segment globs (`color.**`), or a trailing `*`
- * mid-segment (`color.palette.blue.*`). No brace expansion, no regex — DTCG
- * paths are dot-delimited and this matches the parity the blocks' `globMatch`
- * ships. Case-sensitive.
+ * Browser-safe DTCG-flavoured path matcher. Exported through the
+ * `@unpunnyfuns/swatchbook-core/match-path` subpath so both the
+ * blocks-side `<TypographyScale>` / `<DimensionScale>` / etc. filters
+ * and the MCP `list_tokens` / `search_tokens` tools share one
+ * implementation — the matcher consumers reach for stays in lockstep.
+ *
+ * Accepts:
+ *   - exact paths (`color.accent.bg`)
+ *   - single-segment wildcard (`color.*`, `color.*.bg`)
+ *   - multi-segment trailing globstar (`color.**`)
+ *   - multi-segment interior globstar (`color.**.500`)
+ *
+ * No brace expansion, no regex, no character classes — DTCG paths are
+ * dot-delimited and this matches what consumers actually want. Case-
+ * sensitive.
  */
 export function matchPath(path: string, filter: string | undefined): boolean {
   if (!filter) return true;

--- a/packages/core/test/match-path.test.ts
+++ b/packages/core/test/match-path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { matchPath } from '#/match.ts';
+import { matchPath } from '#/match-path.ts';
 
 describe('matchPath', () => {
   it('returns true for every path when the filter is omitted or "**"', () => {

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -5,7 +5,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { computeContrast } from '#/contrast.ts';
 import { formatColorEveryWay } from '#/format-color.ts';
-import { matchPath } from '#/match.ts';
+import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 /**
  * Build a swatchbook MCP server bound to a loaded project. Tools expose the


### PR DESCRIPTION
## Summary

Closes #890. Consolidates the two divergent path-matchers onto a single \`@unpunnyfuns/swatchbook-core/match-path\` subpath:

- \`packages/blocks/src/internal/use-project.ts:globMatch\` (5-line prefix matcher; treated \`color.*\` as \"any descendants\")
- \`packages/mcp/src/match.ts:matchPath\` (full mid-string \`*\` / \`**\` matcher; treated \`color.*\` as strict single-segment per conventional glob spec)

The blocks version was a documented narrow subset; the audit (#887 #8) flagged them as \"diverged despite a comment claiming parity.\" On closer inspection they're genuinely divergent — different semantic for \`color.*\`. Going with the **conventional glob spec** as the unified semantics (mcp's version): \`*\` matches a single segment, \`**\` matches any number of segments.

**Breaking change for blocks \`filter\` props:** any consumer passing \`filter=\"color.*\"\` to a block (\`<ColorPalette>\`, \`<ColorTable>\`, \`<TokenTable>\`, \`<TypographyScale>\`, \`<DimensionScale>\`, etc.) expecting \"all descendants of color\" needs to update to \`filter=\"color.**\"\`. Pre-1.0 minor bump.

**Internal migration (all in this PR):**
- 5 blocks test files (\`color-table-expansion\`, \`color-table-grouping\`, \`color-table\`, \`color-palette\`, \`token-table\`) — \`.*\` → \`.**\`
- 13 blocks-source consumers (\`ColorTable\`, \`ColorPalette\`, \`TokenTable\`, \`TypographyScale\`, \`OpacityScale\`, \`FontWeightScale\`, \`FontFamilySample\`, \`DimensionScale\`, \`MotionPreview\`, \`ShadowPreview\`, \`BorderPreview\`, \`StrokeStyleSample\`, \`GradientPalette\`) — drop \`globMatch\` import, add \`matchPath\` import from core subpath
- 8 MDX files (\`apps/storybook/src/docs/*\`, \`apps/docs/docs/quickstart.mdx\`, \`apps/docs/docs/guides/authoring-doc-stories.mdx\`, \`apps/docs/docs/reference/blocks/*.mdx\`) — \`.*\` → \`.**\`
- 2 BlockAssertions stories — \`.*\` → \`.**\`

**Touched files:**
- New \`packages/core/src/match-path.ts\` + \`./match-path\` subpath in core's \`package.json\` exports + tsdown entry
- \`packages/mcp/src/server.ts\` imports from the core subpath; deleted \`packages/mcp/src/match.ts\`
- \`packages/blocks/src/internal/use-project.ts\` — \`globMatch\` export removed
- Test moved: \`packages/mcp/test/match.test.ts\` → \`packages/core/test/match-path.test.ts\` (import path updated)

The unified spec also gains mid-string globs (\`color.**.500\`) for blocks consumers that didn't have them before.

Milestone: Maintenance
Closes: #890
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] No remaining \`globMatch\` references in blocks src (\`grep -rn 'globMatch' packages/blocks/src\` → no matches)
- [x] All internal \`filter=\"<path>.*\"\` consumers migrated to \`**\`
- [x] mcp's matchPath behavior unchanged (test moved to core, semantics preserved)