### PR TITLE
docs: drift fixes from doc audit

### DIFF
--- a/.changeset/docs-drift-fixes.md
+++ b/.changeset/docs-drift-fixes.md
@@ -1,0 +1,12 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Doc-audit drift fixes (third of three thematic PRs after #918 and #920):
+
+- `core.mdx` + `core/README.md` "Boundaries" / "Do / don't" — rewrite the stale `parserInput`-references-the-AST line. `parserInput` no longer ships on `Project` (removed in #901); the real reason not to ship `Project` to the browser is that `resolveAt` is a function, `varianceByPath` is a Map, and `cwd` is a Node-side absolute path.
+- `core.mdx` `SwatchbookIntegration` example — add the previously-omitted `autoInject?: boolean` field with its documented semantics.
+- `architecture.mdx` `Project` inline shape — add the missing `listing: TokenListingByPath` field.
+- `addon.mdx` block-side hooks section — soften the wrong "not re-exported from the addon" claim; the addon's main entry does `export * from blocks` + `from switcher`, so block-side hooks are reachable from `@unpunnyfuns/swatchbook-addon` directly.
+- `addon/src/index.ts` — actually export the addon-namespace constants (`ADDON_ID`, `AXES_GLOBAL_KEY`, `COLOR_FORMAT_GLOBAL_KEY`, `PARAM_KEY`, `TOOL_ID`, `VIRTUAL_MODULE_ID`) that `addon.mdx`'s "Exported constants" section claimed were importable but weren't. `TOOL_ID` added to the doc list.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -54,6 +54,7 @@ interface Project {
   varianceByPath: ReadonlyMap<string, AxisVarianceResult>; // O(1) per-token variance lookup
   sourceFiles: string[];       // every file that fed the build (for watchers)
   cwd: string;                 // loader cwd — config-relative paths resolve here
+  listing: TokenListingByPath; // per-token plugin-token-listing data: names.<platform>, previewValue, source
   diagnostics: Diagnostic[];   // parser / validator / resolver findings
 }
 ```

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -104,7 +104,7 @@ Paths autocomplete from the generated `.swatchbook/tokens.d.ts`. Add `"include":
 
 ### Block-side hooks live in `@unpunnyfuns/swatchbook-blocks`
 
-`useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the contexts that back them (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) are exported from `@unpunnyfuns/swatchbook-blocks` — see the [blocks reference](./blocks/index.mdx). They are **not** re-exported from the addon; import them from blocks.
+`useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the contexts that back them (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) live canonically in `@unpunnyfuns/swatchbook-blocks` — see the [blocks reference](./blocks/index.mdx). They're also re-exported from the addon's main entry (`import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon'` works) so consumers picking up the addon don't need a separate blocks dependency for the common hook surface.
 
 The preview decorator mounts a `SwatchbookProvider` (from blocks) that populates every context, so the hooks resolve wherever the addon is registered.
 
@@ -114,7 +114,9 @@ The preview decorator mounts a `SwatchbookProvider` (from blocks) that populates
 import {
   ADDON_ID,
   AXES_GLOBAL_KEY,
+  COLOR_FORMAT_GLOBAL_KEY,
   PARAM_KEY,
+  TOOL_ID,
   VIRTUAL_MODULE_ID,
 } from '@unpunnyfuns/swatchbook-addon';
 ```

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -304,6 +304,12 @@ interface SwatchbookIntegration {
   virtualModule?: {
     virtualId: string;                 // e.g. 'virtual:swatchbook/tailwind.css'
     render(project: Project): string;  // produce the module body
+    /** When `true`, the addon's preset auto-injects `import '<virtualId>';`
+     * into the preview bundle. Appropriate for integrations contributing
+     * global CSS (Tailwind's `@theme` block, a rules-heavy stylesheet).
+     * Leave `false` (default) when consumers import named exports from
+     * the virtual module per-site. */
+    autoInject?: boolean;
   };
 }
 ```
@@ -395,4 +401,4 @@ The shape of `project.resolveAt` — also returned by `buildResolveAt()` from th
 - ✅ Use this package at build time — Node scripts, SSR, Storybook presets. It has no DOM dependency.
 - ✅ Ship `project.cells` / `project.jointOverrides` / `project.defaultTokens` to the browser via the [`/snapshot-for-wire`](#browser-safe-subpaths) subpath — that's exactly what the addon's preview does.
 - ❌ Don't import from `@terrazzo/parser` directly unless you need features core doesn't expose.
-- ❌ Don't ship the full `Project` object to the browser — `parserInput` carries the raw Terrazzo AST. Use `snapshotForWire(project, css)` to get a JSON-friendly subset.
+- ❌ Don't ship the full `Project` object to the browser — `resolveAt` is a function, `varianceByPath` is a Map, and `cwd` is a Node-side absolute path. Use `snapshotForWire(project, css)` to get a JSON-friendly subset.

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -4,6 +4,21 @@ import * as previewExports from '#/preview.tsx';
 export type { AddonOptions } from '#/options.ts';
 
 /**
+ * Public namespace constants — addon ID, parameter / global keys, the
+ * canonical virtual module ID. Useful for consumer code that needs to
+ * reach into the addon's namespace (custom toolbar registrations,
+ * channel events, manager hooks that need a stable handle on these keys).
+ */
+export {
+  ADDON_ID,
+  AXES_GLOBAL_KEY,
+  COLOR_FORMAT_GLOBAL_KEY,
+  PARAM_KEY,
+  TOOL_ID,
+  VIRTUAL_MODULE_ID,
+} from '#/constants.ts';
+
+/**
  * Re-export the full user-facing surface from `@unpunnyfuns/swatchbook-blocks`
  * and `@unpunnyfuns/swatchbook-switcher` so consumers can
  * `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'`

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,7 +49,7 @@ Leaf utilities consumers need without the loader's Node deps live on dedicated s
 - ✅ Build-time use — Node, scripts, SSR, Storybook presets.
 - ✅ Pair with [Terrazzo](https://terrazzo.app/)'s CLI for production artifact emission (CSS / JS / Tailwind / Swift / Sass / …).
 - ✅ Ship `project.cells` / `project.jointOverrides` / `project.defaultTokens` to the browser via the `snapshot-for-wire` subpath — that's exactly what the addon's preview does.
-- ❌ Don't ship the full `Project` object to the browser. `parserInput` carries the raw Terrazzo AST; use `snapshotForWire(project, css)` to get a JSON-friendly subset.
+- ❌ Don't ship the full `Project` object to the browser. `resolveAt` is a function, `varianceByPath` is a Map, and `cwd` is a Node-side absolute path; use `snapshotForWire(project, css)` to get a JSON-friendly subset.
 - ❌ Don't reach into `@terrazzo/parser` directly. Stay on the core surface so upgrades don't churn your code.
 
 ## Credits


### PR DESCRIPTION
## Summary
Third of three thematic doc-audit PRs after #918 (vocab sweep) and #920 (undocumented public-surface coverage). Substantive type / shape drift fixes.

- `core.mdx` + `core/README.md` Boundaries / Do-Don't — drop the stale "parserInput references the AST" line. `parserInput` no longer ships on `Project` (removed in PR #901). The real reason not to ship `Project` to the browser is that `resolveAt` is a function, `varianceByPath` is a `Map`, and `cwd` is a Node-side absolute path. Reframed accordingly.
- `core.mdx` `SwatchbookIntegration` example — add the previously omitted `autoInject?: boolean` field with its documented semantics (auto-inject a side-effect import for integrations that contribute global CSS).
- `architecture.mdx` `Project` inline shape — add the missing `listing: TokenListingByPath` field.
- `addon.mdx` block-side hooks section — soften the inaccurate "not re-exported from the addon" claim. The addon's main entry does `export * from blocks` + `from switcher`, so block-side hooks (`useActiveTheme`, etc.) reach via `@unpunnyfuns/swatchbook-addon` directly.
- `addon/src/index.ts` — actually export `ADDON_ID`, `AXES_GLOBAL_KEY`, `COLOR_FORMAT_GLOBAL_KEY`, `PARAM_KEY`, `TOOL_ID`, `VIRTUAL_MODULE_ID`. The addon docs have been documenting these as importable from the main entry, but `index.ts` didn't re-export them. Documented behavior is the contract; aligning the code is the fix. `TOOL_ID` (previously absent from docs) added to the doc list.

Closes #921

## Test plan
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 turbo tasks green
- [x] `pnpm --filter swatchbook-addon build && pnpm --filter swatchbook-storybook build:storybook` — both clean post-export-additions
- [x] Confirmed the new exports go through the addon's `dist/index.mjs` (so the `import { ADDON_ID } from '@unpunnyfuns/swatchbook-addon'` pattern docs document now actually works)