### PR TITLE
docs: sweep stale 'permutation' prose to 'theme'

### DIFF
--- a/.changeset/sweep-permutation-vocab.md
+++ b/.changeset/sweep-permutation-vocab.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-switcher': patch
+---
+
+Sweep stale "permutation" prose to "theme" across docs and the switcher README, mirroring the API rename that landed in PR #905. The literal Terrazzo field name `cssOptions.permutations` and the rendered `'permutations'` keyword stay as-is — they're Terrazzo API surface, not swatchbook's. Switcher README also drops the stale `permutations={...}` prop and the removed `SwitcherPermutation` type from its usage example.
+
+Tightened the prose around `baseSelector` / `baseScheme` / `modeSelectors` to describe current behavior neutrally ("swatchbook ignores them — `permutations`-based emission supersedes them") instead of upgrade-flavoured "deprecated" framing.
+
+Docs-only change; docs-site snapshot patch bump per the standing policy so the fix reaches `/`, not just `/next/`.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -16,7 +16,7 @@ Monorepo under `@unpunnyfuns`. pnpm workspaces + Turborepo orchestration. Every 
 
 | Package | Role | Depends on |
 | --- | --- | --- |
-| `@unpunnyfuns/swatchbook-core` | Framework-free DTCG loader. Parses a resolver, normalizes axes, resolves permutations, emits CSS and diagnostics. | — |
+| `@unpunnyfuns/swatchbook-core` | Framework-free DTCG loader. Parses a resolver, normalizes axes, resolves themes via cells + joint overrides, emits CSS and diagnostics. | — |
 | `@unpunnyfuns/swatchbook-addon` | Storybook 10 addon. Toolbar, preview decorator, Vite plugin that publishes a virtual module. Re-exports `-blocks` + `-switcher`. | core, blocks, switcher |
 | `@unpunnyfuns/swatchbook-blocks` | MDX doc blocks + the `SwatchbookProvider` + hooks. Pure React, framework-agnostic beyond Storybook. | — (peer: storybook) |
 | `@unpunnyfuns/swatchbook-switcher` | Framework-agnostic axis / preset popover UI. Used by the addon toolbar and the docs-site navbar. | — |
@@ -158,7 +158,7 @@ useChannelGlobals() store            ← packages/blocks/src/internal/channel-gl
    ↓
 useProject() recomputes activeTheme  ← packages/blocks/src/internal/use-project.ts
    ↓
