### PR TITLE
refactor(core,addon,blocks,mcp): add core/themes subpath (enumerateThemes + tupleToName)

### DIFF
--- a/.changeset/themes-subpath.md
+++ b/.changeset/themes-subpath.md
@@ -1,0 +1,25 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-mcp": patch
+---
+
+Closes #889. Adds `@unpunnyfuns/swatchbook-core/themes` subpath consolidating the "themes-a-project-surfaces" enumeration + the `tupleToName` join. Eliminates duplicated `enumerateThemeNames` / `buildTupleByName` / inline `tupleToName` impls across 4 packages.
+
+**New exports** (subpath: `/themes`):
+- `tupleToName(axes, tuple)` — synthesizes the canonical theme name (`axisValues.join(' · ')` in declared axis order) for the `data-<prefix>-theme` attribute. Same form `Project.cells` keys against.
+- `enumerateThemes({ axes, presets, defaultTuple })` — iterates default tuple + per-axis non-default singletons + presets, deduped by name. Same order the loader produces.
+- `ThemeEntry`, `ThemeEnumAxis`, `ThemeEnumPreset` types.
+
+Pure functions, structural input types — no `Project` import, no Terrazzo parser, no Node deps.
+
+**Consumer migrations:**
+- `packages/addon/src/preset.ts` — `enumerateThemeNames` (16-line local impl with its own inline `tupleToName`) replaced with `enumerateThemes(project).map(t => t.name)`.
+- `packages/addon/src/preview.tsx` — `matchPermutationName` now wraps `tupleToName(virtualAxes, tuple)` instead of inlining the join.
+- `packages/blocks/src/internal/use-project.ts` — local `tupleToName` helper deleted; consumers import from core subpath.
+- `packages/mcp/src/server.ts` — local `buildTupleByName` (20-line preset-fill impl) and `tupleToName` (5-line) deleted; `buildTupleByName` now wraps `enumerateThemes(project)`.
+
+The internal `permutationID` in `core/types.ts` stays (still used by the loader's per-tuple keys via `Object.values(input).join(…)`); it's a slightly different signature (joins `Object.values` not `axes.map`) and remains an internal detail. The new `tupleToName(axes, tuple)` is the consumer-facing replacement that's explicit about axis ordering.
+
+Sixth core subpath (joining `/fuzzy`, `/resolve-at`, `/css-var`, `/data-attr`, `/snapshot-for-wire`, `/match-path`). Pre-1.0 minor bump on core (new public subpath); patch on consumer packages.

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -3,6 +3,7 @@ import { dirname, isAbsolute, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { loadProject } from '@unpunnyfuns/swatchbook-core';
+import { enumerateThemes } from '@unpunnyfuns/swatchbook-core/themes';
 import { createJiti } from 'jiti';
 import type { InlineConfig } from 'vite';
 import type { AddonOptions } from '#/options.ts';
@@ -85,7 +86,7 @@ async function writeTokenCodegen(project: Project, options: PresetOptions): Prom
 export function renderTokenTypes(project: Project): string {
   const sorted = [...project.varianceByPath.keys()].toSorted();
   const tokenEntries = sorted.map((p) => `    ${JSON.stringify(p)}: string;`);
-  const themeNames = enumerateThemeNames(project);
+  const themeNames = project.axes.length === 0 ? [] : enumerateThemes(project).map((t) => t.name);
   const themeUnion =
     themeNames.length > 0 ? themeNames.map((n) => JSON.stringify(n)).join(' | ') : 'string';
 
@@ -100,31 +101,4 @@ export function renderTokenTypes(project: Project): string {
     '}',
     '',
   ].join('\n');
-}
-
-/**
- * Default tuple + one per non-default cell on each axis + each
- * preset — same set the resolver loader's singleton enumeration
- * produces.
- */
-function enumerateThemeNames(project: Project): string[] {
-  if (project.axes.length === 0) return [];
-  const names = new Set<string>();
-  const tupleToName = (tuple: Record<string, string>): string =>
-    project.axes.map((a) => tuple[a.name] ?? a.default).join(' · ');
-  names.add(tupleToName(project.defaultTuple));
-  for (const axis of project.axes) {
-    for (const ctx of axis.contexts) {
-      if (ctx === axis.default) continue;
-      names.add(tupleToName({ ...project.defaultTuple, [axis.name]: ctx }));
-    }
-  }
-  for (const preset of project.presets) {
-    const tuple: Record<string, string> = { ...project.defaultTuple };
-    for (const [axis, ctx] of Object.entries(preset.axes)) {
-      if (ctx !== undefined) tuple[axis] = ctx;
-    }
-    names.add(tupleToName(tuple));
-  }
-  return [...names];
 }

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -9,6 +9,7 @@ import type { Decorator, Preview } from '@storybook/react-vite';
 import { useEffect, useMemo } from 'react';
 import { addons } from 'storybook/preview-api';
 import { dataAttr } from '@unpunnyfuns/swatchbook-core/data-attr';
+import { tupleToName } from '@unpunnyfuns/swatchbook-core/themes';
 // Side-effect import for integrations that opted into `autoInject`
 // (e.g. Tailwind's `@theme` block). When no integration opts in, the
 // virtual module body is empty — still a valid no-op.
@@ -92,15 +93,14 @@ function forEachPinnedAxis(cb: (name: string, value: string) => void): void {
 }
 
 /**
- * Compose a stable theme name from a tuple — the same `Light · Brand A
- * · Normal` form `permutationID` produced server-side. Used for the
- * `data-<prefix>-theme` attribute and the `swatchbook/theme` channel
- * signal. Returns empty string when there are no axes (no name to
- * write).
+ * Compose a stable theme name from a tuple — `axisValues.join(' · ')`
+ * in axis order. Used for the `data-<prefix>-theme` attribute and the
+ * `swatchbook/theme` channel signal. Returns empty string when there
+ * are no axes (no name to write).
  */
 function matchPermutationName(tuple: Readonly<Record<string, string>>): string {
   if (virtualAxes.length === 0) return '';
-  return virtualAxes.map((axis) => tuple[axis.name] ?? axis.default).join(' · ');
+  return tupleToName(virtualAxes, tuple);
 }
 
 /**

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,5 +1,6 @@
 import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
 import { makeCssVar } from '@unpunnyfuns/swatchbook-core/css-var';
+import { tupleToName } from '@unpunnyfuns/swatchbook-core/themes';
 import type { Axis, Cells, JointOverrides, TokenMap } from '@unpunnyfuns/swatchbook-core';
 import { useEffect, useMemo } from 'react';
 import type { VirtualTokenListingShape, VirtualVarianceByPathShape } from '#/contexts.ts';
@@ -62,19 +63,6 @@ function defaultTuple(axes: readonly VirtualAxis[]): Record<string, string> {
   const out: Record<string, string> = {};
   for (const axis of axes) out[axis.name] = axis.default;
   return out;
-}
-
-/**
- * Synthesize a permutation name from a tuple — same form
- * `permutationID` produces server-side (axis values joined by ` · `).
- * Used by the AxisVariance grid for `data-<prefix>-theme` attribution
- * and similar display-only callers.
- */
-function tupleToName(
-  axes: readonly VirtualAxis[],
-  tuple: Readonly<Record<string, string>>,
-): string {
-  return axes.map((a) => tuple[a.name] ?? a.default).join(' · ');
 }
 
 /**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,6 +50,10 @@
     "./snapshot-for-wire": {
       "types": "./dist/snapshot-for-wire.d.mts",
       "import": "./dist/snapshot-for-wire.mjs"
+    },
+    "./themes": {
+      "types": "./dist/themes.d.mts",
+      "import": "./dist/themes.mjs"
     }
   },
   "imports": {
@@ -60,7 +64,7 @@
   ],
   "sideEffects": false,
   "scripts": {
-    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts src/css-var.ts src/data-attr.ts src/snapshot-for-wire.ts --format esm --dts --clean --sourcemap",
+    "build": "tsdown src/index.ts src/fuzzy.ts src/resolve-at.ts src/css-var.ts src/data-attr.ts src/snapshot-for-wire.ts src/themes.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/core/src/themes.ts
+++ b/packages/core/src/themes.ts
@@ -1,0 +1,89 @@
+/**
+ * Browser-safe theme-enumeration + naming helpers. Exported through the
+ * `@unpunnyfuns/swatchbook-core/themes` subpath so the addon's preset
+ * codegen, the addon's preview decorator, the MCP server's tuple lookup,
+ * and the blocks-side display name share one implementation. Same set
+ * of "themes a project surfaces" (default + per-axis singletons +
+ * presets) consumers iterate over; same `tupleToName` join everyone
+ * uses for the `data-<prefix>-theme` attribute.
+ *
+ * Pure functions over structural input types — no `Project` import, no
+ * Terrazzo parser, no Node deps.
+ */
+
+/** One named theme produced by enumeration — the canonical name + the tuple it resolves to. */
+export interface ThemeEntry {
+  readonly name: string;
+  readonly tuple: Readonly<Record<string, string>>;
+}
+
+/** Minimal axis shape `enumerateThemes` and `tupleToName` need. */
+export interface ThemeEnumAxis {
+  readonly name: string;
+  readonly default: string;
+  readonly contexts: readonly string[];
+}
+
+/** Minimal preset shape `enumerateThemes` needs. */
+export interface ThemeEnumPreset {
+  readonly name: string;
+  readonly axes: Partial<Record<string, string>>;
+}
+
+/**
+ * Synthesize the canonical theme name from a tuple — axis values joined
+ * by ` · ` in axis declaration order. Same form `Project.cells` keys
+ * against and the `data-<prefix>-theme` attribute holds. Falls back to
+ * each axis's `default` when the tuple omits it.
+ */
+export function tupleToName(
+  axes: readonly { readonly name: string; readonly default: string }[],
+  tuple: Readonly<Record<string, string>>,
+): string {
+  return axes.map((a) => tuple[a.name] ?? a.default).join(' · ');
+}
+
+/**
+ * Enumerate every theme a project surfaces:
+ *
+ *   1. The default tuple (axes at their defaults), always first.
+ *   2. Per-axis non-default singletons (`{...defaults, [axis]: ctx}`)
+ *      for each `(axis, non-default-context)` pair.
+ *   3. Presets — fill omitted axes from defaults.
+ *
+ * Deduped by name (presets pointing at a singleton or the default tuple
+ * collapse into the singleton entry). Order matches the loader's own
+ * singleton enumeration: default → per-axis singletons → presets.
+ */
+export function enumerateThemes(input: {
+  readonly axes: readonly ThemeEnumAxis[];
+  readonly presets: readonly ThemeEnumPreset[];
+  readonly defaultTuple: Readonly<Record<string, string>>;
+}): ThemeEntry[] {
+  const out: ThemeEntry[] = [];
+  const seen = new Set<string>();
+
+  const push = (tuple: Record<string, string>): void => {
+    const name = tupleToName(input.axes, tuple);
+    if (seen.has(name)) return;
+    seen.add(name);
+    out.push({ name, tuple });
+  };
+
+  push({ ...input.defaultTuple });
+  for (const axis of input.axes) {
+    for (const ctx of axis.contexts) {
+      if (ctx === axis.default) continue;
+      push({ ...input.defaultTuple, [axis.name]: ctx });
+    }
+  }
+  for (const preset of input.presets) {
+    const tuple: Record<string, string> = { ...input.defaultTuple };
+    for (const [a, c] of Object.entries(preset.axes)) {
+      if (c !== undefined) tuple[a] = c;
+    }
+    push(tuple);
+  }
+
+  return out;
+}

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,7 @@
 import type { Project, TokenMap } from '@unpunnyfuns/swatchbook-core';
 import { emitAxisProjectedCss } from '@unpunnyfuns/swatchbook-core';
 import { fuzzyFilter, fuzzyMatches } from '@unpunnyfuns/swatchbook-core/fuzzy';
+import { enumerateThemes, tupleToName } from '@unpunnyfuns/swatchbook-core/themes';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { computeContrast } from '#/contrast.ts';
@@ -576,35 +577,10 @@ export function createServer(initial: Project): McpServer & {
  */
 function buildTupleByName(project: Project): Map<string, Record<string, string>> {
   const out = new Map<string, Record<string, string>>();
-  const defaultName = tupleToName(project.axes, project.defaultTuple);
-  out.set(defaultName, { ...project.defaultTuple });
-  for (const axis of project.axes) {
-    for (const ctx of axis.contexts) {
-      if (ctx === axis.default) continue;
-      const tuple = { ...project.defaultTuple, [axis.name]: ctx };
-      out.set(tupleToName(project.axes, tuple), tuple);
-    }
-  }
-  for (const preset of project.presets) {
-    const tuple: Record<string, string> = { ...project.defaultTuple };
-    for (const [axis, ctx] of Object.entries(preset.axes)) {
-      if (ctx !== undefined) tuple[axis] = ctx;
-    }
-    out.set(tupleToName(project.axes, tuple), tuple);
+  for (const { name, tuple } of enumerateThemes(project)) {
+    out.set(name, { ...tuple });
   }
   return out;
-}
-
-/**
- * Synthesize the tuple's stable name — axis values joined by ` · ` in
- * axis order. Inlined here rather than imported so MCP doesn't depend
- * on `permutationID` staying in core's public API.
- */
-function tupleToName(
-  axes: readonly { name: string; default: string }[],
-  tuple: Readonly<Record<string, string>>,
-): string {
-  return axes.map((a) => tuple[a.name] ?? a.default).join(' · ');
 }
 
 function stringifyValue(value: unknown): string {


### PR DESCRIPTION
## Summary

Closes #889. Adds \`@unpunnyfuns/swatchbook-core/themes\` subpath consolidating the \"themes-a-project-surfaces\" enumeration + the \`tupleToName\` join.

**New exports** (subpath: \`/themes\`):
- \`tupleToName(axes, tuple)\` — synthesizes the canonical theme name (\`axisValues.join(' · ')\` in declared axis order) for the \`data-<prefix>-theme\` attribute. Same form \`Project.cells\` keys against.
- \`enumerateThemes({ axes, presets, defaultTuple })\` — iterates default tuple + per-axis non-default singletons + presets, deduped by name. Same order the loader produces.
- \`ThemeEntry\`, \`ThemeEnumAxis\`, \`ThemeEnumPreset\` structural types.

Pure functions, structural input types — no \`Project\` import, no Terrazzo parser, no Node deps. Same shape as the existing \`/fuzzy\` / \`/resolve-at\` / \`/css-var\` / \`/data-attr\` / \`/snapshot-for-wire\` / \`/match-path\` subpaths.

**Consumer migrations:**
- \`packages/addon/src/preset.ts\` — \`enumerateThemeNames\` (16-line local impl with its own inline \`tupleToName\`) replaced with \`enumerateThemes(project).map(t => t.name)\`.
- \`packages/addon/src/preview.tsx\` — \`matchPermutationName\` now wraps \`tupleToName(virtualAxes, tuple)\` instead of inlining the join.
- \`packages/blocks/src/internal/use-project.ts\` — local \`tupleToName\` helper deleted; imports from core subpath.
- \`packages/mcp/src/server.ts\` — local \`buildTupleByName\` (20-line preset-fill impl) and \`tupleToName\` (5-line) deleted; \`buildTupleByName\` now wraps \`enumerateThemes(project)\`.

**Internal note:** the \`permutationID\` in \`core/types.ts\` stays — it's still used by the loader's per-tuple keys via \`Object.values(input).join(…)\`. Slightly different signature (joins \`Object.values\` not \`axes.map\`); remains an internal detail. The new \`tupleToName(axes, tuple)\` is the consumer-facing replacement that's explicit about axis ordering.

Sixth core subpath. Pre-1.0 minor bump on core (new public subpath); patch on consumer packages (no public API change, internal cleanup).

Milestone: Maintenance
Closes: #889
Plan impact: None.

## Test plan

- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — all 37 tasks green
- [x] No remaining inline \`tupleToName\` definitions outside core/themes.ts (\`grep -rn 'function tupleToName\\\\|const tupleToName' packages/{addon,blocks,mcp}/src\` → no matches)
- [x] No remaining inline singleton+preset enumeration outside core/themes.ts (\`grep -rn 'enumerateThemeNames\\\\|buildTupleByName' packages/{addon,mcp}/src\` → no matches in the previously-duplicated impls; only the call-sites for the new helpers)