### PR TITLE
perf(blocks,addon): narrow useMemo deps to specific fields

### DIFF
--- a/.changeset/perf-narrow-memo-deps.md
+++ b/.changeset/perf-narrow-memo-deps.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Narrow `useMemo` dep arrays in `TokenTable`, `ColorPalette`, `ColorTable`, and the addon preview decorator to the specific fields each memo body actually consumes. Previously they depended on the whole `project` / `globals` / `parameters` object — token-value HMR or Storybook's per-render object recreation invalidated downstream memos even when the consumed fields were unchanged.
+
+- `resolveCssVar` and `resolveColorValue` in `packages/blocks/src/internal/use-project.ts` now take `Pick<ProjectData, 'listing' | 'cssVarPrefix'>` and `Pick<ProjectData, 'listing'>` respectively. Existing callers passing the full `ProjectData` keep working via structural subtyping.
+- `resolveTuple` and `resolveColorFormat` in `packages/addon/src/preview.tsx` take their inputs directly (`axesGlobal` + `paramSwatchbook` / `colorFormatGlobal`) instead of the broader `SwatchbookGlobals` + `StoryParameters` bags.

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -232,27 +232,24 @@ function normalizeTuple(partial: Readonly<Record<string, string>>): Record<strin
  *   4. virtual module default.
  */
 function resolveTuple(
-  globals: SwatchbookGlobals,
-  parameters: StoryParameters,
+  axesGlobal: SwatchbookGlobals[typeof AXES_GLOBAL_KEY],
+  paramSwatchbook: StoryParameters['swatchbook'],
 ): Record<string, string> {
-  const param = parameters.swatchbook;
-  const paramAxes = param?.axes;
+  const paramAxes = paramSwatchbook?.axes;
   if (paramAxes) {
     return normalizeTuple(paramAxes);
   }
-  if (param?.permutation) {
-    const hit = tupleForName(param.permutation);
+  if (paramSwatchbook?.permutation) {
+    const hit = tupleForName(paramSwatchbook.permutation);
     if (hit) return normalizeTuple(hit);
   }
-  const globalAxes = globals[AXES_GLOBAL_KEY];
-  if (globalAxes && typeof globalAxes === 'object') {
-    return normalizeTuple(globalAxes as Record<string, string>);
+  if (axesGlobal && typeof axesGlobal === 'object') {
+    return normalizeTuple(axesGlobal as Record<string, string>);
   }
   return defaultTuple();
 }
 
-function resolveColorFormat(globals: SwatchbookGlobals): ColorFormat {
-  const raw = globals[COLOR_FORMAT_GLOBAL_KEY];
+function resolveColorFormat(raw: SwatchbookGlobals[typeof COLOR_FORMAT_GLOBAL_KEY]): ColorFormat {
   if (typeof raw === 'string' && (COLOR_FORMATS as readonly string[]).includes(raw)) {
     return raw as ColorFormat;
   }
@@ -277,8 +274,14 @@ const previewResolveAt = buildResolveAt(
 const themedDecorator: Decorator = (Story, context) => {
   const globals = context.globals as SwatchbookGlobals;
   const parameters = context.parameters as StoryParameters;
-  const tuple = useMemo(() => resolveTuple(globals, parameters), [globals, parameters]);
-  const colorFormat = useMemo(() => resolveColorFormat(globals), [globals]);
+  const axesGlobal = globals[AXES_GLOBAL_KEY];
+  const colorFormatGlobal = globals[COLOR_FORMAT_GLOBAL_KEY];
+  const paramSwatchbook = parameters.swatchbook;
+  const tuple = useMemo(
+    () => resolveTuple(axesGlobal, paramSwatchbook),
+    [axesGlobal, paramSwatchbook],
+  );
+  const colorFormat = useMemo(() => resolveColorFormat(colorFormatGlobal), [colorFormatGlobal]);
   const themeName = useMemo(() => matchThemeName(tuple), [tuple]);
 
   useEffect(() => {
@@ -400,7 +403,7 @@ function installGlobalAxisApplier(): void {
   channel.on(INIT_REQUEST_EVENT, broadcastInit);
   const apply = (globals: SwatchbookGlobals): void => {
     ensureStylesheet(css, cssVarPrefix);
-    const tuple = resolveTuple(globals, {});
+    const tuple = resolveTuple(globals[AXES_GLOBAL_KEY], undefined);
     setRootAxes(tuple);
   };
   // Storybook fires `globalsUpdated`, `setGlobals`, and `updateGlobals`
@@ -415,7 +418,7 @@ function installGlobalAxisApplier(): void {
   let lastApplied = '';
   const onGlobals = (payload: { globals?: SwatchbookGlobals }): void => {
     if (!payload.globals) return;
-    const tuple = resolveTuple(payload.globals, {});
+    const tuple = resolveTuple(payload.globals[AXES_GLOBAL_KEY], undefined);
     const fingerprint = matchThemeName(tuple);
     if (fingerprint === lastApplied) return;
     lastApplied = fingerprint;

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -72,10 +72,11 @@ export function ColorPalette({
   sortDir = 'asc',
 }: ColorPaletteProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
   const colorFormat = useColorFormat();
 
   const groups = useMemo(() => {
+    const projectFields = { listing, cssVarPrefix };
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'color') return false;
       return matchPath(path, filter);
@@ -92,11 +93,11 @@ export function ColorPalette({
       const groupKey = segments.slice(0, effectiveGroupBy).join('.');
       const leaf = segments.slice(effectiveGroupBy).join('.') || segments.at(-1) || path;
       const list = bucket.get(groupKey) ?? [];
-      const formatted = resolveColorValue(path, token.$value, colorFormat, project);
+      const formatted = resolveColorValue(path, token.$value, colorFormat, projectFields);
       list.push({
         path,
         leaf,
-        cssVar: resolveCssVar(path, project),
+        cssVar: resolveCssVar(path, projectFields),
         value: formatted.value,
         outOfGamut: formatted.outOfGamut,
       });
@@ -106,7 +107,7 @@ export function ColorPalette({
     return [...bucket.entries()].toSorted(([a], [b]) =>
       a.localeCompare(b, undefined, { numeric: true }),
     );
-  }, [resolved, filter, groupBy, project, colorFormat, sortBy, sortDir]);
+  }, [resolved, listing, cssVarPrefix, filter, groupBy, colorFormat, sortBy, sortDir]);
 
   const totalCount = groups.reduce((acc, [, swatches]) => acc + swatches.length, 0);
   const captionText =

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -100,7 +100,7 @@ export function ColorTable({
   variants,
 }: ColorTableProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
   const colorFormat = useColorFormat();
   const [query, setQuery] = useState('');
   const [selectedByBase, setSelectedByBase] = useState<Record<string, string>>({});
@@ -109,6 +109,7 @@ export function ColorTable({
   const defs = useMemo(() => buildVariantDefs(variants), [variants]);
 
   const groups = useMemo<Group[]>(() => {
+    const projectFields = { listing, cssVarPrefix };
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'color') return false;
       return matchPath(path, filter);
@@ -118,7 +119,7 @@ export function ColorTable({
     const groupMap = new Map<string, { base: string; variants: Variant[] }>();
     for (const [path, token] of sorted) {
       const raw = token.$value as NormalizedColor;
-      const hex = resolveColorValue(path, raw, 'hex', project);
+      const hex = resolveColorValue(path, raw, 'hex', projectFields);
       const hsl = formatColor(raw, 'hsl');
       const oklch = formatColor(raw, 'oklch');
       const active = pickActiveFormat(raw, colorFormat, hex, hsl, oklch);
@@ -126,7 +127,7 @@ export function ColorTable({
       const variant: Variant = {
         label: match?.label ?? BASE_LABEL,
         path,
-        cssVar: resolveCssVar(path, project),
+        cssVar: resolveCssVar(path, projectFields),
         value: active.value,
         outOfGamut: active.outOfGamut,
         hex: hex.value,
@@ -149,7 +150,7 @@ export function ColorTable({
       out.push({ base, variants: vs, searchText });
     }
     return out;
-  }, [resolved, filter, project, sortBy, sortDir, defs, colorFormat]);
+  }, [resolved, listing, cssVarPrefix, filter, sortBy, sortDir, defs, colorFormat]);
 
   const visibleGroups = useMemo(() => {
     if (!searchable || query.trim() === '') return groups;

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -62,12 +62,13 @@ export function TokenTable({
   onSelect,
 }: TokenTableProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
   const colorFormat = useColorFormat();
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState('');
 
   const rows = useMemo(() => {
+    const projectFields = { listing, cssVarPrefix };
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (!matchPath(path, filter)) return false;
       if (type && token.$type !== type) return false;
@@ -76,17 +77,19 @@ export function TokenTable({
     const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
     return entries.map(([path, token]) => {
       const isColor = token.$type === 'color';
-      const color = isColor ? resolveColorValue(path, token.$value, colorFormat, project) : null;
+      const color = isColor
+        ? resolveColorValue(path, token.$value, colorFormat, projectFields)
+        : null;
       return {
         path,
         type: token.$type ?? '',
-        value: formatTokenValue(token.$value, token.$type, colorFormat, project.listing[path]),
+        value: formatTokenValue(token.$value, token.$type, colorFormat, listing[path]),
         outOfGamut: color?.outOfGamut ?? false,
-        cssVar: resolveCssVar(path, project),
+        cssVar: resolveCssVar(path, projectFields),
         isColor,
       };
     });
-  }, [resolved, filter, type, project, colorFormat, sortBy, sortDir]);
+  }, [resolved, listing, cssVarPrefix, filter, type, colorFormat, sortBy, sortDir]);
 
   const visibleRows = useMemo(() => {
     if (!searchable || query.trim() === '') return rows;

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -262,7 +262,10 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
  * path — covers non-resolver projects, hand-built snapshots, and any
  * listing-plugin miss.
  */
-export function resolveCssVar(path: string, project: ProjectData): string {
+export function resolveCssVar(
+  path: string,
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+): string {
   const listed = project.listing[path]?.names?.['css'];
   if (listed) return `var(${listed})`;
   return makeCssVar(path, project.cssVarPrefix);
@@ -284,7 +287,7 @@ export function resolveColorValue(
   path: string | undefined,
   raw: unknown,
   colorFormat: ColorFormat,
-  project: ProjectData,
+  project: Pick<ProjectData, 'listing'>,
 ): FormatColorResult {
   if (path !== undefined && colorFormat === 'hex') {
     const listed = project.listing[path]?.previewValue;


### PR DESCRIPTION
## Summary

- `TokenTable`, `ColorPalette`, `ColorTable` row/group memos previously depended on the whole `project` object; replaced with `[listing, cssVarPrefix, …]`. Refactored `resolveCssVar` / `resolveColorValue` to take `Pick<ProjectData, …>` so callsites can pass narrow shapes without a parallel adapter. Existing callers passing the full `ProjectData` still work via structural subtyping (zero ripple to the 15+ other callsites).
- Preview decorator's `tuple` / `colorFormat` memos previously depended on the whole `globals` + `parameters` bags; Storybook recreates those per story render. Refactored `resolveTuple` to take `(axesGlobal, paramSwatchbook)` and `resolveColorFormat` to take `colorFormatGlobal` directly. Memos dep on the narrow primitives only.

Closes #936

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green