-blocks re-render with new active permutation / resolved tokens
+blocks re-render with new active theme / resolved tokens
 ```
 
 Two paths through `useProject`:

--- a/apps/docs/docs/guides/sharing-terrazzo-options.mdx
+++ b/apps/docs/docs/guides/sharing-terrazzo-options.mdx
@@ -135,7 +135,7 @@ The shared-options module above closes each of these gaps in one place.
 Five fields are stripped at the type level. They're load-bearing for how swatchbook emits CSS and publishes the listing; letting consumers override them breaks the preview model.
 
 - **`cssOptions.variableName`** — swatchbook routes naming through `@terrazzo/token-tools`' `makeCSSVar` with your `cssVarPrefix`, so every variable carries the prefix and kebab-cases consistently with what the listing records under `names.css`. A custom policy would make the listing's `names.css` disagree with the emitted stylesheet, which is worse than the default.
-- **`cssOptions.permutations`** — swatchbook synthesizes one permutation per resolver theme (or per layered tuple) so the emitted stylesheet declares each permutation under a compound `data-<prefix>-<axis>` selector. Overriding this defeats axis-aware rendering.
+- **`cssOptions.permutations`** — swatchbook synthesizes one entry per resolver theme (or per layered tuple) so the emitted stylesheet declares each theme under a compound `data-<prefix>-<axis>` selector. Overriding this defeats axis-aware rendering.
 - **`cssOptions.filename`** — the internal stylesheet is captured in memory, never written to disk.
 - **`cssOptions.skipBuild`** — setting `true` nulls out the listing's `previewValue` derivation, breaking every block that displays a value.
 - **`listingOptions.filename`** — the listing is captured in memory; the `outputFile` handler finds the entry by filename, and swatchbook owns that handshake.
@@ -144,13 +144,13 @@ Everything else passes through untouched.
 
 ### Soft-inert knobs (type-accepted, runtime-ignored)
 
-Three older `plugin-css` options predate permutations and pre-`permutations`-era builds still expose them:
+Three `plugin-css` options pass the type check but swatchbook ignores them — `permutations`-based emission supersedes them:
 
 - `baseSelector`
 - `baseScheme`
 - `modeSelectors`
 
-Setting any of these doesn't hit a type error because they're still part of `CSSPluginOptions`, but swatchbook always drives emission through permutations, so they do nothing in the preview. Load emits a `swatchbook/css-options` warn diagnostic listing the offending keys — visible in the preview's diagnostic overlay and on `Project.diagnostics` for programmatic consumers — so the "my setting isn't taking effect" failure mode turns into an explicit signal.
+Setting any of these doesn't hit a type error because they're still part of `CSSPluginOptions`, but swatchbook always drives emission through the `permutations` API, so they do nothing in the preview. Load emits a `swatchbook/css-options` warn diagnostic listing the offending keys — visible in the preview's diagnostic overlay and on `Project.diagnostics` for programmatic consumers — so the "my setting isn't taking effect" failure mode turns into an explicit signal.
 
 ## Per-platform identifier display
 
@@ -242,7 +242,7 @@ If you're weighing whether to add Terrazzo to an SD-only pipeline, the pragmatic
 ## Common pitfalls
 
 - **`cssVarPrefix` drift** — swatchbook's `cssVarPrefix` is independent of the prefix plugin-css would pick if you set `variableName` yourself. Since swatchbook owns `variableName`, setting `cssVarPrefix: 'sb'` is the only lever you need for prefix control on the swatchbook side. Production's prefix lives in its own plugin-css call (or in a `variableName` policy you ship). Both sides should pick the same prefix — the guide's "one shared module" pattern doesn't cover prefix because swatchbook takes it from a top-level field; double-check that `cssVarPrefix: 'ds'` in swatchbook matches whatever `--ds-*` your production stylesheet emits.
-- **Resolver vs `tokens` divergence** — if your production build reads a flat `tokens.json` but swatchbook reads a DTCG resolver, the two pipelines see different permutation sets. The listing will only reflect swatchbook's resolver view. Keep both on the same shape; if production needs flat output, emit it with Terrazzo's `plugin-js` or similar from the resolver's own permutations.
+- **Resolver vs `tokens` divergence** — if your production build reads a flat `tokens.json` but swatchbook reads a DTCG resolver, the two pipelines see different theme sets. The listing will only reflect swatchbook's resolver view. Keep both on the same shape; if production needs flat output, emit it with Terrazzo's `plugin-js` or similar driven from the resolver's themes.
 - **Plugin loaded but not listed** — a plugin in `terrazzoPlugins` without a matching entry in `listingOptions.platforms` runs but doesn't contribute to `names.*`. Conversely, a platform entry in `listingOptions.platforms` whose plugin isn't in `terrazzoPlugins` will fail at listing time. Both sides or neither.
 - **Plugins that write to disk** — swatchbook captures `outputFile` calls in memory. A plugin that writes via `fs` directly (bypassing the Terrazzo build API) will try to write files relative to the Storybook preview's cwd during HMR. Prefer plugins that use the supported `outputFile` hook.
 - **`@terrazzo/cli` vs `@terrazzo/parser`'s `defineConfig`** — `@terrazzo/cli` is what a `tz build` consumer already has installed; `@terrazzo/parser` exports a lower-level `defineConfig` that takes a `cwd` option. Prefer the cli export in user-facing config files.

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -64,7 +64,7 @@ For a browsable tree + diagnostics surface, compose `<Diagnostics />` + `<TokenN
 | Key | Type | Purpose |
 | --- | --- | --- |
 | `swatchbookAxes` | `Record<string, string>` | Active tuple. Preferred input. |
