### PR TITLE
perf(blocks): memo ColorTable GroupRow and collapse Diagnostics traversals

### DIFF
--- a/.changeset/perf-grouprow-diagnostics.md
+++ b/.changeset/perf-grouprow-diagnostics.md
@@ -1,0 +1,8 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Two small perf fixes in blocks:
+
+- `GroupRow` in `<ColorTable>` is now wrapped in `React.memo`. Every variant-pill click or row-expand mutates `selectedByBase` / `expandedByBase` at the parent, but with no memo every row re-rendered on each mutation. With `memo` only the affected row re-renders; the parent's existing `useCallback`-wrapped handlers carry stable identity.
+- `<Diagnostics>` collapsed the three separate traversals over `diagnostics` (`summaryText` for counts, `hasErrorsOrWarnings` for the open-flag, `summaryVariant` for the className) into one `summarize()` walk that returns `{ text, variant, hasErrorsOrWarnings }`. Wrapped in `useMemo` keyed on `diagnostics` so the walk only runs when the array identity changes.

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,7 +1,7 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { memo, useCallback, useMemo, useState } from 'react';
 import './ColorTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
@@ -247,21 +247,23 @@ export function ColorTable({
   );
 }
 
-function GroupRow({
-  group,
-  selectedLabel,
-  expanded,
-  onToggleExpand,
-  onSelectVariant,
-  onSelect,
-}: {
+interface GroupRowProps {
   group: Group;
   selectedLabel: string | undefined;
   expanded: boolean;
   onToggleExpand(base: string): void;
   onSelectVariant(base: string, label: string): void;
   onSelect?(path: string): void;
-}): ReactElement {
+}
+
+const GroupRow = memo(function GroupRow({
+  group,
+  selectedLabel,
+  expanded,
+  onToggleExpand,
+  onSelectVariant,
+  onSelect,
+}: GroupRowProps): ReactElement {
   const multi = group.variants.length > 1;
   const active =
     group.variants.find((v) => v.label === selectedLabel) ?? (group.variants[0] as Variant);
@@ -375,7 +377,7 @@ function GroupRow({
       )}
     </>
   );
-}
+});
 
 function ExpandedDetail({ group, active }: { group: Group; active: Variant }): ReactElement {
   const hasDescription = active.description !== undefined && active.description.length > 0;

--- a/packages/blocks/src/Diagnostics.tsx
+++ b/packages/blocks/src/Diagnostics.tsx
@@ -1,5 +1,6 @@
 import cx from 'clsx';
 import type { ReactElement } from 'react';
+import { useMemo } from 'react';
 import './Diagnostics.css';
 import { themeAttrs } from '#/internal/data-attr.ts';
 import { useProject } from '#/internal/use-project.ts';
@@ -18,26 +19,38 @@ const severityLabel: Record<DiagnosticSeverity, string> = {
   info: 'INFO',
 };
 
-function summaryText(diagnostics: readonly VirtualDiagnostic[]): string {
-  if (diagnostics.length === 0) return '✔ OK · no diagnostics';
-  const counts = { error: 0, warn: 0, info: 0 };
-  for (const d of diagnostics) counts[d.severity] += 1;
+interface DiagnosticsSummary {
+  text: string;
+  variant: 'ok' | 'error' | 'warn' | null;
+  hasErrorsOrWarnings: boolean;
+}
+
+function summarize(diagnostics: readonly VirtualDiagnostic[]): DiagnosticsSummary {
+  if (diagnostics.length === 0) {
+    return { text: '✔ OK · no diagnostics', variant: 'ok', hasErrorsOrWarnings: false };
+  }
+  let errors = 0;
+  let warnings = 0;
+  let infos = 0;
+  for (const d of diagnostics) {
+    if (d.severity === 'error') errors += 1;
+    else if (d.severity === 'warn') warnings += 1;
+    else infos += 1;
+  }
   const parts: string[] = [];
-  if (counts.error > 0) parts.push(`✖ ${counts.error} error${counts.error === 1 ? '' : 's'}`);
-  if (counts.warn > 0) parts.push(`⚠ ${counts.warn} warning${counts.warn === 1 ? '' : 's'}`);
-  if (counts.info > 0) parts.push(`${counts.info} info`);
-  return parts.join(' · ');
+  if (errors > 0) parts.push(`✖ ${errors} error${errors === 1 ? '' : 's'}`);
+  if (warnings > 0) parts.push(`⚠ ${warnings} warning${warnings === 1 ? '' : 's'}`);
+  if (infos > 0) parts.push(`${infos} info`);
+  const variant = errors > 0 ? 'error' : warnings > 0 ? 'warn' : null;
+  return {
+    text: parts.join(' · '),
+    variant,
+    hasErrorsOrWarnings: errors > 0 || warnings > 0,
+  };
 }
 
 function diagnosticKey(d: VirtualDiagnostic, i: number): string {
   return `${d.severity}:${d.group}:${d.filename ?? ''}:${d.line ?? ''}:${d.message}:${i}`;
-}
-
-function summaryVariant(diagnostics: readonly VirtualDiagnostic[]): 'ok' | 'error' | 'warn' | null {
-  if (diagnostics.length === 0) return 'ok';
-  if (diagnostics.some((d) => d.severity === 'error')) return 'error';
-  if (diagnostics.some((d) => d.severity === 'warn')) return 'warn';
-  return null;
 }
 
 /**
@@ -52,20 +65,16 @@ function summaryVariant(diagnostics: readonly VirtualDiagnostic[]): 'ok' | 'erro
  */
 export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
   const { activeAxes, cssVarPrefix, diagnostics } = useProject();
-
-  const hasErrorsOrWarnings = diagnostics.some(
-    (d) => d.severity === 'error' || d.severity === 'warn',
-  );
-  const headingText = caption ?? `Diagnostics · ${summaryText(diagnostics)}`;
-  const variant = summaryVariant(diagnostics);
+  const summary = useMemo(() => summarize(diagnostics), [diagnostics]);
+  const headingText = caption ?? `Diagnostics · ${summary.text}`;
 
   return (
     <div {...themeAttrs(cssVarPrefix, activeAxes)} data-testid="diagnostics">
-      <details open={hasErrorsOrWarnings}>
+      <details open={summary.hasErrorsOrWarnings}>
         <summary
           className={cx(
             'sb-diagnostics__summary',
-            variant && `sb-diagnostics__summary--${variant}`,
+            summary.variant && `sb-diagnostics__summary--${summary.variant}`,
           )}
         >
           {headingText}


### PR DESCRIPTION
## Summary

- `GroupRow` in `<ColorTable>` is now `React.memo`-wrapped. Variant-pill clicks and row-expand toggles mutate state at the parent (`selectedByBase` / `expandedByBase`); without `memo` every row re-rendered on every click. Parent's handlers are already `useCallback`-stable, so memo equality holds.
- `<Diagnostics>` used three separate traversals over the diagnostics array (`summaryText` counts, `hasErrorsOrWarnings` early-exit, `summaryVariant` up to two `.some()` walks). Collapsed into a single `summarize()` pass that returns all three signals, memoized against the array identity.

Closes #938

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green