### PR TITLE
feat(core): stress-scale benchmark fixture and phase-partitioned harness

### DIFF
--- a/.changeset/stress-bench.md
+++ b/.changeset/stress-bench.md
@@ -1,0 +1,13 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Add a phase-partitioned benchmark harness for `loadProject`.
+
+`packages/core/bench/fixtures/stress/` carries a deterministic generator + checked-in output modelling a realistic consumer shape (6 modifier axes, 200 mixed-type tokens with ~40% aliases, 30% per-context overlay density). `packages/core/bench/run.mts` imports the loader's exported sub-phases directly and times each — `parse`, `buildCells`, `probe`, `variance`, `listing`, `emitCss`, `snapshotWire` — and partitions `resolver.apply` call counts between cell construction and joint-pair probing via a thin `wrapResolver()` proxy.
+
+Run-friendly via `pnpm --filter @unpunnyfuns/swatchbook-core bench`. Writes `packages/core/bench/baseline.json` so future PRs can diff against a known floor. Resilient to per-phase failures (writes a partial baseline with `errors[phase]` annotations).
+
+Also adds `probeJointOverrides`'s implementation as a per-arity generator (`probeJointOverridesByArity`) and an opt-in `maxArity` cap via `ProbeOptions`. Default behaviour unchanged — `loadProject` and all existing call sites continue to do the full arity sweep. The generator + option are net-new advanced-consumer surface; the bench uses them when measuring against fixtures large enough to make all-arities sweeps impractical.
+
+Initial baseline on the realistic fixture: `probe` is ~93% of total `loadProject` wall-clock (~2s of ~2.15s at 6 axes), with ~70× more `resolver.apply` calls than `buildCells`. The probe cost is the wall a future alias-graph optimisation can target.

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ __screenshots__/
 
 # Superpowers local working artifacts (specs/plans not meant to ship)
 docs/superpowers/
+
+# Bench harness writes a phase-log + baseline per run; the harness +
+# fixture + generator ship, the per-run output stays local.
+packages/core/bench/phase-log.txt

--- a/packages/core/bench/baseline.json
+++ b/packages/core/bench/baseline.json
@@ -1,0 +1,28 @@
+{
+  "fixtureVersion": "2.0.0",
+  "node": "v24.15.0",
+  "generatedAt": "2026-05-18T15:11:02.388Z",
+  "loadMs": {
+    "parse": 112.86,
+    "buildCells": 2.58,
+    "probe": 2015.23,
+    "variance": 3.55,
+    "listing": 13.99,
+    "snapshotWire": 0.14,
+    "emitCss": 6.61,
+    "total": 2154.96
+  },
+  "resolverApplyCount": {
+    "atCells": 11,
+    "atProbe": 277,
+    "total": 288
+  },
+  "wireBytes": 0,
+  "cssBytes": 39451,
+  "jointOverrideCount": 7,
+  "axisCount": 6,
+  "defaultTokenCount": 200,
+  "errors": {
+    "snapshotWire": "Cannot read properties of undefined (reading 'app.terrazzo.listing')"
+  }
+}

