### PR TITLE
refactor(core,blocks,addon): brand TupleKey for canonical tuple keys

### DIFF
--- a/.changeset/types-brand-tuple-key.md
+++ b/.changeset/types-brand-tuple-key.md
@@ -1,0 +1,15 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Brand `TupleKey` for canonical-tuple-key strings.
+
+`canonicalKey` and `jointOverrideKey` now return a `TupleKey = string & { readonly __brand: 'TupleKey' }` instead of bare `string`. `Project.jointOverrides` and the in-memory memo Map inside `buildResolveAt` use it too, as does the wire-shape `jointOverrides` entry the addon ships through `virtual:swatchbook/tokens` for the blocks preview.
+
+The brand catches places that pass an arbitrary string (token paths, axis names, theme display names) into a context expecting a canonical tuple key — these used to all compile as plain `string`. Structurally still `string`, so JSON round-trips and `Map` lookups behave identically; the brand is purely compile-time.
+
+Scope is intentionally narrow per [issue #941](https://github.com/unpunnyfuns/swatchbook/issues/941)'s "alternative narrower scope" — axis and context names stay bare `string` to avoid casting every fixture literal.
+
+`TupleKey` is exported from `@unpunnyfuns/swatchbook-core`.

--- a/packages/addon/src/channel-types.ts
+++ b/packages/addon/src/channel-types.ts
@@ -20,6 +20,7 @@ import type {
   Diagnostic,
   DiagnosticSeverity,
   Preset,
+  TupleKey,
 } from '@unpunnyfuns/swatchbook-core';
 
 export type { DiagnosticSeverity };
@@ -100,7 +101,7 @@ export interface VirtualJointOverride {
  * as an array of `[key, entry]` pairs so JSON round-trips don't drop
  * the iteration order or the entry structure.
  */
-export type VirtualJointOverrides = readonly (readonly [string, VirtualJointOverride])[];
+export type VirtualJointOverrides = readonly (readonly [TupleKey, VirtualJointOverride])[];
 
 /**
  * Wire-payload variance types — re-exports of core's discriminated

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -1,4 +1,10 @@
-import type { Axis, AxisVarianceResult, Diagnostic, Preset } from '@unpunnyfuns/swatchbook-core';
+import type {
+  Axis,
+  AxisVarianceResult,
+  Diagnostic,
+  Preset,
+  TupleKey,
+} from '@unpunnyfuns/swatchbook-core';
 import type { SlimListedToken } from '@unpunnyfuns/swatchbook-core/snapshot-for-wire';
 import { createContext, useContext } from 'react';
 import { useChannelGlobals } from '#/internal/channel-globals.ts';
@@ -113,7 +119,7 @@ export interface ProjectSnapshot {
    * Same ascending-arity iteration order the Map carries on the
    * server side. Empty array when no joint divergences exist.
    */
-  jointOverrides: readonly (readonly [string, VirtualJointOverrideShape])[];
+  jointOverrides: readonly (readonly [TupleKey, VirtualJointOverrideShape])[];
   /**
    * Cached per-path variance results. Blocks read this for O(1) axis
    * variance lookup instead of recomputing on each render.

--- a/packages/blocks/src/internal/channel-tokens.ts
+++ b/packages/blocks/src/internal/channel-tokens.ts
@@ -12,6 +12,7 @@ import {
   presets as initialPresets,
   varianceByPath as initialVarianceByPath,
 } from 'virtual:swatchbook/tokens';
+import type { TupleKey } from '@unpunnyfuns/swatchbook-core';
 import type {
   VirtualJointOverrideShape,
   VirtualTokenListingShape,
@@ -50,7 +51,7 @@ export interface TokenSnapshot {
   readonly cssVarPrefix: string;
   readonly listing: Readonly<Record<string, VirtualTokenListingShape>>;
   readonly cells: Record<string, Record<string, Record<string, VirtualToken>>>;
-  readonly jointOverrides: readonly (readonly [string, VirtualJointOverrideShape])[];
+  readonly jointOverrides: readonly (readonly [TupleKey, VirtualJointOverrideShape])[];
   readonly varianceByPath: VirtualVarianceByPathShape;
   readonly defaultTuple: Record<string, string>;
   /** Monotonic counter, bumped on each update. Useful as a React key. */

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -8,6 +8,7 @@
  * the `addon/src/virtual.d.ts` → `addon/src/channel-types.ts` pattern.
  */
 declare module 'virtual:swatchbook/tokens' {
+  import type { TupleKey } from '@unpunnyfuns/swatchbook-core';
   import type {
     VirtualAxisShape,
     VirtualDiagnosticShape,
@@ -26,7 +27,7 @@ declare module 'virtual:swatchbook/tokens' {
   export const cssVarPrefix: string;
   export const listing: Readonly<Record<string, VirtualTokenListingShape>>;
   export const cells: Record<string, Record<string, Record<string, VirtualTokenShape>>>;
-  export const jointOverrides: readonly (readonly [string, VirtualJointOverrideShape])[];
+  export const jointOverrides: readonly (readonly [TupleKey, VirtualJointOverrideShape])[];
   export const varianceByPath: VirtualVarianceByPathShape;
   export const defaultTuple: Record<string, string>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject } from '#/load.ts';
 export { emitAxisProjectedCss } from '#/css-axis-projected.ts';
 export { jointOverrideKey } from '#/joint-overrides.ts';
+export type { TupleKey } from '#/tuple-key.ts';
 export { type ListedToken, type TokenListingByPath } from '#/token-listing.ts';
 
 export type {

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -1,6 +1,7 @@
 import type { Resolver } from '@terrazzo/parser';
 import { buildResolveAt } from '#/resolve-at.ts';
 import { canonicalKey } from '#/tuple-key.ts';
+import type { TupleKey } from '#/tuple-key.ts';
 import type { Axis, Cells, JointOverride, JointOverrides, TokenMap } from '#/types.ts';
 import { valueKey } from '#/value-key.ts';
 
@@ -63,7 +64,7 @@ export function probeJointOverrides(
   // Internal Map keyed on canonicalKey for dedupe across arity passes.
   // Materialized to the public array shape on return so the wire
   // boundary doesn't have to marshal a Map.
-  const overrides = new Map<string, JointOverride>();
+  const overrides = new Map<TupleKey, JointOverride>();
   const jointTouching = new Map<string, Set<string>>();
   // Baseline carries the values for paths that delta cells omit;
   // touching detection compares against this to avoid flagging
@@ -179,6 +180,6 @@ function* contextProducts(axisCombo: readonly Axis[]): Generator<Record<string, 
  * Canonical key for a partial tuple — axes sorted by name so
  * `{A:a,B:b}` and `{B:b,A:a}` produce the same lookup key.
  */
-export function jointOverrideKey(axes: Readonly<Record<string, string>>): string {
+export function jointOverrideKey(axes: Readonly<Record<string, string>>): TupleKey {
   return canonicalKey(axes);
 }

--- a/packages/core/src/resolve-at.ts
+++ b/packages/core/src/resolve-at.ts
@@ -9,6 +9,7 @@
  * shipping `@terrazzo/parser` to the client.
  */
 import { canonicalKey } from '#/tuple-key.ts';
+import type { TupleKey } from '#/tuple-key.ts';
 import type { Axis, Cells, JointOverrides, ResolveAt, TokenMap } from '#/types.ts';
 
 /**
@@ -40,7 +41,7 @@ export function buildResolveAt(
   jointOverrides: JointOverrides,
   defaultTuple: Readonly<Record<string, string>>,
 ): ResolveAt {
-  const memo = new Map<string, TokenMap>();
+  const memo = new Map<TupleKey, TokenMap>();
   return function resolveAt(tuple: Record<string, string>): TokenMap {
     const full: Record<string, string> = { ...defaultTuple };
     for (const axis of axes) {

--- a/packages/core/src/tuple-key.ts
+++ b/packages/core/src/tuple-key.ts
@@ -1,4 +1,15 @@
 /**
+ * Branded canonical-tuple-key type. Structurally `string` so JSON
+ * serialization / `Map` lookups behave identically at runtime; the
+ * brand catches places that pass arbitrary strings (token paths, axis
+ * names, theme display names) into a context expecting a canonical
+ * tuple key, which used to all compile as plain `string`.
+ *
+ * Produced by {@link canonicalKey} and {@link jointOverrideKey}.
+ */
+export type TupleKey = string & { readonly __brand: 'TupleKey' };
+
+/**
  * Canonical key for an axis tuple — axes sorted by name so `{A:a,B:b}`
  * and `{B:b,A:a}` produce the same lookup key. Used as the Map key for
  * `Project.jointOverrides` and the memoization key inside
@@ -6,9 +17,9 @@
  * browser-safe `resolve-at` subpath can use it without pulling the
  * Terrazzo parser.
  */
-export function canonicalKey(tuple: Readonly<Record<string, string>>): string {
+export function canonicalKey(tuple: Readonly<Record<string, string>>): TupleKey {
   return Object.keys(tuple)
     .toSorted()
     .map((k) => `${k}:${tuple[k]}`)
-    .join('|');
+    .join('|') as TupleKey;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -4,6 +4,7 @@ import type { CSSPluginOptions } from '@terrazzo/plugin-css';
 import type { TokenListingPluginOptions } from '@terrazzo/plugin-token-listing';
 import type { ChromeRole } from '#/chrome.ts';
 import type { TokenListingByPath } from '#/token-listing.ts';
+import type { TupleKey } from '#/tuple-key.ts';
 
 /**
  * Swatchbook's public token shape — the contract surfaced on
@@ -130,7 +131,7 @@ export interface JointOverride {
  * uses a temporary Map keyed on canonical tuple, materialized to this
  * array shape on return.
  */
-export type JointOverrides = readonly (readonly [string, JointOverride])[];
+export type JointOverrides = readonly (readonly [TupleKey, JointOverride])[];
 
 /**
  * Compute the resolved `TokenMap` for any tuple of axis selections


### PR DESCRIPTION
## Summary

Narrow-scope take on [#941](https://github.com/unpunnyfuns/swatchbook/issues/941). `canonicalKey` and `jointOverrideKey` now return a branded `TupleKey = string & { readonly __brand: 'TupleKey' }` instead of bare \`string\`. The brand flows through:

- `Project.jointOverrides` (entry key in the `[key, override]` pairs).
- The in-memory memo \`Map\` inside \`buildResolveAt\`.
- The wire-shape entries the addon ships through \`virtual:swatchbook/tokens\` — both \`packages/addon/src/channel-types.ts\` (\`VirtualJointOverrides\`) and the blocks-side mirror in \`packages/blocks/src/contexts.ts\` + \`virtual.d.ts\`.

The brand catches places that pass arbitrary strings (token paths, axis names, theme display names) into a context expecting a canonical tuple key — all previously plain \`string\`. Structurally still \`string\`: JSON serialization + \`Map\` lookups behave identically at runtime, the brand is purely compile-time.

Per #941's own \"alternative narrower scope\" recommendation, axis and context names stay bare \`string\`. Branding those too would force casts on every fixture literal (\`'mode' as AxisName\`), which the issue flagged as the dominant cost. The canonical-key string is where the actual confusion risk lives, so it's where the brand earns its keep.

\`TupleKey\` is exported from \`@unpunnyfuns/swatchbook-core\`.

Closes #941

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green
- [x] No runtime behavior changes (brand is structural \`string\`); existing test fixtures unchanged