### PR TITLE
fix(blocks,addon): drop composed data-prefix-theme attribute

### DIFF
--- a/.changeset/drop-data-theme-attr.md
+++ b/.changeset/drop-data-theme-attr.md
@@ -1,0 +1,11 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+Drop the composed `data-<prefix>-theme="<tuple name>"` attribute. The per-axis attributes (`data-<prefix>-<axis>="<context>"`) are the actual scoping surface — the smart CSS emitter targets single-axis selectors plus joint compounds across multiple, never `[data-*-theme]`. The composed attribute was a v0.5-era artifact from before axes landed.
+
+- `themeAttrs(prefix, tuple)` (blocks): signature change. Now takes the active tuple and returns per-axis attrs + the stable `data-swatchbook-block` marker + wrapper classes. Replaces the old `themeAttrs(prefix, themeName)` shape.
+- `perAxisAttrs(prefix, tuple)` (blocks): new helper for elements that want per-axis cell scoping without block-wrapper chrome — used by `AxisVariance` so each grid swatch's CSS vars resolve at the cell's tuple instead of the document root's active tuple. **Fixes a visual bug**: grid swatches previously all showed the active tuple's color because the per-cell `data-<prefix>-theme` they wrote had zero CSS rules keyed against it.
+- Preview decorator (addon): stops writing `data-<prefix>-theme` on `<html>` and the story wrapper.
+- `ProjectData.themeNameForTuple` / `TokenDetailData.themeNameForTuple` (blocks): removed. Synthesise tuple names locally with `tupleToName` if needed.

--- a/apps/docs/docs/guides/consuming-the-active-theme.mdx
+++ b/apps/docs/docs/guides/consuming-the-active-theme.mdx
@@ -87,7 +87,7 @@ Inside the preview, prefer `useActiveAxes()` — it's reactive without the obser
 
 ## What the DOM contract guarantees
 
