### PR TITLE
perf(core): conservatively bail alias-graph on $extends in modifier source

### DIFF
--- a/.changeset/alias-graph-extends-bail.md
+++ b/.changeset/alias-graph-extends-bail.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Conservatively widen alias-graph connectivity when a modifier uses DTCG `$extends`. Terrazzo's `loadResolver` leaves `$extends` directives un-flattened in `resolver.source.modifiers` (flattening runs lazily inside `apply()`), so a literal walk of the modifier source misses inherited token paths. Rather than silently mis-cull a real joint divergence, an axis whose overlays use `$extends` is now marked wildcard-connected — connected to every other axis, giving up the orthogonality skip but preserving correctness.
+
+Configs without `$extends` (including the reference and stress fixtures) are unaffected. Configs that adopt `$extends` keep their pair-and-up correctness; speedup degrades on the affected axes only. Active `$extends` expansion (recovering the speedup) remains tracked as future work.

--- a/packages/core/src/alias-graph.ts
+++ b/packages/core/src/alias-graph.ts
@@ -57,7 +57,10 @@ export function buildAliasGraph(input: BuildAliasGraphInput): AliasGraph {
   const { axes, resolverModifiers, baseline } = input;
 
   // 1. Walk resolver source modifiers → per-axis, per-context declared paths.
+  // Track which axes use `$extends` in any non-default context — those
+  // axes get a wildcard-connection marker (see step 4).
   const pathsByAxisContext = new Map<string, Map<string, Set<string>>>();
+  const wildcardAxes = new Set<string>();
   for (const axis of axes) {
     const modifier = resolverModifiers[axis.name];
     if (!modifier?.contexts) continue;
@@ -68,7 +71,11 @@ export function buildAliasGraph(input: BuildAliasGraphInput): AliasGraph {
       // its writes either.
       if (contextName === axis.default) continue;
       const paths = new Set<string>();
-      for (const node of groupNodes) collectPathsWithValue(node, '', paths);
+      let sawExtends = false;
+      for (const node of groupNodes) {
+        if (collectPathsWithValue(node, '', paths)) sawExtends = true;
+      }
+      if (sawExtends) wildcardAxes.add(axis.name);
       if (paths.size > 0) perContext.set(contextName, paths);
     }
     pathsByAxisContext.set(axis.name, perContext);
@@ -100,17 +107,28 @@ export function buildAliasGraph(input: BuildAliasGraphInput): AliasGraph {
     axisReach.set(axis.name, reach);
   }
 
-  // 4. Pair (A, B) connected iff axisReach[A] ∩ axisReach[B] non-empty.
+  // 4. Pair (A, B) connected iff axisReach[A] ∩ axisReach[B] non-empty,
+  //    OR either axis is wildcard-marked (used `$extends`). The wildcard
+  //    marker is the conservative bail for `$extends`: Terrazzo's
+  //    `loadResolver` leaves `$extends` directives un-flattened in
+  //    `resolver.source.modifiers`, so the literal walk above misses
+  //    inherited paths. Rather than silently mis-cull, we widen the
+  //    affected axes to "could be anywhere" and let the probe re-confirm.
   const connectedAxes = new Map<string, Set<string>>();
   for (const axis of axes) connectedAxes.set(axis.name, new Set());
   for (let i = 0; i < axes.length; i++) {
     const a = axes[i]!;
-    const reachA = axisReach.get(a.name);
-    if (!reachA || reachA.size === 0) continue;
     for (let j = i + 1; j < axes.length; j++) {
       const b = axes[j]!;
+      const wildcard = wildcardAxes.has(a.name) || wildcardAxes.has(b.name);
+      if (wildcard) {
+        connectedAxes.get(a.name)!.add(b.name);
+        connectedAxes.get(b.name)!.add(a.name);
+        continue;
+      }
+      const reachA = axisReach.get(a.name);
       const reachB = axisReach.get(b.name);
-      if (!reachB || reachB.size === 0) continue;
+      if (!reachA || !reachB || reachA.size === 0 || reachB.size === 0) continue;
       if (setsIntersect(reachA, reachB)) {
         connectedAxes.get(a.name)!.add(b.name);
         connectedAxes.get(b.name)!.add(a.name);
@@ -156,18 +174,28 @@ export function isAxisComboConnected(graph: AliasGraph, combo: readonly Axis[]):
  * `$value` is a token leaf; its absolute path is `prefix` joined with
  * the keys we descended through. Skip DTCG meta keys (`$type`,
  * `$description`, `$extensions`, `$defs`) and the `$value` itself.
+ *
+ * Returns `true` if any `$extends` directive was encountered during
+ * the walk. Terrazzo's `loadResolver` leaves these un-flattened in
+ * `resolver.source.modifiers` (flattening only runs lazily inside
+ * `apply()`), so the literal walk can't observe the inherited paths.
+ * The caller widens the affected axis to wildcard-connected rather
+ * than risk a silent mis-cull. See issue #971 for the active-expand
+ * follow-up.
  */
-function collectPathsWithValue(node: unknown, prefix: string, out: Set<string>): void {
-  if (!isPlainObject(node)) return;
+function collectPathsWithValue(node: unknown, prefix: string, out: Set<string>): boolean {
+  if (!isPlainObject(node)) return false;
   if ('$value' in node) {
     if (prefix) out.add(prefix);
-    return;
+    return false;
   }
+  let sawExtends = '$extends' in node;
   for (const [key, child] of Object.entries(node)) {
     if (key.startsWith('$')) continue;
     const childPath = prefix ? `${prefix}.${key}` : key;
-    collectPathsWithValue(child, childPath, out);
+    if (collectPathsWithValue(child, childPath, out)) sawExtends = true;
   }
+  return sawExtends;
 }
 
 /**

--- a/packages/core/test/alias-graph.test.ts
+++ b/packages/core/test/alias-graph.test.ts
@@ -323,6 +323,79 @@ describe('alias-graph', () => {
     expect(isAxisComboConnected(graph, axes)).toBe(false);
   });
 
+  it('axis becomes wildcard-connected when its modifier uses $extends', () => {
+    // Terrazzo's `loadResolver` does NOT pre-flatten `$extends` in
+    // `resolver.source.modifiers[A].contexts[c]` — flattening only
+    // happens lazily during `apply()`. A literal walk of the context
+    // Groups therefore misses inherited paths. To avoid silently
+    // mis-culling a real joint divergence, an axis that uses
+    // `$extends` anywhere in its overlays is marked as connected to
+    // every other axis (conservative bail; gives up speedup but keeps
+    // correctness).
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+      { name: 'brand', contexts: ['default', 'a'], default: 'default', source: 'resolver' },
+      {
+        name: 'density',
+        contexts: ['comfortable', 'compact'],
+        default: 'comfortable',
+        source: 'resolver',
+      },
+    ];
+    const resolverModifiers = {
+      mode: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              color: {
+                $extends: '{base.dark-palette}',
+                $type: 'color',
+              },
+            },
+          ],
+        },
+      },
+      brand: {
+        default: 'default',
+        contexts: {
+          default: [],
+          a: [
+            {
+              spacing: {
+                $type: 'dimension',
+                md: { $value: { value: 16, unit: 'px' } },
+              },
+            },
+          ],
+        },
+      },
+      density: {
+        default: 'comfortable',
+        contexts: {
+          comfortable: [],
+          compact: [
+            {
+              radius: {
+                $type: 'dimension',
+                sm: { $value: { value: 4, unit: 'px' } },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline: {} });
+    // mode used $extends — wildcard-connect to brand and density even
+    // though brand+density write strictly disjoint paths.
+    expect(graph.connectedAxes.get('mode')?.has('brand')).toBe(true);
+    expect(graph.connectedAxes.get('mode')?.has('density')).toBe(true);
+    // brand vs density remain disconnected — neither used $extends and
+    // their paths don't overlap.
+    expect(graph.connectedAxes.get('brand')?.has('density') ?? false).toBe(false);
+  });
+
   it('isAxisComboConnected returns true trivially for arity < 2', () => {
     const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline: {} });
     expect(isAxisComboConnected(graph, [])).toBe(true);


### PR DESCRIPTION
**Milestone:** Maintenance
**Plan impact:** none

Closes #971

## Summary

Conservatively widens alias-graph connectivity when a modifier contains DTCG `$extends`, preventing the silent-miss footgun that `loadResolver`'s late `$extends` flattening would otherwise expose.

## What's happening

`buildAliasGraph` reads `resolver.source.modifiers[A].contexts[c]` to determine which token paths axis `A` writes in each non-default context. Two axes are deemed "connected" iff their reach sets intersect under alias closure. Currently the walk descends Terrazzo's inlined Group objects and collects every node with a `$value`.

`loadResolver`'s `normalizeResolver` step bundles `$ref` resolution but does NOT flatten `$extends`. The `flatten$extends` pass only runs lazily inside `processTokens` when `apply()` is invoked. So `resolver.source.modifiers[A].contexts[c]` carries `$extends` directives as raw members; our walk skips them (`key.startsWith('$')` filter) without expanding the inherited group.

Effect: if axis A's overlay inherits a group of tokens via `$extends`, those paths are missing from `pathsByAxisContext.get(A)`. If axis B writes paths that exist only in A's inherited content, the graph reports A and B as orthogonal and the probe culls their combination — silently missing a real joint divergence.

## What this PR does

Detects `$extends` during the walk and marks the axis as **wildcard-connected** — it's reported as connected to every other axis, bypassing the orthogonality check entirely. Pair-probing happens unconditionally for that axis; correctness is preserved.

What's NOT in the PR (deliberately):

- **Active `$extends` expansion.** The issue's preferred fix (re-parse each modifier file via `parse({ resolveAliases: false })`) needs per-modifier file URIs, which `ResolverModifierNormalized` doesn't expose. An alternative would be to feed the merged Group content back through `parse()` as a synthetic input — async, pulls in machinery, may fail on cross-file `$extends`. Trade-off didn't feel right for a "close the footgun" patch; left for issue #971 follow-up.

## Empirical

- Reference fixture: no `$extends`, no change in behavior. `accent.fg` joint divergence still detected (`joint-overrides-graph-culling.test.ts`).
- Stress fixture: no `$extends`, no change.
- New unit test: synthetic 3-axis config where `mode` uses `$extends` and brand/density write strictly disjoint paths. Pre-fix: mode↔brand and mode↔density both classified as disconnected (silently mis-culled). Post-fix: mode wildcard-connected to both; brand↔density remain disjoint (their walks saw no `$extends`).

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter='@unpunnyfuns/*'` — 37/37 green
- [x] alias-graph unit tests: 9/9 (was 8 before the new `$extends` test)
- [x] reference fixture `accent.fg` joint case still detected
- [x] full core suite: 176 tests pass