### PR TITLE
fix(a11y): add disclosure semantics to TokenTable + ColorTable rows

### DIFF
--- a/.changeset/a11y-table-row-disclosure.md
+++ b/.changeset/a11y-table-row-disclosure.md
@@ -7,6 +7,6 @@ Add disclosure semantics to clickable `<TokenTable>` rows and `<ColorTable>` gro
 - `<TokenTable>` rows already carry `tabIndex={0}` + `aria-label="Inspect <path>"` + Enter/Space activation; they now also carry `aria-haspopup="dialog"` so SR users hear the row will open a dialog before activating.
 - `<ColorTable>` group rows split by mode:
   - When `onSelect` is set (consumer owns the follow-up UI), the row carries `aria-haspopup="dialog"` — same as TokenTable.
-  - In the default in-place-expand mode, the row carries `aria-expanded={expanded}` + `aria-controls={detailId}` pointing at the detail `<tr>` (now also id'd) so SR users hear the row's expand/collapse state + can jump to the panel.
+  - In the default in-place-expand mode, the row's `aria-label` already rotates between `"Expand <base>"` and `"Collapse <base>"` to communicate state. No additional ARIA: `aria-expanded` on `<tr>` is invalid outside a `treegrid`, and the row isn't a popup trigger.
 
 `<tr>` elements keep their table-row semantics; the ARIA attributes layer disclosure cues on top without replacing roles.

--- a/.changeset/a11y-table-row-disclosure.md
+++ b/.changeset/a11y-table-row-disclosure.md
@@ -1,0 +1,12 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Add disclosure semantics to clickable `<TokenTable>` rows and `<ColorTable>` group rows.
+
+- `<TokenTable>` rows already carry `tabIndex={0}` + `aria-label="Inspect <path>"` + Enter/Space activation; they now also carry `aria-haspopup="dialog"` so SR users hear the row will open a dialog before activating.
+- `<ColorTable>` group rows split by mode:
+  - When `onSelect` is set (consumer owns the follow-up UI), the row carries `aria-haspopup="dialog"` — same as TokenTable.
+  - In the default in-place-expand mode, the row carries `aria-expanded={expanded}` + `aria-controls={detailId}` pointing at the detail `<tr>` (now also id'd) so SR users hear the row's expand/collapse state + can jump to the panel.
+
+`<tr>` elements keep their table-row semantics; the ARIA attributes layer disclosure cues on top without replacing roles.

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -272,7 +272,6 @@ function GroupRow({
     else onToggleExpand(group.base);
   };
 
-  const detailId = `sb-color-table-detail-${group.base.replaceAll('.', '-')}`;
   return (
     <>
       <tr
@@ -294,9 +293,7 @@ function GroupRow({
               ? `Collapse ${group.base}`
               : `Expand ${group.base}`
         }
-        {...(onSelect
-          ? { 'aria-haspopup': 'dialog' as const }
-          : { 'aria-expanded': expanded, 'aria-controls': detailId })}
+        {...(onSelect ? { 'aria-haspopup': 'dialog' as const } : {})}
         data-testid="color-table-row"
         data-path={active.path}
         data-base={group.base}
@@ -370,7 +367,7 @@ function GroupRow({
         </td>
       </tr>
       {expanded && !onSelect && (
-        <tr className="sb-color-table__detail-row" id={detailId} data-testid="color-table-detail">
+        <tr className="sb-color-table__detail-row" data-testid="color-table-detail">
           <td colSpan={COLUMN_COUNT} className="sb-color-table__td sb-color-table__detail-cell">
             <ExpandedDetail group={group} active={active} />
           </td>

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -272,6 +272,7 @@ function GroupRow({
     else onToggleExpand(group.base);
   };
 
+  const detailId = `sb-color-table-detail-${group.base.replaceAll('.', '-')}`;
   return (
     <>
       <tr
@@ -293,6 +294,9 @@ function GroupRow({
               ? `Collapse ${group.base}`
               : `Expand ${group.base}`
         }
+        {...(onSelect
+          ? { 'aria-haspopup': 'dialog' as const }
+          : { 'aria-expanded': expanded, 'aria-controls': detailId })}
         data-testid="color-table-row"
         data-path={active.path}
         data-base={group.base}
@@ -366,7 +370,7 @@ function GroupRow({
         </td>
       </tr>
       {expanded && !onSelect && (
-        <tr className="sb-color-table__detail-row" data-testid="color-table-detail">
+        <tr className="sb-color-table__detail-row" id={detailId} data-testid="color-table-detail">
           <td colSpan={COLUMN_COUNT} className="sb-color-table__td sb-color-table__detail-cell">
             <ExpandedDetail group={group} active={active} />
           </td>

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -167,6 +167,7 @@ export function TokenTable({
                 }
               }}
               tabIndex={0}
+              aria-haspopup="dialog"
               aria-label={`Inspect ${row.path}`}
               data-testid="token-table-row"
               data-path={row.path}


### PR DESCRIPTION
## Summary
Critical a11y finding from audit #928. Clickable `<tr>` rows that act as disclosure triggers lacked any signal to SR users that activation would do anything beyond selecting the row.

**TokenTable rows** (`packages/blocks/src/TokenTable.tsx`): rows already carry `tabIndex={0}` + `aria-label="Inspect <path>"` + Enter/Space activation. Added `aria-haspopup="dialog"` so SR announces "Inspect color.accent.bg, has popup dialog" instead of just the path.

**ColorTable group rows** (`packages/blocks/src/ColorTable.tsx`):
- When `onSelect` is set (consumer owns the follow-up UI), the row carries `aria-haspopup="dialog"`.
- In the default in-place-expand mode, the row's `aria-label` already rotates `"Expand <base>"` / `"Collapse <base>"` to communicate state. No additional ARIA: `aria-expanded` on `<tr>` in a plain `<table>` is invalid per axe-core's `aria-conditional-attr` (only supported in `treegrid`/`grid`), and the row isn't a popup trigger either.

Closes #928

## Test plan
- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 turbo tasks green
- [x] Storybook interaction tests / axe checks (CI)
- [ ] Browser smoke (manual): VO/NVDA reads "has popup dialog" on TokenTable + onSelect ColorTable rows; expand/collapse rows read their label rotation