--- a/packages/core/bench/fixtures/stress/gen.mts
+++ b/packages/core/bench/fixtures/stress/gen.mts
@@ -1,0 +1,289 @@
+/**
+ * Deterministic generator for the stress-scale benchmark fixture.
+ *
+ * Models a realistic consumer scale (matching the shape at
+ * https://torquens.bill.works/token-adventure/): 6 modifier axes with
+ * small context counts, a few hundred tokens of mixed types, partial
+ * overlay density per modifier-context, and a small alias chain depth
+ * so each `resolver.apply` does real graph-rebuild work.
+ *
+ * No joint divergences are seeded — every modifier-context overlay is
+ * a primitive redefinition, so cell-composition (last-wins) and
+ * `resolver.apply` always agree. `probeJointOverrides` should find
+ * zero overrides; the bench then measures the COST of those probes
+ * (the work an alias-graph optimisation would elide).
+ *
+ * Run:
+ *   node packages/core/bench/fixtures/stress/gen.mts
+ */
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const FIXTURE_VERSION = '2.0.0';
+const SEED_STRING = 'swatchbook-stress-2026';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+interface AxisDef {
+  name: string;
+  contexts: readonly string[];
+}
+
+// Axis shape mirrors the friend's torquens.bill.works/token-adventure demo:
+// 6 modifiers with small context counts. First context in each list is the
+// default; resolution order = array order.
+const AXES: readonly AxisDef[] = [
+  { name: 'disabled', contexts: ['enabled', 'disabled'] },
+  { name: 'forced', contexts: ['standard', 'forced'] },
+  { name: 'container', contexts: ['panel', 'control-primary', 'control-secondary'] },
+  { name: 'sentiment', contexts: ['neutral', 'positive', 'negative', 'warning'] },
+  { name: 'state', contexts: ['default', 'hover', 'active'] },
+  { name: 'mode', contexts: ['light', 'dark'] },
+];
+
+const TOTAL_TOKENS = 200;
+const ALIAS_FRACTION = 0.4; // 40% of tokens are aliases to other tokens
+const OVERLAY_DENSITY = 0.3; // each modifier-context overlay redefines ~30% of tokens
+
+interface TypeMix {
+  type: string;
+  fraction: number;
+}
+const TYPE_MIX: readonly TypeMix[] = [
+  { type: 'color', fraction: 0.5 },
+  { type: 'dimension', fraction: 0.2 },
+  { type: 'fontWeight', fraction: 0.1 },
+  { type: 'duration', fraction: 0.1 },
+  { type: 'number', fraction: 0.1 },
+];
+
+function lcgFromString(seed: string): () => number {
+  let state = 0;
+  for (let i = 0; i < seed.length; i++) {
+    state = (state * 31 + seed.charCodeAt(i)) >>> 0;
+  }
+  if (state === 0) state = 1;
+  return function next(): number {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+const rng = lcgFromString(SEED_STRING);
+
+function pickType(): string {
+  const r = rng();
+  let acc = 0;
+  for (const { type, fraction } of TYPE_MIX) {
+    acc += fraction;
+    if (r < acc) return type;
+  }
+  return TYPE_MIX[TYPE_MIX.length - 1]!.type;
+}
+
+interface NestedTokenGroup {
+  [key: string]: NestedTokenGroup | { $type?: string; $value: unknown };
+}
+
+function placeToken(
+  root: NestedTokenGroup,
+  path: string,
+  $type: string,
+  $value: unknown,
+): void {
+  const segments = path.split('.');
+  let node = root;
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i] as string;
+    const existing = node[seg];
+    if (!existing || typeof existing !== 'object' || '$value' in existing) {
+      const fresh: NestedTokenGroup = {};
+      node[seg] = fresh;
+      node = fresh;
+    } else {
+      node = existing as NestedTokenGroup;
+    }
+  }
+  const leaf = segments[segments.length - 1] as string;
+  node[leaf] = { $type, $value };
+}
+
+function primitiveValue($type: string): unknown {
+  switch ($type) {
+    case 'color':
+      return { colorSpace: 'srgb', components: [rng(), rng(), rng()] };
+    case 'dimension':
+      return { value: 4 + Math.floor(rng() * 60), unit: 'px' };
+    case 'fontWeight':
+      return [100, 200, 300, 400, 500, 600, 700, 800, 900][Math.floor(rng() * 9)]!;
+    case 'duration':
+      return { value: 50 + Math.floor(rng() * 500), unit: 'ms' };
+    case 'number':
+      return Math.floor(rng() * 100) / 10;
+    default:
+      return 0;
+  }
+}
+
+interface TokenSpec {
+  path: string;
+  $type: string;
+  /** True if this token's base-set value is a primitive (overlay-safe). */
+  primitive: boolean;
+}
+
+/**
+ * Generate one base-set entry per token. Some are primitives; others
+ * are aliases pointing at a primitive token in the same set. Each
+ * alias resolves through one or two hops at apply time, which exercises
+ * Terrazzo's alias-resolution work without exploding the graph.
+ *
+ * `spec.primitive` flags whether the base-set value is primitive-shaped.
+ * Modifier overlays only redefine primitive-shaped paths: redefining
+ * an alias-shaped base with a primitive-shaped overlay triggers
+ * Terrazzo's destructiveMerge to crash (object-into-string).
+ */
+function buildSpecsAndBase(): {
+  specs: readonly TokenSpec[];
+  set: NestedTokenGroup;
+} {
+  const specs: TokenSpec[] = [];
+  const set: NestedTokenGroup = {};
+
+  // Per-type primitive token pools — aliases must point at a token of
+  // the same DTCG type to keep the parser happy.
+  const primitivesByType = new Map<string, string[]>();
+  for (let i = 0; i < TOTAL_TOKENS; i++) {
+    const $type = pickType();
+    const path = `${$type}.t${String(i).padStart(3, '0')}`;
+    const list = primitivesByType.get($type) ?? [];
+    // Force the first ~10 tokens per type to be primitive so aliases
+    // later have a target to point at.
+    const asPrimitive = list.length < 10 || rng() >= ALIAS_FRACTION;
+    if (asPrimitive) {
+      placeToken(set, path, $type, primitiveValue($type));
+      list.push(path);
+      primitivesByType.set($type, list);
+    } else {
+      const target = list[Math.floor(rng() * list.length)] as string;
+      placeToken(set, path, $type, `{${target}}`);
+    }
+    specs.push({ path, $type, primitive: asPrimitive });
+  }
+  return { specs, set };
+}
+
+/**
+ * For each non-default modifier-context, emit a cell file that
+ * redefines a random subset of tokens with fresh primitive values.
+ * Primitive overlays compose correctly under last-wins, so the probe
+ * finds zero joint divergences — which is the structural property
+ * we're measuring "wasted work" against.
+ */
+function buildModifierOverlays(specs: readonly TokenSpec[]): {
+  axisIdx: number;
+  ctxIdx: number;
+  overlay: NestedTokenGroup;
+}[] {
+  const overlays: { axisIdx: number; ctxIdx: number; overlay: NestedTokenGroup }[] = [];
+  for (let axisIdx = 0; axisIdx < AXES.length; axisIdx++) {
+    const axis = AXES[axisIdx]!;
+    for (let ctxIdx = 1; ctxIdx < axis.contexts.length; ctxIdx++) {
+      const overlay: NestedTokenGroup = {};
+      for (const spec of specs) {
+        if (!spec.primitive) continue;
+        if (rng() < OVERLAY_DENSITY) {
+          placeToken(overlay, spec.path, spec.$type, primitiveValue(spec.$type));
+        }
+      }
+      overlays.push({ axisIdx, ctxIdx, overlay });
+    }
+  }
+  return overlays;
+}
+
+interface ResolverManifest {
+  $schema: string;
+  version: string;
+  name: string;
+  description: string;
+  sets: Record<string, { description: string; sources: { $ref: string }[] }>;
+  modifiers: Record<
+    string,
+    {
+      description: string;
+      contexts: Record<string, { $ref: string }[]>;
+      default: string;
+    }
+  >;
+  resolutionOrder: { $ref: string }[];
+}
+
+function buildResolverManifest(): ResolverManifest {
+  const modifiers: ResolverManifest['modifiers'] = {};
+  for (let axisIdx = 0; axisIdx < AXES.length; axisIdx++) {
+    const axis = AXES[axisIdx]!;
+    const contexts: Record<string, { $ref: string }[]> = {};
+    for (let ctxIdx = 0; ctxIdx < axis.contexts.length; ctxIdx++) {
+      const ctx = axis.contexts[ctxIdx] as string;
+      contexts[ctx] =
+        ctxIdx === 0 ? [] : [{ $ref: `./modifiers/${axis.name}/${ctx}.json` }];
+    }
+    modifiers[axis.name] = {
+      description: `Stress fixture modifier ${axis.name}.`,
+      contexts,
+      default: axis.contexts[0]!,
+    };
+  }
+  const resolutionOrder: { $ref: string }[] = [
+    { $ref: '#/sets/base' },
+    ...AXES.map((a) => ({ $ref: `#/modifiers/${a.name}` })),
+  ];
+  return {
+    $schema: 'https://www.designtokens.org/TR/2025.10/resolver/',
+    version: '2025.10',
+    name: 'swatchbook-stress',
+    description: `Stress fixture v${FIXTURE_VERSION}: realistic 6-axis shape matching the torquens.bill.works/token-adventure demo. ${TOTAL_TOKENS} tokens (~${Math.round(ALIAS_FRACTION * 100)}% aliases), ${AXES.length} modifiers with ${AXES.map((a) => a.contexts.length).join('/')} contexts. Each non-default modifier-context overlay redefines ~${Math.round(OVERLAY_DENSITY * 100)}% of tokens with primitive values; no joint divergences seeded so probeJointOverrides should produce zero overrides. Generated from gen.mts (seed "${SEED_STRING}").`,
+    sets: {
+      base: {
+        description: 'Base set — mixed primitive + alias tokens across DTCG types.',
+        sources: [{ $ref: './sets/base.json' }],
+      },
+    },
+    modifiers,
+    resolutionOrder,
+  };
+}
+
+function writeJson(path: string, data: unknown): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`);
+}
+
+function main(): void {
+  const outDir = __dirname;
+  for (const sub of ['sets', 'modifiers']) {
+    rmSync(join(outDir, sub), { recursive: true, force: true });
+  }
+  rmSync(join(outDir, 'resolver.json'), { force: true });
+
+  const { specs, set } = buildSpecsAndBase();
+  const overlays = buildModifierOverlays(specs);
+
+  writeJson(join(outDir, 'sets', 'base.json'), set);
+  for (const { axisIdx, ctxIdx, overlay } of overlays) {
+    const axis = AXES[axisIdx]!;
+    const ctx = axis.contexts[ctxIdx] as string;
+    writeJson(join(outDir, 'modifiers', axis.name, `${ctx}.json`), overlay);
+  }
+  writeJson(join(outDir, 'resolver.json'), buildResolverManifest());
+
+  const cartesianCount = AXES.reduce((n, a) => n * a.contexts.length, 1);
+  // eslint-disable-next-line no-console
+  console.log(
+    `Generated stress fixture v${FIXTURE_VERSION}: ${AXES.length} axes (${AXES.map((a) => `${a.name}=${a.contexts.length}`).join(', ')}), ${specs.length} tokens, ${overlays.length} non-default modifier cells, ${cartesianCount} cartesian permutations.`,
+  );
+}
+
+main();

--- a/packages/core/bench/fixtures/stress/modifiers/container/control-primary.json
+++ b/packages/core/bench/fixtures/stress/modifiers/container/control-primary.json
@@ -1,0 +1,299 @@
+{
+  "number": {
+    "t000": {
+      "$type": "number",
+      "$value": 1.5
+    },
+    "t029": {
+      "$type": "number",
+      "$value": 0.4
+    },
+    "t036": {
+      "$type": "number",
+      "$value": 3.7
+    },
+    "t052": {
+      "$type": "number",
+      "$value": 2.8
+    },
+    "t196": {
+      "$type": "number",
+      "$value": 1
+    }
+  },
+  "color": {
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.897579321404919,
+          0.45602949569001794,
+          0.7323813999537379
+        ]
+      }
+    },
+    "t008": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9490378606133163,
+          0.48100535315461457,
+          0.6715276576578617
+        ]
+      }
+    },
+    "t038": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7768979552201927,
+          0.3049808640498668,
+          0.5088005773723125
+        ]
+      }
+    },
+    "t044": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.34888959606178105,
+          0.6909527089446783,
+          0.29392411350272596
+        ]
+      }
+    },
+    "t047": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7368374753277749,
+          0.6346879373304546,
+          0.1749529477674514
+        ]
+      }
+    },
+    "t057": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.11712279333733022,
+          0.05364779243245721,
+          0.3277666086796671
+        ]
+      }
+    },
+    "t079": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9106291634961963,
+          0.24443647894077003,
+          0.8661768580786884
+        ]
+      }
+    },
+    "t080": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.35810840874910355,
+          0.6351410744246095,
+          0.432974596042186
+        ]
+      }
+    },
+    "t091": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6617342631798238,
+          0.46048736898228526,
+          0.9739232112187892
+        ]
+      }
+    },
+    "t102": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.33791807829402387,
+          0.32534033292904496,
+          0.35373669140972197
+        ]
+      }
+    },
+    "t117": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47508489643223584,
+          0.9233018402010202,
+          0.23162857606075704
+        ]
+      }
+    },
+    "t140": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2367551752831787,
+          0.14420620584860444,
+          0.07085812115110457
+        ]
+      }
+    },
+    "t169": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5317146023735404,
+          0.4845837901812047,
+          0.06941934255883098
+        ]
+      }
+    },
+    "t172": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21732254675589502,
+          0.048206829000264406,
+          0.7081096379552037
+        ]
+      }
+    },
+    "t177": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.07439808314666152,
+          0.7054176696110517,
+          0.582577308639884
+        ]
+      }
+    },
+    "t188": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05295300483703613,
+          0.8364443404134363,
+          0.7517946478910744
+        ]
+      }
+    }
+  },
+  "fontWeight": {
+    "t012": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t045": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t065": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t077": {
+      "$type": "fontWeight",
+      "$value": 200
+    }
+  },
+  "dimension": {
+    "t016": {
+      "$type": "dimension",
+      "$value": {
+        "value": 39,
+        "unit": "px"
+      }
+    },
+    "t022": {
+      "$type": "dimension",
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      }
+    },
+    "t027": {
+      "$type": "dimension",
+      "$value": {
+        "value": 55,
+        "unit": "px"
+      }
+    },
+    "t040": {
+      "$type": "dimension",
+      "$value": {
+        "value": 7,
+        "unit": "px"
+      }
+    },
+    "t069": {
+      "$type": "dimension",
+      "$value": {
+        "value": 53,
+        "unit": "px"
+      }
+    },
+    "t081": {
+      "$type": "dimension",
+      "$value": {
+        "value": 59,
+        "unit": "px"
+      }
+    },
+    "t101": {
+      "$type": "dimension",
+      "$value": {
+        "value": 21,
+        "unit": "px"
+      }
+    },
+    "t122": {
+      "$type": "dimension",
+      "$value": {
+        "value": 61,
+        "unit": "px"
+      }
+    },
+    "t138": {
+      "$type": "dimension",
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      }
+    },
+    "t166": {
+      "$type": "dimension",
+      "$value": {
+        "value": 30,
+        "unit": "px"
+      }
+    },
+    "t190": {
+      "$type": "dimension",
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      }
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/container/control-secondary.json
+++ b/packages/core/bench/fixtures/stress/modifiers/container/control-secondary.json
@@ -1,0 +1,394 @@
+{
+  "number": {
+    "t000": {
+      "$type": "number",
+      "$value": 8.4
+    },
+    "t010": {
+      "$type": "number",
+      "$value": 9.1
+    },
+    "t052": {
+      "$type": "number",
+      "$value": 2
+    },
+    "t061": {
+      "$type": "number",
+      "$value": 8.2
+    },
+    "t127": {
+      "$type": "number",
+      "$value": 2
+    },
+    "t170": {
+      "$type": "number",
+      "$value": 9.6
+    },
+    "t191": {
+      "$type": "number",
+      "$value": 3.7
+    }
+  },
+  "color": {
+    "t001": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2988471647258848,
+          0.8129333262331784,
+          0.08091625408269465
+        ]
+      }
+    },
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.909813700011,
+          0.8850787826813757,
+          0.9968106898013502
+        ]
+      }
+    },
+    "t014": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.09377951244823635,
+          0.5790258734486997,
+          0.27807016973383725
+        ]
+      }
+    },
+    "t017": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9115023603662848,
+          0.7024566631298512,
+          0.9132641884498298
+        ]
+      }
+    },
+    "t031": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9743218147195876,
+          0.2547140943352133,
+          0.21394129376858473
+        ]
+      }
+    },
+    "t044": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.49594440613873303,
+          0.09869604744017124,
+          0.27443332388065755
+        ]
+      }
+    },
+    "t048": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4608085926156491,
+          0.6586915361694992,
+          0.7653105084318668
+        ]
+      }
+    },
+    "t055": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5902046910487115,
+          0.69943582941778,
+          0.6600296031683683
+        ]
+      }
+    },
+    "t057": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5603846265003085,
+          0.45649339887313545,
+          0.9108272786252201
+        ]
+      }
+    },
+    "t058": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5185466930270195,
+          0.1702787724789232,
+          0.5098284524865448
+        ]
+      }
+    },
+    "t084": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3708686358295381,
+          0.3521221347618848,
+          0.3324324991554022
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4105329748708755,
+          0.6360649168491364,
+          0.19178628153167665
+        ]
+      }
+    },
+    "t091": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.39790912927128375,
+          0.9294682564213872,
+          0.3855877823662013
+        ]
+      }
+    },
+    "t102": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.021476436406373978,
+          0.30137729248963296,
+          0.2738492791540921
+        ]
+      }
+    },
+    "t103": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.17308920715004206,
+          0.5485993965994567,
+          0.646692683454603
+        ]
+      }
+    },
+    "t107": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5733860412146896,
+          0.6363208540715277,
+          0.20569138252176344
+        ]
+      }
+    },
+    "t112": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9284688904881477,
+          0.916007756954059,
+          0.04771192790940404
+        ]
+      }
+    },
+    "t116": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.679281750228256,
+          0.6913666606415063,
+          0.32687227614223957
+        ]
+      }
+    },
+    "t129": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.939044096507132,
+          0.610806506825611,
+          0.9368418729864061
+        ]
+      }
+    },
+    "t141": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.10052911820821464,
+          0.4665535013191402,
+          0.20285121467895806
+        ]
+      }
+    },
+    "t149": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7390364266466349,
+          0.8441319628618658,
+          0.9915506199467927
+        ]
+      }
+    },
+    "t152": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7838060648646206,
+          0.026186755392700434,
+          0.7450880075339228
+        ]
+      }
+    },
+    "t176": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8783529826905578,
+          0.7345809736289084,
+          0.631197631591931
+        ]
+      }
+    },
+    "t182": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8997504934668541,
+          0.42620588815771043,
+          0.5920536858029664
+        ]
+      }
+    },
+    "t184": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.11340927402488887,
+          0.8079142509959638,
+          0.7047070295084268
+        ]
+      }
+    },
+    "t198": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.953315099934116,
+          0.05278580728918314,
+          0.5319460004102439
+        ]
+      }
+    }
+  },
+  "dimension": {
+    "t016": {
+      "$type": "dimension",
+      "$value": {
+        "value": 5,
+        "unit": "px"
+      }
+    },
+    "t040": {
+      "$type": "dimension",
+      "$value": {
+        "value": 57,
+        "unit": "px"
+      }
+    },
+    "t056": {
+      "$type": "dimension",
+      "$value": {
+        "value": 8,
+        "unit": "px"
+      }
+    },
+    "t122": {
+      "$type": "dimension",
+      "$value": {
+        "value": 34,
+        "unit": "px"
+      }
+    },
+    "t142": {
+      "$type": "dimension",
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      }
+    }
+  },
+  "duration": {
+    "t025": {
+      "$type": "duration",
+      "$value": {
+        "value": 304,
+        "unit": "ms"
+      }
+    },
+    "t088": {
+      "$type": "duration",
+      "$value": {
+        "value": 160,
+        "unit": "ms"
+      }
+    },
+    "t095": {
+      "$type": "duration",
+      "$value": {
+        "value": 453,
+        "unit": "ms"
+      }
+    }
+  },
+  "fontWeight": {
+    "t065": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t077": {
+      "$type": "fontWeight",
+      "$value": 400
+    },
+    "t094": {
+      "$type": "fontWeight",
+      "$value": 900
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/disabled/disabled.json
+++ b/packages/core/bench/fixtures/stress/modifiers/disabled/disabled.json
@@ -1,0 +1,372 @@
+{
+  "color": {
+    "t001": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5360242142342031,
+          0.9412661597598344,
+          0.2906422112137079
+        ]
+      }
+    },
+    "t004": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5174861466512084,
+          0.8643225755076855,
+          0.7710649031214416
+        ]
+      }
+    },
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6819833223707974,
+          0.5257372243795544,
+          0.9894783506169915
+        ]
+      }
+    },
+    "t013": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4086113933008164,
+          0.11550201429054141,
+          0.22640493628568947
+        ]
+      }
+    },
+    "t017": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.41307572345249355,
+          0.10464773466810584,
+          0.00661640171892941
+        ]
+      }
+    },
+    "t026": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9498129151761532,
+          0.578701559221372,
+          0.4489309270866215
+        ]
+      }
+    },
+    "t032": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.030492668971419334,
+          0.04588762461207807,
+          0.33442539209499955
+        ]
+      }
+    },
+    "t047": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.016921544447541237,
+          0.56983951642178,
+          0.35713993618264794
+        ]
+      }
+    },
+    "t067": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47102610883302987,
+          0.969873271882534,
+          0.5439482477959245
+        ]
+      }
+    },
+    "t079": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14259165828116238,
+          0.6160684246569872,
+          0.5306201444473118
+        ]
+      }
+    },
+    "t085": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7360174853820354,
+          0.7409235052764416,
+          0.9336882417555898
+        ]
+      }
+    },
+    "t087": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24554061237722635,
+          0.7238851755391806,
+          0.20788232749328017
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05048721074126661,
+          0.4605270796455443,
+          0.07331497245468199
+        ]
+      }
+    },
+    "t103": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8990076885093004,
+          0.008783916011452675,
+          0.28386693610809743
+        ]
+      }
+    },
+    "t137": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6361967024859041,
+          0.5522733223624527,
+          0.9879733345005661
+        ]
+      }
+    },
+    "t140": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.305944997118786,
+          0.3323971200734377,
+          0.552358211716637
+        ]
+      }
+    },
+    "t141": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8713447342161089,
+          0.3297890415415168,
+          0.34043986606411636
+        ]
+      }
+    },
+    "t159": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2109778441954404,
+          0.13217738829553127,
+          0.8033205920364708
+        ]
+      }
+    },
+    "t167": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7411611217539757,
+          0.4522555093280971,
+          0.8377323236782104
+        ]
+      }
+    },
+    "t182": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.43480205186642706,
+          0.12145093735307455,
+          0.35756559926085174
+        ]
+      }
+    },
+    "t183": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.30076513928361237,
+          0.32953402772545815,
+          0.8635676910635084
+        ]
+      }
+    },
+    "t184": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9337090088520199,
+          0.22402738127857447,
+          0.41289069200865924
+        ]
+      }
+    },
+    "t193": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4460716242901981,
+          0.6064896148163825,
+          0.3621702119708061
+        ]
+      }
+    }
+  },
+  "duration": {
+    "t005": {
+      "$type": "duration",
+      "$value": {
+        "value": 111,
+        "unit": "ms"
+      }
+    },
+    "t113": {
+      "$type": "duration",
+      "$value": {
+        "value": 119,
+        "unit": "ms"
+      }
+    }
+  },
+  "fontWeight": {
+    "t009": {
+      "$type": "fontWeight",
+      "$value": 900
+    },
+    "t041": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t045": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t054": {
+      "$type": "fontWeight",
+      "$value": 400
+    },
+    "t065": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t180": {
+      "$type": "fontWeight",
+      "$value": 300
+    }
+  },
+  "dimension": {
+    "t016": {
+      "$type": "dimension",
+      "$value": {
+        "value": 27,
+        "unit": "px"
+      }
+    },
+    "t022": {
+      "$type": "dimension",
+      "$value": {
+        "value": 43,
+        "unit": "px"
+      }
+    },
+    "t039": {
+      "$type": "dimension",
+      "$value": {
+        "value": 14,
+        "unit": "px"
+      }
+    },
+    "t053": {
+      "$type": "dimension",
+      "$value": {
+        "value": 42,
+        "unit": "px"
+      }
+    },
+    "t059": {
+      "$type": "dimension",
+      "$value": {
+        "value": 45,
+        "unit": "px"
+      }
+    },
+    "t125": {
+      "$type": "dimension",
+      "$value": {
+        "value": 53,
+        "unit": "px"
+      }
+    },
+    "t187": {
+      "$type": "dimension",
+      "$value": {
+        "value": 25,
+        "unit": "px"
+      }
+    }
+  },
+  "number": {
+    "t029": {
+      "$type": "number",
+      "$value": 2.3
+    },
+    "t093": {
+      "$type": "number",
+      "$value": 1.8
+    },
+    "t120": {
+      "$type": "number",
+      "$value": 0.6
+    },
+    "t170": {
+      "$type": "number",
+      "$value": 2.7
+    },
+    "t191": {
+      "$type": "number",
+      "$value": 3.9
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/forced/forced.json
+++ b/packages/core/bench/fixtures/stress/modifiers/forced/forced.json
@@ -1,0 +1,366 @@
+{
+  "number": {
+    "t000": {
+      "$type": "number",
+      "$value": 4.8
+    },
+    "t052": {
+      "$type": "number",
+      "$value": 9.9
+    },
+    "t120": {
+      "$type": "number",
+      "$value": 9.5
+    },
+    "t127": {
+      "$type": "number",
+      "$value": 5.3
+    },
+    "t156": {
+      "$type": "number",
+      "$value": 4
+    },
+    "t191": {
+      "$type": "number",
+      "$value": 2.3
+    },
+    "t196": {
+      "$type": "number",
+      "$value": 5.8
+    }
+  },
+  "duration": {
+    "t005": {
+      "$type": "duration",
+      "$value": {
+        "value": 417,
+        "unit": "ms"
+      }
+    },
+    "t020": {
+      "$type": "duration",
+      "$value": {
+        "value": 141,
+        "unit": "ms"
+      }
+    },
+    "t088": {
+      "$type": "duration",
+      "$value": {
+        "value": 88,
+        "unit": "ms"
+      }
+    },
+    "t095": {
+      "$type": "duration",
+      "$value": {
+        "value": 317,
+        "unit": "ms"
+      }
+    },
+    "t113": {
+      "$type": "duration",
+      "$value": {
+        "value": 509,
+        "unit": "ms"
+      }
+    },
+    "t121": {
+      "$type": "duration",
+      "$value": {
+        "value": 346,
+        "unit": "ms"
+      }
+    },
+    "t192": {
+      "$type": "duration",
+      "$value": {
+        "value": 287,
+        "unit": "ms"
+      }
+    }
+  },
+  "color": {
+    "t007": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.37807251140475273,
+          0.3831139688845724,
+          0.015125565696507692
+        ]
+      }
+    },
+    "t008": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4449135297909379,
+          0.9292432337533683,
+          0.8297312981449068
+        ]
+      }
+    },
+    "t011": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5803719037212431,
+          0.7791095750872046,
+          0.601540002040565
+        ]
+      }
+    },
+    "t026": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.700033153872937,
+          0.921518323244527,
+          0.5230665691196918
+        ]
+      }
+    },
+    "t047": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45699841529130936,
+          0.5232807395514101,
+          0.109069783706218
+        ]
+      }
+    },
+    "t087": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.32082269550301135,
+          0.6333001228049397,
+          0.1229798651766032
+        ]
+      }
+    },
+    "t103": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.06200732383877039,
+          0.9767807021271437,
+          0.13427615677937865
+        ]
+      }
+    },
+    "t108": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.22688823961652815,
+          0.38311567436903715,
+          0.8539470944087952
+        ]
+      }
+    },
+    "t112": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6950694469269365,
+          0.7072140318341553,
+          0.6724067202303559
+        ]
+      }
+    },
+    "t116": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8571079988032579,
+          0.9277759657707065,
+          0.5254924581386149
+        ]
+      }
+    },
+    "t159": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.35327159776352346,
+          0.6423353017307818,
+          0.4041814024094492
+        ]
+      }
+    },
+    "t163": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9817023302894086,
+          0.3073929506354034,
+          0.4872243676800281
+        ]
+      }
+    },
+    "t169": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.17200490925461054,
+          0.7076450034510344,
+          0.03543730592355132
+        ]
+      }
+    },
+    "t172": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2157714345958084,
+          0.1832385607995093,
+          0.4014827760402113
+        ]
+      }
+    },
+    "t182": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6869913635309786,
+          0.5354493749327958,
+          0.10687798471190035
+        ]
+      }
+    },
+    "t184": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.46358186891302466,
+          0.8464204252231866,
+          0.19436259754002094
+        ]
+      }
+    },
+    "t188": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.11160444119013846,
+          0.6185399880632758,
+          0.5096989970188588
+        ]
+      }
+    },
+    "t193": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6177121484652162,
+          0.5499920367728919,
+          0.7310773706994951
+        ]
+      }
+    },
+    "t198": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45135535579174757,
+          0.5096672314684838,
+          0.08452805085107684
+        ]
+      }
+    }
+  },
+  "dimension": {
+    "t015": {
+      "$type": "dimension",
+      "$value": {
+        "value": 5,
+        "unit": "px"
+      }
+    },
+    "t016": {
+      "$type": "dimension",
+      "$value": {
+        "value": 55,
+        "unit": "px"
+      }
+    },
+    "t064": {
+      "$type": "dimension",
+      "$value": {
+        "value": 15,
+        "unit": "px"
+      }
+    },
+    "t086": {
+      "$type": "dimension",
+      "$value": {
+        "value": 42,
+        "unit": "px"
+      }
+    },
+    "t105": {
+      "$type": "dimension",
+      "$value": {
+        "value": 7,
+        "unit": "px"
+      }
+    },
+    "t122": {
+      "$type": "dimension",
+      "$value": {
+        "value": 38,
+        "unit": "px"
+      }
+    },
+    "t142": {
+      "$type": "dimension",
+      "$value": {
+        "value": 17,
+        "unit": "px"
+      }
+    },
+    "t199": {
+      "$type": "dimension",
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      }
+    }
+  },
+  "fontWeight": {
+    "t023": {
+      "$type": "fontWeight",
+      "$value": 300
+    },
+    "t045": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t054": {
+      "$type": "fontWeight",
+      "$value": 500
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/mode/dark.json
+++ b/packages/core/bench/fixtures/stress/modifiers/mode/dark.json
@@ -1,0 +1,293 @@
+{
+  "color": {
+    "t001": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.44402378750965,
+          0.9309724729973823,
+          0.19168394058942795
+        ]
+      }
+    },
+    "t011": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8177201787475497,
+          0.9165977379307151,
+          0.08579709636978805
+        ]
+      }
+    },
+    "t031": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5238831457681954,
+          0.8292777782771736,
+          0.8299547852948308
+        ]
+      }
+    },
+    "t051": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.21133372629992664,
+          0.5068373582325876,
+          0.6897800706792623
+        ]
+      }
+    },
+    "t085": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.960324255283922,
+          0.9670944430399686,
+          0.11386907659471035
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2563769605476409,
+          0.09632353484630585,
+          0.16790802008472383
+        ]
+      }
+    },
+    "t092": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3340783091261983,
+          0.9335662580560893,
+          0.6117587848566473
+        ]
+      }
+    },
+    "t109": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6045278958044946,
+          0.031831949250772595,
+          0.31139461509883404
+        ]
+      }
+    },
+    "t147": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4971524684224278,
+          0.9485688144341111,
+          0.7419139116536826
+        ]
+      }
+    },
+    "t157": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9467737702652812,
+          0.8460187900345773,
+          0.6625502775423229
+        ]
+      }
+    },
+    "t172": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.1949740443378687,
+          0.40721946372650564,
+          0.2139273346401751
+        ]
+      }
+    },
+    "t188": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9884409019723535,
+          0.8284235044848174,
+          0.8698705635033548
+        ]
+      }
+    },
+    "t193": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3392128152772784,
+          0.4474173847120255,
+          0.6583557571284473
+        ]
+      }
+    }
+  },
+  "dimension": {
+    "t015": {
+      "$type": "dimension",
+      "$value": {
+        "value": 57,
+        "unit": "px"
+      }
+    },
+    "t016": {
+      "$type": "dimension",
+      "$value": {
+        "value": 15,
+        "unit": "px"
+      }
+    },
+    "t027": {
+      "$type": "dimension",
+      "$value": {
+        "value": 57,
+        "unit": "px"
+      }
+    },
+    "t035": {
+      "$type": "dimension",
+      "$value": {
+        "value": 12,
+        "unit": "px"
+      }
+    },
+    "t040": {
+      "$type": "dimension",
+      "$value": {
+        "value": 13,
+        "unit": "px"
+      }
+    },
+    "t042": {
+      "$type": "dimension",
+      "$value": {
+        "value": 43,
+        "unit": "px"
+      }
+    },
+    "t064": {
+      "$type": "dimension",
+      "$value": {
+        "value": 38,
+        "unit": "px"
+      }
+    },
+    "t076": {
+      "$type": "dimension",
+      "$value": {
+        "value": 21,
+        "unit": "px"
+      }
+    },
+    "t083": {
+      "$type": "dimension",
+      "$value": {
+        "value": 24,
+        "unit": "px"
+      }
+    },
+    "t086": {
+      "$type": "dimension",
+      "$value": {
+        "value": 55,
+        "unit": "px"
+      }
+    },
+    "t096": {
+      "$type": "dimension",
+      "$value": {
+        "value": 55,
+        "unit": "px"
+      }
+    },
+    "t125": {
+      "$type": "dimension",
+      "$value": {
+        "value": 62,
+        "unit": "px"
+      }
+    }
+  },
+  "number": {
+    "t029": {
+      "$type": "number",
+      "$value": 7.4
+    },
+    "t061": {
+      "$type": "number",
+      "$value": 9.2
+    },
+    "t093": {
+      "$type": "number",
+      "$value": 6.2
+    },
+    "t124": {
+      "$type": "number",
+      "$value": 2.7
+    },
+    "t156": {
+      "$type": "number",
+      "$value": 2.3
+    },
+    "t170": {
+      "$type": "number",
+      "$value": 5.3
+    },
+    "t191": {
+      "$type": "number",
+      "$value": 2
+    }
+  },
+  "fontWeight": {
+    "t054": {
+      "$type": "fontWeight",
+      "$value": 300
+    },
+    "t065": {
+      "$type": "fontWeight",
+      "$value": 600
+    },
+    "t094": {
+      "$type": "fontWeight",
+      "$value": 800
+    }
+  },
+  "duration": {
+    "t088": {
+      "$type": "duration",
+      "$value": {
+        "value": 357,
+        "unit": "ms"
+      }
+    },
+    "t134": {
+      "$type": "duration",
+      "$value": {
+        "value": 173,
+        "unit": "ms"
+      }
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/sentiment/negative.json
+++ b/packages/core/bench/fixtures/stress/modifiers/sentiment/negative.json
@@ -1,0 +1,335 @@
+{
+  "number": {
+    "t000": {
+      "$type": "number",
+      "$value": 9.3
+    },
+    "t093": {
+      "$type": "number",
+      "$value": 6.8
+    },
+    "t170": {
+      "$type": "number",
+      "$value": 2.2
+    }
+  },
+  "color": {
+    "t004": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.26327859493903816,
+          0.03930887533351779,
+          0.8417824965436012
+        ]
+      }
+    },
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.28273700387217104,
+          0.0474382983520627,
+          0.469632440013811
+        ]
+      }
+    },
+    "t007": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3931774527300149,
+          0.9355734009295702,
+          0.5512502656783909
+        ]
+      }
+    },
+    "t008": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6600692609790713,
+          0.022699161432683468,
+          0.5577517102938145
+        ]
+      }
+    },
+    "t013": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9363745658192784,
+          0.11023830715566874,
+          0.6542862623464316
+        ]
+      }
+    },
+    "t014": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4864188798237592,
+          0.6220066156238317,
+          0.7979392313864082
+        ]
+      }
+    },
+    "t017": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45664126379415393,
+          0.035684936912730336,
+          0.705682635307312
+        ]
+      }
+    },
+    "t032": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4829611396417022,
+          0.1270300771575421,
+          0.9752486306242645
+        ]
+      }
+    },
+    "t057": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.02352845878340304,
+          0.9439244167879224,
+          0.025921889347955585
+        ]
+      }
+    },
+    "t079": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7776924348436296,
+          0.7361760654021055,
+          0.7013314124196768
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9028863406274468,
+          0.12220087368041277,
+          0.645330861909315
+        ]
+      }
+    },
+    "t102": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.04787121317349374,
+          0.06717558251693845,
+          0.6725569798145443
+        ]
+      }
+    },
+    "t103": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5006098940502852,
+          0.9199620238505304,
+          0.02381777693517506
+        ]
+      }
+    },
+    "t109": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5738530112430453,
+          0.9196073028724641,
+          0.581881761085242
+        ]
+      }
+    },
+    "t112": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5959342566784471,
+          0.7046656650491059,
+          0.8521838358137757
+        ]
+      }
+    },
+    "t157": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4945438918657601,
+          0.9076758271548897,
+          0.34226296562701464
+        ]
+      }
+    },
+    "t183": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6596525320783257,
+          0.36702564801089466,
+          0.6028233072720468
+        ]
+      }
+    },
+    "t188": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08995072566904128,
+          0.467712233774364,
+          0.9419912460725754
+        ]
+      }
+    }
+  },
+  "duration": {
+    "t005": {
+      "$type": "duration",
+      "$value": {
+        "value": 115,
+        "unit": "ms"
+      }
+    },
+    "t088": {
+      "$type": "duration",
+      "$value": {
+        "value": 544,
+        "unit": "ms"
+      }
+    },
+    "t121": {
+      "$type": "duration",
+      "$value": {
+        "value": 101,
+        "unit": "ms"
+      }
+    },
+    "t192": {
+      "$type": "duration",
+      "$value": {
+        "value": 249,
+        "unit": "ms"
+      }
+    }
+  },
+  "dimension": {
+    "t015": {
+      "$type": "dimension",
+      "$value": {
+        "value": 19,
+        "unit": "px"
+      }
+    },
+    "t053": {
+      "$type": "dimension",
+      "$value": {
+        "value": 34,
+        "unit": "px"
+      }
+    },
+    "t056": {
+      "$type": "dimension",
+      "$value": {
+        "value": 58,
+        "unit": "px"
+      }
+    },
+    "t059": {
+      "$type": "dimension",
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      }
+    },
+    "t069": {
+      "$type": "dimension",
+      "$value": {
+        "value": 6,
+        "unit": "px"
+      }
+    },
+    "t122": {
+      "$type": "dimension",
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      }
+    },
+    "t138": {
+      "$type": "dimension",
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      }
+    },
+    "t142": {
+      "$type": "dimension",
+      "$value": {
+        "value": 19,
+        "unit": "px"
+      }
+    },
+    "t187": {
+      "$type": "dimension",
+      "$value": {
+        "value": 5,
+        "unit": "px"
+      }
+    },
+    "t190": {
+      "$type": "dimension",
+      "$value": {
+        "value": 11,
+        "unit": "px"
+      }
+    },
+    "t199": {
+      "$type": "dimension",
+      "$value": {
+        "value": 43,
+        "unit": "px"
+      }
+    }
+  },
+  "fontWeight": {
+    "t077": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t094": {
+      "$type": "fontWeight",
+      "$value": 500
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/sentiment/positive.json
+++ b/packages/core/bench/fixtures/stress/modifiers/sentiment/positive.json
@@ -1,0 +1,366 @@
+{
+  "color": {
+    "t004": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5695282844826579,
+          0.30379646900109947,
+          0.05363202793523669
+        ]
+      }
+    },
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3413168308325112,
+          0.6339094585273415,
+          0.3775231959298253
+        ]
+      }
+    },
+    "t007": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.34760615369305015,
+          0.3690438971389085,
+          0.02895311452448368
+        ]
+      }
+    },
+    "t018": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.34319958183914423,
+          0.5200287743937224,
+          0.13176568364724517
+        ]
+      }
+    },
+    "t032": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9680490386672318,
+          0.06215554685331881,
+          0.6976939933374524
+        ]
+      }
+    },
+    "t038": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.017841892316937447,
+          0.5118768231477588,
+          0.005117996130138636
+        ]
+      }
+    },
+    "t044": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.17941645137034357,
+          0.40478519396856427,
+          0.31105849728919566
+        ]
+      }
+    },
+    "t067": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9072160378564149,
+          0.011480921879410744,
+          0.5175592990126461
+        ]
+      }
+    },
+    "t084": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8336178520694375,
+          0.9912838533055037,
+          0.991991316433996
+        ]
+      }
+    },
+    "t087": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4711059429682791,
+          0.8557872476521879,
+          0.5044662309810519
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.767369405599311,
+          0.7959231659770012,
+          0.24391584075056016
+        ]
+      }
+    },
+    "t091": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.40458961040712893,
+          0.7573308991268277,
+          0.4509370557498187
+        ]
+      }
+    },
+    "t092": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0605923265684396,
+          0.6784493047744036,
+          0.06509758695028722
+        ]
+      }
+    },
+    "t103": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4449993008747697,
+          0.6973565488588065,
+          0.6455571777187288
+        ]
+      }
+    },
+    "t112": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5250569949857891,
+          0.7306466933805496,
+          0.9233672320842743
+        ]
+      }
+    },
+    "t117": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9143956913612783,
+          0.724231104599312,
+          0.015451142564415932
+        ]
+      }
+    },
+    "t129": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2385231836233288,
+          0.0382885942235589,
+          0.5583679422270507
+        ]
+      }
+    },
+    "t141": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.09942103456705809,
+          0.03363070520572364,
+          0.38565052999183536
+        ]
+      }
+    },
+    "t149": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13790972996503115,
+          0.429338016314432,
+          0.09767375281080604
+        ]
+      }
+    },
+    "t163": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9848716657143086,
+          0.7454410823993385,
+          0.5537487317342311
+        ]
+      }
+    },
+    "t169": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7248307287227362,
+          0.10479518538340926,
+          0.44201829214580357
+        ]
+      }
+    },
+    "t193": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.32699658907949924,
+          0.2335055263247341,
+          0.022273650858551264
+        ]
+      }
+    },
+    "t194": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8728057211264968,
+          0.17902605491690338,
+          0.5801285314373672
+        ]
+      }
+    },
+    "t198": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.27735216752626,
+          0.8527196208015084,
+          0.3628826036583632
+        ]
+      }
+    }
+  },
+  "duration": {
+    "t005": {
+      "$type": "duration",
+      "$value": {
+        "value": 339,
+        "unit": "ms"
+      }
+    },
+    "t113": {
+      "$type": "duration",
+      "$value": {
+        "value": 294,
+        "unit": "ms"
+      }
+    },
+    "t121": {
+      "$type": "duration",
+      "$value": {
+        "value": 234,
+        "unit": "ms"
+      }
+    }
+  },
+  "dimension": {
+    "t027": {
+      "$type": "dimension",
+      "$value": {
+        "value": 53,
+        "unit": "px"
+      }
+    },
+    "t039": {
+      "$type": "dimension",
+      "$value": {
+        "value": 35,
+        "unit": "px"
+      }
+    },
+    "t059": {
+      "$type": "dimension",
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      }
+    },
+    "t101": {
+      "$type": "dimension",
+      "$value": {
+        "value": 60,
+        "unit": "px"
+      }
+    },
+    "t105": {
+      "$type": "dimension",
+      "$value": {
+        "value": 37,
+        "unit": "px"
+      }
+    },
+    "t142": {
+      "$type": "dimension",
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      }
+    },
+    "t187": {
+      "$type": "dimension",
+      "$value": {
+        "value": 19,
+        "unit": "px"
+      }
+    }
+  },
+  "fontWeight": {
+    "t077": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t094": {
+      "$type": "fontWeight",
+      "$value": 900
+    }
+  },
+  "number": {
+    "t120": {
+      "$type": "number",
+      "$value": 3.2
+    },
+    "t168": {
+      "$type": "number",
+      "$value": 8.8
+    },
+    "t196": {
+      "$type": "number",
+      "$value": 4.8
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/sentiment/warning.json
+++ b/packages/core/bench/fixtures/stress/modifiers/sentiment/warning.json
@@ -1,0 +1,463 @@
+{
+  "color": {
+    "t001": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4006145289167762,
+          0.13481316971592605,
+          0.1273893746547401
+        ]
+      }
+    },
+    "t007": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.47862007981166244,
+          0.32441648025996983,
+          0.5778726991266012
+        ]
+      }
+    },
+    "t038": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6926589303184301,
+          0.34205625765025616,
+          0.42833326547406614
+        ]
+      }
+    },
+    "t051": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4593650042079389,
+          0.769697192357853,
+          0.45517742820084095
+        ]
+      }
+    },
+    "t062": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9160428578034043,
+          0.47395318443886936,
+          0.16039608186110854
+        ]
+      }
+    },
+    "t067": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7835734514519572,
+          0.8353460419457406,
+          0.6065377066843212
+        ]
+      }
+    },
+    "t084": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.13735997094772756,
+          0.3417097390629351,
+          0.6394817049149424
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4800282975193113,
+          0.33799630450084805,
+          0.5348172469530255
+        ]
+      }
+    },
+    "t103": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.20812223106622696,
+          0.8927334842737764,
+          0.43897878052666783
+        ]
+      }
+    },
+    "t108": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6683998792432249,
+          0.5450653017032892,
+          0.05738564021885395
+        ]
+      }
+    },
+    "t109": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2098619774915278,
+          0.7441520581487566,
+          0.940658031962812
+        ]
+      }
+    },
+    "t110": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29620012966915965,
+          0.7569055308122188,
+          0.41474318131804466
+        ]
+      }
+    },
+    "t115": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6623389243613929,
+          0.9341406202875078,
+          0.6520520367193967
+        ]
+      }
+    },
+    "t116": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8679914528038353,
+          0.7090462767519057,
+          0.4898784386459738
+        ]
+      }
+    },
+    "t117": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.10773952188901603,
+          0.3637402872554958,
+          0.03771192696876824
+        ]
+      }
+    },
+    "t137": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.16741330502554774,
+          0.8676156227011234,
+          0.13044456019997597
+        ]
+      }
+    },
+    "t139": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.10424773232080042,
+          0.1927092531695962,
+          0.6057000949513167
+        ]
+      }
+    },
+    "t140": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5872233503032476,
+          0.18323148600757122,
+          0.6253147253300995
+        ]
+      }
+    },
+    "t141": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3575697841588408,
+          0.08104496728628874,
+          0.6102401826065034
+        ]
+      }
+    },
+    "t147": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6836455506272614,
+          0.3462258151266724,
+          0.7609916971996427
+        ]
+      }
+    },
+    "t152": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7042568058241159,
+          0.2957823593169451,
+          0.3677100108470768
+        ]
+      }
+    },
+    "t157": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8168894301634282,
+          0.11481075314804912,
+          0.6049517292995006
+        ]
+      }
+    },
+    "t163": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7460273434408009,
+          0.39990877197124064,
+          0.3847334021702409
+        ]
+      }
+    },
+    "t167": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2635531492996961,
+          0.041906049475073814,
+          0.9030704700853676
+        ]
+      }
+    },
+    "t184": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9783844754565507,
+          0.6550772879272699,
+          0.7587551118340343
+        ]
+      }
+    },
+    "t188": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8268530692439526,
+          0.8411512630991638,
+          0.5422781084198505
+        ]
+      }
+    },
+    "t194": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.36235224222764373,
+          0.6020619415212423,
+          0.38927861861884594
+        ]
+      }
+    },
+    "t195": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8967182287015021,
+          0.1456973406020552,
+          0.1019336087629199
+        ]
+      }
+    }
+  },
+  "duration": {
+    "t002": {
+      "$type": "duration",
+      "$value": {
+        "value": 241,
+        "unit": "ms"
+      }
+    },
+    "t113": {
+      "$type": "duration",
+      "$value": {
+        "value": 493,
+        "unit": "ms"
+      }
+    },
+    "t134": {
+      "$type": "duration",
+      "$value": {
+        "value": 425,
+        "unit": "ms"
+      }
+    },
+    "t179": {
+      "$type": "duration",
+      "$value": {
+        "value": 435,
+        "unit": "ms"
+      }
+    }
+  },
+  "fontWeight": {
+    "t009": {
+      "$type": "fontWeight",
+      "$value": 600
+    },
+    "t012": {
+      "$type": "fontWeight",
+      "$value": 600
+    },
+    "t041": {
+      "$type": "fontWeight",
+      "$value": 700
+    },
+    "t045": {
+      "$type": "fontWeight",
+      "$value": 700
+    },
+    "t065": {
+      "$type": "fontWeight",
+      "$value": 400
+    },
+    "t094": {
+      "$type": "fontWeight",
+      "$value": 600
+    },
+    "t097": {
+      "$type": "fontWeight",
+      "$value": 300
+    },
+    "t180": {
+      "$type": "fontWeight",
+      "$value": 400
+    }
+  },
+  "dimension": {
+    "t015": {
+      "$type": "dimension",
+      "$value": {
+        "value": 30,
+        "unit": "px"
+      }
+    },
+    "t016": {
+      "$type": "dimension",
+      "$value": {
+        "value": 39,
+        "unit": "px"
+      }
+    },
+    "t019": {
+      "$type": "dimension",
+      "$value": {
+        "value": 42,
+        "unit": "px"
+      }
+    },
+    "t040": {
+      "$type": "dimension",
+      "$value": {
+        "value": 30,
+        "unit": "px"
+      }
+    },
+    "t056": {
+      "$type": "dimension",
+      "$value": {
+        "value": 33,
+        "unit": "px"
+      }
+    },
+    "t081": {
+      "$type": "dimension",
+      "$value": {
+        "value": 41,
+        "unit": "px"
+      }
+    },
+    "t125": {
+      "$type": "dimension",
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      }
+    },
+    "t142": {
+      "$type": "dimension",
+      "$value": {
+        "value": 15,
+        "unit": "px"
+      }
+    },
+    "t187": {
+      "$type": "dimension",
+      "$value": {
+        "value": 25,
+        "unit": "px"
+      }
+    }
+  },
+  "number": {
+    "t029": {
+      "$type": "number",
+      "$value": 0.3
+    },
+    "t124": {
+      "$type": "number",
+      "$value": 0.9
+    },
+    "t127": {
+      "$type": "number",
+      "$value": 8.5
+    },
+    "t191": {
+      "$type": "number",
+      "$value": 2.1
+    },
+    "t196": {
+      "$type": "number",
+      "$value": 1.7
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/state/active.json
+++ b/packages/core/bench/fixtures/stress/modifiers/state/active.json
@@ -1,0 +1,392 @@
+{
+  "color": {
+    "t001": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7451963203493506,
+          0.14119747560471296,
+          0.9641489076893777
+        ]
+      }
+    },
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.29220041702501476,
+          0.1352165355347097,
+          0.5398788854945451
+        ]
+      }
+    },
+    "t007": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.43640562309883535,
+          0.30585656175389886,
+          0.12952138134278357
+        ]
+      }
+    },
+    "t018": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.33462956361472607,
+          0.5104437747504562,
+          0.6602344759739935
+        ]
+      }
+    },
+    "t044": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5210079608950764,
+          0.012176849879324436,
+          0.907113355351612
+        ]
+      }
+    },
+    "t055": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5086767745669931,
+          0.4442540970630944,
+          0.2869819200132042
+        ]
+      }
+    },
+    "t057": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.019927756395190954,
+          0.48478167806752026,
+          0.45875331200659275
+        ]
+      }
+    },
+    "t063": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6020186070818454,
+          0.25802088156342506,
+          0.44395233294926584
+        ]
+      }
+    },
+    "t079": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7838113559409976,
+          0.8333156618755311,
+          0.9881513412110507
+        ]
+      }
+    },
+    "t087": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8368846208322793,
+          0.6095588225871325,
+          0.1352348194923252
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8923241933807731,
+          0.16405510413460433,
+          0.05827762512490153
+        ]
+      }
+    },
+    "t107": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6640147555153817,
+          0.39699221355840564,
+          0.7003412779886276
+        ]
+      }
+    },
+    "t112": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5291624190285802,
+          0.3116015202831477,
+          0.7566172792576253
+        ]
+      }
+    },
+    "t116": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4793608249165118,
+          0.31316212960518897,
+          0.4298490500077605
+        ]
+      }
+    },
+    "t129": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08586185984313488,
+          0.4483233669307083,
+          0.688408310059458
+        ]
+      }
+    },
+    "t137": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.1954328860156238,
+          0.16066312906332314,
+          0.030972100794315338
+        ]
+      }
+    },
+    "t152": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.038331140065565705,
+          0.37698560860008,
+          0.20622302102856338
+        ]
+      }
+    },
+    "t157": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14713672152720392,
+          0.9874680419452488,
+          0.47858688817359507
+        ]
+      }
+    },
+    "t159": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.12122232909314334,
+          0.8334017372690141,
+          0.26279567857272923
+        ]
+      }
+    },
+    "t163": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2554198557045311,
+          0.9713845574297011,
+          0.11652364605106413
+        ]
+      }
+    },
+    "t172": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7818399763200432,
+          0.42265209276229143,
+          0.2107731259893626
+        ]
+      }
+    },
+    "t184": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7813617694191635,
+          0.43531040591187775,
+          0.2894684411585331
+        ]
+      }
+    }
+  },
+  "duration": {
+    "t002": {
+      "$type": "duration",
+      "$value": {
+        "value": 461,
+        "unit": "ms"
+      }
+    },
+    "t005": {
+      "$type": "duration",
+      "$value": {
+        "value": 492,
+        "unit": "ms"
+      }
+    },
+    "t020": {
+      "$type": "duration",
+      "$value": {
+        "value": 87,
+        "unit": "ms"
+      }
+    },
+    "t121": {
+      "$type": "duration",
+      "$value": {
+        "value": 476,
+        "unit": "ms"
+      }
+    },
+    "t134": {
+      "$type": "duration",
+      "$value": {
+        "value": 323,
+        "unit": "ms"
+      }
+    },
+    "t179": {
+      "$type": "duration",
+      "$value": {
+        "value": 251,
+        "unit": "ms"
+      }
+    }
+  },
+  "number": {
+    "t010": {
+      "$type": "number",
+      "$value": 4.5
+    },
+    "t036": {
+      "$type": "number",
+      "$value": 1.6
+    },
+    "t052": {
+      "$type": "number",
+      "$value": 9.6
+    },
+    "t061": {
+      "$type": "number",
+      "$value": 3.8
+    },
+    "t170": {
+      "$type": "number",
+      "$value": 8.9
+    }
+  },
+  "dimension": {
+    "t019": {
+      "$type": "dimension",
+      "$value": {
+        "value": 22,
+        "unit": "px"
+      }
+    },
+    "t039": {
+      "$type": "dimension",
+      "$value": {
+        "value": 47,
+        "unit": "px"
+      }
+    },
+    "t076": {
+      "$type": "dimension",
+      "$value": {
+        "value": 47,
+        "unit": "px"
+      }
+    },
+    "t086": {
+      "$type": "dimension",
+      "$value": {
+        "value": 23,
+        "unit": "px"
+      }
+    },
+    "t096": {
+      "$type": "dimension",
+      "$value": {
+        "value": 31,
+        "unit": "px"
+      }
+    },
+    "t105": {
+      "$type": "dimension",
+      "$value": {
+        "value": 63,
+        "unit": "px"
+      }
+    },
+    "t122": {
+      "$type": "dimension",
+      "$value": {
+        "value": 51,
+        "unit": "px"
+      }
+    },
+    "t138": {
+      "$type": "dimension",
+      "$value": {
+        "value": 30,
+        "unit": "px"
+      }
+    }
+  },
+  "fontWeight": {
+    "t023": {
+      "$type": "fontWeight",
+      "$value": 900
+    },
+    "t041": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t045": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t054": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t077": {
+      "$type": "fontWeight",
+      "$value": 400
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/modifiers/state/hover.json
+++ b/packages/core/bench/fixtures/stress/modifiers/state/hover.json
@@ -1,0 +1,337 @@
+{
+  "fontWeight": {
+    "t003": {
+      "$type": "fontWeight",
+      "$value": 200
+    },
+    "t023": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t054": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t077": {
+      "$type": "fontWeight",
+      "$value": 700
+    }
+  },
+  "color": {
+    "t004": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4904357672203332,
+          0.8315003979951143,
+          0.4360407905187458
+        ]
+      }
+    },
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.027003208873793483,
+          0.7523186239413917,
+          0.393584017874673
+        ]
+      }
+    },
+    "t008": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7143736560828984,
+          0.04595935926772654,
+          0.7385530853644013
+        ]
+      }
+    },
+    "t011": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2142407950013876,
+          0.3953676575329155,
+          0.5862229489721358
+        ]
+      }
+    },
+    "t017": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3387643767055124,
+          0.01020371587947011,
+          0.5762422478292137
+        ]
+      }
+    },
+    "t031": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2175714410841465,
+          0.3390385617967695,
+          0.3981427405960858
+        ]
+      }
+    },
+    "t038": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8338091801851988,
+          0.4617157408501953,
+          0.6296066441573203
+        ]
+      }
+    },
+    "t047": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9114459624979645,
+          0.8267948972061276,
+          0.01234000246040523
+        ]
+      }
+    },
+    "t057": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.39721645903773606,
+          0.9625477604568005,
+          0.04704232863150537
+        ]
+      }
+    },
+    "t062": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7153885788284242,
+          0.4102423556614667,
+          0.8931253757327795
+        ]
+      }
+    },
+    "t080": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.18317766208201647,
+          0.034045041305944324,
+          0.05844774981960654
+        ]
+      }
+    },
+    "t084": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.45945495972409844,
+          0.5029027278069407,
+          0.39907082077115774
+        ]
+      }
+    },
+    "t092": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4021481319796294,
+          0.8554513654671609,
+          0.4201721989084035
+        ]
+      }
+    },
+    "t109": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.04424590687267482,
+          0.6542052119038999,
+          0.16641231183893979
+        ]
+      }
+    },
+    "t152": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.32416330417618155,
+          0.15995183144696057,
+          0.05830722488462925
+        ]
+      }
+    },
+    "t155": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6762405843473971,
+          0.5947288239840418,
+          0.23181001003831625
+        ]
+      }
+    },
+    "t159": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08040938153862953,
+          0.6618735601659864,
+          0.32380326138809323
+        ]
+      }
+    },
+    "t169": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.1953488120343536,
+          0.217419455293566,
+          0.3548904957715422
+        ]
+      }
+    },
+    "t172": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.959235071670264,
+          0.9937399190384895,
+          0.17480551451444626
+        ]
+      }
+    },
+    "t177": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4492155483458191,
+          0.7466782974079251,
+          0.92906089941971
+        ]
+      }
+    },
+    "t198": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9601598053704947,
+          0.2361022955738008,
+          0.40960795362479985
+        ]
+      }
+    }
+  },
+  "duration": {
+    "t005": {
+      "$type": "duration",
+      "$value": {
+        "value": 254,
+        "unit": "ms"
+      }
+    },
+    "t020": {
+      "$type": "duration",
+      "$value": {
+        "value": 486,
+        "unit": "ms"
+      }
+    },
+    "t113": {
+      "$type": "duration",
+      "$value": {
+        "value": 116,
+        "unit": "ms"
+      }
+    },
+    "t134": {
+      "$type": "duration",
+      "$value": {
+        "value": 407,
+        "unit": "ms"
+      }
+    }
+  },
+  "dimension": {
+    "t035": {
+      "$type": "dimension",
+      "$value": {
+        "value": 54,
+        "unit": "px"
+      }
+    },
+    "t039": {
+      "$type": "dimension",
+      "$value": {
+        "value": 58,
+        "unit": "px"
+      }
+    },
+    "t086": {
+      "$type": "dimension",
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      }
+    },
+    "t105": {
+      "$type": "dimension",
+      "$value": {
+        "value": 19,
+        "unit": "px"
+      }
+    },
+    "t125": {
+      "$type": "dimension",
+      "$value": {
+        "value": 22,
+        "unit": "px"
+      }
+    },
+    "t166": {
+      "$type": "dimension",
+      "$value": {
+        "value": 26,
+        "unit": "px"
+      }
+    }
+  },
+  "number": {
+    "t120": {
+      "$type": "number",
+      "$value": 6.9
+    },
+    "t123": {
+      "$type": "number",
+      "$value": 2.8
+    }
+  }
+}

--- a/packages/core/bench/fixtures/stress/resolver.json
+++ b/packages/core/bench/fixtures/stress/resolver.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://www.designtokens.org/TR/2025.10/resolver/",
+  "version": "2025.10",
+  "name": "swatchbook-stress",
+  "description": "Stress fixture v2.0.0: realistic 6-axis shape matching the torquens.bill.works/token-adventure demo. 200 tokens (~40% aliases), 6 modifiers with 2/2/3/4/3/2 contexts. Each non-default modifier-context overlay redefines ~30% of tokens with primitive values; no joint divergences seeded so probeJointOverrides should produce zero overrides. Generated from gen.mts (seed \"swatchbook-stress-2026\").",
+  "sets": {
+    "base": {
+      "description": "Base set — mixed primitive + alias tokens across DTCG types.",
+      "sources": [
+        {
+          "$ref": "./sets/base.json"
+        }
+      ]
+    }
+  },
+  "modifiers": {
+    "disabled": {
+      "description": "Stress fixture modifier disabled.",
+      "contexts": {
+        "enabled": [],
+        "disabled": [
+          {
+            "$ref": "./modifiers/disabled/disabled.json"
+          }
+        ]
+      },
+      "default": "enabled"
+    },
+    "forced": {
+      "description": "Stress fixture modifier forced.",
+      "contexts": {
+        "standard": [],
+        "forced": [
+          {
+            "$ref": "./modifiers/forced/forced.json"
+          }
+        ]
+      },
+      "default": "standard"
+    },
+    "container": {
+      "description": "Stress fixture modifier container.",
+      "contexts": {
+        "panel": [],
+        "control-primary": [
+          {
+            "$ref": "./modifiers/container/control-primary.json"
+          }
+        ],
+        "control-secondary": [
+          {
+            "$ref": "./modifiers/container/control-secondary.json"
+          }
+        ]
+      },
+      "default": "panel"
+    },
+    "sentiment": {
+      "description": "Stress fixture modifier sentiment.",
+      "contexts": {
+        "neutral": [],
+        "positive": [
+          {
+            "$ref": "./modifiers/sentiment/positive.json"
+          }
+        ],
+        "negative": [
+          {
+            "$ref": "./modifiers/sentiment/negative.json"
+          }
+        ],
+        "warning": [
+          {
+            "$ref": "./modifiers/sentiment/warning.json"
+          }
+        ]
+      },
+      "default": "neutral"
+    },
+    "state": {
+      "description": "Stress fixture modifier state.",
+      "contexts": {
+        "default": [],
+        "hover": [
+          {
+            "$ref": "./modifiers/state/hover.json"
+          }
+        ],
+        "active": [
+          {
+            "$ref": "./modifiers/state/active.json"
+          }
+        ]
+      },
+      "default": "default"
+    },
+    "mode": {
+      "description": "Stress fixture modifier mode.",
+      "contexts": {
+        "light": [],
+        "dark": [
+          {
+            "$ref": "./modifiers/mode/dark.json"
+          }
+        ]
+      },
+      "default": "light"
+    }
+  },
+  "resolutionOrder": [
+    {
+      "$ref": "#/sets/base"
+    },
+    {
+      "$ref": "#/modifiers/disabled"
+    },
+    {
+      "$ref": "#/modifiers/forced"
+    },
+    {
+      "$ref": "#/modifiers/container"
+    },
+    {
+      "$ref": "#/modifiers/sentiment"
+    },
+    {
+      "$ref": "#/modifiers/state"
+    },
+    {
+      "$ref": "#/modifiers/mode"
+    }
+  ]
+}

--- a/packages/core/bench/fixtures/stress/sets/base.json
+++ b/packages/core/bench/fixtures/stress/sets/base.json
@@ -1,0 +1,1411 @@
+{
+  "number": {
+    "t000": {
+      "$type": "number",
+      "$value": 2.6
+    },
+    "t010": {
+      "$type": "number",
+      "$value": 9.4
+    },
+    "t029": {
+      "$type": "number",
+      "$value": 7.5
+    },
+    "t036": {
+      "$type": "number",
+      "$value": 1.2
+    },
+    "t052": {
+      "$type": "number",
+      "$value": 8.5
+    },
+    "t061": {
+      "$type": "number",
+      "$value": 2.5
+    },
+    "t093": {
+      "$type": "number",
+      "$value": 9.8
+    },
+    "t120": {
+      "$type": "number",
+      "$value": 4.8
+    },
+    "t123": {
+      "$type": "number",
+      "$value": 0.7
+    },
+    "t124": {
+      "$type": "number",
+      "$value": 1.1
+    },
+    "t127": {
+      "$type": "number",
+      "$value": 6.6
+    },
+    "t131": {
+      "$type": "number",
+      "$value": "{number.t061}"
+    },
+    "t132": {
+      "$type": "number",
+      "$value": "{number.t124}"
+    },
+    "t156": {
+      "$type": "number",
+      "$value": 5.4
+    },
+    "t165": {
+      "$type": "number",
+      "$value": "{number.t093}"
+    },
+    "t168": {
+      "$type": "number",
+      "$value": 4.9
+    },
+    "t170": {
+      "$type": "number",
+      "$value": 7.3
+    },
+    "t191": {
+      "$type": "number",
+      "$value": 8.2
+    },
+    "t196": {
+      "$type": "number",
+      "$value": 9.2
+    }
+  },
+  "color": {
+    "t001": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8626894780900329,
+          0.43958578491583467,
+          0.7647050025407225
+        ]
+      }
+    },
+    "t004": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.19837273634038866,
+          0.6150249582715333,
+          0.654734896728769
+        ]
+      }
+    },
+    "t006": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.522920134710148,
+          0.8732963819056749,
+          0.8961595164146274
+        ]
+      }
+    },
+    "t007": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.721155975246802,
+          0.38576565589755774,
+          0.814450855134055
+        ]
+      }
+    },
+    "t008": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.65013845753856,
+          0.9521023444831371,
+          0.3910187666770071
+        ]
+      }
+    },
+    "t011": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7215120561886579,
+          0.09139539860188961,
+          0.1619257831480354
+        ]
+      }
+    },
+    "t013": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4918625939171761,
+          0.8202079604379833,
+          0.8914160069543868
+        ]
+      }
+    },
+    "t014": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.14006533450447023,
+          0.4869840261526406,
+          0.3221996969077736
+        ]
+      }
+    },
+    "t017": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.17953478707931936,
+          0.3775311768986285,
+          0.31829516240395606
+        ]
+      }
+    },
+    "t018": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7992031599860638,
+          0.875943775754422,
+          0.5494056020397693
+        ]
+      }
+    },
+    "t021": {
+      "$type": "color",
+      "$value": "{color.t014}"
+    },
+    "t024": {
+      "$type": "color",
+      "$value": "{color.t007}"
+    },
+    "t026": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7852402818389237,
+          0.31619590730406344,
+          0.2286732690408826
+        ]
+      }
+    },
+    "t028": {
+      "$type": "color",
+      "$value": "{color.t026}"
+    },
+    "t030": {
+      "$type": "color",
+      "$value": "{color.t001}"
+    },
+    "t031": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.22771397582255304,
+          0.8416740079410374,
+          0.6641360281500965
+        ]
+      }
+    },
+    "t032": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3219594336114824,
+          0.7623001255560666,
+          0.8525591846555471
+        ]
+      }
+    },
+    "t033": {
+      "$type": "color",
+      "$value": "{color.t014}"
+    },
+    "t034": {
+      "$type": "color",
+      "$value": "{color.t001}"
+    },
+    "t037": {
+      "$type": "color",
+      "$value": "{color.t008}"
+    },
+    "t038": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7434508744627237,
+          0.8028830380644649,
+          0.12500222632661462
+        ]
+      }
+    },
+    "t043": {
+      "$type": "color",
+      "$value": "{color.t038}"
+    },
+    "t044": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2902237307280302,
+          0.8914580473210663,
+          0.4422850706614554
+        ]
+      }
+    },
+    "t046": {
+      "$type": "color",
+      "$value": "{color.t008}"
+    },
+    "t047": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.05761701287701726,
+          0.19442708999849856,
+          0.9880477236583829
+        ]
+      }
+    },
+    "t048": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8927824825514108,
+          0.9978368598967791,
+          0.6352876590099186
+        ]
+      }
+    },
+    "t049": {
+      "$type": "color",
+      "$value": "{color.t044}"
+    },
+    "t050": {
+      "$type": "color",
+      "$value": "{color.t038}"
+    },
+    "t051": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6884497334249318,
+          0.02859710738994181,
+          0.8362462157383561
+        ]
+      }
+    },
+    "t055": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7295244622509927,
+          0.9415963063947856,
+          0.8279697534162551
+        ]
+      }
+    },
+    "t057": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9206874675583094,
+          0.5430054678581655,
+          0.41245458577759564
+        ]
+      }
+    },
+    "t058": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9532723785378039,
+          0.941953610861674,
+          0.5701875006780028
+        ]
+      }
+    },
+    "t060": {
+      "$type": "color",
+      "$value": "{color.t004}"
+    },
+    "t062": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.24191208113916218,
+          0.9429261367768049,
+          0.36388638406060636
+        ]
+      }
+    },
+    "t063": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9742075307294726,
+          0.026155448285862803,
+          0.6336259986273944
+        ]
+      }
+    },
+    "t066": {
+      "$type": "color",
+      "$value": "{color.t007}"
+    },
+    "t067": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.06482449336908758,
+          0.2258931533433497,
+          0.037136811995878816
+        ]
+      }
+    },
+    "t068": {
+      "$type": "color",
+      "$value": "{color.t004}"
+    },
+    "t070": {
+      "$type": "color",
+      "$value": "{color.t063}"
+    },
+    "t071": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.756821057992056,
+          0.8076221998780966,
+          0.5783200615551323
+        ]
+      }
+    },
+    "t072": {
+      "$type": "color",
+      "$value": "{color.t063}"
+    },
+    "t073": {
+      "$type": "color",
+      "$value": "{color.t001}"
+    },
+    "t074": {
+      "$type": "color",
+      "$value": "{color.t026}"
+    },
+    "t075": {
+      "$type": "color",
+      "$value": "{color.t004}"
+    },
+    "t079": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.346368495374918,
+          0.2558319082017988,
+          0.8430675719864666
+        ]
+      }
+    },
+    "t080": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.48380624200217426,
+          0.8210366419516504,
+          0.2525125436950475
+        ]
+      }
+    },
+    "t082": {
+      "$type": "color",
+      "$value": "{color.t071}"
+    },
+    "t084": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7613562217447907,
+          0.7010677205398679,
+          0.9835995964240283
+        ]
+      }
+    },
+    "t085": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9366626162081957,
+          0.5773119197692722,
+          0.35932192066684365
+        ]
+      }
+    },
+    "t087": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.46896932646632195,
+          0.40420432738028467,
+          0.44410064117982984
+        ]
+      }
+    },
+    "t089": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5718820460606366,
+          0.1987870540469885,
+          0.2572055363561958
+        ]
+      }
+    },
+    "t090": {
+      "$type": "color",
+      "$value": "{color.t067}"
+    },
+    "t091": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0825319227296859,
+          0.6847496032714844,
+          0.06945344037376344
+        ]
+      }
+    },
+    "t092": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.0590984346345067,
+          0.05797797511331737,
+          0.025093467440456152
+        ]
+      }
+    },
+    "t098": {
+      "$type": "color",
+      "$value": "{color.t087}"
+    },
+    "t099": {
+      "$type": "color",
+      "$value": "{color.t031}"
+    },
+    "t102": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6978764233645052,
+          0.9896687758155167,
+          0.6551322957966477
+        ]
+      }
+    },
+    "t103": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4852918474934995,
+          0.6485170901287347,
+          0.1455145049840212
+        ]
+      }
+    },
+    "t106": {
+      "$type": "color",
+      "$value": "{color.t092}"
+    },
+    "t107": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9834558451548219,
+          0.07672430272214115,
+          0.7560565448366106
+        ]
+      }
+    },
+    "t108": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.42651230632327497,
+          0.6327507221139967,
+          0.6317947732750326
+        ]
+      }
+    },
+    "t109": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.7252470473758876,
+          0.07760132220573723,
+          0.5769124776124954
+        ]
+      }
+    },
+    "t110": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5631309247110039,
+          0.7385225566104054,
+          0.4946099079679698
+        ]
+      }
+    },
+    "t112": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4145334924105555,
+          0.597522652707994,
+          0.6295667465310544
+        ]
+      }
+    },
+    "t114": {
+      "$type": "color",
+      "$value": "{color.t084}"
+    },
+    "t115": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.19361605192534626,
+          0.9948990098200738,
+          0.51038873125799
+        ]
+      }
+    },
+    "t116": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.43192131305113435,
+          0.05967441224493086,
+          0.7871099663898349
+        ]
+      }
+    },
+    "t117": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2578423779923469,
+          0.32029568403959274,
+          0.40954397595487535
+        ]
+      }
+    },
+    "t118": {
+      "$type": "color",
+      "$value": "{color.t084}"
+    },
+    "t119": {
+      "$type": "color",
+      "$value": "{color.t058}"
+    },
+    "t129": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2586576861795038,
+          0.4211559114046395,
+          0.7794987803790718
+        ]
+      }
+    },
+    "t130": {
+      "$type": "color",
+      "$value": "{color.t017}"
+    },
+    "t136": {
+      "$type": "color",
+      "$value": "{color.t110}"
+    },
+    "t137": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3594775446690619,
+          0.5961082431022078,
+          0.30941767524927855
+        ]
+      }
+    },
+    "t139": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08375771762803197,
+          0.05100277275778353,
+          0.6263926224783063
+        ]
+      }
+    },
+    "t140": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6232149482239038,
+          0.09776036627590656,
+          0.8097433762159199
+        ]
+      }
+    },
+    "t141": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.658465295098722,
+          0.18139217304997146,
+          0.04291397659108043
+        ]
+      }
+    },
+    "t144": {
+      "$type": "color",
+      "$value": "{color.t102}"
+    },
+    "t145": {
+      "$type": "color",
+      "$value": "{color.t038}"
+    },
+    "t147": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.48788706329651177,
+          0.4501015990972519,
+          0.6003053260501474
+        ]
+      }
+    },
+    "t148": {
+      "$type": "color",
+      "$value": "{color.t109}"
+    },
+    "t149": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.3821086243260652,
+          0.5939743164926767,
+          0.33522794558666646
+        ]
+      }
+    },
+    "t152": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.642585024703294,
+          0.0743122233543545,
+          0.7896468797698617
+        ]
+      }
+    },
+    "t153": {
+      "$type": "color",
+      "$value": "{color.t026}"
+    },
+    "t154": {
+      "$type": "color",
+      "$value": "{color.t013}"
+    },
+    "t155": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.059229186503216624,
+          0.6977322394959629,
+          0.992014990421012
+        ]
+      }
+    },
+    "t157": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9977207116317004,
+          0.3035967289470136,
+          0.5813185006845742
+        ]
+      }
+    },
+    "t158": {
+      "$type": "color",
+      "$value": "{color.t092}"
+    },
+    "t159": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6213834236841649,
+          0.47937585739418864,
+          0.3350970346946269
+        ]
+      }
+    },
+    "t162": {
+      "$type": "color",
+      "$value": "{color.t080}"
+    },
+    "t163": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.08767486386932433,
+          0.23885005991905928,
+          0.13205474498681724
+        ]
+      }
+    },
+    "t167": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4401092471089214,
+          0.08061195025220513,
+          0.8425615245942026
+        ]
+      }
+    },
+    "t169": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.2598169108387083,
+          0.9795817737467587,
+          0.5880137963686138
+        ]
+      }
+    },
+    "t172": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6665903134271502,
+          0.47752530011348426,
+          0.03623937023803592
+        ]
+      }
+    },
+    "t176": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8903077677823603,
+          0.7732359061483294,
+          0.7327495208010077
+        ]
+      }
+    },
+    "t177": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6030612934846431,
+          0.8356054984033108,
+          0.4782977437134832
+        ]
+      }
+    },
+    "t181": {
+      "$type": "color",
+      "$value": "{color.t089}"
+    },
+    "t182": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8909939676523209,
+          0.9700744522269815,
+          0.4136610892601311
+        ]
+      }
+    },
+    "t183": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9567519582342356,
+          0.7893478139303625,
+          0.4060504094231874
+        ]
+      }
+    },
+    "t184": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.4549445719458163,
+          0.8496860826853663,
+          0.9628498321399093
+        ]
+      }
+    },
+    "t186": {
+      "$type": "color",
+      "$value": "{color.t155}"
+    },
+    "t188": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.8378164898604155,
+          0.7288528808858246,
+          0.0776244499720633
+        ]
+      }
+    },
+    "t189": {
+      "$type": "color",
+      "$value": "{color.t014}"
+    },
+    "t193": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.19888641103170812,
+          0.639390526805073,
+          0.7526981870178133
+        ]
+      }
+    },
+    "t194": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.9720772984437644,
+          0.2012600798625499,
+          0.6705011837184429
+        ]
+      }
+    },
+    "t195": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.5068010000977665,
+          0.1707557076588273,
+          0.3803587823640555
+        ]
+      }
+    },
+    "t197": {
+      "$type": "color",
+      "$value": "{color.t006}"
+    },
+    "t198": {
+      "$type": "color",
+      "$value": {
+        "colorSpace": "srgb",
+        "components": [
+          0.6068677078001201,
+          0.7073939677793533,
+          0.18028590083122253
+        ]
+      }
+    }
+  },
+  "duration": {
+    "t002": {
+      "$type": "duration",
+      "$value": {
+        "value": 315,
+        "unit": "ms"
+      }
+    },
+    "t005": {
+      "$type": "duration",
+      "$value": {
+        "value": 475,
+        "unit": "ms"
+      }
+    },
+    "t020": {
+      "$type": "duration",
+      "$value": {
+        "value": 252,
+        "unit": "ms"
+      }
+    },
+    "t025": {
+      "$type": "duration",
+      "$value": {
+        "value": 319,
+        "unit": "ms"
+      }
+    },
+    "t088": {
+      "$type": "duration",
+      "$value": {
+        "value": 76,
+        "unit": "ms"
+      }
+    },
+    "t095": {
+      "$type": "duration",
+      "$value": {
+        "value": 249,
+        "unit": "ms"
+      }
+    },
+    "t113": {
+      "$type": "duration",
+      "$value": {
+        "value": 51,
+        "unit": "ms"
+      }
+    },
+    "t121": {
+      "$type": "duration",
+      "$value": {
+        "value": 496,
+        "unit": "ms"
+      }
+    },
+    "t134": {
+      "$type": "duration",
+      "$value": {
+        "value": 471,
+        "unit": "ms"
+      }
+    },
+    "t146": {
+      "$type": "duration",
+      "$value": {
+        "value": 106,
+        "unit": "ms"
+      }
+    },
+    "t179": {
+      "$type": "duration",
+      "$value": {
+        "value": 325,
+        "unit": "ms"
+      }
+    },
+    "t185": {
+      "$type": "duration",
+      "$value": "{duration.t121}"
+    },
+    "t192": {
+      "$type": "duration",
+      "$value": {
+        "value": 480,
+        "unit": "ms"
+      }
+    }
+  },
+  "fontWeight": {
+    "t003": {
+      "$type": "fontWeight",
+      "$value": 700
+    },
+    "t009": {
+      "$type": "fontWeight",
+      "$value": 800
+    },
+    "t012": {
+      "$type": "fontWeight",
+      "$value": 800
+    },
+    "t023": {
+      "$type": "fontWeight",
+      "$value": 200
+    },
+    "t041": {
+      "$type": "fontWeight",
+      "$value": 400
+    },
+    "t045": {
+      "$type": "fontWeight",
+      "$value": 800
+    },
+    "t054": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t065": {
+      "$type": "fontWeight",
+      "$value": 100
+    },
+    "t077": {
+      "$type": "fontWeight",
+      "$value": 200
+    },
+    "t094": {
+      "$type": "fontWeight",
+      "$value": 500
+    },
+    "t097": {
+      "$type": "fontWeight",
+      "$value": 300
+    },
+    "t104": {
+      "$type": "fontWeight",
+      "$value": "{fontWeight.t012}"
+    },
+    "t111": {
+      "$type": "fontWeight",
+      "$value": "{fontWeight.t054}"
+    },
+    "t133": {
+      "$type": "fontWeight",
+      "$value": "{fontWeight.t045}"
+    },
+    "t143": {
+      "$type": "fontWeight",
+      "$value": "{fontWeight.t054}"
+    },
+    "t161": {
+      "$type": "fontWeight",
+      "$value": "{fontWeight.t077}"
+    },
+    "t178": {
+      "$type": "fontWeight",
+      "$value": "{fontWeight.t097}"
+    },
+    "t180": {
+      "$type": "fontWeight",
+      "$value": 700
+    }
+  },
+  "dimension": {
+    "t015": {
+      "$type": "dimension",
+      "$value": {
+        "value": 13,
+        "unit": "px"
+      }
+    },
+    "t016": {
+      "$type": "dimension",
+      "$value": {
+        "value": 26,
+        "unit": "px"
+      }
+    },
+    "t019": {
+      "$type": "dimension",
+      "$value": {
+        "value": 39,
+        "unit": "px"
+      }
+    },
+    "t022": {
+      "$type": "dimension",
+      "$value": {
+        "value": 11,
+        "unit": "px"
+      }
+    },
+    "t027": {
+      "$type": "dimension",
+      "$value": {
+        "value": 18,
+        "unit": "px"
+      }
+    },
+    "t035": {
+      "$type": "dimension",
+      "$value": {
+        "value": 26,
+        "unit": "px"
+      }
+    },
+    "t039": {
+      "$type": "dimension",
+      "$value": {
+        "value": 46,
+        "unit": "px"
+      }
+    },
+    "t040": {
+      "$type": "dimension",
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      }
+    },
+    "t042": {
+      "$type": "dimension",
+      "$value": {
+        "value": 5,
+        "unit": "px"
+      }
+    },
+    "t053": {
+      "$type": "dimension",
+      "$value": {
+        "value": 50,
+        "unit": "px"
+      }
+    },
+    "t056": {
+      "$type": "dimension",
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      }
+    },
+    "t059": {
+      "$type": "dimension",
+      "$value": {
+        "value": 54,
+        "unit": "px"
+      }
+    },
+    "t064": {
+      "$type": "dimension",
+      "$value": {
+        "value": 38,
+        "unit": "px"
+      }
+    },
+    "t069": {
+      "$type": "dimension",
+      "$value": {
+        "value": 32,
+        "unit": "px"
+      }
+    },
+    "t076": {
+      "$type": "dimension",
+      "$value": {
+        "value": 10,
+        "unit": "px"
+      }
+    },
+    "t078": {
+      "$type": "dimension",
+      "$value": "{dimension.t027}"
+    },
+    "t081": {
+      "$type": "dimension",
+      "$value": {
+        "value": 43,
+        "unit": "px"
+      }
+    },
+    "t083": {
+      "$type": "dimension",
+      "$value": {
+        "value": 52,
+        "unit": "px"
+      }
+    },
+    "t086": {
+      "$type": "dimension",
+      "$value": {
+        "value": 44,
+        "unit": "px"
+      }
+    },
+    "t096": {
+      "$type": "dimension",
+      "$value": {
+        "value": 29,
+        "unit": "px"
+      }
+    },
+    "t100": {
+      "$type": "dimension",
+      "$value": "{dimension.t019}"
+    },
+    "t101": {
+      "$type": "dimension",
+      "$value": {
+        "value": 20,
+        "unit": "px"
+      }
+    },
+    "t105": {
+      "$type": "dimension",
+      "$value": {
+        "value": 18,
+        "unit": "px"
+      }
+    },
+    "t122": {
+      "$type": "dimension",
+      "$value": {
+        "value": 23,
+        "unit": "px"
+      }
+    },
+    "t125": {
+      "$type": "dimension",
+      "$value": {
+        "value": 48,
+        "unit": "px"
+      }
+    },
+    "t126": {
+      "$type": "dimension",
+      "$value": "{dimension.t027}"
+    },
+    "t128": {
+      "$type": "dimension",
+      "$value": "{dimension.t042}"
+    },
+    "t135": {
+      "$type": "dimension",
+      "$value": "{dimension.t015}"
+    },
+    "t138": {
+      "$type": "dimension",
+      "$value": {
+        "value": 56,
+        "unit": "px"
+      }
+    },
+    "t142": {
+      "$type": "dimension",
+      "$value": {
+        "value": 40,
+        "unit": "px"
+      }
+    },
+    "t150": {
+      "$type": "dimension",
+      "$value": "{dimension.t064}"
+    },
+    "t151": {
+      "$type": "dimension",
+      "$value": "{dimension.t027}"
+    },
+    "t160": {
+      "$type": "dimension",
+      "$value": "{dimension.t105}"
+    },
+    "t164": {
+      "$type": "dimension",
+      "$value": "{dimension.t138}"
+    },
+    "t166": {
+      "$type": "dimension",
+      "$value": {
+        "value": 21,
+        "unit": "px"
+      }
+    },
+    "t171": {
+      "$type": "dimension",
+      "$value": "{dimension.t022}"
+    },
+    "t173": {
+      "$type": "dimension",
+      "$value": "{dimension.t086}"
+    },
+    "t174": {
+      "$type": "dimension",
+      "$value": "{dimension.t086}"
+    },
+    "t175": {
+      "$type": "dimension",
+      "$value": "{dimension.t019}"
+    },
+    "t187": {
+      "$type": "dimension",
+      "$value": {
+        "value": 43,
+        "unit": "px"
+      }
+    },
+    "t190": {
+      "$type": "dimension",
+      "$value": {
+        "value": 55,
+        "unit": "px"
+      }
+    },
+    "t199": {
+      "$type": "dimension",
+      "$value": {
+        "value": 36,
+        "unit": "px"
+      }
+    }
+  }
+}

--- a/packages/core/bench/resolver-counter.ts
+++ b/packages/core/bench/resolver-counter.ts
@@ -1,0 +1,35 @@
+/**
+ * Wrap a Terrazzo `Resolver` so every `.apply()` invocation increments
+ * a counter. Used by the bench harness to partition `resolver.apply`
+ * cost between cell construction and the joint-pair probe — the two
+ * resolver-bound phases.
+ */
+import type { Resolver, TokenNormalized } from '@terrazzo/parser';
+
+export interface CountedResolver {
+  resolver: Resolver;
+  getCount(): number;
+  reset(): void;
+}
+
+export function wrapResolver(inner: Resolver): CountedResolver {
+  let count = 0;
+  const proxied: Resolver = new Proxy(inner, {
+    get(target, prop, receiver) {
+      if (prop === 'apply') {
+        return (tuple: Record<string, string>): Record<string, TokenNormalized> => {
+          count++;
+          return target.apply(tuple);
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+  return {
+    resolver: proxied,
+    getCount: () => count,
+    reset: () => {
+      count = 0;
+    },
+  };
+}

--- a/packages/core/bench/run.mts
+++ b/packages/core/bench/run.mts
@@ -1,0 +1,266 @@
+/**
+ * Phase-partitioned benchmark harness for the stress-scale fixture.
+ *
+ * Imports the loader's exported sub-phases directly (no `loadProject`
+ * orchestration), times each, counts `resolver.apply` invocations
+ * separately for cell construction and the joint-pair probe.
+ *
+ * Resilient to per-phase failures: each phase logs its start/end to
+ * stdout AND to `phase-log.txt` before proceeding. If a phase OOMs or
+ * hangs, the log file tells you exactly which one. Writes
+ * `baseline.json` once the run completes; on failure, leaves the
+ * partial log in place so the failure mode is the artifact.
+ *
+ * Run:
+ *   node packages/core/bench/run.mts
+ *   node --max-old-space-size=8192 packages/core/bench/run.mts  # for stress fixture
+ */
+import { appendFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { BufferedLogger } from '#/diagnostics.ts';
+import { buildCells } from '#/cells.ts';
+import { computeTokenListing } from '#/token-listing.ts';
+import { probeJointOverrides } from '#/joint-overrides.ts';
+import { buildResolveAt } from '#/resolve-at.ts';
+import { buildVarianceByPath } from '#/variance-by-path.ts';
+import { permutationID } from '#/types.ts';
+import { normalizePermutations } from '#/permutations/normalize.ts';
+import { wrapResolver } from './resolver-counter.ts';
+import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
+import { snapshotForWire } from '#/snapshot-for-wire.ts';
+import type { Config, TokenMap } from '#/types.ts';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = join(__dirname, 'fixtures/stress');
+const BASELINE_PATH = join(__dirname, 'baseline.json');
+const LOG_PATH = join(__dirname, 'phase-log.txt');
+
+interface PhaseTimings {
+  parse: number;
+  buildCells: number;
+  probe: number;
+  variance: number;
+  listing: number;
+  snapshotWire: number;
+  emitCss: number;
+}
+
+interface Baseline {
+  fixtureVersion: string;
+  node: string;
+  generatedAt: string;
+  loadMs: PhaseTimings & { total: number };
+  resolverApplyCount: { atCells: number; atProbe: number; total: number };
+  wireBytes: number;
+  cssBytes: number;
+  jointOverrideCount: number;
+  axisCount: number;
+  defaultTokenCount: number;
+  errors: Record<string, string>;
+}
+
+const FIXTURE_VERSION = '2.0.0';
+
+function logPhase(line: string): void {
+  const stamp = new Date().toISOString();
+  const out = `[${stamp}] ${line}`;
+  // eslint-disable-next-line no-console
+  console.log(out);
+  appendFileSync(LOG_PATH, `${out}\n`);
+}
+
+async function timed<T>(label: string, fn: () => Promise<T> | T): Promise<{ result: T; ms: number }> {
+  logPhase(`${label}: start`);
+  const t0 = process.hrtime.bigint();
+  const result = await fn();
+  const t1 = process.hrtime.bigint();
+  const ms = Number(t1 - t0) / 1_000_000;
+  logPhase(`${label}: done in ${ms.toFixed(2)}ms`);
+  return { result, ms };
+}
+
+async function timedSafe<T>(
+  label: string,
+  fn: () => Promise<T> | T,
+  fallback: T,
+): Promise<{ result: T; ms: number; error: string | null }> {
+  logPhase(`${label}: start`);
+  const t0 = process.hrtime.bigint();
+  try {
+    const result = await fn();
+    const t1 = process.hrtime.bigint();
+    const ms = Number(t1 - t0) / 1_000_000;
+    logPhase(`${label}: done in ${ms.toFixed(2)}ms`);
+    return { result, ms, error: null };
+  } catch (err) {
+    const t1 = process.hrtime.bigint();
+    const ms = Number(t1 - t0) / 1_000_000;
+    const msg = err instanceof Error ? err.message : String(err);
+    logPhase(`${label}: FAILED after ${ms.toFixed(2)}ms — ${msg}`);
+    return { result: fallback, ms, error: msg };
+  }
+}
+
+async function main(): Promise<void> {
+  writeFileSync(LOG_PATH, '');
+  logPhase(`bench start | node ${process.version} | fixture v${FIXTURE_VERSION}`);
+
+  const config: Config = { resolver: 'resolver.json' };
+  const logger = new BufferedLogger({ level: 'warn' });
+
+  // Phase: normalize / parse. Includes Terrazzo's `loadResolver` (manifest
+  // parse + permutation listing) + the 65-call singleton-enumeration loop.
+  const { result: normalized, ms: parseMs } = await timed('parse', () =>
+    normalizePermutations(config, FIXTURE_DIR, logger),
+  );
+
+  if (!normalized.parserInput?.resolver) {
+    throw new Error('stress fixture must produce a resolver-backed project');
+  }
+
+  // Wrap the resolver so we can count `.apply` calls. Reset the counter
+  // before each phase to partition cost.
+  const counted = wrapResolver(normalized.parserInput.resolver);
+
+  // Default-tuple resolved tokens. Singleton enumeration produces this
+  // already, but mirror loadProject's fallback logic to stay realistic.
+  const defaultTuple: Record<string, string> = {};
+  for (const axis of normalized.axes) defaultTuple[axis.name] = axis.default;
+  const defaultId = permutationID(defaultTuple);
+  const defaultTokens: TokenMap =
+    normalized.resolved[defaultId] ?? counted.resolver.apply(defaultTuple);
+
+  // Phase: buildCells. Each non-default cell is one `resolver.apply` call
+  // via the wrapped resolver, so this is where the per-cell apply cost
+  // accumulates.
+  counted.reset();
+  const resolveTuple = (tuple: Readonly<Record<string, string>>): TokenMap =>
+    counted.resolver.apply(tuple as Record<string, string>);
+  const { result: cells, ms: buildCellsMs } = await timed('buildCells', () =>
+    buildCells(normalized.axes, resolveTuple, defaultTuple),
+  );
+  const applyCountAtCells = counted.getCount();
+  logPhase(`buildCells: resolver.apply count = ${applyCountAtCells}`);
+
+  // Phase: probeJointOverrides. This is the suspected hot path —
+  // pair-by-context-product applies that scale as `Σ pairs × ctx_a × ctx_b`.
+  // Default sweep (all arities); at extreme axis counts this OOMs, but
+  // at the realistic 6-axis fixture it completes in seconds.
+  counted.reset();
+  const { result: probeResult, ms: probeMs } = await timed('probe', () =>
+    probeJointOverrides(normalized.axes, cells, defaultTuple, counted.resolver),
+  );
+  const applyCountAtProbe = counted.getCount();
+  const { overrides: jointOverrides, jointTouching } = probeResult;
+  logPhase(
+    `probe: resolver.apply count = ${applyCountAtProbe}, jointOverrides = ${jointOverrides.length}`,
+  );
+
+  // Phase: variance. Pure cells + jointTouching analysis, no resolver calls.
+  const baselineForVariance =
+    normalized.axes[0] !== undefined
+      ? (cells[normalized.axes[0].name]?.[normalized.axes[0].default] ?? defaultTokens)
+      : defaultTokens;
+  const { result: varianceByPath, ms: varianceMs } = await timed('variance', () =>
+    buildVarianceByPath(normalized.axes, cells, jointTouching, baselineForVariance),
+  );
+
+  // Phase: listing. Uses the parser input + the cssVarPrefix; produces
+  // path-indexed `ListedToken` data.
+  const { result: listingResult, ms: listingMs } = await timed('listing', () =>
+    computeTokenListing(normalized.parserInput!, FIXTURE_DIR, 'swatch', {}),
+  );
+
+  // Build the same `resolveAt` `loadProject` would, for downstream emit.
+  const resolveAt = buildResolveAt(normalized.axes, cells, jointOverrides, defaultTuple);
+
+  // Assemble a synthetic `Project` shape sufficient for snapshotForWire +
+  // emitAxisProjectedCss. The bench bypasses `loadProject` but its outputs
+  // share the wire/emit consumer surface.
+  const project = {
+    config: { ...config, cssVarPrefix: 'swatch' },
+    axes: normalized.axes,
+    disabledAxes: [] as string[],
+    presets: [] as never[],
+    chrome: new Map(),
+    defaultTokens,
+    cells,
+    jointOverrides,
+    defaultTuple,
+    resolveAt,
+    varianceByPath,
+    sourceFiles: normalized.sourceFiles,
+    cwd: FIXTURE_DIR,
+    listing: listingResult,
+    diagnostics: [] as never[],
+    parserInput: normalized.parserInput,
+  } as unknown as Parameters<typeof snapshotForWire>[0];
+
+  // Phase: emit CSS. The smart emitter walks variance + cells + joints.
+  const { result: css, ms: emitCssMs, error: emitCssError } = await timedSafe(
+    'emitCss',
+    () => emitAxisProjectedCss(project),
+    '',
+  );
+
+  // Phase: snapshot-for-wire. Marshals the project for wire transport;
+  // captures the JSON payload size the addon would ship to the preview.
+  // Some core helpers (slimListing) assume every listing entry has the
+  // Terrazzo plugin extension; synthetic fixtures may lack it. Tolerate
+  // the failure so the rest of the baseline still lands.
+  const { result: wireSnapshot, ms: snapshotWireMs, error: snapshotWireError } =
+    await timedSafe('snapshotWire', () => snapshotForWire(project, css), null);
+
+  const wireBytes = wireSnapshot
+    ? Buffer.byteLength(JSON.stringify(wireSnapshot), 'utf8')
+    : 0;
+  const cssBytes = Buffer.byteLength(css, 'utf8');
+
+  const total = parseMs + buildCellsMs + probeMs + varianceMs + listingMs + emitCssMs + snapshotWireMs;
+
+  const errors: Record<string, string> = {};
+  if (emitCssError !== null) errors['emitCss'] = emitCssError;
+  if (snapshotWireError !== null) errors['snapshotWire'] = snapshotWireError;
+
+  const baseline: Baseline = {
+    fixtureVersion: FIXTURE_VERSION,
+    node: process.version,
+    generatedAt: new Date().toISOString(),
+    loadMs: {
+      parse: round(parseMs),
+      buildCells: round(buildCellsMs),
+      probe: round(probeMs),
+      variance: round(varianceMs),
+      listing: round(listingMs),
+      snapshotWire: round(snapshotWireMs),
+      emitCss: round(emitCssMs),
+      total: round(total),
+    },
+    resolverApplyCount: {
+      atCells: applyCountAtCells,
+      atProbe: applyCountAtProbe,
+      total: applyCountAtCells + applyCountAtProbe,
+    },
+    wireBytes,
+    cssBytes,
+    jointOverrideCount: jointOverrides.length,
+    axisCount: normalized.axes.length,
+    defaultTokenCount: Object.keys(defaultTokens).length,
+    errors,
+  };
+
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(baseline, null, 2)}\n`);
+  logPhase(`baseline written to ${relative(process.cwd(), BASELINE_PATH)}`);
+  logPhase(`total ${total.toFixed(2)}ms`);
+}
+
+function round(ms: number): number {
+  return Math.round(ms * 100) / 100;
+}
+
+main().catch((err) => {
+  logPhase(`FATAL: ${err instanceof Error ? err.message : String(err)}`);
+  if (err instanceof Error && err.stack) logPhase(err.stack);
+  process.exitCode = 1;
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,7 +78,9 @@
     "test:watch": "vitest",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
     "format": "oxfmt -c ../../.oxfmtrc.json src",
-    "format:check": "oxfmt --check -c ../../.oxfmtrc.json src"
+    "format:check": "oxfmt --check -c ../../.oxfmtrc.json src",
+    "bench:gen": "node bench/fixtures/stress/gen.mts",
+    "bench": "node bench/run.mts"
   },
   "dependencies": {
     "@leeoniya/ufuzzy": "1.0.19",

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -45,25 +45,76 @@ export interface JointProbeResult {
  * dark, Dark+BrandA → white), so the touching signal flags brand
  * even though no override is needed.
  *
- * Pair-only at this stage. Triple-and-higher joint variance is a
- * documented limitation; the algorithm extends naturally to arity N.
+ * The probe iterates arity 2..`maxArity` (default `axes.length`). At
+ * each arity, every divergent partial tuple is recorded as an override
+ * the cell-composer can patch back in. Higher arities are bounded only
+ * by `C(N, k) × Π(ctx_i - 1)` over the chosen combo — combinatorial
+ * at scale (11 axes with rich context counts → millions of
+ * `resolver.apply` calls). `options.maxArity` caps the sweep; pair-only
+ * is empirically sufficient for real-world joint divergences observed
+ * so far, and is the bench's default for large fixtures.
  *
  * Resolver-less projects (layered / plain-parse) return empty
  * collections — no resolver to probe with.
  */
+export interface ProbeOptions {
+  /**
+   * Inclusive maximum arity to probe. Defaults to `axes.length` — the
+   * full sweep. Capping is useful for benchmarks and for projects with
+   * many axes where arity-3+ probes explode combinatorially: at 11
+   * axes a context-rich fixture can reach millions of `resolver.apply`
+   * calls. Real-world joint divergences observed so far are pair-
+   * shaped; higher arities are conservative coverage, not load-bearing
+   * correctness.
+   */
+  maxArity?: number;
+}
+
 export function probeJointOverrides(
   axes: readonly Axis[],
   cells: Cells,
   defaultTuple: Readonly<Record<string, string>>,
   resolver: Resolver | undefined,
+  options: ProbeOptions = {},
 ): JointProbeResult {
   if (!resolver || axes.length < 2) {
     return { overrides: [], jointTouching: new Map() };
   }
 
+  // Consume the per-arity generator and accumulate. Generator yields
+  // an incremental snapshot after each arity so callers that only want
+  // pair-level divergence (the bench, or a `maxArity: 2` consumer) can
+  // stop early without paying for higher arities.
+  let result: JointProbeResult = { overrides: [], jointTouching: new Map() };
+  for (const snapshot of probeJointOverridesByArity(axes, cells, defaultTuple, resolver, options)) {
+    result = snapshot;
+  }
+  return result;
+}
+
+/**
+ * Per-arity generator. Yields the accumulated `{ overrides, jointTouching }`
+ * after completing each arity from 2 up to `options.maxArity ?? axes.length`.
+ *
+ * Each yielded value is a fresh materialization — caller-visible iteration
+ * order is "after arity 2 ... after arity 3 ..." Caller decides when to
+ * stop; breaking out of the `for...of` skips remaining arities, which is
+ * the load-bearing affordance for the bench harness and for caller-driven
+ * budgeting (e.g. abort when wall-clock exceeds a threshold).
+ *
+ * The generator itself is internal; the publicly-exported entry is the
+ * materializing wrapper above. Both share the same options.
+ */
+export function* probeJointOverridesByArity(
+  axes: readonly Axis[],
+  cells: Cells,
+  defaultTuple: Readonly<Record<string, string>>,
+  resolver: Resolver,
+  options: ProbeOptions = {},
+): Generator<JointProbeResult> {
   // Internal Map keyed on canonicalKey for dedupe across arity passes.
-  // Materialized to the public array shape on return so the wire
-  // boundary doesn't have to marshal a Map.
+  // Materialized to the public array shape on each yield so consumers
+  // see the same wire-friendly shape `loadProject` expects.
   const overrides = new Map<TupleKey, JointOverride>();
   const jointTouching = new Map<string, Set<string>>();
   // Baseline carries the values for paths that delta cells omit;
@@ -81,12 +132,13 @@ export function probeJointOverrides(
     set.add(axisName);
   };
 
-  // Iterate arity 2..axes.length. At each arity, build a composer
-  // over `cells + accumulated overrides` so arity-N probes see the
-  // (N-1)-level corrections already recorded — higher-arity
-  // divergences get recorded only when they're not already implied
-  // by a lower-arity override.
-  for (let arity = 2; arity <= axes.length; arity++) {
+  const maxArity = Math.min(options.maxArity ?? axes.length, axes.length);
+
+  // Iterate arity 2..maxArity. At each arity, build a composer over
+  // `cells + accumulated overrides` so arity-N probes see the (N-1)-level
+  // corrections already recorded — higher-arity divergences get recorded
+  // only when they're not already implied by a lower-arity override.
+  for (let arity = 2; arity <= maxArity; arity++) {
     const composer = buildResolveAt(axes, cells, [...overrides.entries()], defaultTuple);
 
     for (const axisCombo of axisCombinations(axes, arity)) {
@@ -142,9 +194,9 @@ export function probeJointOverrides(
         }
       }
     }
-  }
 
-  return { overrides: [...overrides.entries()], jointTouching };
+    yield { overrides: [...overrides.entries()], jointTouching };
+  }
 }
 
 function* axisCombinations(axes: readonly Axis[], k: number): Generator<readonly Axis[]> {


### PR DESCRIPTION
## Summary

Measurement scaffolding for [#954](https://github.com/unpunnyfuns/swatchbook/issues/954). Lands a deterministic stress-scale fixture, a phase-partitioned bench harness, and a checked-in baseline file. Confirms (empirically) the consumer's diagnosis that \`probeJointOverrides\` is the hot path.

### Fixture (\`packages/core/bench/fixtures/stress/\`)

Generated from \`gen.mts\` (seeded LCG). Mirrors a consumer's actual project shape — 6 modifier axes matching https://torquens.bill.works/token-adventure/, 200 mixed-type tokens (~40% aliases for non-trivial \`resolver.apply\` work), 30% per-context overlay density. No joint divergences are seeded by design — primitive overlays compose correctly under last-wins, so any overrides the probe finds are real (or, as it happens here, real-but-mysterious — see \"Findings\" below).

### Bench (\`packages/core/bench/run.mts\`)

Imports the loader's exported sub-phases directly — \`normalizePermutations\`, \`buildCells\`, \`probeJointOverrides\`, \`buildVarianceByPath\`, \`computeTokenListing\`, \`emitAxisProjectedCss\`, \`snapshotForWire\` — and times each. \`resolver.apply\` invocations counted per phase via a thin \`wrapResolver()\` proxy. Resilient to per-phase failures (writes a partial \`baseline.json\` with \`errors[phase]\` annotations).

Run: \`pnpm --filter @unpunnyfuns/swatchbook-core bench\`.

### \`probeJointOverrides\` refactor

Internal implementation now goes through a per-arity generator (\`probeJointOverridesByArity\`). New \`ProbeOptions.maxArity\` lets callers cap the sweep — useful for bench-against-larger-fixtures where higher arities go combinatorial. **Default behaviour unchanged**: \`loadProject\` and existing call sites continue to do the full arity sweep. The generator + option are net-new advanced-consumer surface, not a behaviour change.

### Initial baseline

At the realistic 6-axis fixture, Node 24.15, full-arity probe, single run:

| phase | ms | resolver.apply |
|---|---:|---:|
| parse | 112 | – |
| buildCells | 2.4 | 11 |
| **probe** | **2015** | **277** |
| variance | 1.8 | – |
| listing | 8.9 | – |
| emitCss | 3.8 | – |
| snapshotWire | (failed) | – |
| **total** | **~2155** | **288** |

Probe is **~93% of total wall-clock**. **~70× more \`resolver.apply\` calls in probe than in \`buildCells\`**. Validates the consumer's diagnosis — the probe is the wall.

### Findings surfaced (separate followups to file)

1. The probe found 7 joint overrides on a fixture designed to produce zero. Primitive-only overlays should compose correctly under last-wins; either the fixture has subtle alias-mediated cross-axis behaviour, or the probe / cells-composer agreement is wider than I understand. Worth investigating.
2. \`snapshot-for-wire\`'s \`slimListing\` crashes when a listing entry lacks the \`app.terrazzo.listing\` extension. Real defensiveness bug.
3. The alias-graph optimisation itself, with the baseline numbers as validation surface. The friend's two-pass algorithm (per-modifier path set → reverse lookup → graph closure) is the proposed approach.

### Out of scope

- Optimising \`probeJointOverrides\`. This PR measures; the optimisation is the followup.
- Storybook \`STRESS=1\` integration. At the realistic 6-axis scale the unrestricted probe completes in ~2s — not the consumer's described startup-hang timeline. Their actual hang is either at a larger scale than modelled or in a different layer (Vite virtual-module emit, listing plugin). Tracked as a separate diagnostic.

Closes #954

## Test plan
- [x] \`pnpm -r format && pnpm turbo run format:check lint typecheck test\` — 37/37 turbo tasks green
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-core bench:gen\` regenerates fixture deterministically
- [x] \`pnpm --filter @unpunnyfuns/swatchbook-core bench\` produces \`baseline.json\` with measured numbers