### PR TITLE
test(core): pin partialAliasOf shapes for typography, transition, gradient

### DIFF
--- a/packages/core/test/alias-graph.test.ts
+++ b/packages/core/test/alias-graph.test.ts
@@ -74,6 +74,97 @@ describe('alias-graph', () => {
     );
   });
 
+  it('partialAliasOf handles typography composite (object map)', () => {
+    // Empirically pinned from `@terrazzo/parser` 2.1: typography
+    // tokens whose `$value.fontFamily` / `$value.fontWeight` reference
+    // other tokens produce a flat object-map `partialAliasOf` of the
+    // same shape as border tokens.
+    const baseline: TokenMap = {
+      'family.sans': {
+        $type: 'fontFamily',
+        $value: ['Inter'],
+      } as never,
+      'weight.bold': {
+        $type: 'fontWeight',
+        $value: 700,
+      } as never,
+      heading: {
+        $type: 'typography',
+        $value: {
+          fontFamily: ['Inter'],
+          fontWeight: 700,
+          fontSize: { value: 24, unit: 'px' },
+          lineHeight: { value: 32, unit: 'px' },
+          letterSpacing: { value: 0, unit: 'px' },
+        },
+        partialAliasOf: { fontFamily: 'family.sans', fontWeight: 'weight.bold' },
+      } as never,
+    };
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline });
+    expect(graph.reachableFromPath.get('heading')).toEqual(
+      new Set(['heading', 'family.sans', 'weight.bold']),
+    );
+  });
+
+  it('partialAliasOf handles transition composite (object map)', () => {
+    // Empirically pinned: transition tokens with aliased `duration` /
+    // `timingFunction` produce an object-map `partialAliasOf` —
+    // structurally identical to typography and border. The walker's
+    // generic recursive descent handles all three uniformly.
+    const baseline: TokenMap = {
+      'dur.short': {
+        $type: 'duration',
+        $value: { value: 100, unit: 'ms' },
+      } as never,
+      'ease.standard': {
+        $type: 'cubicBezier',
+        $value: [0.4, 0, 0.2, 1],
+      } as never,
+      enter: {
+        $type: 'transition',
+        $value: {
+          duration: { value: 100, unit: 'ms' },
+          timingFunction: [0.4, 0, 0.2, 1],
+          delay: { value: 0, unit: 'ms' },
+        },
+        partialAliasOf: { duration: 'dur.short', timingFunction: 'ease.standard' },
+      } as never,
+    };
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline });
+    expect(graph.reachableFromPath.get('enter')).toEqual(
+      new Set(['enter', 'dur.short', 'ease.standard']),
+    );
+  });
+
+  it('partialAliasOf handles gradient composite (array of objects)', () => {
+    // Empirically pinned: gradient tokens whose `$value` is an array
+    // of stops with aliased `color` produce an array-of-object-maps
+    // `partialAliasOf` — structurally identical to shadow. The
+    // recursive walker treats both the same way.
+    const baseline: TokenMap = {
+      'color.red': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 0, 0], alpha: 1 },
+      } as never,
+      'color.blue': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 1], alpha: 1 },
+      } as never,
+      bg: {
+        $type: 'gradient',
+        $value: [
+          { color: { colorSpace: 'srgb', components: [1, 0, 0], alpha: 1 }, position: 0 },
+          { color: { colorSpace: 'srgb', components: [0, 0, 1], alpha: 1 }, position: 1 },
+        ],
+        partialAliasOf: [{ color: 'color.red' }, { color: 'color.blue' }],
+      } as never,
+    };
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline });
+    expect(graph.reachableFromPath.get('bg')).toEqual(
+      new Set(['bg', 'color.red', 'color.blue']),
+    );
+  });
+
   it('partialAliasOf handles shadow composite (array of objects)', () => {
     const baseline: TokenMap = {
       'shadow.lg': {


### PR DESCRIPTION
**Milestone:** Maintenance
**Plan impact:** none

Closes #973

## Summary

Empirical verification of `collectPartialAliasTargets` against the three composite types that hadn't been pinned: typography, transition, gradient. All three use shapes the walker already handles — no code change, only new pinning tests.

## Empirical findings

| Composite | partialAliasOf shape | Walker handling |
|-----------|---------------------|-----------------|
| Typography | `{"fontFamily":"family.sans","fontWeight":"weight.bold"}` (object map) | same path as border |
| Transition | `{"duration":"dur.short","timingFunction":"ease.standard"}` (object map) | same path as border |
| Gradient | `[{"color":"color.red"},{"color":"color.blue"}]` (array of object maps) | same path as shadow |

Confirmed by parsing synthetic tokens with `@terrazzo/parser` 2.1's `parse()`.

## Implication for #972

`collectPartialAliasTargets` is single-hop — it visits the immediate target paths and stops. The transitive-walk follow-up (#972) was filed under the assumption that a composite-aliases-composite case might need recursive walking. From this probe, none of the three composite types produce a `partialAliasOf` that points to *another* composite's path (they all alias primitive tokens). Whether composite-aliasing-composite is even producible in DTCG remains to be verified before #972 ships — likely it can collapse to "no work needed."

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter='@unpunnyfuns/*'` — 37/37 green
- [x] `alias-graph.test.ts` — 13/13 (was 10 before)
- [x] No source changes; existing walker already correct