### PR TITLE
docs: cover undocumented public surface

### DIFF
--- a/.changeset/cover-undocumented-public-surface.md
+++ b/.changeset/cover-undocumented-public-surface.md
@@ -1,0 +1,15 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Cover the public-surface exports that shipped without doc entries:
+
+- Three new core subpaths landed in earlier PRs (`/themes`, `/match-path`, `/style-element`) get rows in the "Browser-safe subpaths" table in `core.mdx` and the matching list in `packages/core/README.md`.
+- `SwatchbookToken` interface gets its own type section in `core.mdx`; `TokenMap` is now typed against it instead of leaking `TokenNormalized`.
+- `jointOverrideKey(axes)` gets a one-line entry in the Functions section.
+- `presetTuple(preset, axes, defaults)` from `@unpunnyfuns/swatchbook-switcher` gets a section in `switcher.mdx`.
+- `useOptionalSwatchbookData()` gets a hook entry in `blocks/hooks.mdx` next to `useSwatchbookData`.
+- Color-formatting exports from blocks (`formatColor`, `COLOR_FORMATS`, `ColorFormat`, `FormatColorResult`, `NormalizedColor`) get a section in `blocks/utility.mdx`.
+- `MotionSpeed` type gets a brief block in `blocks/samples.mdx` alongside `MotionSample`.
+
+Docs-only patch bump per the standing snapshot policy.

