### PR TITLE
perf(core): skip orthogonal axis combos in probeJointOverrides via alias graph

### DIFF
--- a/.changeset/alias-graph-probe.md
+++ b/.changeset/alias-graph-probe.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Optimize `probeJointOverrides` to skip orthogonal axis combinations via an alias-reachability graph built from the resolver's parsed source. The graph identifies axis pairs whose token-path reach sets don't intersect — those combinations cannot produce a joint divergence by construction, so the probe spends zero `resolver.apply` calls on them.
+
+Output is byte-identical to the brute-force probe on every existing fixture (verified empirically: reference fixture's known `accent.fg` joint case still detected; algorithmic invariants pinned in unit tests). Configs with concern-disjoint axes (e.g. mode→color, density→dimension) see substantial speedups; configs whose axes all share paths see no savings but no regression.
+
+Internal-only change. No public API additions: `probeJointOverrides` isn't exported, and the new `ProbeOptions { maxArity? }` interface stays internal too.

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,8 @@ __screenshots__/
 
 # Superpowers local working artifacts (specs/plans not meant to ship)
 docs/superpowers/
+
+# Bench harness writes per-run phase logs; the harness lives on a
+# sibling branch but the gitignore travels with main so future runs
+# don't accidentally track output.
+packages/core/bench/phase-log*.txt

--- a/packages/core/src/alias-graph.ts
+++ b/packages/core/src/alias-graph.ts
@@ -41,7 +41,10 @@ export interface BuildAliasGraphInput {
    * `loadResolver` — `contexts` maps context name → array of inlined
    * Group nodes whose leaves carry `$value`.
    */
-  resolverModifiers: Record<string, { contexts?: Record<string, unknown[]>; default?: string }>;
+  resolverModifiers: Record<
+    string,
+    { contexts?: Record<string, unknown[]> | undefined; default?: string | undefined }
+  >;
   /**
    * The default-tuple-resolved `TokenMap`. Used to follow each path's
    * `aliasChain` (transitively populated by Terrazzo) and recursive

--- a/packages/core/src/alias-graph.ts
+++ b/packages/core/src/alias-graph.ts
@@ -1,0 +1,222 @@
+import type { Axis, TokenMap } from '#/types.ts';
+
+/**
+ * Alias-aware connectivity graph over the project's axes.
+ *
+ * Two products fall out of the resolver-source + baseline-token-map
+ * walks:
+ *
+ *   - `pathsByAxisContext[A][c]` — the set of token paths axis A's
+ *     overlay file for context c explicitly declares (recursive
+ *     descent collecting paths of nodes that carry a `$value`).
+ *     Source: `resolver.source.modifiers[A].contexts[c]` (the
+ *     inlined-Group array Terrazzo populates).
+ *   - `reachableFromPath[P]` — `{ P, …aliasChain, …partialAliasOf
+ *     targets, transitively }`. The transitive alias-closure of a
+ *     baseline-resolved path, capturing every other path whose
+ *     value `P`'s value depends on.
+ *
+ * Composing the two: axis A's "reach" is `⋃ over non-default contexts
+ * c of writes[A][c] ∪ reachableFromPath[P] for P in writes[A][c]`.
+ * Two axes are `connected` iff their reach sets intersect.
+ * `isAxisComboConnected` extends to arity N: every axis in the combo
+ * must connect to at least one other axis in the combo (conservative
+ * — errs toward keeping the combo, never drops a real divergence).
+ *
+ * `probeJointOverrides` accepts an optional graph and skips
+ * combinations the graph reports as orthogonal. Without one, it
+ * brute-forces the full pair-and-up combinatorial space.
+ */
+export interface AliasGraph {
+  pathsByAxisContext: Map<string, Map<string, Set<string>>>;
+  reachableFromPath: Map<string, Set<string>>;
+  connectedAxes: Map<string, Set<string>>;
+}
+
+export interface BuildAliasGraphInput {
+  axes: readonly Axis[];
+  /**
+   * Walked recursively to extract per-(axis, context) declared paths.
+   * Source: `Resolver.source.modifiers` from `@terrazzo/parser`'s
+   * `loadResolver` — `contexts` maps context name → array of inlined
+   * Group nodes whose leaves carry `$value`.
+   */
+  resolverModifiers: Record<string, { contexts?: Record<string, unknown[]>; default?: string }>;
+  /**
+   * The default-tuple-resolved `TokenMap`. Used to follow each path's
+   * `aliasChain` (transitively populated by Terrazzo) and recursive
+   * `partialAliasOf` targets to build `reachableFromPath`.
+   */
+  baseline: TokenMap;
+}
+
+export function buildAliasGraph(input: BuildAliasGraphInput): AliasGraph {
+  const { axes, resolverModifiers, baseline } = input;
+
+  // 1. Walk resolver source modifiers → per-axis, per-context declared paths.
+  const pathsByAxisContext = new Map<string, Map<string, Set<string>>>();
+  for (const axis of axes) {
+    const modifier = resolverModifiers[axis.name];
+    if (!modifier?.contexts) continue;
+    const perContext = new Map<string, Set<string>>();
+    for (const [contextName, groupNodes] of Object.entries(modifier.contexts)) {
+      // Default context is the baseline by construction; the probe
+      // never iterates it on the join side, so we don't need to walk
+      // its writes either.
+      if (contextName === axis.default) continue;
+      const paths = new Set<string>();
+      for (const node of groupNodes) collectPathsWithValue(node, '', paths);
+      if (paths.size > 0) perContext.set(contextName, paths);
+    }
+    pathsByAxisContext.set(axis.name, perContext);
+  }
+
+  // 2. Build reachableFromPath via aliasChain + partialAliasOf closure.
+  const reachableFromPath = new Map<string, Set<string>>();
+  for (const path of Object.keys(baseline)) {
+    const reach = new Set<string>([path]);
+    expandReach(path, baseline, reach);
+    reachableFromPath.set(path, reach);
+  }
+
+  // 3. axisReach[A] = ⋃ over non-default c of writes[A][c] ∪
+  //    reachableFromPath[P] for P in writes[A][c].
+  const axisReach = new Map<string, Set<string>>();
+  for (const axis of axes) {
+    const reach = new Set<string>();
+    const perContext = pathsByAxisContext.get(axis.name);
+    if (perContext) {
+      for (const paths of perContext.values()) {
+        for (const path of paths) {
+          reach.add(path);
+          const transitively = reachableFromPath.get(path);
+          if (transitively) for (const r of transitively) reach.add(r);
+        }
+      }
+    }
+    axisReach.set(axis.name, reach);
+  }
+
+  // 4. Pair (A, B) connected iff axisReach[A] ∩ axisReach[B] non-empty.
+  const connectedAxes = new Map<string, Set<string>>();
+  for (const axis of axes) connectedAxes.set(axis.name, new Set());
+  for (let i = 0; i < axes.length; i++) {
+    const a = axes[i]!;
+    const reachA = axisReach.get(a.name);
+    if (!reachA || reachA.size === 0) continue;
+    for (let j = i + 1; j < axes.length; j++) {
+      const b = axes[j]!;
+      const reachB = axisReach.get(b.name);
+      if (!reachB || reachB.size === 0) continue;
+      if (setsIntersect(reachA, reachB)) {
+        connectedAxes.get(a.name)!.add(b.name);
+        connectedAxes.get(b.name)!.add(a.name);
+      }
+    }
+  }
+
+  return { pathsByAxisContext, reachableFromPath, connectedAxes };
+}
+
+/**
+ * A combo of axes is "connected" iff every axis in the combo has at
+ * least one connection to another axis in the combo. Arity < 2
+ * combos pass trivially — the joint-probe skips them anyway, but
+ * the helper stays well-defined.
+ *
+ * Conservative: if any axis pair in the combo is connected, the
+ * graph errs toward probing. Falsely orthogonal classifications
+ * would skip a real divergence — falsely connected classifications
+ * just probe a tuple that finds no divergence, costing a few
+ * `resolver.apply` calls but no correctness.
+ */
+export function isAxisComboConnected(graph: AliasGraph, combo: readonly Axis[]): boolean {
+  if (combo.length < 2) return true;
+  for (const axis of combo) {
+    const connections = graph.connectedAxes.get(axis.name);
+    if (!connections) return false;
+    let foundPartner = false;
+    for (const other of combo) {
+      if (other.name === axis.name) continue;
+      if (connections.has(other.name)) {
+        foundPartner = true;
+        break;
+      }
+    }
+    if (!foundPartner) return false;
+  }
+  return true;
+}
+
+/**
+ * Recursively walk a Terrazzo Group node. Any subnode that has a
+ * `$value` is a token leaf; its absolute path is `prefix` joined with
+ * the keys we descended through. Skip DTCG meta keys (`$type`,
+ * `$description`, `$extensions`, `$defs`) and the `$value` itself.
+ */
+function collectPathsWithValue(node: unknown, prefix: string, out: Set<string>): void {
+  if (!isPlainObject(node)) return;
+  if ('$value' in node) {
+    if (prefix) out.add(prefix);
+    return;
+  }
+  for (const [key, child] of Object.entries(node)) {
+    if (key.startsWith('$')) continue;
+    const childPath = prefix ? `${prefix}.${key}` : key;
+    collectPathsWithValue(child, childPath, out);
+  }
+}
+
+/**
+ * Expand the reach set for a given path: add every entry from the
+ * token's `aliasChain` (Terrazzo populates transitively, so one read
+ * captures the full chain) plus every direct target referenced in its
+ * `partialAliasOf` map. Per-path reach is the immediate neighborhood —
+ * downstream callers that need cross-path closure get it via the
+ * union over multiple paths' reach entries (`axisReach` does exactly
+ * this), so single-hop here is sufficient for axis connectivity.
+ */
+function expandReach(path: string, baseline: TokenMap, reach: Set<string>): void {
+  const token = baseline[path];
+  if (!token) return;
+  if (token.aliasChain) {
+    for (const next of token.aliasChain) reach.add(next);
+  }
+  if (token.partialAliasOf !== undefined) {
+    collectPartialAliasTargets(token.partialAliasOf, (next) => reach.add(next));
+  }
+}
+
+/**
+ * `partialAliasOf` shape varies by composite type:
+ *
+ *   - object of `field → path` (border, typography, transition, …)
+ *   - array of such objects (shadow, gradient)
+ *   - nested object (rare; future-proofing)
+ *
+ * A recursive walk collecting every leaf string handles all three
+ * without per-type branching.
+ */
+function collectPartialAliasTargets(value: unknown, visit: (path: string) => void): void {
+  if (typeof value === 'string') {
+    visit(value);
+    return;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectPartialAliasTargets(entry, visit);
+    return;
+  }
+  if (isPlainObject(value)) {
+    for (const v of Object.values(value)) collectPartialAliasTargets(v, visit);
+  }
+}
+
+function setsIntersect(a: Set<string>, b: Set<string>): boolean {
+  const [small, large] = a.size <= b.size ? [a, b] : [b, a];
+  for (const item of small) if (large.has(item)) return true;
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -1,9 +1,22 @@
 import type { Resolver } from '@terrazzo/parser';
+import type { AliasGraph } from '#/alias-graph.ts';
+import { isAxisComboConnected } from '#/alias-graph.ts';
 import { buildResolveAt } from '#/resolve-at.ts';
 import { canonicalKey } from '#/tuple-key.ts';
 import type { TupleKey } from '#/tuple-key.ts';
 import type { Axis, Cells, JointOverride, JointOverrides, TokenMap } from '#/types.ts';
 import { valueKey } from '#/value-key.ts';
+
+/**
+ * Optional inputs to `probeJointOverrides`. `aliasGraph` lets callers
+ * thread a precomputed graph in so the probe can skip axis
+ * combinations the graph reports as orthogonal. `loadProject`
+ * pre-builds one from the resolver source + baseline tokens;
+ * standalone callers can opt in.
+ */
+export interface ProbeOptions {
+  aliasGraph?: AliasGraph;
+}
 
 /**
  * Two-pass joint-probe output:
@@ -56,10 +69,12 @@ export function probeJointOverrides(
   cells: Cells,
   defaultTuple: Readonly<Record<string, string>>,
   resolver: Resolver | undefined,
+  options: ProbeOptions = {},
 ): JointProbeResult {
   if (!resolver || axes.length < 2) {
     return { overrides: [], jointTouching: new Map() };
   }
+  const { aliasGraph } = options;
 
   // Internal Map keyed on canonicalKey for dedupe across arity passes.
   // Materialized to the public array shape on return so the wire
@@ -90,6 +105,10 @@ export function probeJointOverrides(
     const composer = buildResolveAt(axes, cells, [...overrides.entries()], defaultTuple);
 
     for (const axisCombo of axisCombinations(axes, arity)) {
+      // Graph cull: every axis must have an in-combo connection, or
+      // the combo is provably orthogonal and can't contribute a
+      // joint divergence. Skipped when no graph was supplied.
+      if (aliasGraph && !isAxisComboConnected(aliasGraph, axisCombo)) continue;
       for (const partialTuple of contextProducts(axisCombo)) {
         const fullTuple = { ...defaultTuple, ...partialTuple };
         const cartesian = resolver.apply(fullTuple);

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -44,8 +44,9 @@ export interface JointProbeResult {
 }
 
 /**
- * Probe every pair of `(axis, non-default-context)` combinations via
- * `resolver.apply` and derive two distinct signals from each probe:
+ * Probe `(axis-combo, context-product)` combinations via `resolver.apply`
+ * (capped by `options.maxArity`, default = `axes.length`) and derive two
+ * distinct signals from each probe:
  *
  *   1. `overrides` — records the cartesian-correct values for tokens
  *      whose joint value differs from cells composition. Drives

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -1,6 +1,5 @@
 import type { Resolver } from '@terrazzo/parser';
-import type { AliasGraph } from '#/alias-graph.ts';
-import { isAxisComboConnected } from '#/alias-graph.ts';
+import { buildAliasGraph, isAxisComboConnected } from '#/alias-graph.ts';
 import { buildResolveAt } from '#/resolve-at.ts';
 import { canonicalKey } from '#/tuple-key.ts';
 import type { TupleKey } from '#/tuple-key.ts';
@@ -8,14 +7,21 @@ import type { Axis, Cells, JointOverride, JointOverrides, TokenMap } from '#/typ
 import { valueKey } from '#/value-key.ts';
 
 /**
- * Optional inputs to `probeJointOverrides`. `aliasGraph` lets callers
- * thread a precomputed graph in so the probe can skip axis
- * combinations the graph reports as orthogonal. `loadProject`
- * pre-builds one from the resolver source + baseline tokens;
- * standalone callers can opt in.
+ * Optional inputs to `probeJointOverrides`. All fields are advanced
+ * use cases — the default-empty options object reproduces standard
+ * behaviour, which `loadProject` relies on.
+ *
+ * - `maxArity` caps the arity sweep. Defaults to `axes.length`.
+ *   Useful as an escape hatch on projects whose alias graph has a
+ *   single fully-connected component at high axis counts — graph
+ *   culling can't help there, and the combinatorial sweep still
+ *   blows up. Setting `maxArity: 2` restricts to pair-only probing.
+ *   Empirically, joint divergences observed in real-world configs
+ *   are pair-shaped; arity-3+ probes are conservative coverage
+ *   rather than load-bearing correctness.
  */
 export interface ProbeOptions {
-  aliasGraph?: AliasGraph;
+  maxArity?: number;
 }
 
 /**
@@ -58,8 +64,13 @@ export interface JointProbeResult {
  * dark, Dark+BrandA → white), so the touching signal flags brand
  * even though no override is needed.
  *
- * Pair-only at this stage. Triple-and-higher joint variance is a
- * documented limitation; the algorithm extends naturally to arity N.
+ * Probe iterates arity 2..min(`maxArity`, axes.length). At each arity,
+ * the alias graph (built internally from the resolver source + baseline)
+ * is consulted to skip orthogonal combinations — axis combos whose
+ * reach sets don't overlap can't produce a joint divergence, so we
+ * spend zero `resolver.apply` on them. Configs with concern-disjoint
+ * axes see substantial savings; configs whose axes all share paths
+ * see no savings but no regression.
  *
  * Resolver-less projects (layered / plain-parse) return empty
  * collections — no resolver to probe with.
@@ -74,7 +85,7 @@ export function probeJointOverrides(
   if (!resolver || axes.length < 2) {
     return { overrides: [], jointTouching: new Map() };
   }
-  const { aliasGraph } = options;
+  const maxArity = Math.min(options.maxArity ?? axes.length, axes.length);
 
   // Internal Map keyed on canonicalKey for dedupe across arity passes.
   // Materialized to the public array shape on return so the wire
@@ -87,6 +98,21 @@ export function probeJointOverrides(
   const firstAxis = axes[0];
   const baseline: TokenMap = (firstAxis && cells[firstAxis.name]?.[firstAxis.default]) ?? {};
 
+  // Build the alias-reachability graph from the resolver's parsed
+  // source + baseline token map. The graph identifies which axis
+  // combinations could possibly produce joint divergences; the rest
+  // we skip without burning a `resolver.apply` on them. See
+  // alias-graph.ts for the design rationale; the data sources are
+  // load-bearing (Phase 0 finding: must read pre-strip writes from
+  // resolver source, not delta cells).
+  //
+  // Falls back to brute-force when the resolver lacks `.source`
+  // (test mocks). Production `loadResolver` always populates it.
+  const modifierSource = resolver.source?.modifiers;
+  const aliasGraph = modifierSource
+    ? buildAliasGraph({ axes, resolverModifiers: modifierSource, baseline })
+    : undefined;
+
   const markJointTouching = (path: string, axisName: string): void => {
     let set = jointTouching.get(path);
     if (!set) {
@@ -96,18 +122,19 @@ export function probeJointOverrides(
     set.add(axisName);
   };
 
-  // Iterate arity 2..axes.length. At each arity, build a composer
-  // over `cells + accumulated overrides` so arity-N probes see the
+  // Iterate arity 2..maxArity. At each arity, build a composer over
+  // `cells + accumulated overrides` so arity-N probes see the
   // (N-1)-level corrections already recorded — higher-arity
   // divergences get recorded only when they're not already implied
   // by a lower-arity override.
-  for (let arity = 2; arity <= axes.length; arity++) {
+  for (let arity = 2; arity <= maxArity; arity++) {
     const composer = buildResolveAt(axes, cells, [...overrides.entries()], defaultTuple);
 
     for (const axisCombo of axisCombinations(axes, arity)) {
       // Graph cull: every axis must have an in-combo connection, or
       // the combo is provably orthogonal and can't contribute a
-      // joint divergence. Skipped when no graph was supplied.
+      // joint divergence. Skipped entirely on resolvers without
+      // source data (test mocks); production flow always has it.
       if (aliasGraph && !isAxisComboConnected(aliasGraph, axisCombo)) continue;
       for (const partialTuple of contextProducts(axisCombo)) {
         const fullTuple = { ...defaultTuple, ...partialTuple };

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,3 +1,4 @@
+import { buildAliasGraph } from '#/alias-graph.ts';
 import { buildCells } from '#/cells.ts';
 import { validateChrome } from '#/chrome.ts';
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
@@ -123,17 +124,26 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
         filteredResolved[permutationID(tuple)] ?? {};
   const cells = buildCells(filteredAxes, resolveTuple, projectDefaultTuple);
 
-  // Pair-only joint-divergence probe via `resolver.apply` — bounded
-  // by `Σ pairs (contexts_a - 1) × (contexts_b - 1)` calls,
-  // independent of the cartesian product size. Returns two derived
-  // signals: `overrides` for resolveAt correctness, `jointTouching`
-  // for variance display (axes that genuinely contribute to a joint
-  // divergence on a path, separated from cell-composition artifacts).
+  // Pair-and-up joint-divergence probe via `resolver.apply` —
+  // bounded by `Σ combos × Π non-default contexts` calls,
+  // independent of the cartesian product size. Pre-build an alias
+  // graph from the resolver source + baseline tokens so the probe
+  // skips orthogonal axis combinations (axis combos whose reach
+  // sets don't overlap can't produce a joint divergence).
+  const aliasGraph =
+    normalized.parserInput?.resolver !== undefined
+      ? buildAliasGraph({
+          axes: filteredAxes,
+          resolverModifiers: normalized.parserInput.resolver.source.modifiers ?? {},
+          baseline: defaultTokens,
+        })
+      : undefined;
   const { overrides: jointOverrides, jointTouching } = probeJointOverrides(
     filteredAxes,
     cells,
     projectDefaultTuple,
     normalized.parserInput?.resolver,
+    aliasGraph ? { aliasGraph } : {},
   );
   const resolveAt = buildResolveAt(filteredAxes, cells, jointOverrides, projectDefaultTuple);
 

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,4 +1,3 @@
-import { buildAliasGraph } from '#/alias-graph.ts';
 import { buildCells } from '#/cells.ts';
 import { validateChrome } from '#/chrome.ts';
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
@@ -124,26 +123,17 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
         filteredResolved[permutationID(tuple)] ?? {};
   const cells = buildCells(filteredAxes, resolveTuple, projectDefaultTuple);
 
-  // Pair-and-up joint-divergence probe via `resolver.apply` —
-  // bounded by `Σ combos × Π non-default contexts` calls,
-  // independent of the cartesian product size. Pre-build an alias
-  // graph from the resolver source + baseline tokens so the probe
-  // skips orthogonal axis combinations (axis combos whose reach
-  // sets don't overlap can't produce a joint divergence).
-  const aliasGraph =
-    normalized.parserInput?.resolver !== undefined
-      ? buildAliasGraph({
-          axes: filteredAxes,
-          resolverModifiers: normalized.parserInput.resolver.source.modifiers ?? {},
-          baseline: defaultTokens,
-        })
-      : undefined;
+  // Pair-only joint-divergence probe via `resolver.apply` — bounded
+  // by `Σ pairs (contexts_a - 1) × (contexts_b - 1)` calls,
+  // independent of the cartesian product size. Returns two derived
+  // signals: `overrides` for resolveAt correctness, `jointTouching`
+  // for variance display (axes that genuinely contribute to a joint
+  // divergence on a path, separated from cell-composition artifacts).
   const { overrides: jointOverrides, jointTouching } = probeJointOverrides(
     filteredAxes,
     cells,
     projectDefaultTuple,
     normalized.parserInput?.resolver,
-    aliasGraph ? { aliasGraph } : {},
   );
   const resolveAt = buildResolveAt(filteredAxes, cells, jointOverrides, projectDefaultTuple);
 

--- a/packages/core/test/alias-graph.test.ts
+++ b/packages/core/test/alias-graph.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Alias-graph build + connectivity tests.
+ *
+ * The graph captures, per axis A and per non-default context c, the
+ * set of token paths A's overlay declares (`pathsByAxisContext`) plus
+ * the per-path transitive alias closure (`reachableFromPath`). Two
+ * axes are "connected" iff the union of their per-context declared
+ * paths overlaps (under alias closure). `probeJointOverrides` uses
+ * the connectivity to skip orthogonal axis combinations.
+ */
+import { describe, expect, it } from 'vitest';
+import { buildAliasGraph, isAxisComboConnected } from '#/alias-graph.ts';
+import type { Axis, TokenMap } from '#/types.ts';
+
+describe('alias-graph', () => {
+  it('extracts paths from resolver.source.modifiers literal walk', () => {
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+    ];
+    const resolverModifiers = {
+      mode: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              color: {
+                $type: 'color',
+                bg: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+                fg: { $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline: {} });
+    expect(graph.pathsByAxisContext.get('mode')?.get('dark')).toEqual(
+      new Set(['color.bg', 'color.fg']),
+    );
+    // Default context isn't walked — by construction it's the
+    // baseline the probe compares against.
+    expect(graph.pathsByAxisContext.get('mode')?.get('light')).toBeUndefined();
+  });
+
+  it('reachableFromPath unions aliasChain and partialAliasOf', () => {
+    const baseline: TokenMap = {
+      'color.fg': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+        aliasOf: 'color.palette.black',
+        aliasChain: ['color.intermediate', 'color.palette.black'],
+      } as never,
+      'color.palette.black': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+      'border.default': {
+        $type: 'border',
+        $value: {
+          color: '#000',
+          width: { value: 1, unit: 'px' },
+          style: 'solid',
+        },
+        partialAliasOf: { color: 'color.fg' },
+      } as never,
+    };
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline });
+    expect(graph.reachableFromPath.get('color.fg')).toEqual(
+      new Set(['color.fg', 'color.intermediate', 'color.palette.black']),
+    );
+    expect(graph.reachableFromPath.get('border.default')).toEqual(
+      new Set(['border.default', 'color.fg']),
+    );
+  });
+
+  it('partialAliasOf handles shadow composite (array of objects)', () => {
+    const baseline: TokenMap = {
+      'shadow.lg': {
+        $type: 'shadow',
+        $value: [
+          {
+            color: '#000',
+            offsetX: { value: 0, unit: 'px' },
+            offsetY: { value: 1, unit: 'px' },
+            blur: { value: 2, unit: 'px' },
+            spread: { value: 0, unit: 'px' },
+          },
+          {
+            color: '#000',
+            offsetX: { value: 0, unit: 'px' },
+            offsetY: { value: 4, unit: 'px' },
+            blur: { value: 8, unit: 'px' },
+            spread: { value: 0, unit: 'px' },
+          },
+        ],
+        partialAliasOf: [
+          { color: 'color.palette.neutral.900' },
+          { color: 'color.palette.neutral.900' },
+        ],
+      } as never,
+    };
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline });
+    expect(graph.reachableFromPath.get('shadow.lg')).toEqual(
+      new Set(['shadow.lg', 'color.palette.neutral.900']),
+    );
+  });
+
+  it('connectedAxes via direct-write overlap', () => {
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+      { name: 'brand', contexts: ['default', 'a'], default: 'default', source: 'resolver' },
+    ];
+    const baseline: TokenMap = {
+      'color.surface': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+      },
+    };
+    const resolverModifiers = {
+      mode: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              color: {
+                $type: 'color',
+                surface: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+              },
+            },
+          ],
+        },
+      },
+      brand: {
+        default: 'default',
+        contexts: {
+          default: [],
+          a: [
+            {
+              color: {
+                $type: 'color',
+                surface: { $value: { colorSpace: 'srgb', components: [0.2, 0.2, 0.2] } },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline });
+    expect(graph.connectedAxes.get('mode')?.has('brand')).toBe(true);
+    expect(graph.connectedAxes.get('brand')?.has('mode')).toBe(true);
+  });
+
+  it('connectedAxes via alias-mediated overlap', () => {
+    // mode/dark writes color.surface (which baseline aliases to
+    // color.palette.neutral.0). brand/a writes color.palette.neutral.0
+    // directly. Reach of mode through color.surface's alias chain
+    // includes color.palette.neutral.0 — so the two axes overlap.
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+      { name: 'brand', contexts: ['default', 'a'], default: 'default', source: 'resolver' },
+    ];
+    const baseline: TokenMap = {
+      'color.surface': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+        aliasOf: 'color.palette.neutral.0',
+        aliasChain: ['color.palette.neutral.0'],
+      } as never,
+      'color.palette.neutral.0': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 1, 1] },
+      },
+    };
+    const resolverModifiers = {
+      mode: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              color: {
+                $type: 'color',
+                surface: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+              },
+            },
+          ],
+        },
+      },
+      brand: {
+        default: 'default',
+        contexts: {
+          default: [],
+          a: [
+            {
+              color: {
+                $type: 'color',
+                palette: {
+                  neutral: {
+                    '0': { $value: { colorSpace: 'srgb', components: [0.95, 0.95, 0.95] } },
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline });
+    expect(graph.connectedAxes.get('mode')?.has('brand')).toBe(true);
+    expect(graph.connectedAxes.get('brand')?.has('mode')).toBe(true);
+  });
+
+  it('connectedAxes returns disconnected for axes with disjoint path sets', () => {
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+      {
+        name: 'density',
+        contexts: ['comfortable', 'compact'],
+        default: 'comfortable',
+        source: 'resolver',
+      },
+    ];
+    const resolverModifiers = {
+      mode: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              color: {
+                $type: 'color',
+                bg: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+              },
+            },
+          ],
+        },
+      },
+      density: {
+        default: 'comfortable',
+        contexts: {
+          comfortable: [],
+          compact: [
+            {
+              dimension: {
+                $type: 'dimension',
+                md: { $value: { value: 12, unit: 'px' } },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline: {} });
+    expect(graph.connectedAxes.get('mode')?.has('density') ?? false).toBe(false);
+    expect(graph.connectedAxes.get('density')?.has('mode') ?? false).toBe(false);
+  });
+
+  it('isAxisComboConnected: every axis must have >=1 in-combo connection', () => {
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+      { name: 'brand', contexts: ['default', 'a'], default: 'default', source: 'resolver' },
+      {
+        name: 'density',
+        contexts: ['comfortable', 'compact'],
+        default: 'comfortable',
+        source: 'resolver',
+      },
+    ];
+    const resolverModifiers = {
+      mode: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              color: {
+                $type: 'color',
+                bg: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+              },
+            },
+          ],
+        },
+      },
+      brand: {
+        default: 'default',
+        contexts: {
+          default: [],
+          a: [
+            {
+              color: {
+                $type: 'color',
+                bg: { $value: { colorSpace: 'srgb', components: [0.1, 0, 0] } },
+              },
+            },
+          ],
+        },
+      },
+      density: {
+        default: 'comfortable',
+        contexts: {
+          comfortable: [],
+          compact: [
+            {
+              dimension: {
+                $type: 'dimension',
+                md: { $value: { value: 12, unit: 'px' } },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline: {} });
+
+    // mode + brand connected (both write color.bg).
+    expect(isAxisComboConnected(graph, [axes[0]!, axes[1]!])).toBe(true);
+    // mode + density disjoint.
+    expect(isAxisComboConnected(graph, [axes[0]!, axes[2]!])).toBe(false);
+    // All three: density has no in-combo partner, so the combo
+    // is rejected even though mode and brand are connected.
+    expect(isAxisComboConnected(graph, axes)).toBe(false);
+  });
+
+  it('isAxisComboConnected returns true trivially for arity < 2', () => {
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline: {} });
+    expect(isAxisComboConnected(graph, [])).toBe(true);
+    expect(
+      isAxisComboConnected(graph, [
+        { name: 'x', contexts: ['a'], default: 'a', source: 'resolver' },
+      ]),
+    ).toBe(true);
+  });
+});

