### PR TITLE
fix(addon): migrate manager toolbar off Storybook 10 deprecations

### DIFF
--- a/.changeset/storybook-11-deprecations.md
+++ b/.changeset/storybook-11-deprecations.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Migrate the manager toolbar off three components deprecated in Storybook 10 and slated for removal in Storybook 11:
+
+- `IconButton` → `Button` (loading-state button) and `ToggleButton` (active disclosure button, with `pressed={open}` replacing the deprecated `active` prop).
+- `WithTooltipPure` → `WithTooltip` (controlled `visible` + `onVisibleChange` props still work the same).
+- `ariaLabel` (about to become mandatory) is now supplied on both buttons. The visible-on-hover tooltip moves from the legacy HTML `title` attribute to the new `tooltip` prop.
+
+No behaviour change — the toolbar pill, popover open/close mechanics, screen-reader semantics, and outside-click handling all preserved.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -3,7 +3,7 @@ import { COLOR_FORMATS, ColorFormatSelector } from '#/ColorFormatSelector.tsx';
 import type { ColorFormat } from '#/ColorFormatSelector.tsx';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
-import { IconButton, WithTooltipPure } from 'storybook/internal/components';
+import { Button, ToggleButton, WithTooltip } from 'storybook/internal/components';
 import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
 import type {
   InitPayload,
@@ -169,7 +169,7 @@ function AxesToolbar(): ReactElement {
   }, [open]);
 
   /**
-   * `WithTooltipPure`'s built-in `closeOnOutsideClick` misses some cases
+   * `WithTooltip`'s built-in `closeOnOutsideClick` misses some cases
    * (portaled popover + manager iframe boundaries). Belt-and-suspenders:
    * close when the user mouses down anywhere that isn't the trigger wrapper
    * or the popover body.
@@ -201,27 +201,35 @@ function AxesToolbar(): ReactElement {
 
   if (axes.length === 0) {
     return h(
-      IconButton,
-      { key: TOOL_ID, title: 'Swatchbook theme (loading…)', disabled: true },
+      Button,
+      {
+        key: TOOL_ID,
+        ariaLabel: 'Swatchbook theme (loading…)',
+        tooltip: 'Swatchbook theme (loading…)',
+        disabled: true,
+      },
       h(SwatchbookIcon),
     );
   }
 
   const summary = axes.map((a) => activeTuple[a.name] ?? a.default).join(' · ');
-  const title = `Swatchbook · ${summary}`;
+  const label = `Swatchbook · ${summary}`;
 
   const button = h(
-    IconButton,
+    ToggleButton,
     {
       key: TOOL_ID,
-      title,
-      active: open,
+      ariaLabel: label,
+      tooltip: label,
+      pressed: open,
       onClick: () => setOpen((prev) => !prev),
-      // Screen-reader disclosure semantics for the popover trigger. We
-      // don't set `aria-controls` because the popover is portaled by
-      // Storybook's `WithTooltipPure` with a dynamically-generated id we
-      // don't have a stable handle on; `aria-haspopup` + `aria-expanded`
-      // is the practical subset of the disclosure pattern.
+      /**
+       * Screen-reader disclosure semantics for the popover trigger. We
+       * don't set `aria-controls` because the popover is portaled by
+       * Storybook's `WithTooltip` with a dynamically-generated id we
+       * don't have a stable handle on; `aria-haspopup` + `aria-expanded`
+       * is the practical subset of the disclosure pattern.
+       */
       'aria-haspopup': 'dialog' as const,
       'aria-expanded': open,
     },
@@ -252,7 +260,7 @@ function AxesToolbar(): ReactElement {
   return h(
     'span',
     { ref: bodyRef, style: { display: 'inline-flex', alignItems: 'center' } },
-    h(WithTooltipPure, {
+    h(WithTooltip, {
       placement: 'bottom',
       trigger: 'click',
       visible: open,


### PR DESCRIPTION
## Summary
Storybook 10 prints four deprecation warnings at runtime for components the manager toolbar uses; all are slated for removal in Storybook 11.

```
IconButton is deprecated and will be removed in Storybook 11, use Button instead.
WithTooltipPure is deprecated and will be removed in Storybook 11. Please use WithTooltip instead.
The `active` prop on `Button` is deprecated and will be removed in Storybook 11. Use specialized components like `ToggleButton` or `Select` instead.
The 'ariaLabel' prop on 'Button' will become mandatory in Storybook 11.
```

Migration:
- `IconButton` → `Button` for the disabled "loading…" state.
- `IconButton` + `active={open}` → `ToggleButton` + `pressed={open}` for the disclosure pill.
- `WithTooltipPure` → `WithTooltip` (controlled `visible` + `onVisibleChange` work the same).
- Both buttons now supply `ariaLabel`; hover tooltip moves from the legacy HTML `title` attribute to the new `tooltip` prop.

Behaviour-preserving — popover open/close mechanics, outside-click handling, and `aria-haspopup` / `aria-expanded` disclosure semantics are unchanged.

Closes #915

## Test plan
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 turbo tasks green
- [x] `pnpm --filter swatchbook-storybook build:storybook` — manager + preview bundles resolve clean
- [ ] Browser smoke (manual): toolbar pill renders, click toggles popover, outside click closes, no deprecation warnings in console