-| `swatchbookTheme` | `string` | Composed permutation ID. Back-compat companion. |
+| `swatchbookTheme` | `string` | Composed theme ID. Back-compat companion. |
 | `swatchbookColorFormat` | `'hex' \| 'rgb' \| 'hsl' \| 'oklch' \| 'raw'` | Display-only color format consumed by the blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`). Does **not** affect emitted CSS. Default `hex`. |
 
 The toolbar writes `swatchbookAxes` and `swatchbookTheme` in lockstep so legacy consumers keep working. `swatchbookColorFormat` is toggled from the color-format picker in the popover; `hex` falls back to space-separated `rgb()` (flagged with a ⚠ warning marker) for colors outside sRGB gamut.

--- a/apps/docs/docs/reference/axes.mdx
+++ b/apps/docs/docs/reference/axes.mdx
@@ -93,7 +93,7 @@ A resolver may declare more modifiers than a given Storybook wants to surface. L
 
 The loader can't blow up on a large cartesian because it doesn't materialize the cartesian in the first place. Two scoping levers remain, both presentational:
 
-- **`presets`** — author named tuples for the handful of permutations that matter (`Default Light`, `Brand A Dark`, `A11y High Contrast`). Toolbar surfaces them as quick-select pills; emit pipelines can fan out on `'presets'` instead of every axis-attribute combination. The right answer when only a handful of tuples are presentational.
+- **`presets`** — author named tuples for the handful of themes that matter (`Default Light`, `Brand A Dark`, `A11y High Contrast`). Toolbar surfaces them as quick-select pills; emit pipelines can fan out on `'presets'` instead of every axis-attribute combination. The right answer when only a handful of tuples are presentational.
 - **`disabledAxes`** — pin state-space modifiers (locale, density, motion-pref, …) to their defaults. They vanish from the toolbar, drop from the project's axis list, and don't contribute to emitted CSS. The right answer when an axis exists in the resolver but doesn't represent presentational variation.
 
 ## See also

--- a/apps/docs/docs/reference/blocks/hooks.mdx
+++ b/apps/docs/docs/reference/blocks/hooks.mdx
@@ -18,7 +18,7 @@ The snapshot's `listing?: Readonly<Record<string, VirtualTokenListingShape>>` fi
 
 ## `useActiveTheme()`
 
-Returns the current composed permutation ID as a string (e.g. `"Dark · Brand A"`).
+Returns the current composed theme ID as a string (e.g. `"Dark · Brand A"`).
 
 ## `useActiveAxes()`
 

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -82,7 +82,7 @@ Glob patterns (relative to the config's cwd) for base DTCG token files.
 
 Path to a [DTCG 2025.10 resolver](https://www.designtokens.org/TR/2025.10/resolver/) document. Mutually exclusive with `axes`.
 
-Terrazzo normalizes the document, then Swatchbook enumerates permutations via `resolver.listPermutations()` and realizes each with `resolver.apply()`. One `Axis` surfaces per modifier; the resolver file itself and every `$ref` target it pulls in land on `Project.sourceFiles`.
+Terrazzo normalizes the document, then Swatchbook enumerates singleton tuples (axes-defaults plus one per non-default `(axis, context)`) and realizes each via `resolver.apply()`. One `Axis` surfaces per modifier; the resolver file itself and every `$ref` target it pulls in land on `Project.sourceFiles`.
 
 ### `axes?: AxisConfig[]`
 
@@ -225,7 +225,7 @@ Four fields are managed internally and stripped from the allowed type:
 - `filename` — the internal stylesheet is captured in memory, never written to disk.
 - `skipBuild` — setting `true` would null out the listing's `previewValue` derivation, breaking every block that displays a value.
 
-Everything else passes through. Deprecated knobs (`baseSelector`, `baseScheme`, `modeSelectors`) still pass the type check but do nothing under swatchbook's permutation-based emission; setting any of them produces a `swatchbook/css-options` warn diagnostic with a pointer to what to use instead.
+Everything else passes through. Three plugin-css selectors (`baseSelector`, `baseScheme`, `modeSelectors`) pass the type check but swatchbook ignores them — `permutations`-based emission supersedes them. Setting any produces a `swatchbook/css-options` warn diagnostic.
 
 ```ts
 defineSwatchbookConfig({

--- a/packages/switcher/README.md
+++ b/packages/switcher/README.md
@@ -21,7 +21,6 @@ import '@unpunnyfuns/swatchbook-switcher/style.css';
 <ThemeSwitcher
   axes={axes}
   presets={presets}
-  permutations={permutations}
   activeTuple={{ mode: 'Dark' }}
   defaults={{ mode: 'Light', brand: 'Default', contrast: 'Normal' }}
   lastApplied={null}
@@ -40,7 +39,7 @@ The component is pure — it doesn't read or write to storage, and it doesn't ba
 
 Color-format selection isn't part of the switcher — hosts that need it slot a `<ColorFormatSelector>` (or any other custom node) into the optional `footer` prop.
 
-`SwitcherAxis` / `SwitcherPreset` / `SwitcherPermutation` are the accepted shapes and are cross-compatible with `Project.axes` / `.presets` / `.permutations` from `@unpunnyfuns/swatchbook-core` — pass them through directly.
+`SwitcherAxis` / `SwitcherPreset` are the accepted shapes and are cross-compatible with `Project.axes` / `Project.presets` from `@unpunnyfuns/swatchbook-core` — pass them through directly.
 
 ## Credits
 


### PR DESCRIPTION
## Summary
First of three thematic doc-audit PRs from the broad post-Storybook-11-era audit (the others land separately).

Sweep stale "permutation" prose to "theme" / "tuple" across the docs site and READMEs, mirroring the API rename that landed in PR #905 (`PermutationContext → ThemeContext`, `useActivePermutation → useActiveTheme`, `ProjectSnapshot.activePermutation → activeTheme`, `permutationNameForTuple → themeNameForTuple`). Body prose was lagging the API names.

- `packages/switcher/README.md` — drops a stale `permutations={...}` prop and the removed `SwitcherPermutation` type from the usage example (both vestigial from before the cartesian drop).
- `apps/docs/docs/reference/blocks/hooks.mdx` — "composed permutation ID" → "composed theme ID" in `useActiveTheme()` blurb.
- `apps/docs/docs/reference/addon.mdx` — Globals table: "Composed permutation ID" → "Composed theme ID" for `swatchbookTheme`.
- `apps/docs/docs/developers/architecture.mdx` — `core` row description + the channel-flow narrative.
- `apps/docs/docs/reference/axes.mdx` — `presets` bullet: "handful of permutations" → "handful of themes".
- `apps/docs/docs/reference/config.mdx` — drops a stale reference to `resolver.listPermutations()`; rephrases "permutation-based emission" as "`permutations`-based emission" (literal Terrazzo API name in backticks).
- `apps/docs/docs/guides/sharing-terrazzo-options.mdx` — four prose touch-ups; literal Terrazzo `cssOptions.permutations` field name preserved.

Out of scope (separate PRs):
- Public-surface coverage gaps (`SwatchbookToken`, new core subpaths, `presetTuple`, color-formatting exports).
- Substantive type / shape drift (`TokenMap` shape, `Project.parserInput` removal, `Project` field set, addon hook description, `SwatchbookIntegration` example).

Closes #917

## Test plan
- [x] `grep -rn permutation apps/docs/docs packages/*/README.md` — only the intentional literal Terrazzo field references remain
- [x] No reference to the renamed-and-moved `consuming-the-active-permutation` route (it's already `consuming-the-active-theme.mdx`)