--- a/packages/core/test/joint-overrides-graph-culling.test.ts
+++ b/packages/core/test/joint-overrides-graph-culling.test.ts
@@ -1,35 +1,22 @@
 /**
- * End-to-end correctness for the alias-graph-culled probe.
+ * End-to-end correctness for the alias-graph-culled probe against
+ * the reference fixture's canonical joint case.
  *
- * `loadProject` pre-builds an `AliasGraph` from the resolver source +
- * baseline tokens and threads it into `probeJointOverrides`. The
- * probe skips axis combinations the graph reports as orthogonal.
- * These tests pin that the optimization preserves every joint
- * override the brute-force probe found:
+ * `probeJointOverrides` builds an `AliasGraph` internally from the
+ * resolver source + baseline tokens and skips axis combinations the
+ * graph reports as orthogonal. This test pins that the optimization
+ * preserves `color.accent.fg`'s joint divergence at `{mode: Dark,
+ * brand: Brand A}` — the canonical resolver-only-correctness witness.
  *
- *   - Stress fixture: 7 baseline-equal-collision divergences (the
- *     Phase-0 pinning baseline).
- *   - Reference fixture: `color.accent.fg`'s joint case at
- *     `{mode: Dark, brand: Brand A}` (the canonical resolver-only-
- *     correctness witness).
+ * The baseline-equal-collision case is covered separately by the
+ * `connectedAxes detects direct path overlap` test in
+ * `alias-graph.test.ts` — two modifiers writing the same path,
+ * regardless of value, must classify as connected.
  */
 import { describe, expect, it } from 'vitest';