-1. **`data-<prefix>-<axisName>="<context>"` attributes on `<html>`** — one per active axis, plus `data-<prefix>-theme` holding the composed tuple string (`"Dark · Brand A · Normal"`). `<prefix>` follows your `cssVarPrefix` config (default `swatch`).
+1. **`data-<prefix>-<axisName>="<context>"` attributes on `<html>`** — one per active axis. `<prefix>` follows your `cssVarPrefix` config (default `swatch`).
 2. **The same attributes on each story's wrapper element.** Redundant with `<html>` in most cases, but useful if your story iframe hosts multiple wrappers.
 3. **Per-tuple CSS** emitted under compound attribute selectors — `[data-<prefix>-mode="Dark"][data-<prefix>-brand="Brand A"] { … }`. One block per tuple, with the default tuple's values in `:root` as the fallback.
 4. **Attributes update on toolbar flip.** Synchronously, before the next paint — observers fire on the microtask queue.

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -54,7 +54,7 @@ export default definePreview({
 
 ## What it registers
 
-- **Preview decorator** — reads the active axis tuple, writes `data-<prefix>-<axis>="<context>"` attributes (plus `data-<prefix>-theme="<composed id>"`) on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager. The prefix follows `cssVarPrefix` (default `swatch`).
+- **Preview decorator** — reads the active axis tuple, writes one `data-<prefix>-<axis>="<context>"` attribute per axis on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager. The prefix follows `cssVarPrefix` (default `swatch`).
 - **Toolbar tool** — a single Swatchbook `IconButton`. Clicking opens a popover containing preset pills, one dropdown per axis, and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`). Escape and outside-click close it.
 
 For a browsable tree + diagnostics surface, compose `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />` on an MDX page — see the [authoring guide](../guides/authoring-doc-stories.mdx)'s dashboard example.

--- a/apps/docs/docs/reference/axes.mdx
+++ b/apps/docs/docs/reference/axes.mdx
@@ -25,7 +25,7 @@ Every resolved token, every CSS selector, every panel readout keys on this tuple
 When a tuple is active, the preview decorator writes one `data-<prefix>-<axisName>="<context>"` attribute per axis to `<html>` and the story wrapper. The prefix follows `cssVarPrefix` (default `swatch`):
 
 ```html
-<html data-swatch-mode="Dark" data-swatch-brand="Brand A" data-swatch-theme="Dark · Brand A">
+<html data-swatch-mode="Dark" data-swatch-brand="Brand A">
 ```
 
 CSS emission matches those attributes with compound selectors. Each non-default tuple gets its own flat block — every var redeclared — with `:root` carrying the default:

--- a/apps/docs/scripts/build-tokens.mts
+++ b/apps/docs/scripts/build-tokens.mts
@@ -42,14 +42,8 @@ const rawCss = emitAxisProjectedCss(project);
  * built-in `[data-theme]` toggle on `<html>` (lowercased), while the
  * non-mode axes (`a11y`, `brand`) keep their prefixed `data-sb-<axis>`
  * attributes that the navbar switcher provider owns.
- *
- * Single-axis projects key everything on `theme` regardless of the
- * resolver's axis name (see `selectorFor` in core). Multi-axis keeps
- * the axis name (`mode`, `a11y`, `brand`). Cover both shapes.
  */
 const css = rawCss
-  .replaceAll('[data-sb-theme="Light"]', '[data-theme="light"]')
-  .replaceAll('[data-sb-theme="Dark"]', '[data-theme="dark"]')
   .replaceAll('[data-sb-mode="Light"]', '[data-theme="light"]')
   .replaceAll('[data-sb-mode="Dark"]', '[data-theme="dark"]');
 

--- a/apps/storybook/src/stories/MotionPreview.stories.tsx
+++ b/apps/storybook/src/stories/MotionPreview.stories.tsx
@@ -16,7 +16,7 @@ export const SystemTransitions = meta.story({
   args: { filter: 'transition.**' },
   play: async ({ canvasElement }) => {
     await waitFor(() => {
-      const wrapper = canvasElement.querySelector('[data-sb-theme]');
+      const wrapper = canvasElement.querySelector('[data-swatchbook-block]');
       expect(
         wrapper?.textContent,
         'motion preview should include at least one transition path',

--- a/apps/storybook/src/stories/Presets.stories.tsx
+++ b/apps/storybook/src/stories/Presets.stories.tsx
@@ -1,4 +1,4 @@
-import { expect, waitFor } from 'storybook/test';
+import { waitFor } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
 import { Button } from '../components/Button.tsx';
 import { Card } from '../components/Card.tsx';
@@ -51,7 +51,7 @@ export const DefaultLightPreset = meta.story({
     const wrapper = await findWrapper(canvasElement);
     await waitForAttr(wrapper, 'data-sb-mode', 'Light');
     await waitForAttr(wrapper, 'data-sb-brand', 'Default');
-    expect(wrapper.getAttribute('data-sb-theme')).toBe('Light · Default · Normal');
+    await waitForAttr(wrapper, 'data-sb-contrast', 'Normal');
   },
 });
 
@@ -67,6 +67,6 @@ export const BrandADarkPreset = meta.story({
     const wrapper = await findWrapper(canvasElement);
     await waitForAttr(wrapper, 'data-sb-mode', 'Dark');
     await waitForAttr(wrapper, 'data-sb-brand', 'Brand A');
-    expect(wrapper.getAttribute('data-sb-theme')).toBe('Dark · Brand A · Normal');
+    await waitForAttr(wrapper, 'data-sb-contrast', 'Normal');
   },
 });

--- a/apps/storybook/src/stories/ThemeSwitch.stories.tsx
+++ b/apps/storybook/src/stories/ThemeSwitch.stories.tsx
@@ -115,8 +115,9 @@ export const PerAxisDataAttrs = meta.story({
     if (!wrapper) throw new Error('expected story wrapper with data-sb-mode attribute');
     expect(wrapper.getAttribute('data-sb-mode')).toBe('Dark');
     expect(wrapper.getAttribute('data-sb-brand')).toBe('Brand A');
-    expect(wrapper.getAttribute('data-sb-theme')).toBe('Dark · Brand A · Normal');
+    expect(wrapper.getAttribute('data-sb-contrast')).toBe('Normal');
     expect(document.documentElement.getAttribute('data-sb-mode')).toBe('Dark');
     expect(document.documentElement.getAttribute('data-sb-brand')).toBe('Brand A');
+    expect(document.documentElement.getAttribute('data-sb-theme')).toBeNull();
   },
 });

--- a/apps/storybook/src/stories/TypographyScale.stories.tsx
+++ b/apps/storybook/src/stories/TypographyScale.stories.tsx
@@ -16,7 +16,7 @@ export default meta;
 export const All = meta.story({
   play: async ({ canvasElement }) => {
     await waitFor(() => {
-      const wrapper = canvasElement.querySelector('[data-sb-theme]');
+      const wrapper = canvasElement.querySelector('[data-swatchbook-block]');
       expect(
         wrapper?.textContent,
         'typography scale should include at least one typography path',

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -92,9 +92,9 @@ function forEachPinnedAxis(cb: (name: string, value: string) => void): void {
 
 /**
  * Compose a stable theme name from a tuple — `axisValues.join(' · ')`
- * in axis order. Used for the `data-<prefix>-theme` attribute and the
- * `swatchbook/theme` channel signal. Returns empty string when there
- * are no axes (no name to write).
+ * in axis order. Used for the `ThemeContext` value the blocks read and
+ * the addon-channel signals downstream consumers subscribe to. Returns
+ * empty string when there are no axes (no name to write).
  */
 function matchThemeName(tuple: Readonly<Record<string, string>>): string {
   if (virtualAxes.length === 0) return '';
@@ -102,17 +102,15 @@ function matchThemeName(tuple: Readonly<Record<string, string>>): string {
 }
 
 /**
- * Write the composed permutation ID to `data-<prefix>-theme` plus one
- * `data-<prefix>-<axis>=<context>` per axis. Prefix follows `cssVarPrefix`
- * so the attr namespace and the emitted-CSS selectors stay in lockstep;
- * empty prefix keeps the bare `data-theme` form.
+ * Write one `data-<prefix>-<axis>=<context>` per axis on `<html>`.
+ * The smart CSS emitter targets these single-axis selectors (and
+ * joint compounds across multiple) — that's the actual scoping
+ * surface the cascade resolves through. Prefix follows `cssVarPrefix`
+ * so attr namespace and emitted selectors stay in lockstep.
  */
-function setRootAxes(themeName: string, tuple: Readonly<Record<string, string>>): void {
+function setRootAxes(tuple: Readonly<Record<string, string>>): void {
   if (typeof document === 'undefined') return;
   const root = document.documentElement;
-  const themeAttr = dataAttr(cssVarPrefix, 'theme');
-  if (themeName) root.setAttribute(themeAttr, themeName);
-  else root.removeAttribute(themeAttr);
   for (const axis of virtualAxes) {
     const attr = dataAttr(cssVarPrefix, axis.name);
     const value = tuple[axis.name];
@@ -289,11 +287,10 @@ const themedDecorator: Decorator = (Story, context) => {
   }, []);
 
   useEffect(() => {
-    setRootAxes(themeName, tuple);
-  }, [themeName, tuple]);
+    setRootAxes(tuple);
+  }, [tuple]);
 
   const wrapperAttrs: Record<string, string> = {};
-  if (themeName) wrapperAttrs[dataAttr(cssVarPrefix, 'theme')] = themeName;
   for (const axis of virtualAxes) {
     const value = tuple[axis.name];
     if (value !== undefined) wrapperAttrs[dataAttr(cssVarPrefix, axis.name)] = value;
@@ -404,7 +401,7 @@ function installGlobalAxisApplier(): void {
   const apply = (globals: SwatchbookGlobals): void => {
     ensureStylesheet(css, cssVarPrefix);
     const tuple = resolveTuple(globals, {});
-    setRootAxes(matchThemeName(tuple), tuple);
+    setRootAxes(tuple);
   };
   // Storybook fires `globalsUpdated`, `setGlobals`, and `updateGlobals`
   // for the same logical change (preview init + every toolbar tick).

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -66,7 +66,7 @@ export function BorderPreview({
   sortDir = 'asc',
 }: BorderPreviewProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const colorFormat = useColorFormat();
 
   const rows = useMemo<Row[]>(() => {
@@ -87,14 +87,14 @@ export function BorderPreview({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No border tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-border-preview__row">

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -72,7 +72,7 @@ export function ColorPalette({
   sortDir = 'asc',
 }: ColorPaletteProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const colorFormat = useColorFormat();
 
   const groups = useMemo(() => {
@@ -115,14 +115,14 @@ export function ColorPalette({
 
   if (totalCount === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No color tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {groups.map(([group, swatches]) => (
         <section key={group} className="sb-color-palette__group">

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -100,7 +100,7 @@ export function ColorTable({
   variants,
 }: ColorTableProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const colorFormat = useColorFormat();
   const [query, setQuery] = useState('');
   const [selectedByBase, setSelectedByBase] = useState<Record<string, string>>({});
@@ -183,14 +183,14 @@ export function ColorTable({
 
   if (groups.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No color tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       {searchable && (
         <div className="sb-color-table__search">
           <input

--- a/packages/blocks/src/Diagnostics.tsx
+++ b/packages/blocks/src/Diagnostics.tsx
@@ -51,7 +51,7 @@ function summaryVariant(diagnostics: readonly VirtualDiagnostic[]): 'ok' | 'erro
  * on their own MDX pages.
  */
 export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
-  const { activeTheme, cssVarPrefix, diagnostics } = useProject();
+  const { activeAxes, cssVarPrefix, diagnostics } = useProject();
 
   const hasErrorsOrWarnings = diagnostics.some(
     (d) => d.severity === 'error' || d.severity === 'warn',
@@ -60,7 +60,7 @@ export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
   const variant = summaryVariant(diagnostics);
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)} data-testid="diagnostics">
+    <div {...themeAttrs(cssVarPrefix, activeAxes)} data-testid="diagnostics">
       <details open={hasErrorsOrWarnings}>
         <summary
           className={cx(

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -72,7 +72,7 @@ export function DimensionScale({
   sortDir = 'asc',
 }: DimensionScaleProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -97,14 +97,14 @@ export function DimensionScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No dimension tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-dimension-scale__row">

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -47,7 +47,7 @@ export function FontFamilySample({
   sortDir = 'asc',
 }: FontFamilySampleProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -67,14 +67,14 @@ export function FontFamilySample({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No fontFamily tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-font-family-sample__row">

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -53,7 +53,7 @@ export function FontWeightScale({
   sortDir = 'asc',
 }: FontWeightScaleProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -74,14 +74,14 @@ export function FontWeightScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No fontWeight tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-font-weight-scale__row">

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -73,7 +73,7 @@ export function GradientPalette({
   sortDir = 'asc',
 }: GradientPaletteProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const colorFormat = useColorFormat();
 
   const rows = useMemo<Row[]>(() => {
@@ -94,14 +94,14 @@ export function GradientPalette({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No gradient tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-gradient-palette__row">

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -44,7 +44,7 @@ function formatSpec(row: Row): string {
 
 export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const [speed, setSpeed] = useState<MotionSpeed>(1);
   const [run, setRun] = useState(0);
   const reducedMotion = usePrefersReducedMotion();
@@ -81,14 +81,14 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No motion tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       <div className="sb-motion-preview__controls">
         <span className="sb-motion-preview__control-label">Speed</span>

--- a/packages/blocks/src/OpacityScale.tsx
+++ b/packages/blocks/src/OpacityScale.tsx
@@ -71,7 +71,7 @@ export function OpacityScale({
   sortDir = 'asc',
 }: OpacityScaleProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -99,7 +99,7 @@ export function OpacityScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No opacity tokens match this filter.</div>
       </div>
     );
@@ -108,7 +108,7 @@ export function OpacityScale({
   const sampleColorVar = resolveCssVar(sampleColor, project);
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       <div className="sb-opacity-scale__grid">
         {rows.map((row) => (

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -83,7 +83,7 @@ export function ShadowPreview({
   sortDir = 'asc',
 }: ShadowPreviewProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const colorFormat = useColorFormat();
 
   const rows = useMemo<Row[]>(() => {
@@ -104,14 +104,14 @@ export function ShadowPreview({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No shadow tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-shadow-preview__row">

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -56,7 +56,7 @@ export function StrokeStyleSample({
   sortDir = 'asc',
 }: StrokeStyleSampleProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -77,14 +77,14 @@ export function StrokeStyleSample({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No strokeStyle tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-stroke-style-sample__row">

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -25,9 +25,9 @@ export interface TokenDetailProps {
 }
 
 export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
-  const { token, cssVar, activeTheme, cssVarPrefix } = useTokenDetailData(path);
+  const { token, cssVar, activeTheme, activeAxes, cssVarPrefix } = useTokenDetailData(path);
   const colorFormat = useColorFormat();
-  const theme = themeAttrs(cssVarPrefix, activeTheme);
+  const theme = themeAttrs(cssVarPrefix, activeAxes);
 
   if (!token) {
     return (

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -209,7 +209,7 @@ export function TokenNavigator({
   searchable = true,
   onSelect,
 }: TokenNavigatorProps): ReactElement {
-  const { resolved, activeTheme, cssVarPrefix } = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = useProject();
 
   const typeFilter = useMemo<ReadonlySet<string> | undefined>(() => {
     if (type === undefined) return undefined;
@@ -442,7 +442,7 @@ export function TokenNavigator({
 
   if (tree.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <EmptyState>
           {root
             ? `No tokens under "${root}"${typeFilter ? ` matching ${typeLabel.slice(3)}` : ''}.`
@@ -455,7 +455,7 @@ export function TokenNavigator({
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       {searchable && (
         <div className="sb-token-navigator__search">
           <input

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -62,7 +62,7 @@ export function TokenTable({
   onSelect,
 }: TokenTableProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const colorFormat = useColorFormat();
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState('');
@@ -111,14 +111,14 @@ export function TokenTable({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       {searchable && (
         <div className="sb-token-table__search">
           <input

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -92,7 +92,7 @@ export function TypographyScale({
   sortBy = 'path',
   sortDir = 'asc',
 }: TypographyScaleProps): ReactElement {
-  const { resolved, activeTheme, cssVarPrefix } = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = useProject();
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -114,14 +114,14 @@ export function TypographyScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No typography tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeTheme)}>
+    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-typography-scale__row">

--- a/packages/blocks/src/internal/data-attr.ts
+++ b/packages/blocks/src/internal/data-attr.ts
@@ -19,19 +19,44 @@ const WRAPPER_CLASSES = 'sb-unstyled sb-block';
 
 /**
  * Spread helper for the common block wrapper. Returns:
- * - `data-<prefix>-theme="<composed theme name>"` — so theme-keyed CSS
- *   emitted by `@unpunnyfuns/swatchbook-core` resolves against this
- *   subtree.
+ * - One `data-<prefix>-<axisName>="<contextName>"` per axis in the tuple.
+ *   These are what the smart CSS emitter actually targets — single-axis
+ *   cell selectors (`[data-<prefix>-mode="Dark"]`) and joint compounds
+ *   (`[data-<prefix>-mode="Dark"][data-<prefix>-brand="Brand A"]`).
+ *   Wrapping a block subtree in these attrs lets the cascade resolve
+ *   per-tuple values inside the block independently of the document
+ *   root — `AxisVariance`'s grid uses this to render real per-cell
+ *   swatches.
  * - `data-swatchbook-block` — stable consumer hook for targeting block
  *   chrome from outside.
  * - `className="sb-unstyled sb-block"` — Storybook's opt-out class so
  *   MDX docs house styles self-exclude the subtree, plus `sb-block`
  *   which carries the shared chrome from `internal/styles.css`.
  */
-export function themeAttrs(prefix: string, themeName: string): Record<string, string> {
+export function themeAttrs(
+  prefix: string,
+  tuple: Readonly<Record<string, string>>,
+): Record<string, string> {
   return {
-    [dataAttr(prefix, 'theme')]: themeName,
+    ...perAxisAttrs(prefix, tuple),
     [BLOCK_ATTR]: '',
     className: WRAPPER_CLASSES,
   };
+}
+
+/**
+ * Spread helper for any element that wants per-axis cell semantics
+ * without the block-wrapper chrome — `AxisVariance`'s grid uses this
+ * on each swatch so the swatch's CSS vars resolve at the cell's own
+ * tuple, not the document root's active tuple.
+ */
+export function perAxisAttrs(
+  prefix: string,
+  tuple: Readonly<Record<string, string>>,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [axisName, contextName] of Object.entries(tuple)) {
+    out[dataAttr(prefix, axisName)] = contextName;
+  }
+  return out;
 }

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -43,12 +43,6 @@ export interface ProjectData {
    * wire — no resolver needed.
    */
   resolveAt: (tuple: Record<string, string>) => ResolvedTokens;
-  /**
-   * Synthesize a display name for a full tuple — `axisValues.join(' · ')`,
-   * matching the form `permutationID` produces server-side. Used by
-   * the AxisVariance grid for `data-<prefix>-theme` attribution.
-   */
-  themeNameForTuple: (tuple: Record<string, string>) => string | undefined;
 }
 
 function ensureStylesheet(css: string): void {
@@ -165,7 +159,6 @@ export function useProject(): ProjectData {
       listing: listing ?? {},
       varianceByPath: varianceByPath ?? {},
       resolveAt,
-      themeNameForTuple: (tuple) => tupleToName(axes, tuple),
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -247,7 +240,6 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
       listing: tokens.listing,
       varianceByPath: tokens.varianceByPath,
       resolveAt,
-      themeNameForTuple: (tuple) => tupleToName(tokens.axes, tuple),
     }),
     [
       activeTheme,

--- a/packages/blocks/src/token-detail/AxisVariance.tsx
+++ b/packages/blocks/src/token-detail/AxisVariance.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import type { ColorFormat } from '#/format-color.ts';
-import { dataAttr } from '@unpunnyfuns/swatchbook-core/data-attr';
+import { perAxisAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
 import type { DetailToken } from '#/token-detail/internal.ts';
@@ -19,16 +19,8 @@ type Variance =
   | { kind: 'multi-axis'; varyingAxes: readonly [string, string, ...string[]] };
 
 export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
-  const {
-    token,
-    cssVar,
-    axes,
-    activeAxes,
-    cssVarPrefix,
-    varianceByPath,
-    resolveAt,
-    themeNameForTuple,
-  } = useTokenDetailData(path);
+  const { token, cssVar, axes, activeAxes, cssVarPrefix, varianceByPath, resolveAt } =
+    useTokenDetailData(path);
   const colorFormat = useColorFormat();
   const tokenType = token?.$type;
   const isColor = tokenType === 'color';
@@ -91,10 +83,9 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
     if (!axis) return <></>;
     const contextValues = axis.contexts.map((ctx) => {
       const target = { ...activeAxes, [axisName]: ctx };
-      const themeName = themeNameForTuple(target) ?? '';
       return {
         ctx,
-        themeName,
+        target,
         value: formatFn(resolveAt(target)[path] as DetailToken | undefined),
       };
     });
@@ -114,11 +105,11 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
                   {row.ctx}
                 </td>
                 <td className="sb-token-detail__theme-cell">
-                  {isColor && row.themeName && (
+                  {isColor && (
                     <span
                       className="sb-token-detail__swatch"
                       style={{ background: cssVar }}
-                      {...{ [dataAttr(cssVarPrefix, 'theme')]: row.themeName }}
+                      {...perAxisAttrs(cssVarPrefix, row.target)}
                       aria-hidden
                     />
                   )}
@@ -171,7 +162,6 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
                   [rowAxis.name]: row,
                   [colAxis.name]: col,
                 };
-                const name = themeNameForTuple(target);
                 const value = formatFn(resolveAt(target)[path] as DetailToken | undefined);
                 return (
                   <td
@@ -180,11 +170,11 @@ export function AxisVariance({ path }: AxisVarianceProps): ReactElement {
                     data-row={row}
                     data-col={col}
                   >
-                    {isColor && name && (
+                    {isColor && (
                       <span
                         className="sb-token-detail__swatch"
                         style={{ background: cssVar }}
-                        {...{ [dataAttr(cssVarPrefix, 'theme')]: name }}
+                        {...perAxisAttrs(cssVarPrefix, target)}
                         aria-hidden
                       />
                     )}

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -36,27 +36,12 @@ export interface TokenDetailData {
    * a derived tuple name.
    */
   resolveAt: (tuple: Record<string, string>) => Record<string, DetailToken>;
-  /**
-   * O(1) tuple → permutation-name lookup, backed by a `Map` built
-   * once per snapshot. The `AxisVariance` grid uses this to derive
-   * the `data-<prefix>-theme` attribute for each cell without an
-   * `Array.find` scan per render cell.
-   */
-  themeNameForTuple: (tuple: Record<string, string>) => string | undefined;
 }
 
 export function useTokenDetailData(path: string): TokenDetailData {
   const project = useProject();
-  const {
-    activeTheme,
-    activeAxes,
-    axes,
-    resolved,
-    cssVarPrefix,
-    varianceByPath,
-    resolveAt,
-    themeNameForTuple,
-  } = project;
+  const { activeTheme, activeAxes, axes, resolved, cssVarPrefix, varianceByPath, resolveAt } =
+    project;
   const typedResolved = resolved as Record<string, DetailToken>;
   return {
     token: typedResolved[path],
@@ -68,6 +53,5 @@ export function useTokenDetailData(path: string): TokenDetailData {
     cssVarPrefix,
     varianceByPath,
     resolveAt: resolveAt as (tuple: Record<string, string>) => Record<string, DetailToken>,
-    themeNameForTuple,
   };
 }

--- a/packages/blocks/test/token-table.browser.test.tsx
+++ b/packages/blocks/test/token-table.browser.test.tsx
@@ -188,7 +188,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
       </SwatchbookProvider>,
     );
 
-    const wrapper = container.querySelector('[data-swatch-theme]') as HTMLElement | null;
+    const wrapper = container.querySelector('[data-swatchbook-block]') as HTMLElement | null;
     expect(wrapper).not.toBeNull();
     expect(wrapper?.style.getPropertyValue('--swatchbook-color-border-default')).toBe('');
     expect(wrapper?.style.getPropertyValue('--sb-color-border-default')).toBe('');


### PR DESCRIPTION
## Summary

- Drop the composed `data-<prefix>-theme="<tuple name>"` attribute from the preview decorator (`<html>` + story wrapper) and from `themeAttrs(prefix, …)` in blocks. The smart CSS emitter targets per-axis attrs + joint compounds only; the composed attr had zero matching selectors and was a v0.5-era artifact from before axes landed.
- Fix `AxisVariance`'s silent-lying grid. Each swatch previously wrote the composed attr per cell, so every cell's CSS vars actually resolved at the document-root's active tuple instead of the cell's own tuple — every grid swatch looked identical regardless of row/column. New `perAxisAttrs(prefix, tuple)` helper writes the per-axis attrs the emitter actually keys on; swatches now show real per-cell values.
- Drop dead `ProjectData.themeNameForTuple` / `TokenDetailData.themeNameForTuple` (no remaining callers).

**Breaking:** `themeAttrs(prefix, themeName)` → `themeAttrs(prefix, tuple)`. DOM contract narrows. Minor bump pre-1.0 on blocks + addon.

## Test plan

- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` (all green; 184 blocks tests, 35 addon tests, all browser-mode tests across chromium + firefox)
- [x] AxisVariance grid swatches now write per-axis attrs (verified via diff + emitter selector inspection)
- [ ] Visual check via Chromatic CI on this PR — the AxisVariance grid stories should newly show variation across cells

Milestone: Maintenance

Closes #955