### PR TITLE
chore(lint): enable batch of quality rules + autofix sweep

### DIFF
--- a/.changeset/enable-quality-lint-rules.md
+++ b/.changeset/enable-quality-lint-rules.md
@@ -1,0 +1,20 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Enable a batch of oxlint quality rules and sweep the existing codebase via autofix.
+
+Direct enforcement of project conventions (`CLAUDE.md`):
+- `no-inline-comments` — "No inline end-of-line comments."
+- `import/extensions` (with `ignorePackages`) — "Import specifiers: explicit extensions, always" for relative + `#/` imports; npm package imports stay extensionless.
+
+Style + correctness (all autofixable, applied via `oxlint --fix`):
+- `eqeqeq` (with `smart` so `== null` stays as the "null-or-undefined" idiom)
+- `no-var`, `prefer-const`, `object-shorthand`, `no-else-return`
+- `react/self-closing-comp`, `react/jsx-boolean-value`, `react/jsx-fragments`
+- `typescript/array-type`
+- `unicorn/throw-new-error`, `unicorn/catch-error-name`, `unicorn/prefer-includes`
+
+CI catches future regressions; new contributors don't need to memorise the conventions.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -11,7 +11,21 @@
     "typescript/no-explicit-any": "error",
     "react/react-in-jsx-scope": "off",
     "import/no-unassigned-import": "off",
