### PR TITLE
feat(a11y): live regions for CopyButton + search match-count

### DIFF
--- a/.changeset/a11y-live-regions.md
+++ b/.changeset/a11y-live-regions.md
@@ -1,0 +1,12 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Add `aria-live` polite live regions for status transitions that were previously visual-only:
+
+- `<CopyButton>` — copy success transition. The icon variant's `✓` glyph is `aria-hidden`; the new sr-only live region announces "Copied" for SR users.
+- `<TokenTable>` + `<TokenNavigator>` — search match-count. The caption text already updates visually, but `<caption>` isn't re-announced by AT mid-interaction. New sr-only live regions announce `N tokens matching "<query>"` as the user types.
+
+Each component carries its own component-namespaced sr-only utility class (`__sr-status` / `__sr-only`) following the existing pattern in `ColorTable`. A future tidy could extract a shared utility.
+
+Audited finding from #932 scoped to the two clear wins; theme/axis-flip page-level announcements are deferred — that wants a debounced single live region in the addon preview decorator and rises above this PR's risk envelope. Gamut warnings already carry `aria-label="out of gamut"` everywhere (`TokenDetail`, `TokenTable`, `ColorPalette`, `ColorTable`); audit's finding there was outdated.

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -148,3 +148,16 @@
   display: inline-block;
   width: 80px;
 }
+
+/* Screen-reader-only live region for search match-count announcements. */
+.sb-token-navigator__sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -474,6 +474,11 @@ export function TokenNavigator({
         {typeLabel}
         {trimmedQuery !== '' ? ` · ${matchCount} matching "${trimmedQuery}"` : ''} · {activeTheme}
       </div>
+      {searchable && (
+        <span role="status" aria-live="polite" className="sb-token-navigator__sr-status">
+          {trimmedQuery !== '' ? `${matchCount} tokens matching "${trimmedQuery}"` : ''}
+        </span>
+      )}
       {visibleTree.length === 0 ? (
         <div className="sb-block__empty">No tokens match "{trimmedQuery}".</div>
       ) : (

--- a/packages/blocks/src/TokenTable.css
+++ b/packages/blocks/src/TokenTable.css
@@ -133,3 +133,16 @@
 .sb-token-table__row:focus-within .sb-token-table__copy-wrap {
   opacity: 1;
 }
+
+/* Screen-reader-only live region for search match-count announcements. */
+.sb-token-table__sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -132,6 +132,13 @@ export function TokenTable({
           />
         </div>
       )}
+      {searchable && (
+        <span role="status" aria-live="polite" className="sb-token-table__sr-status">
+          {query.trim() !== ''
+            ? `${visibleRows.length} of ${rows.length} tokens match "${query.trim()}"`
+            : ''}
+        </span>
+      )}
       <table className="sb-token-table__table">
         <caption className="sb-token-table__caption">{captionText}</caption>
         <thead>

--- a/packages/blocks/src/internal/CopyButton.css
+++ b/packages/blocks/src/internal/CopyButton.css
@@ -43,3 +43,16 @@
 .sb-copy-button--copied {
   color: var(--swatchbook-accent-default, Highlight);
 }
+
+/* Screen-reader-only live region: visually hidden, still announced by AT. */
+.sb-copy-button__sr-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/packages/blocks/src/internal/CopyButton.tsx
+++ b/packages/blocks/src/internal/CopyButton.tsx
@@ -57,21 +57,28 @@ export function CopyButton({
   if (className) classes.push(className);
 
   return (
-    <button
-      type="button"
-      className={classes.join(' ')}
-      onClick={handleClick}
-      aria-label={ariaLabel}
-      title={ariaLabel}
-      data-copied={copied ? 'true' : undefined}
-    >
-      {variant === 'text' ? (
-        <span className="sb-copy-button__text">{copied ? 'Copied' : 'Copy'}</span>
-      ) : (
-        <span className="sb-copy-button__glyph" aria-hidden>
-          {copied ? '✓' : '⧉'}
-        </span>
-      )}
-    </button>
+    <>
+      <button
+        type="button"
+        className={classes.join(' ')}
+        onClick={handleClick}
+        aria-label={ariaLabel}
+        title={ariaLabel}
+        data-copied={copied ? 'true' : undefined}
+      >
+        {variant === 'text' ? (
+          <span className="sb-copy-button__text">{copied ? 'Copied' : 'Copy'}</span>
+        ) : (
+          <span className="sb-copy-button__glyph" aria-hidden>
+            {copied ? '✓' : '⧉'}
+          </span>
+        )}
+      </button>
+      {/* Polite live region announces the transition to SR users — the
+          icon variant's "✓ Copied" cue is otherwise visual-only. */}
+      <span role="status" aria-live="polite" className="sb-copy-button__sr-status">
+        {copied ? 'Copied' : ''}
+      </span>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Add \`aria-live\` polite live regions for status transitions previously visual-only.

- **\`<CopyButton>\`** — the icon variant's \`✓\` glyph cue is \`aria-hidden\` (the glyph is decorative); the new sr-only live region announces \"Copied\" for SR users.
- **\`<TokenTable>\` + \`<TokenNavigator>\`** — search match-count. The caption text already updates visually, but \`<caption>\` isn't re-announced by AT mid-interaction. New sr-only live regions speak \`N tokens matching \"<query>\"\` on each keystroke.

Each component carries its own component-namespaced sr-only utility class (\`__sr-status\`) following the existing pattern in \`ColorTable\`. A future tidy could extract a shared utility — noted as a nit, not a blocker.

**Scoped down from the audit finding:**
- Theme/axis-flip page-level announcements **deferred** — that finding wants a debounced single live region in the addon preview decorator, which is broader scope than this PR. Worth a follow-up.
- Gamut warnings: the audit said they had no status text, but all four sites (\`TokenDetail\`, \`TokenTable\`, \`ColorPalette\`, \`ColorTable\`) already carry \`aria-label=\"out of gamut\"\` on the \`⚠\` span. The audit was outdated; no change needed.

Closes #932

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green
- [ ] Browser smoke (manual): VO/NVDA pass through CopyButton + TokenTable / TokenNavigator search to confirm the live regions announce