### PR TITLE
refactor(core): tighten Project type surface

### DIFF
--- a/.changeset/project-surface-tightening.md
+++ b/.changeset/project-surface-tightening.md
@@ -1,0 +1,17 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Tighten the canonical `Project` type surface — pre-1.0 readonly + closed-set narrowing pass.
+
+- `Project.chrome: Record<string, string>` → `Partial<Record<ChromeRole, string>>`. The `validateChrome` loader already enforces keys ∈ `CHROME_ROLES` at runtime; the type now reflects it. Same on `CommonConfig.chrome`.
+- `Project.axes: Axis[]` → `readonly Axis[]`. Matches the existing `readonly` on sibling fields (`disabledAxes`, `presets`); post-load the array is immutable in practice.
+- `Project.sourceFiles: string[]` → `readonly string[]`. Same rationale.
+- `SnapshotForWire.varianceByPath` drops the `ReturnType<Project['varianceByPath']['get']>` indirection (which carries an unused `| undefined`) for the direct `Record<string, AxisVarianceResult>` it always actually is.
+- `Permutation.input: Record<string, string>` → `Readonly<Record<string, string>>`. Internal `@internal` field; readonly matches its consumer pattern.
+- Added `never` exhaustiveness `default:` branches to two switches over closed unions: `axisTouchesToken` over `VarianceInfo` (`packages/core/src/css-axis-projected.ts`) and `AxisVariance`'s render switch over `AxisVarianceResult` (`packages/blocks/src/token-detail/AxisVariance.tsx`). A future variant lands and these throw loudly at runtime instead of falling through silently.
+- Aligned `addon/channel-types.ts` `VirtualToken` with `blocks/contexts.ts` `VirtualTokenShape` — added the missing `aliasOf` / `aliasChain` / `aliasedBy` / `partialAliasOf` fields so what ships over the channel matches what blocks expect to read.
+
+Closes #940

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ npm-debug.log*
 pnpm-debug.log*
 .vitest-attachments/
 __screenshots__/
+
+# Superpowers local working artifacts (specs/plans not meant to ship)
+docs/superpowers/

--- a/packages/addon/src/channel-types.ts
+++ b/packages/addon/src/channel-types.ts
@@ -28,9 +28,19 @@ export type VirtualPreset = Preset;
 export type VirtualDiagnostic = Diagnostic;
 
 export interface VirtualToken {
-  $type?: string;
+  $type?: string | undefined;
   $value?: unknown;
-  $description?: string;
+  $description?: string | undefined;
+  aliasOf?: string | undefined;
+  aliasChain?: readonly string[] | undefined;
+  aliasedBy?: readonly string[] | undefined;
+  /**
+   * Per-sub-field alias map for composite tokens — same shape as
+   * `blocks/contexts.ts`'s `VirtualTokenShape.partialAliasOf`. Typed as
+   * `unknown` because the structure varies per composite `$type`; the
+   * block narrows it at the consumer.
+   */
+  partialAliasOf?: unknown;
 }
 
 /**

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -48,6 +48,10 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
         return { kind: 'one-axis', axis: result.axis, varyingAxes: result.varyingAxes };
       case 'multi':
         return { kind: 'multi-axis', varyingAxes: result.varyingAxes };
+      default: {
+        const exhaustive: never = result;
+        throw new Error(`unhandled AxisVarianceResult kind: ${JSON.stringify(exhaustive)}`);
+      }
     }
   }, [path, varianceByPath]);
 

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -197,6 +197,10 @@ function axisTouchesToken(axisName: string, info: VarianceInfo | undefined): boo
     case 'orthogonal-after-probe':
     case 'joint-variant':
       return info.touching.has(axisName);
+    default: {
+      const exhaustive: never = info;
+      throw new Error(`unhandled VarianceInfo kind: ${JSON.stringify(exhaustive)}`);
+    }
   }
 }
 

--- a/packages/core/src/snapshot-for-wire.ts
+++ b/packages/core/src/snapshot-for-wire.ts
@@ -25,7 +25,7 @@
  * import-resolution constraints.
  */
 import type { ListedToken } from '#/token-listing.ts';
-import type { JointOverrides, Project } from '#/types.ts';
+import type { AxisVarianceResult, JointOverrides, Project } from '#/types.ts';
 
 /**
  * Slimmed `ListedToken` — the three fields blocks actually consume.
@@ -59,7 +59,7 @@ export interface SnapshotForWire {
   listing: Readonly<Record<string, SlimListedToken>>;
   cells: Project['cells'];
   jointOverrides: JointOverrides;
-  varianceByPath: Record<string, ReturnType<Project['varianceByPath']['get']>>;
+  varianceByPath: Record<string, AxisVarianceResult>;
   defaultTuple: Project['defaultTuple'];
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,6 +2,7 @@ import type { InputSourceWithDocument } from '@terrazzo/json-schema-tools';
 import type { Plugin, Resolver, TokenNormalized } from '@terrazzo/parser';
 import type { CSSPluginOptions } from '@terrazzo/plugin-css';
 import type { TokenListingPluginOptions } from '@terrazzo/plugin-token-listing';
+import type { ChromeRole } from '#/chrome.ts';
 import type { TokenListingByPath } from '#/token-listing.ts';
 
 /**
@@ -149,7 +150,7 @@ export type ResolveAt = (tuple: Record<string, string>) => TokenMap;
 export interface Permutation {
   name: string;
   /** The resolver input tuple (e.g. `{ theme: 'Light' }` or `{ mode: 'Dark', brand: 'Brand A' }`). */
