### PR TITLE
feat(a11y): page-level theme/axis-flip live region in preview decorator

### DIFF
--- a/.changeset/a11y-page-live-region.md
+++ b/.changeset/a11y-page-live-region.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Add a page-level `role="status" aria-live="polite"` region to the addon's preview decorator so screen readers announce theme/axis-flip changes. When a user flips the toolbar or applies a preset, the region's text content becomes `Theme: <composed tuple name>` after a 250ms debounce — rapid axis flips collapse into one announcement instead of bursting through.
+
+The element renders inside the existing `themedDecorator` wrapper (sibling of the per-story `<Story />` container) with the standard visually-hidden style so it's discoverable by SR but stays out of visual + pointer flow. Initial story mount stays silent (no spurious announcement on page load); only subsequent `themeName` changes fire.

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -6,7 +6,8 @@ import type {
   JointOverrides,
 } from '@unpunnyfuns/swatchbook-core';
 import type { Decorator, Preview } from '@storybook/react-vite';
-import { useEffect, useMemo } from 'react';
+import type { CSSProperties } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { addons } from 'storybook/preview-api';
 import { dataAttr } from '@unpunnyfuns/swatchbook-core/data-attr';
 import { ensureStyleElement } from '@unpunnyfuns/swatchbook-core/style-element';
@@ -47,6 +48,24 @@ import {
   TOKENS_UPDATED_EVENT,
 } from '#/constants.ts';
 import type { StoryParameters, SwatchbookGlobals } from '#/globals.ts';
+
+/**
+ * Standard visually-hidden style for the theme-flip live region.
+ * Keeps the announcement element discoverable by SR but out of visual
+ * + pointer flow. The clip-path / `position: absolute` combination is
+ * the canonical sr-only pattern.
+ */
+const SR_ONLY_STYLE: CSSProperties = {
+  position: 'absolute',
+  width: 1,
+  height: 1,
+  padding: 0,
+  margin: -1,
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+  border: 0,
+};
 
 /**
  * The `html, body { ... }` rules that paint the iframe's own chrome
@@ -293,6 +312,23 @@ const themedDecorator: Decorator = (Story, context) => {
     setRootAxes(tuple);
   }, [tuple]);
 
+  // Page-level live region announces theme/axis flips to SR users.
+  // Initial mount stays silent (no spurious announcement on every story
+  // load); subsequent `themeName` changes schedule a debounced update so
+  // rapid axis flips (or per-story tuple overrides while paging through
+  // a Storybook docs index) collapse into one announcement.
+  const [announcement, setAnnouncement] = useState('');
+  const initialThemeRef = useRef(themeName);
+  useEffect(() => {
+    if (themeName === initialThemeRef.current) return;
+    const timer = setTimeout(() => {
+      setAnnouncement(themeName ? `Theme: ${themeName}` : '');
+    }, 250);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [themeName]);
+
   const wrapperAttrs: Record<string, string> = {};
   for (const axis of virtualAxes) {
     const value = tuple[axis.name];
@@ -335,6 +371,9 @@ const themedDecorator: Decorator = (Story, context) => {
               }}
             >
               <Story />
+            </div>
+            <div role="status" aria-live="polite" style={SR_ONLY_STYLE}>
+              {announcement}
             </div>
           </ColorFormatContext.Provider>
         </AxesContext.Provider>


### PR DESCRIPTION
## Summary

Adds the page-level live region that was deferred from [#947](https://github.com/unpunnyfuns/swatchbook/pull/947). When a Storybook user flips the toolbar or applies a preset, the region's text becomes \`Theme: <composed tuple name>\` after a 250ms debounce — rapid axis flips collapse into one announcement instead of bursting through.

**Implementation:**

- New \`<div role=\"status\" aria-live=\"polite\">\` rendered inside \`themedDecorator\`, sibling of the per-story wrapper, with the standard visually-hidden style (off-flow, not a pointer target, available to SR).
- Local \`announcement\` state + \`useEffect\` keyed on \`themeName\`. Effect schedules a 250ms \`setTimeout\` that updates the state; cleanup clears any pending timer so rapid changes collapse.
- A \`useRef\` captures the initial \`themeName\` on mount; the effect early-returns when the current value still equals the initial, so loading the story doesn't fire a spurious announcement.

**Behavior on MDX:** the addon's preview decorator is bypassed in pure MDX renders without a story. The live region only fires from real-story preview renders — fine, the toolbar isn't visible on MDX-only docs pages anyway.

Closes #948

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green
- [ ] Browser smoke (manual): toolbar mode flip → VO/NVDA announces \"Theme: Dark · Brand A · Normal\" after ~250ms; rapid flips produce one final announcement