### PR TITLE
chore: enable correctness-leaning oxlint quality rules

### DIFF
--- a/.changeset/enable-correctness-lint-rules.md
+++ b/.changeset/enable-correctness-lint-rules.md
@@ -1,0 +1,12 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+---
+
+Enable a small batch of correctness-leaning oxlint rules — the ones without safe autofix that nudge style consistency rather than mechanical reshape.
+
+- `no-throw-literal` — throw `Error` (or subclass), not strings. Better stack traces; matches established codebase pattern.
+- `typescript/no-inferrable-types` — strip redundant annotations like `let x: string = 'foo'`. Lets TS do its job.
+- `typescript/consistent-type-definitions: ["error", "interface"]` — pick `interface` for object shapes; `type` stays valid for unions / intersections / primitives.
+
+Codebase was nearly compliant — only two pre-existing violations across the monorepo. Fixed both in the same PR.

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -25,7 +25,10 @@
     "typescript/array-type": "error",
     "unicorn/throw-new-error": "error",
     "unicorn/catch-error-name": "error",
-    "unicorn/prefer-includes": "error"
+    "unicorn/prefer-includes": "error",
+    "no-throw-literal": "error",
+    "typescript/no-inferrable-types": "error",
+    "typescript/consistent-type-definitions": ["error", "interface"]
   },
   "overrides": [
     {

--- a/packages/core/test/_helpers.ts
+++ b/packages/core/test/_helpers.ts
@@ -40,7 +40,7 @@ export function extractBlock(css: string, selector: string): string {
  */
 export function tupleSelector(
   tuple: Readonly<Record<string, string>>,
-  prefix: string = 'sb',
+  prefix = 'sb',
 ): string {
   const attr = prefix ? `data-${prefix}-` : 'data-';
   return Object.entries(tuple)

--- a/packages/integrations/src/css-in-js.ts
+++ b/packages/integrations/src/css-in-js.ts
@@ -96,7 +96,9 @@ function collectPaths(project: Project): string[] {
   return [...project.varianceByPath.keys()].toSorted();
 }
 
-type TreeNode = { [key: string]: TreeNode | string };
+interface TreeNode {
+  [key: string]: TreeNode | string;
+}
 
 /**
  * Build a nested object tree from a sorted path list. Leaves hold the


### PR DESCRIPTION
## Summary
Second batch of oxlint enablements after #912. Three correctness-leaning rules with no safe autofix that nudge consistency where the alternative was fine but not preferred.

- `no-throw-literal` — `throw 'msg'` → `throw new Error('msg')`. Better stack traces; codebase already does this everywhere (zero pre-existing violations).
- `typescript/no-inferrable-types` — drop annotations like `prefix: string = 'sb'` where TS infers identically. One pre-existing site in `core/test/_helpers.ts`.
- `typescript/consistent-type-definitions: ["error", "interface"]` — prefer `interface` for object shapes; `type` still fine for unions / intersections / primitives. Matches the dominant existing style. One pre-existing site (`integrations/src/css-in-js.ts` — a recursive `TreeNode` type, converted to `interface` with the same recursion).

Closes #913

## Test plan
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 turbo tasks green
- [x] `pnpm --filter swatchbook-storybook build:storybook` — manager + preview bundles resolve clean (no behavior change from either fix)