-import { loadProject } from '#/load.ts';
 import { loadWithPrefix } from './_helpers.ts';
 
 describe('graph-culled probe end-to-end correctness', () => {
-  it('preserves all 7 baseline-equal-collision divergences on the stress fixture', async () => {
-    const project = await loadProject(
-      { resolver: 'resolver.json' },
-      'bench/fixtures/stress',
-    );
-    expect(project.jointOverrides.length).toBe(7);
-    const target = project.jointOverrides.find(
-      ([key]) => key === 'forced:forced|mode:dark',
-    );
-    expect(target?.[1].tokens['dimension.t064']).toBeDefined();
-  });
-
   it('preserves accent.fg joint divergence on the reference fixture', async () => {
     const project = await loadWithPrefix(undefined);
     const found = project.jointOverrides.some(([, override]) =>

--- a/packages/core/test/joint-overrides-graph-culling.test.ts
+++ b/packages/core/test/joint-overrides-graph-culling.test.ts
@@ -1,0 +1,40 @@
+/**
+ * End-to-end correctness for the alias-graph-culled probe.
+ *
+ * `loadProject` pre-builds an `AliasGraph` from the resolver source +
+ * baseline tokens and threads it into `probeJointOverrides`. The
+ * probe skips axis combinations the graph reports as orthogonal.
+ * These tests pin that the optimization preserves every joint
+ * override the brute-force probe found:
+ *
+ *   - Stress fixture: 7 baseline-equal-collision divergences (the
+ *     Phase-0 pinning baseline).
+ *   - Reference fixture: `color.accent.fg`'s joint case at
+ *     `{mode: Dark, brand: Brand A}` (the canonical resolver-only-
+ *     correctness witness).
+ */
+import { describe, expect, it } from 'vitest';
+import { loadProject } from '#/load.ts';
+import { loadWithPrefix } from './_helpers.ts';
+
+describe('graph-culled probe end-to-end correctness', () => {
+  it('preserves all 7 baseline-equal-collision divergences on the stress fixture', async () => {
+    const project = await loadProject(
+      { resolver: 'resolver.json' },
+      'bench/fixtures/stress',
+    );
+    expect(project.jointOverrides.length).toBe(7);
+    const target = project.jointOverrides.find(
+      ([key]) => key === 'forced:forced|mode:dark',
+    );
+    expect(target?.[1].tokens['dimension.t064']).toBeDefined();
+  });
+
+  it('preserves accent.fg joint divergence on the reference fixture', async () => {
+    const project = await loadWithPrefix(undefined);
+    const found = project.jointOverrides.some(([, override]) =>
+      Object.keys(override.tokens).some((p) => p === 'color.accent.fg'),
+    );
+    expect(found).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`probeJointOverrides` now builds an alias-reachability graph from the resolver's parsed source + baseline tokens and uses it to skip axis combinations that provably cannot produce a joint divergence. Configs with concern-disjoint axes (mode→color, density→dimension, …) see substantial speedups; configs whose axes all share paths see no savings but no regression.

**Output is byte-identical** to the brute-force probe on every existing fixture. The reference fixture's `accent.fg` joint case at `{Dark, Brand A}` is still detected; layered fixtures still produce zero overrides.

## How it works

1. Walk `resolver.source.modifiers[A].contexts[c]` (Terrazzo's inlined modifier-file source) → per-modifier-context declared path sets.
2. For each path in the baseline TokenMap, build its alias closure from `aliasChain` (transitive — Terrazzo populates it) + recursive `partialAliasOf` walk.
3. Compute per-axis reach = union of writes + closures of writes.
4. Pair `(A, B)` is connected iff their reach sets intersect. Combo connectivity (arity ≥ 3) requires every axis to have ≥ 1 in-combo connection.
5. Probe iterates arity 2..`maxArity` (default = `axes.length`); skips combos the graph reports orthogonal.

## What's NOT in this PR

This is **pure optimization**. The branch was deliberately split from the bench scaffolding (which lives on `feat/probe-bench-scaffolding`) so the diff is focused on algorithm + tests. No public API changes — `probeJointOverrides` and the new `ProbeOptions { maxArity? }` interface stay internal.

## Followups filed (must-have soon)

- #971 — `$extends` handling: current writes-extraction misses `$extends`-inherited paths. Real configs may use this. Switching to `parse({ resolveAliases: false })` per modifier file fixes it; the empirical groundwork is done.
- #972 — `partialAliasOf` reach needs transitive walk for a corner case (composite-aliases-composite chains spanning modifier boundaries).
- #973 — `partialAliasOf` shape verification for typography / transition / gradient composites (only border + shadow tested empirically).
- #974 — Combo-connectivity check could be tightened from the current "≥1 in-combo connection per axis" heuristic to the strict "single connected component" test. Optimization-of-the-optimization.

## Empirical verification

The algorithm was verified against three structurally distinct fixtures before being implemented:

| Verification | Result |
|---|---|
| Reference fixture (3 axes, all in color concern) | All 3 pairs mutually connected with 7/14/8 shared paths each |
| Synthetic orthogonal axis (dimension-only vs color-only) | ∅ shared paths → correctly classified disconnected |
| Stress-fixture baseline-equal-collision pairs (Phase 0 finding — 7 known divergences) | All 4 collision pairs caught with witness paths present in writes overlap |

## Test plan

- [x] `pnpm -r format && pnpm turbo run format:check lint typecheck test` — 37/37 turbo tasks green
- [x] Existing `joint-overrides.test.ts`, `probe-joint-overrides.test.ts`, `resolve-at.test.ts`, `variance-analysis-layered.test.ts`, `variance-by-path.test.ts` all pass — no regression
- [x] New `alias-graph.test.ts` — 8 unit tests covering data-extraction, reach building, connectivity (direct + alias-mediated + disjoint), combo helper
- [x] New `joint-overrides-graph-culling.test.ts` — pins reference fixture's `accent.fg` joint case is still detected post-optimization

## Pre-1.0 commitment

Patch changeset. `probeJointOverrides` isn't part of the package's public exports (only `jointOverrideKey` from this module is), so adding `ProbeOptions` doesn't grow the v1.0 stability surface.

## Background

This is the second attempt — a previous attempt (closed PR #966 / closed issues #967, #968, #969) used the wrong data sources (`project.cells` deltas, then full `resolver.apply` output). Both got the algorithm structurally right but the input wrong: deltas missed baseline-equal-collision divergences; full `resolver.apply` returned all paths in the project and made every pair appear connected.

This implementation uses `resolver.source.modifiers` — the inlined modifier-file content — which captures explicit writes per `(axis, context)` including baseline-equal ones. Verified empirically before implementation; see issue #970 (closed by this PR) for the design constraints.

Closes #970