### PR TITLE
fix(changesets): strip stray Closes #N lines from merged changesets

### DIFF
--- a/.changeset/docs-refresh-post-cartesian-drop.md
+++ b/.changeset/docs-refresh-post-cartesian-drop.md
@@ -3,7 +3,7 @@
 "@unpunnyfuns/swatchbook-switcher": patch
 ---
 
-Closes #888. Refreshes the npm landing page + apps/docs reference against the current post-cartesian-drop public API. The single biggest user-visible debt heading into 0.60.
+Refreshes the npm landing page + apps/docs reference against the current post-cartesian-drop public API. The single biggest user-visible debt heading into 0.60.
 
 **`packages/core/README.md`** — rewritten Usage example (removed `permutationsResolved` access; shows `defaultTokens` + `resolveAt`), added Browser-safe subpaths section (5 subpaths), updated Boundaries to reference `snapshot-for-wire` instead of removed `permutationsResolved` projections.
 

--- a/.changeset/drop-emit-via-terrazzo-and-parserinput.md
+++ b/.changeset/drop-emit-via-terrazzo-and-parserinput.md
@@ -2,7 +2,7 @@
 "@unpunnyfuns/swatchbook-core": minor
 ---
 
-Closes #891. Removes the dead `emitViaTerrazzo` emitter and drops `Project.parserInput` from the public type. Two birds, one PR — `emitViaTerrazzo` was the only remaining public consumer of `parserInput`, and removing it lets the field move into a loader-internal closed-over local.
+Removes the dead `emitViaTerrazzo` emitter and drops `Project.parserInput` from the public type. Two birds, one PR — `emitViaTerrazzo` was the only remaining public consumer of `parserInput`, and removing it lets the field move into a loader-internal closed-over local.
 
 **What's gone:**
 - `packages/core/src/emit-via-terrazzo.ts` — ~260 lines of code, dead since the "smart emitter is the only emitter" commit (905165d / PR #806). No consumer in any package; the smart `emitAxisProjectedCss` is the sole emission path.

--- a/.changeset/match-path-subpath.md
+++ b/.changeset/match-path-subpath.md
@@ -4,7 +4,7 @@
 "@unpunnyfuns/swatchbook-mcp": patch
 ---
 
-Closes #890. Consolidates the two divergent path-matchers onto a single `@unpunnyfuns/swatchbook-core/match-path` subpath:
+Consolidates the two divergent path-matchers onto a single `@unpunnyfuns/swatchbook-core/match-path` subpath:
 
 - `packages/blocks/src/internal/use-project.ts:globMatch` (5-line prefix matcher; treated `color.*` as "any descendants")
 - `packages/mcp/src/match.ts:matchPath` (full mid-string `*` / `**` matcher; treated `color.*` as strict single-segment per conventional glob spec)

--- a/.changeset/test-hygiene-batch.md
+++ b/.changeset/test-hygiene-batch.md
@@ -4,7 +4,7 @@
 "@unpunnyfuns/swatchbook-switcher": patch
 ---
 
-Closes #896. Four contained test-hygiene items bundled into one PR:
+Four contained test-hygiene items bundled into one PR:
 
 **Switcher `.browser.test.tsx` infix** (#896 #14) — `packages/switcher/test/theme-switcher.test.tsx` → `theme-switcher.browser.test.tsx`. Matches the convention established by #877 (`.browser.` opt-in for tests requiring the browser harness). Switcher's `include: ['test/**/*.test.{ts,tsx}']` glob continues to match.
 

--- a/.changeset/themes-subpath.md
+++ b/.changeset/themes-subpath.md
@@ -5,7 +5,7 @@
 "@unpunnyfuns/swatchbook-mcp": patch
 ---
 
-Closes #889. Adds `@unpunnyfuns/swatchbook-core/themes` subpath consolidating the "themes-a-project-surfaces" enumeration + the `tupleToName` join. Eliminates duplicated `enumerateThemeNames` / `buildTupleByName` / inline `tupleToName` impls across 4 packages.
+Adds `@unpunnyfuns/swatchbook-core/themes` subpath consolidating the "themes-a-project-surfaces" enumeration + the `tupleToName` join. Eliminates duplicated `enumerateThemeNames` / `buildTupleByName` / inline `tupleToName` impls across 4 packages.
 
 **New exports** (subpath: `/themes`):
 - `tupleToName(axes, tuple)` — synthesizes the canonical theme name (`axisValues.join(' · ')` in declared axis order) for the `data-<prefix>-theme` attribute. Same form `Project.cells` keys against.


### PR DESCRIPTION
## Summary
Five merged changesets carried `Closes #N` lines in their description prose:

- `docs-refresh-post-cartesian-drop.md` → `Closes #888` (also wrong issue: should've been #890)
- `themes-subpath.md` → `Closes #889` (should've been #888)
- `test-hygiene-batch.md` → `Closes #896` (should've been #895)
- `match-path-subpath.md` → `Closes #890` (should've been #889)
- `drop-emit-via-terrazzo-and-parserinput.md` → `Closes #891` (should've been #893)

The v0.57.0 release PR (#906) concatenates each changeset's prose into its body. GitHub's auto-close parser sees those references and fires them on release-PR merge — closing the (wrong) issues again, including ones that had been manually reopened. Three issues (#891, #892, #896) got mis-closed once already due to this; I reopened them earlier, but they'd close again on #906's merge without this fix.

`Closes` belongs in PR bodies (one PR → one well-scoped issue) and not in changesets (the release PR aggregates many changeset paragraphs with no per-PR scoping). The PR-to-issue link is already canonical via each individual PR.

Closes #908

## Test plan
- [x] `grep -rn 'Closes #' .changeset/` — only the still-open `swatchbook-token-brand.md` (PR #903 branch) retains a `Closes` line, expected since that PR hasn't merged yet
- [x] Prose still reads cleanly after the prefix strip — the descriptive content was always the real signal