--- a/apps/docs/docs/reference/blocks/hooks.mdx
+++ b/apps/docs/docs/reference/blocks/hooks.mdx
@@ -16,6 +16,12 @@ Returns the full `ProjectSnapshot` the provider is holding (themes, axes, preset
 
 The snapshot's `listing?: Readonly<Record<string, VirtualTokenListingShape>>` field carries per-token metadata from `@terrazzo/plugin-token-listing` — authoritative CSS variable names (`names.css`), preview values, source file + line references. Empty for layered / plain-parse projects; read-it-when-present, fall back gracefully. Blocks that need a token's CSS var reference should call `resolveCssVar(path, project)` (also re-exported) rather than constructing the var string themselves — it reads the listing first and falls back to `makeCssVar` when a listing entry is missing.
 
+Throws when no `SwatchbookProvider` is mounted above. For code paths that need to handle the no-provider case (MDX doc blocks rendered without a preview decorator, conditional fallbacks), use [`useOptionalSwatchbookData`](#useoptionalswatchbookdata) instead.
+
+## `useOptionalSwatchbookData()`
+
+Returns the `ProjectSnapshot | null` from the nearest `SwatchbookProvider`, or `null` when no provider is mounted. Same shape and reactivity as `useSwatchbookData()`; the only difference is the null sentinel in the absent-provider case. Consumers that prefer to throw can stay on `useSwatchbookData`.
+
 ## `useActiveTheme()`
 
 Returns the current composed theme ID as a string (e.g. `"Dark · Brand A"`).

--- a/apps/docs/docs/reference/blocks/samples.mdx
+++ b/apps/docs/docs/reference/blocks/samples.mdx
@@ -14,7 +14,14 @@ Lower-level than the per-type overview blocks — these render the visual for **
 <MotionSample path="transition.enter" />
 ```
 
-Animated ball + track for one `transition` / `duration` / `cubicBezier`. `speed?: 0.25 | 0.5 | 1 | 2` (default `1`); `runKey?: number` forces a restart when it changes.
+Animated ball + track for one `transition` / `duration` / `cubicBezier`. `speed?: MotionSpeed` (default `1`); `runKey?: number` forces a restart when it changes.
+
+```ts
+import type { MotionSpeed } from '@unpunnyfuns/swatchbook-blocks';
+type MotionSpeed = 0.25 | 0.5 | 1 | 2;
+```
+
+The four allowed playback rates the speed pills surface above the sample track. Re-exported for hosts that want to drive the speed externally.
 
 ## ShadowSample
 

--- a/apps/docs/docs/reference/blocks/utility.mdx
+++ b/apps/docs/docs/reference/blocks/utility.mdx
@@ -67,3 +67,43 @@ if (errors.length > 0) {
   process.exit(1);
 }
 ```
+
+## Color formatting
+
+The color-rendering blocks (`<ColorPalette>`, `<ColorTable>`, `<TokenDetail>`, sub-color fields in `<ShadowPreview>` / `<BorderPreview>` / `<GradientPalette>`) all route through one helper. The helper plus its types are exported from `@unpunnyfuns/swatchbook-blocks` for custom blocks that need to stringify a color the same way.
+
+```ts
+import {
+  formatColor,
+  COLOR_FORMATS,
+  type ColorFormat,
+  type FormatColorResult,
+  type NormalizedColor,
+} from '@unpunnyfuns/swatchbook-blocks';
+
+type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw';
+
+const COLOR_FORMATS: readonly ColorFormat[];
+
+function formatColor(
+  value: unknown,
+  format: ColorFormat,
+  fallback?: string,
+): FormatColorResult;
+
+interface FormatColorResult {
+  /** Display string — e.g. "rgb(59 132 246)" or "#3b82f6". */
+  value: string;
+  /** True when the requested format can't losslessly represent the color. */
+  outOfGamut: boolean;
+}
+```
+
+- `hex` falls back to space-separated `rgb()` for out-of-gamut colors and marks them `outOfGamut: true`; blocks render a ⚠ glyph beside the value.
+- `oklch` is wide-gamut and never marks `outOfGamut`.
+- `raw` returns a compact JSON of the normalized Terrazzo shape — useful for DTCG authors who want to see exactly what the parser stored.
+- `fallback` defaults to `'—'`; pass a custom string when integrating with surfaces that need a different placeholder.
+
+`COLOR_FORMATS` is the runtime list used to validate stored user choices — reach for it when you need to enumerate the formats (toolbar pills, validation) without duplicating the union.
+
+`NormalizedColor` is the shape `formatColor` accepts — a structural copy of Terrazzo's `ColorValueNormalized` (`colorSpace`, `components` / `channels`, `alpha`, optional `hex`). Use it when typing custom block code that produces or consumes the same payload.

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -92,6 +92,14 @@ const css = emitAxisProjectedCss(project);
 
 For production builds, prefer Terrazzo's CLI — `emitAxisProjectedCss` exists primarily for tooling that wants the same emission the addon does.
 
+### `jointOverrideKey(axes)`
+
+```ts
+function jointOverrideKey(axes: Readonly<Record<string, string>>): string;
+```
+
+Canonical stringification of a joint-override's `axes` tuple — `{ mode: 'Dark', brand: 'Brand A' }` becomes `"brand:Brand A|mode:Dark"` (alphabetical-by-axis, pipe-joined `axis:context` pairs). The same key shape `Project.jointOverrides` uses internally; reach for it when you need to look up or compare joint-override entries from outside the loader.
+
 ## Browser-safe subpaths
 
 Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths. Each is tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports — safe to import from preview-side bundles, the Storybook manager, or any browser consumer.
@@ -100,9 +108,12 @@ Leaf utilities consumers need without the loader's Node deps live on dedicated s
 | --- | --- | --- |
 | `/resolve-at` | `buildResolveAt(axes, cells, jointOverrides, defaultTuple)` | Compose tokens for any tuple without the loader. |
 | `/snapshot-for-wire` | `snapshotForWire(project, css)` + `SnapshotForWire` type | JSON-friendly subset of `Project` for cross-boundary transport. |
+| `/themes` | `enumerateThemes({axes, presets, defaultTuple})` + `tupleToName(axes, tuple)` + `ThemeEntry` / `ThemeEnumAxis` / `ThemeEnumPreset` types | Enumerate axis singletons + presets as a unified theme list; compose stable theme IDs from tuples. |
+| `/match-path` | `matchPath(path, filter)` | Glob-style path matcher (`*` single-segment, `**` multi-segment, bare prefix treated as descendants); shared by blocks' filter prop and the MCP `list_tokens` tool. |
 | `/fuzzy` | `fuzzyFilter` + `fuzzyMatches` | uFuzzy-backed token search; powers the MCP `search_tokens` tool. |
 | `/css-var` | `makeCssVar(path, prefix)` | Compose `var(--prefix-path)` strings — same shape Terrazzo's plugin-css emits. |
 | `/data-attr` | `dataAttr(prefix, key)` | Compose `data-prefix-key` attribute names — namespaced to `cssVarPrefix`. |
+| `/style-element` | `ensureStyleElement(elementId, text)` + `SWATCHBOOK_STYLE_ELEMENT_ID` | Idempotent `<style>` injector — shared between the addon's preview decorator and the blocks-side stylesheet path. |
 
 ```ts
 import { buildResolveAt } from '@unpunnyfuns/swatchbook-core/resolve-at';
@@ -370,13 +381,30 @@ type AxisVariancePerAxis = Record<
 type VarianceKind = 'constant' | 'single' | 'multi';
 ```
 
+### `SwatchbookToken`
+
+```ts
+interface SwatchbookToken {
+  $type?: string | undefined;
+  $value?: unknown;
+  $description?: string | undefined;
+  aliasOf?: string | undefined;
+  aliasChain?: readonly string[] | undefined;
+  aliasedBy?: readonly string[] | undefined;
+  /** Per-sub-field alias map for composite tokens; shape varies per `$type`. */
+  partialAliasOf?: unknown;
+}
+```
+
+The seven fields downstream consumers actually read off a resolved token. Structurally compatible with Terrazzo's `TokenNormalized`, so resolver output flows in without casts; carrying the narrower interface means a Terrazzo-side field rename or restructure doesn't ripple onto the swatchbook public surface.
+
 ### `TokenMap`
 
 ```ts
-type TokenMap = Record<string, TokenNormalized>;
+type TokenMap = Record<string, SwatchbookToken>;
 ```
 
-`TokenNormalized` is Terrazzo's per-token shape — see [`@terrazzo/parser`](https://terrazzo.app/) for its fields. Keyed by DTCG flat path (`"color.accent.bg"`).
+Resolved-token map keyed by DTCG flat path (`"color.accent.bg"`). The shape `project.defaultTokens`, `project.resolveAt(tuple)`, and every `cells[axis][context]` cell carry.
 
 ### `ListedToken`
 

--- a/apps/docs/docs/reference/switcher.mdx
+++ b/apps/docs/docs/reference/switcher.mdx
@@ -118,6 +118,20 @@ interface SwitcherPreset {
 
 `SwitcherAxis` and `SwitcherPreset` are structurally compatible with `Project.axes` / `Project.presets` from `@unpunnyfuns/swatchbook-core` — pass them through unchanged. The shapes are re-declared in the switcher package so it stays framework-agnostic and doesn't pull `core` as a runtime dependency.
 
+## `presetTuple(preset, axes, defaults)`
+
+```ts
+function presetTuple(
+  preset: SwitcherPreset,
+  axes: readonly SwitcherAxis[],
+  defaults: Readonly<Record<string, string>>,
+): Record<string, string>;
+```
+
+Compose a preset's sanitized partial tuple with the axis defaults — the omitted axes fall back to their defaults, and any context the preset names that isn't listed on its axis is silently dropped. Mirrors the preview decorator's own fallback logic so what a host sends out matches what the preview honors.
+
+The Storybook addon's manager toolbar imports this directly to avoid carrying a byte-identical local copy; other hosts that apply presets through their own pathway are welcome to.
+
 ## Axis-state propagation
 
 The component is *pure*: it reads its inputs, draws the menu, and calls back when the user clicks. It does not:

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -40,9 +40,12 @@ Leaf utilities consumers need without the loader's Node deps live on dedicated s
 
 - `@unpunnyfuns/swatchbook-core/resolve-at` — `buildResolveAt(axes, cells, jointOverrides, defaultTuple)`
 - `@unpunnyfuns/swatchbook-core/snapshot-for-wire` — `snapshotForWire(project, css)` + `SnapshotForWire` type
+- `@unpunnyfuns/swatchbook-core/themes` — `enumerateThemes({axes, presets, defaultTuple})` + `tupleToName(axes, tuple)` + `ThemeEntry` type
+- `@unpunnyfuns/swatchbook-core/match-path` — `matchPath(path, filter)` glob-style matcher (`*` / `**`)
 - `@unpunnyfuns/swatchbook-core/fuzzy` — uFuzzy-backed token search
 - `@unpunnyfuns/swatchbook-core/css-var` — `makeCssVar(path, prefix)`
 - `@unpunnyfuns/swatchbook-core/data-attr` — `dataAttr(prefix, key)`
+- `@unpunnyfuns/swatchbook-core/style-element` — `ensureStyleElement(id, text)` + `SWATCHBOOK_STYLE_ELEMENT_ID`
 
 ## Boundaries
 


### PR DESCRIPTION
## Summary
Second of three thematic doc-audit PRs after #918's vocab sweep. Closes the gaps between exported surface and documented surface.

**Subpaths table (`core.mdx` + `packages/core/README.md`)** — three subpaths landed in earlier PRs without doc entries; rows added:

- `/themes` — `enumerateThemes` + `tupleToName` + `ThemeEntry` / `ThemeEnumAxis` / `ThemeEnumPreset` (PR #899)
- `/match-path` — `matchPath(path, filter)` (PR #898)
- `/style-element` — `ensureStyleElement` + `SWATCHBOOK_STYLE_ELEMENT_ID` (PR #902)

**New type / function sections:**

- `SwatchbookToken` interface (PR #903) — its own type section in `core.mdx`; `TokenMap` is now typed against it instead of leaking `TokenNormalized`.
- `jointOverrideKey(axes)` — short Functions entry covering the canonical key shape (`brand:Brand A|mode:Dark`).
- `presetTuple(preset, axes, defaults)` from switcher (PR #902) — section in `switcher.mdx`.
- `useOptionalSwatchbookData()` — hook entry in `blocks/hooks.mdx` beside `useSwatchbookData` (the throwing variant gets a forward-reference to this null-returning sibling).
- Color-formatting exports from blocks — `formatColor`, `COLOR_FORMATS`, `ColorFormat`, `FormatColorResult`, `NormalizedColor` — full section in `blocks/utility.mdx`.
- `MotionSpeed` type — short block in `blocks/samples.mdx` beside `MotionSample`.

PR 3 follows with the substantive type-shape drift fixes (architecture.mdx `Project` shape, addon hook description, `SwatchbookIntegration` example).

Closes #919

## Test plan
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 turbo tasks green
- [x] Cross-checked each new doc entry against the actual export — `jointOverrideKey`'s canonical-key example matches `canonicalKey` in `tuple-key.ts` (`brand:Brand A|mode:Dark`); `presetTuple` signature mirrors `packages/switcher/src/preset-tuple.ts`; subpath descriptions match what the modules actually export.