### PR TITLE
perf(core): tighten isAxisComboConnected to strict connected-component test

### DIFF
--- a/.changeset/alias-graph-strict-component.md
+++ b/.changeset/alias-graph-strict-component.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Tighten `isAxisComboConnected` to require a single connected component over the induced subgraph (BFS from `combo[0]`) instead of "every axis has ≥1 in-combo partner." The prior heuristic accepted combos spanning two disjoint sub-clusters when each sub-cluster was internally connected — such combos can't produce a joint divergence, since the cross-cluster cartesian is the independent product of two unrelated value sets.
+
+Pair-arity (arity 2) is unchanged. Higher-arity culling tightens on configs with multiple disjoint clusters; configs that form a single big cluster see no change. Correctness preserved: the new test is strictly more selective than the old, never the other direction.

--- a/packages/core/src/alias-graph.ts
+++ b/packages/core/src/alias-graph.ts
@@ -140,33 +140,41 @@ export function buildAliasGraph(input: BuildAliasGraphInput): AliasGraph {
 }
 
 /**
- * A combo of axes is "connected" iff every axis in the combo has at
- * least one connection to another axis in the combo. Arity < 2
- * combos pass trivially — the joint-probe skips them anyway, but
- * the helper stays well-defined.
+ * A combo of axes is "connected" iff the subgraph induced by the
+ * combo (axis nodes, edges restricted to in-combo endpoints) is a
+ * single connected component. Arity < 2 combos pass trivially —
+ * `probeJointOverrides` skips them anyway, but the helper stays
+ * well-defined.
  *
- * Conservative: if any axis pair in the combo is connected, the
- * graph errs toward probing. Falsely orthogonal classifications
- * would skip a real divergence — falsely connected classifications
- * just probe a tuple that finds no divergence, costing a few
- * `resolver.apply` calls but no correctness.
+ * Implementation: BFS from `combo[0]`, only traversing edges whose
+ * other endpoint is also in `combo`. Combo is connected iff every
+ * axis is visited.
+ *
+ * Conservative still: falsely orthogonal classifications would skip a
+ * real divergence — falsely connected classifications just probe a
+ * tuple that finds no divergence, costing a few `resolver.apply`
+ * calls. The strict-component test tightens culling over the prior
+ * "every axis has ≥1 in-combo partner" heuristic without crossing
+ * into the wrong-answer side: a combo spanning two disjoint clusters
+ * can't produce a joint divergence — the cross-cluster cartesian is
+ * the independent product of two unrelated value sets.
  */
 export function isAxisComboConnected(graph: AliasGraph, combo: readonly Axis[]): boolean {
   if (combo.length < 2) return true;
-  for (const axis of combo) {
-    const connections = graph.connectedAxes.get(axis.name);
-    if (!connections) return false;
-    let foundPartner = false;
-    for (const other of combo) {
-      if (other.name === axis.name) continue;
-      if (connections.has(other.name)) {
-        foundPartner = true;
-        break;
-      }
+  const inCombo = new Set(combo.map((a) => a.name));
+  const visited = new Set<string>([combo[0]!.name]);
+  const queue: string[] = [combo[0]!.name];
+  while (queue.length > 0) {
+    const cur = queue.shift()!;
+    const neighbours = graph.connectedAxes.get(cur);
+    if (!neighbours) continue;
+    for (const n of neighbours) {
+      if (!inCombo.has(n) || visited.has(n)) continue;
+      visited.add(n);
+      queue.push(n);
     }
-    if (!foundPartner) return false;
   }
-  return true;
+  return visited.size === combo.length;
 }
 
 /**

--- a/packages/core/test/alias-graph.test.ts
+++ b/packages/core/test/alias-graph.test.ts
@@ -257,7 +257,7 @@ describe('alias-graph', () => {
     expect(graph.connectedAxes.get('density')?.has('mode') ?? false).toBe(false);
   });
 
-  it('isAxisComboConnected: every axis must have >=1 in-combo connection', () => {
+  it('isAxisComboConnected rejects combos with a fully-isolated axis', () => {
     const axes: Axis[] = [
       { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
       { name: 'brand', contexts: ['default', 'a'], default: 'default', source: 'resolver' },
@@ -318,8 +318,98 @@ describe('alias-graph', () => {
     expect(isAxisComboConnected(graph, [axes[0]!, axes[1]!])).toBe(true);
     // mode + density disjoint.
     expect(isAxisComboConnected(graph, [axes[0]!, axes[2]!])).toBe(false);
-    // All three: density has no in-combo partner, so the combo
-    // is rejected even though mode and brand are connected.
+    // All three: density has no edge at all — BFS from mode reaches
+    // {mode, brand} but never density. The combo is rejected.
+    expect(isAxisComboConnected(graph, axes)).toBe(false);
+  });
+
+  it('isAxisComboConnected rejects combos spanning disjoint clusters', () => {
+    // 4 axes in two disjoint clusters:
+    //   {mode, brand} share `color.bg`.
+    //   {density, motion} share `dimension.md`.
+    //   No edges between clusters.
+    // Combo of all four: every axis has an in-combo partner, but the
+    // induced subgraph has two components. The probe can't produce a
+    // joint divergence here — a tuple `{mode, brand, density, motion}`
+    // is the cross-product of two independent groups whose value sets
+    // never interact. Strict-component test correctly rejects.
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+      { name: 'brand', contexts: ['default', 'a'], default: 'default', source: 'resolver' },
+      {
+        name: 'density',
+        contexts: ['comfortable', 'compact'],
+        default: 'comfortable',
+        source: 'resolver',
+      },
+      { name: 'motion', contexts: ['normal', 'fast'], default: 'normal', source: 'resolver' },
+    ];
+    const resolverModifiers = {
+      mode: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              color: {
+                $type: 'color',
+                bg: { $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+              },
+            },
+          ],
+        },
+      },
+      brand: {
+        default: 'default',
+        contexts: {
+          default: [],
+          a: [
+            {
+              color: {
+                $type: 'color',
+                bg: { $value: { colorSpace: 'srgb', components: [0.1, 0, 0] } },
+              },
+            },
+          ],
+        },
+      },
+      density: {
+        default: 'comfortable',
+        contexts: {
+          comfortable: [],
+          compact: [
+            {
+              dimension: {
+                $type: 'dimension',
+                md: { $value: { value: 12, unit: 'px' } },
+              },
+            },
+          ],
+        },
+      },
+      motion: {
+        default: 'normal',
+        contexts: {
+          normal: [],
+          fast: [
+            {
+              dimension: {
+                $type: 'dimension',
+                md: { $value: { value: 8, unit: 'px' } },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline: {} });
+
+    // Sub-clusters are connected on their own.
+    expect(isAxisComboConnected(graph, [axes[0]!, axes[1]!])).toBe(true);
+    expect(isAxisComboConnected(graph, [axes[2]!, axes[3]!])).toBe(true);
+    // Cross-cluster pairs disconnected.
+    expect(isAxisComboConnected(graph, [axes[0]!, axes[2]!])).toBe(false);
+    // Full combo: two components — strict test rejects.
     expect(isAxisComboConnected(graph, axes)).toBe(false);
   });
 


### PR DESCRIPTION
**Milestone:** Maintenance
**Plan impact:** none

Closes #974

## Summary

Replaces the "every axis has ≥1 in-combo partner" heuristic in `isAxisComboConnected` with a BFS-based single-connected-component test. Pair-arity unchanged; higher-arity culling tightens on configs with multiple disjoint clusters.

## What changes

Counter-example the prior heuristic mis-accepted: 4 axes split into two disjoint clusters `{A↔B}` and `{C↔D}` with no bridge. Every axis has an in-combo partner, so the partner heuristic returned `true`. But the full combo `{A, B, C, D}` is the cross-product of two independent value sets — no joint divergence possible. The strict-component check correctly rejects.

## What's NOT in this PR

- The `connectedAxes` adjacency itself is unchanged. Only the per-combo consultation logic tightens.
- No new public API. `isAxisComboConnected` already wasn't exported; remains internal.

## Empirical

- Reference fixture: single cluster (mode/brand/contrast all share paths). No behavior change. `accent.fg` joint divergence still detected.
- Stress-sparse fixture: doesn't have disjoint clusters at arity 3+. No regression.
- New unit test pins the divergence between old and new heuristics on a synthetic 4-axis disjoint-cluster setup.

## Correctness

Strict-component is strictly more selective than the partner heuristic:
- If every axis has an in-combo partner AND the subgraph is one component, both return `true`.
- If every axis has a partner BUT the subgraph has ≥2 components, partner heuristic returns `true` (over-probe), strict returns `false` (correct skip).
- If any axis has no partner, both return `false`.

So strict can only narrow what gets probed, never widen. A real divergence requires the joint value at some tuple to differ from the cells-composition value — that requires alias-connectivity through the graph, which requires the axes to share a connected component in the alias-reach overlay. Two disjoint clusters can't share that connectivity by construction.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter='@unpunnyfuns/*'` — 37/37 green
- [x] alias-graph unit tests: 10/10 (was 9 before disjoint-cluster test)
- [x] reference fixture `accent.fg` joint case still detected