### PR TITLE
fix(core): correct variance-analysis docstring on layered projects

### DIFF
--- a/.changeset/variance-docstring-fix.md
+++ b/.changeset/variance-docstring-fix.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Fix `analyzeProjectVariance` docstring: layered / plain-parse multi-touch tokens classify as `orthogonal-after-probe`, not `joint-variant` with empty `jointCases` as the docstring previously claimed.
+
+The implementation was correct; the comment had drifted. Cascade composition over per-axis cells IS the spec for layered modifiers (the loader builds the cells by cascade in the first place), so there's no hidden joint resolution for `analyzeProjectVariance` to surface — `orthogonal-after-probe` is the right classification. No behavioural change.

--- a/packages/core/src/variance-analysis.ts
+++ b/packages/core/src/variance-analysis.ts
@@ -40,9 +40,13 @@ import { valueKey } from '#/value-key.ts';
  * `$extensions` annotation is the future override).
  *
  * Layered and plain-parse projects don't have `project.parserInput.resolver`,
- * so Phase 3 is skipped — multi-touch tokens in those projects are
- * conservatively classified as `joint-variant` with empty `jointCases`.
- * The downstream emitter falls back to cartesian-style emit for them.
+ * so `project.jointOverrides` is empty — there's no resolver to probe for
+ * joint divergence in Phase 3. Multi-touch tokens in those projects
+ * classify as `orthogonal-after-probe`: cascade composition over per-axis
+ * cells IS the spec for layered modifiers (the loader builds the cells
+ * by cascade in the first place), so there's no hidden joint resolution
+ * to surface. The emitter routes them via projection, which produces
+ * the same result the layered config defined.
  */
 
 /** Distinguishes a token's variance shape so the emitter can route it. */

--- a/packages/core/test/variance-analysis-layered.test.ts
+++ b/packages/core/test/variance-analysis-layered.test.ts
@@ -41,14 +41,14 @@ beforeAll(async () => {
   variance = analyzeProjectVariance(layeredProject);
 }, 30_000);
 
-it("classifies multi-touch tokens in a layered project as orthogonal-after-probe (Phase 3 skipped, jointCases empty)", () => {
+it('classifies multi-touch tokens in a layered project as orthogonal-after-probe', () => {
   // `color.text` is overridden by both modes/dark.json and brands/brand-a.json
-  // in this layered fixture — multi-touch by construction. The classifier's
-  // top-of-file docstring claims layered projects conservatively classify
-  // these as `joint-variant` with empty `jointCases`; the implementation
-  // actually returns `orthogonal-after-probe` (see `variance-analysis.ts:208`
-  // — when `jointCases.length === 0`, the kind is `orthogonal-after-probe`,
-  // not `joint-variant`). Tracked separately; this test pins current behaviour.
+  // in this layered fixture — multi-touch by construction. Layered projects
+  // have no resolver to probe in Phase 3, so `jointOverrides` is empty.
+  // Cascade composition over per-axis cells IS the spec for layered
+  // modifiers (the loader builds the cells by cascade), so multi-touch
+  // tokens correctly classify as `orthogonal-after-probe` — projection
+  // emit produces the same result the layered config defined.
   const info = variance.get('color.text');
   expect(info, 'fixture must define color.text as a multi-touch token').toBeDefined();
   expect(info?.kind).toBe('orthogonal-after-probe');


### PR DESCRIPTION
## Summary

The classifier's top-of-file docstring claimed layered / plain-parse multi-touch tokens are "conservatively classified as \`joint-variant\` with empty \`jointCases\`." The implementation actually returns \`orthogonal-after-probe\` for them, and that's the correct semantics — cascade composition over per-axis cells IS the spec for layered modifiers (the loader builds the cells by cascade in the first place), so there's no hidden joint resolution to surface. Projection emit produces the same result the layered config defined.

Updated the docstring + the test comment in \`variance-analysis-layered.test.ts\` (which previously called out the discrepancy as "tracked separately"). No code-path change.

Closes #942

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green