### PR TITLE
fix(a11y): drop literal backticks from MotionSample reduced-motion prose

### DIFF
--- a/.changeset/a11y-motion-sample-prose.md
+++ b/.changeset/a11y-motion-sample-prose.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+`<MotionSample>`'s reduced-motion fallback prose wrapped the CSS media query in literal backticks (`Animation suppressed by \`prefers-reduced-motion: reduce\`.`). Screen-readers read the backticks aloud verbatim. Wrap the identifier in `<code>` instead — readable in print, parsed as a code-span by SR voicing.

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ npm-debug.log*
 pnpm-debug.log*
 .vitest-attachments/
 __screenshots__/
+
+# Superpowers local working artifacts (specs/plans not meant to ship)
+docs/superpowers/

--- a/packages/blocks/src/motion-preview/MotionSample.tsx
+++ b/packages/blocks/src/motion-preview/MotionSample.tsx
@@ -163,7 +163,7 @@ export function MotionSample({ path, speed = 1, runKey = 0 }: MotionSampleProps)
   if (reducedMotion) {
     return (
       <div style={styles.reducedMotion}>
-        Animation suppressed by `prefers-reduced-motion: reduce`.
+        Animation suppressed by <code>prefers-reduced-motion: reduce</code>.
       </div>
     );
   }


### PR DESCRIPTION
## Summary
`<MotionSample>`'s reduced-motion fallback wrapped \`prefers-reduced-motion: reduce\` in literal markdown-style backticks. Screen-readers read those backticks aloud verbatim ('backtick prefers-reduced-motion: reduce backtick'). Wrapping the identifier in `<code>` instead gets the same monospace visual + clean SR voicing as a code-span.

Closes #934

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green
- [x] No regression: the static fallback only renders under \`prefers-reduced-motion\` or Chromatic; the live animation path is unchanged.