-  input: Record<string, string>;
+  input: Readonly<Record<string, string>>;
   /** Source files this tuple was parsed from (layered loader populates; resolver mode leaves empty). */
   sources: readonly string[];
 }
@@ -238,7 +239,7 @@ interface CommonConfig {
    * `swatchbook/chrome`) and are dropped. Without a chrome map, blocks
    * fall back to the `Canvas` / `CanvasText` system colors.
    */
-  chrome?: Record<string, string>;
+  chrome?: Partial<Record<ChromeRole, string>>;
   /**
    * Options forwarded to the `@terrazzo/plugin-css` instance swatchbook
    * runs internally (for the stylesheet it emits and for the Token
@@ -349,7 +350,7 @@ export interface Diagnostic {
  */
 export interface Project {
   config: Config;
-  axes: Axis[];
+  axes: readonly Axis[];
   /**
    * Axis names suppressed via `config.disabledAxes`. Validated against the
    * resolver's axis list at load time — unknown names are dropped here and
@@ -361,12 +362,13 @@ export interface Project {
   /** Validated + sanitized presets from `config.presets`. Empty if unset. */
   presets: readonly Preset[];
   /**
-   * Validated chrome-alias map from `config.chrome`. Keys are swatchbook
-   * block chrome paths; values are token paths that resolve in at least
-   * one permutation. Invalid entries from the raw config are dropped and
-   * reported as diagnostics. Empty if the config doesn't supply any.
+   * Validated chrome-alias map from `config.chrome`. Keys are members
+   * of the closed `ChromeRole` set; values are token paths that resolve
+   * in at least one permutation. Invalid entries from the raw config
+   * are dropped and reported as diagnostics. Empty when the config
+   * doesn't supply any.
    */
-  chrome: Record<string, string>;
+  chrome: Partial<Record<ChromeRole, string>>;
   /** Resolved tokens at the project's default tuple. Convenience for global views. */
   defaultTokens: TokenMap;
   /**
@@ -411,7 +413,7 @@ export interface Project {
    * the plain-parse fallback consumed. Consumers use this for file-watching
    * (the addon's Vite plugin does exactly that).
    */
-  sourceFiles: string[];
+  sourceFiles: readonly string[];
   /**
    * Absolute path of the directory all config-relative paths (resolver,
    * token globs, layered overlays) resolved against. Passed into


### PR DESCRIPTION
## Summary
Pre-1.0 readonly + closed-set narrowing pass on the canonical `Project` type surface in `packages/core/src/types.ts`. Each item is a one-line type change; ripple effects are minimal (validators already enforce the runtime invariants the types now reflect).

- `Project.chrome: Record<string, string>` → `Partial<Record<ChromeRole, string>>` — `validateChrome` already enforces keys ∈ `CHROME_ROLES`. Same on `CommonConfig.chrome`.
- `Project.axes: Axis[]` → `readonly Axis[]` — matches the existing `readonly` on sibling fields (`disabledAxes`, `presets`).
- `Project.sourceFiles: string[]` → `readonly string[]` — same rationale.
- `SnapshotForWire.varianceByPath` drops the `ReturnType<Project['varianceByPath']['get']>` indirection (which carried an unused `| undefined`) for the direct `Record<string, AxisVarianceResult>` it always actually is.
- `Permutation.input: Record<string, string>` → `Readonly<Record<string, string>>` — `@internal` field; readonly matches consumer usage.

Plus two related touches:

- `never`-exhaustiveness `default:` branches on two switches over closed unions: `axisTouchesToken` over `VarianceInfo` (`css-axis-projected.ts`) and the `AxisVariance` block's render switch over `AxisVarianceResult`. Future variant lands → throw loudly at runtime instead of falling through.
- Aligned `addon/channel-types.ts` `VirtualToken` with `blocks/contexts.ts` `VirtualTokenShape` — added the missing `aliasOf` / `aliasChain` / `aliasedBy` / `partialAliasOf` fields so what the channel ships matches what blocks read.

Also includes the `.gitignore` entry for `docs/superpowers/` (also shipped in #944 — innocuous if both land).

Closes #940

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green
- [x] \`pnpm --filter swatchbook-storybook build:storybook\` — manager + preview bundles resolve clean