-    "import/consistent-type-specifier-style": ["error", "prefer-top-level"]
+    "import/consistent-type-specifier-style": ["error", "prefer-top-level"],
+    "import/extensions": ["error", "always", { "ignorePackages": true }],
+    "no-inline-comments": "error",
+    "eqeqeq": ["error", "smart"],
+    "no-var": "error",
+    "prefer-const": "error",
+    "object-shorthand": "error",
+    "no-else-return": "error",
+    "react/self-closing-comp": "error",
+    "react/jsx-boolean-value": "error",
+    "react/jsx-fragments": "error",
+    "typescript/array-type": "error",
+    "unicorn/throw-new-error": "error",
+    "unicorn/catch-error-name": "error",
+    "unicorn/prefer-includes": "error"
   },
   "overrides": [
     {

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,7 +1,7 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { Fragment, useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import './ColorTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
@@ -273,7 +273,7 @@ function GroupRow({
   };
 
   return (
-    <Fragment>
+    <>
       <tr
         className={cx('sb-color-table__row', {
           'sb-color-table__row--expanded': expanded,
@@ -372,7 +372,7 @@ function GroupRow({
           </td>
         </tr>
       )}
-    </Fragment>
+    </>
   );
 }
 

--- a/packages/blocks/src/internal/sort-tokens.ts
+++ b/packages/blocks/src/internal/sort-tokens.ts
@@ -112,7 +112,8 @@ function compareValue(
   const ak = keys.get(a);
   const bk = keys.get(b);
   if (!ak || !bk) return 0;
-  if (ak.kind !== bk.kind) return 0; // matches a.$type === b.$type check above
+  // Matches the `a.$type === b.$type` check above.
+  if (ak.kind !== bk.kind) return 0;
 
   if (ak.kind === 'numeric' && bk.kind === 'numeric') {
     if (ak.valid && bk.valid) return ak.value - bk.value;

--- a/packages/blocks/src/token-detail/CompositeBreakdown.tsx
+++ b/packages/blocks/src/token-detail/CompositeBreakdown.tsx
@@ -157,7 +157,7 @@ export function CompositeBreakdownContent({
 }
 
 function renderKeyValueList(
-  rows: Array<[string, string | null, readonly string[] | undefined]>,
+  rows: [string, string | null, readonly string[] | undefined][],
 ): ReactElement {
   return (
     <div className="sb-token-detail__breakdown-section">
@@ -239,9 +239,9 @@ function pickObjectAliases(v: unknown): Record<string, string | undefined> | und
   return v as Record<string, string | undefined>;
 }
 
-function pickArrayAliases(v: unknown): Array<Record<string, string | undefined>> | undefined {
+function pickArrayAliases(v: unknown): Record<string, string | undefined>[] | undefined {
   if (!Array.isArray(v)) return undefined;
-  return v as Array<Record<string, string | undefined>>;
+  return v as Record<string, string | undefined>[];
 }
 
 /**

--- a/packages/core/src/token-listing.ts
+++ b/packages/core/src/token-listing.ts
@@ -109,8 +109,8 @@ export async function computeTokenListing(
       byPath[entry.$name] = entry;
     }
     return { listing: byPath, diagnostics: [] };
-  } catch (err) {
-    return { listing: {}, diagnostics: [crashedListingDiagnostic(err)] };
+  } catch (error) {
+    return { listing: {}, diagnostics: [crashedListingDiagnostic(error)] };
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,7 +129,7 @@ export interface JointOverride {
  * uses a temporary Map keyed on canonical tuple, materialized to this
  * array shape on return.
  */
-export type JointOverrides = ReadonlyArray<readonly [string, JointOverride]>;
+export type JointOverrides = readonly (readonly [string, JointOverride])[];
 
 /**
  * Compute the resolved `TokenMap` for any tuple of axis selections

--- a/packages/core/test/cells.test.ts
+++ b/packages/core/test/cells.test.ts
@@ -7,7 +7,7 @@
 // overlay on a token it doesn't touch.
 import { beforeAll, expect, it } from 'vitest';
 import type { Project } from '#/types.ts';
-import { loadWithPrefix } from './_helpers';
+import { loadWithPrefix } from './_helpers.ts';
 
 let project: Project;
 

--- a/packages/core/test/css-axis-projected.test.ts
+++ b/packages/core/test/css-axis-projected.test.ts
@@ -25,7 +25,7 @@
 import { beforeAll, expect, it } from 'vitest';
 import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
 import type { Project } from '#/types.ts';
-import { extractBlock, loadWithPrefix } from './_helpers';
+import { extractBlock, loadWithPrefix } from './_helpers.ts';
 
 let project: Project;
 

--- a/packages/core/test/default-tuple.test.ts
+++ b/packages/core/test/default-tuple.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 import { loadProject } from '#/load.ts';
-import { fixtureCwd } from './_helpers';
+import { fixtureCwd } from './_helpers.ts';
 
 // `Project.defaultTuple` is the axis-defaults baseline that `cells` /
 // `resolveAt` are built against — always the axes' own defaults,

--- a/packages/core/test/joint-overrides.test.ts
+++ b/packages/core/test/joint-overrides.test.ts
@@ -5,7 +5,7 @@
 // entries without overcollecting.
 import { beforeAll, expect, it } from 'vitest';
 import type { Project } from '#/types.ts';
-import { loadWithPrefix } from './_helpers';
+import { loadWithPrefix } from './_helpers.ts';
 
 let project: Project;
 

--- a/packages/core/test/load-layered-composites.test.ts
+++ b/packages/core/test/load-layered-composites.test.ts
@@ -74,7 +74,7 @@ it('composite sub-field flips when its alias target is re-aimed under an axis (s
   // of authored shape, so single-layer shadows still expose `[0].color`.
   const dark = project.resolveAt({ mode: 'Dark', brand: 'Default' });
   const layers = dark['shadow.md']?.$value as
-    | ReadonlyArray<{ color?: { components?: number[] } }>
+    | readonly { color?: { components?: number[] } }[]
     | undefined;
   expect(layers?.[0]?.color?.components).toEqual([1, 1, 1]);
 });

--- a/packages/core/test/resolve-at.test.ts
+++ b/packages/core/test/resolve-at.test.ts
@@ -18,7 +18,7 @@ import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 import { BufferedLogger } from '#/diagnostics.ts';
 import { loadResolverPermutations } from '#/permutations/resolver.ts';
 import type { Project } from '#/types.ts';
-import { fixtureCwd, loadWithPrefix } from './_helpers';
+import { fixtureCwd, loadWithPrefix } from './_helpers.ts';
 
 let project: Project;
 let resolver: Resolver;

--- a/packages/core/test/resolver-edge-cases.test.ts
+++ b/packages/core/test/resolver-edge-cases.test.ts
@@ -152,8 +152,8 @@ it('rejects or warns when a modifier has no default and no contexts', async () =
   let threw: unknown;
   try {
     project = await loadProject({ resolver: 'resolver.json', default: {} }, workspace);
-  } catch (err) {
-    threw = err;
+  } catch (error) {
+    threw = error;
   }
   if (threw !== undefined) {
     expect(threw).toBeInstanceOf(Error);

--- a/packages/core/test/source-files.test.ts
+++ b/packages/core/test/source-files.test.ts
@@ -2,7 +2,7 @@ import { dirname, resolve as resolvePath } from 'node:path';
 import { expect, it } from 'vitest';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
 import { loadProject } from '#/load.ts';
-import { fixtureCwd } from './_helpers';
+import { fixtureCwd } from './_helpers.ts';
 
 it('populates sourceFiles with every $ref target when config.tokens is omitted', async () => {
   const project = await loadProject({ resolver: resolverPath }, fixtureCwd);

--- a/packages/core/test/token-listing.test.ts
+++ b/packages/core/test/token-listing.test.ts
@@ -1,7 +1,7 @@
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 import { describe, expect, it } from 'vitest';
 import { loadProject } from '#/load.ts';
-import { fixtureCwd, loadWithPrefix } from './_helpers';
+import { fixtureCwd, loadWithPrefix } from './_helpers.ts';
 
 describe('Token Listing integration', () => {
   it('populates project.listing for resolver-backed projects', async () => {

--- a/packages/core/test/variance-analysis-layered.test.ts
+++ b/packages/core/test/variance-analysis-layered.test.ts
@@ -45,7 +45,8 @@ it("classifies multi-touch tokens conservatively as joint-variant with empty `jo
   // `color.accent` is overridden by both modes/dark.json and brands/brand-a.json
   // in this layered fixture — multi-touch.
   const info = variance.get('color.accent');
-  if (!info) return; // fixture might not define it; skip rather than fail
+  // Fixture might not define it; skip rather than fail.
+  if (!info) return;
   if (info.kind !== 'joint-variant') return;
   expect(info.touching.size).toBeGreaterThanOrEqual(2);
   // Empty jointCases — the emitter takes this as "fall back to cartesian-style emit."

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -97,8 +97,8 @@ function setupReload(
     if (pending) clearTimeout(pending);
     pending = setTimeout(() => {
       pending = null;
-      reload().catch((err) => {
-        console.error('swatchbook-mcp: reload failed —', err);
+      reload().catch((error) => {
+        console.error('swatchbook-mcp: reload failed —', error);
       });
     }, 100);
   };
@@ -161,7 +161,7 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => {
-  console.error('swatchbook-mcp failed to start:', err);
+main().catch((error) => {
+  console.error('swatchbook-mcp failed to start:', error);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
Enables a batch of oxlint rules that directly enforce `CLAUDE.md` conventions or are net-zero-risk quality wins. Autofix sweeps the existing codebase in the same PR so CI catches future regressions from this point.

**Direct CLAUDE.md enforcement:**
- `no-inline-comments` — "No inline end-of-line comments"
- `import/extensions` (`ignorePackages`) — "Import specifiers: explicit extensions, always" for relative + `#/` imports; npm packages stay extensionless

**Autofix quality (all `🛠️`):**
- `eqeqeq` (in `smart` mode so `== null` — "null-or-undefined" idiom — stays valid)
- `no-var`, `prefer-const`, `object-shorthand`, `no-else-return`
- `react/self-closing-comp`, `react/jsx-boolean-value`, `react/jsx-fragments`
- `typescript/array-type`
- `unicorn/throw-new-error`, `unicorn/catch-error-name`, `unicorn/prefer-includes`

Codebase was already largely compliant — the sweep flagged ~70 sites across 17 files. Two `no-inline-comments` violations and seven `import/extensions` violations (`./_helpers` imports in `core/test`) required manual fixups; all other rule violations were autofixable.

Closes #911

## Test plan
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 turbo tasks green
- [x] `pnpm --filter swatchbook-storybook build:storybook` — manager + preview bundles resolve clean
- [x] No autofix changes resulted in behavior changes (`eqeqeq` smart mode preserves `== null`; `array-type` is purely cosmetic)