### PR TITLE
perf(blocks): useDeferredValue on TokenTable / TokenNavigator / ColorTable search

### DIFF
--- a/.changeset/perf-defer-search.md
+++ b/.changeset/perf-defer-search.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Wrap the search-query state with `useDeferredValue` in `<TokenTable>`, `<TokenNavigator>`, and `<ColorTable>`. The input controls the immediate `query` (still re-renders on every keystroke so the field stays responsive), but the heavy memos — `fuzzyFilter` scans, `pruneTreeForMatches` rebuilds, group visibility — key off the deferred copy and run at React's chosen tempo. Keystroke latency stops scaling with token count on large projects.

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,7 +1,7 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import './ColorTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
@@ -103,6 +103,7 @@ export function ColorTable({
   const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
   const colorFormat = useColorFormat();
   const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query);
   const [selectedByBase, setSelectedByBase] = useState<Record<string, string>>({});
   const [expandedByBase, setExpandedByBase] = useState<ReadonlySet<string>>(() => new Set());
 
@@ -152,9 +153,9 @@ export function ColorTable({
   }, [resolved, filter, project, sortBy, sortDir, defs, colorFormat]);
 
   const visibleGroups = useMemo(() => {
-    if (!searchable || query.trim() === '') return groups;
-    return fuzzyFilter(groups, query, (g) => g.searchText);
-  }, [groups, query, searchable]);
+    if (!searchable || deferredQuery.trim() === '') return groups;
+    return fuzzyFilter(groups, deferredQuery, (g) => g.searchText);
+  }, [groups, deferredQuery, searchable]);
 
   const totalTokens = useMemo(() => groups.reduce((n, g) => n + g.variants.length, 0), [groups]);
 

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -1,6 +1,6 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import type { KeyboardEvent, ReactElement } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
 import './TokenNavigator.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
