### PR TITLE
fix(a11y): align toolbar haspopup, restore pill focus, announce diagnostic severity

### DIFF
--- a/.changeset/a11y-theme-switcher-widget.md
+++ b/.changeset/a11y-theme-switcher-widget.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Three small ThemeSwitcher / addon-toolbar / Diagnostics a11y touches bundled.
+
+- **Addon toolbar `aria-haspopup`** — was `"dialog"` but the switcher body renders `role="group"` (settings panel, not modal dialog). Promised more than the popover delivered; switched to generic `aria-haspopup={true}` so the trigger announces "has popup" without claiming a dialog flavour that doesn't match.
+- **ThemeSwitcher `OptionPill`** — dropped `onMouseDown={(e) => e.preventDefault()}`. The preventDefault stripped focus on mouse-click so subsequent Tab restarted at the manager toolbar instead of the just-clicked pill, hurting keyboard users alternating mouse + Tab. The pill's `:focus-visible` ring already gates ring-on-mouse, so removing preventDefault doesn't bring back sticky focus rings for normal users.
+- **Diagnostics severity SR distinction** — explicit `role="list"` on the diagnostics `<ul>` (CSS-styled lists can shed list semantics in some AT combos), `aria-hidden` on the redundant severity-label span, and `aria-label="<severity>: <message>"` on each row so SR users hear "Error: <message>" / "Warning: <message>" / "Info: <message>" as one announcement unit.

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -229,8 +229,14 @@ function AxesToolbar(): ReactElement {
        * Storybook's `WithTooltip` with a dynamically-generated id we
        * don't have a stable handle on; `aria-haspopup` + `aria-expanded`
        * is the practical subset of the disclosure pattern.
+       *
+       * `aria-haspopup="true"` (generic) rather than `"dialog"`: the
+       * switcher body is `role="group"` (it's a settings panel of
+       * independent controls, not a modal dialog), so promising
+       * `"dialog"` would misalign the trigger with what AT finds when
+       * focus enters the popover.
        */
-      'aria-haspopup': 'dialog' as const,
+      'aria-haspopup': true as const,
       'aria-expanded': open,
     },
     h(SwatchbookIcon),

--- a/packages/blocks/src/Diagnostics.tsx
+++ b/packages/blocks/src/Diagnostics.tsx
@@ -71,13 +71,18 @@ export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
           {headingText}
         </summary>
         {diagnostics.length > 0 && (
-          <ul className="sb-diagnostics__list">
+          <ul role="list" className="sb-diagnostics__list">
             {diagnostics.map((d, i) => (
-              <li key={diagnosticKey(d, i)} className="sb-diagnostics__row">
+              <li
+                key={diagnosticKey(d, i)}
+                className="sb-diagnostics__row"
+                aria-label={`${severityLabel[d.severity]}: ${d.message}`}
+              >
                 <span
                   className={cx('sb-diagnostics__label', {
                     [`sb-diagnostics__label--${d.severity}`]: d.severity !== 'info',
                   })}
+                  aria-hidden
                 >
                   {severityLabel[d.severity]}
                 </span>

--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -110,11 +110,6 @@ function OptionPill({ label, active, title, onClick, trailing }: OptionPillProps
       type="button"
       title={title}
       onClick={onClick}
-      // Skip focus on mouse click so host permutations that paint a :focus
-      // border-color don't stick it on the previously-clicked pill.
-      // Keyboard tabbing still lands focus normally; only preventDefault
-      // on mousedown blocks the implicit focus-on-click behavior.
-      onMouseDown={(event) => event.preventDefault()}
       className={cx('sb-switcher__pill', active && 'sb-switcher__pill--active')}
     >
       {label}


### PR DESCRIPTION
## Summary
Three small adjacent a11y touches bundled per audit finding #933.

- **Addon toolbar \`aria-haspopup\`** — was \`\"dialog\"\` but the switcher body renders \`role=\"group\"\` (settings panel, not modal dialog). Promised more than the popover delivers; switched to generic \`aria-haspopup={true}\`.
- **ThemeSwitcher \`OptionPill\`** — dropped \`onMouseDown={(e) => e.preventDefault()}\`. The preventDefault stripped focus on mouse-click so subsequent Tab restarted at the manager toolbar. The pill's \`:focus-visible\` rule already gates ring-on-mouse, so no sticky-ring regression for normal users.
- **Diagnostics severity SR distinction** — explicit \`role=\"list\"\` on the diagnostics \`<ul>\` (CSS-styled lists can shed list semantics in some AT/browser combos), \`aria-hidden\` on the redundant visual severity-label span, and \`aria-label=\"<severity>: <message>\"\` on each row so SR users hear \"Error: <message>\" / \"Warning: <message>\" / \"Info: <message>\" as one announcement unit.

Closes #933

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green
- [ ] Browser smoke (manual): VO/NVDA confirm the toolbar trigger announces "popup, collapsed/expanded" without claiming dialog; SR reads each diagnostic row with severity prefix