@@ -231,18 +231,19 @@ export function TokenNavigator({
 
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query);
 
   const { visibleTree, searchExpanded } = useMemo(() => {
-    if (!searchable || query.trim() === '') {
+    if (!searchable || deferredQuery.trim() === '') {
       return { visibleTree: tree, searchExpanded: null as Set<string> | null };
     }
     const leafPaths: string[] = [];
     collectLeafPaths(tree, leafPaths);
-    const matches = new Set(fuzzyFilter(leafPaths, query, (p) => p));
+    const matches = new Set(fuzzyFilter(leafPaths, deferredQuery, (p) => p));
     const expandOut = new Set<string>();
     const pruned = matches.size === 0 ? [] : pruneTreeForMatches(tree, matches, expandOut);
     return { visibleTree: pruned, searchExpanded: expandOut };
-  }, [tree, query, searchable]);
+  }, [tree, deferredQuery, searchable]);
 
   const effectiveExpanded = useMemo(() => {
     if (!searchExpanded) return expanded;

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,7 +1,7 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import './TokenTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
@@ -66,6 +66,7 @@ export function TokenTable({
   const colorFormat = useColorFormat();
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const deferredQuery = useDeferredValue(query);
 
   const rows = useMemo(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
@@ -89,9 +90,9 @@ export function TokenTable({
   }, [resolved, filter, type, project, colorFormat, sortBy, sortDir]);
 
   const visibleRows = useMemo(() => {
-    if (!searchable || query.trim() === '') return rows;
-    return fuzzyFilter(rows, query, (row) => `${row.path} ${row.type} ${row.value}`);
-  }, [rows, query, searchable]);
+    if (!searchable || deferredQuery.trim() === '') return rows;
+    return fuzzyFilter(rows, deferredQuery, (row) => `${row.path} ${row.type} ${row.value}`);
+  }, [rows, deferredQuery, searchable]);
 
   const handleRowClick = useCallback(
     (path: string) => {

--- a/packages/blocks/test/color-table.browser.test.tsx
+++ b/packages/blocks/test/color-table.browser.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { userEvent } from '@vitest/browser/context';
 import { ColorTable, SwatchbookProvider } from '#/index.ts';
@@ -62,9 +62,13 @@ describe('ColorTable — base rendering', () => {
     const input = screen.getByTestId('color-table-search') as HTMLInputElement;
     await userEvent.fill(input, 'default text');
 
-    const rows = screen.getAllByTestId('color-table-row');
-    expect(rows.length).toBe(1);
-    expect(rows[0]?.getAttribute('data-path')).toBe('color.text.default');
+    // Filter is deferred via `useDeferredValue`; wait for the narrow
+    // commit before asserting on the row set.
+    await waitFor(() => {
+      const rows = screen.getAllByTestId('color-table-row');
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.getAttribute('data-path')).toBe('color.text.default');
+    });
   });
 
   it('renders the empty state when the filter matches no colors', () => {

--- a/packages/blocks/test/token-navigator.browser.test.tsx
+++ b/packages/blocks/test/token-navigator.browser.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { userEvent } from '@vitest/browser/context';
 import { SwatchbookProvider, TokenNavigator } from '#/index.ts';
@@ -128,11 +128,14 @@ describe('TokenNavigator', () => {
     await userEvent.fill(input, 'bg');
 
     // `color.bg` is the single leaf matching 'bg'; `radius` and `color.fg` /
-    // `color.palette.blue.500` prune out.
-    const leafPaths = within(screen.getByRole('tree'))
-      .getAllByTestId('token-navigator-leaf')
-      .map((el) => el.getAttribute('data-path'));
-    expect(leafPaths).toEqual(['color.bg']);
+    // `color.palette.blue.500` prune out. The filter runs through
+    // `useDeferredValue`, so wait for the deferred render to commit.
+    await waitFor(() => {
+      const leafPaths = within(screen.getByRole('tree'))
+        .getAllByTestId('token-navigator-leaf')
+        .map((el) => el.getAttribute('data-path'));
+      expect(leafPaths).toEqual(['color.bg']);
+    });
     expect(container.textContent).toContain('matching "bg"');
   });
 
@@ -148,11 +151,14 @@ describe('TokenNavigator', () => {
 
     // `color.palette.blue.500` is nested under `color > palette > blue`.
     // Even though `initiallyExpanded={0}` leaves everything collapsed, the
-    // search should reveal the matching leaf.
-    const leafPaths = within(screen.getByRole('tree'))
-      .getAllByTestId('token-navigator-leaf')
-      .map((el) => el.getAttribute('data-path'));
-    expect(leafPaths).toContain('color.palette.blue.500');
+    // search should reveal the matching leaf once the deferred render
+    // commits.
+    await waitFor(() => {
+      const leafPaths = within(screen.getByRole('tree'))
+        .getAllByTestId('token-navigator-leaf')
+        .map((el) => el.getAttribute('data-path'));
+      expect(leafPaths).toContain('color.palette.blue.500');
+    });
   });
 
   it('shows an empty message when the search matches nothing', async () => {
@@ -165,7 +171,7 @@ describe('TokenNavigator', () => {
     const input = screen.getByTestId('token-navigator-search') as HTMLInputElement;
     await userEvent.fill(input, 'xyz-no-match');
 
-    screen.getByText(/No tokens match "xyz-no-match"/);
+    await screen.findByText(/No tokens match "xyz-no-match"/);
     expect(screen.queryByRole('tree')).toBeNull();
   });
 

--- a/packages/blocks/test/token-table.browser.test.tsx
+++ b/packages/blocks/test/token-table.browser.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { userEvent } from '@vitest/browser/context';
 import { SwatchbookProvider, TokenTable } from '#/index.ts';
@@ -128,16 +128,19 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     const before = within(screen.getByRole('table')).getAllByRole('row').length;
     expect(before).toBeGreaterThan(2);
 
-    // Typing narrows rows to those whose path contains the needle.
+    // Typing narrows rows to those whose path contains the needle. The
+    // filter runs through `useDeferredValue`, so wait for the deferred
+    // render to commit before asserting on the row set.
     await userEvent.fill(input, 'surface');
 
-    const after = within(screen.getByRole('table')).getAllByRole('row');
-    // Header row + at least one matching row; no non-matching rows.
-    const bodyRows = after.filter((r) => r.getAttribute('data-path'));
-    expect(bodyRows.length).toBeGreaterThan(0);
-    for (const row of bodyRows) {
-      expect(row.getAttribute('data-path')).toContain('surface');
-    }
+    await waitFor(() => {
+      const after = within(screen.getByRole('table')).getAllByRole('row');
+      const bodyRows = after.filter((r) => r.getAttribute('data-path'));
+      expect(bodyRows.length).toBeGreaterThan(0);
+      for (const row of bodyRows) {
+        expect(row.getAttribute('data-path')).toContain('surface');
+      }
+    });
     expect(container.textContent).toContain('matching "surface"');
   });
 
@@ -152,7 +155,7 @@ describe('SwatchbookProvider + blocks (no Storybook, no virtual module)', () => 
     const input = screen.getByTestId('token-table-search') as HTMLInputElement;
     await userEvent.fill(input, 'xyz-no-match');
 
-    screen.getByText(/No tokens match "xyz-no-match"/);
+    await screen.findByText(/No tokens match "xyz-no-match"/);
   });
 
   it('hides the search input when searchable={false}', () => {


### PR DESCRIPTION
## Summary

In all three search-equipped blocks (`<TokenTable>`, `<TokenNavigator>`, `<ColorTable>`), the input field and the heavy filter / tree-prune memo were both driven by the same `query` state. Every keystroke ran the `fuzzyFilter` scan synchronously — on large projects (hundreds of tokens) the latency stretches past the perception threshold.

Wrapped `query` with `useDeferredValue` and re-keyed each heavy memo on the deferred copy. The input still re-renders on every keystroke (immediate feedback); the filter / prune work runs at React's chosen tempo.

Closes #937

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green