### PR TITLE
perf(core): make expandReach transitively chase partialAliasOf targets

### DIFF
--- a/.changeset/alias-graph-transitive-partial-alias.md
+++ b/.changeset/alias-graph-transitive-partial-alias.md
@@ -1,0 +1,9 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+Make `expandReach` recursively chase `partialAliasOf` targets so the alias-graph captures composite tokens' full transitive reach. Previously, a composite C whose `partialAliasOf` referenced a primitive X stopped at X — if X itself aliased onward to Y (via `aliasChain`), Y was missing from C's reach set, causing axes that wrote Y to be falsely classified as orthogonal to axes that wrote C. The probe could silently skip the corresponding combinations.
+
+Single-hop `aliasChain` walks remain — Terrazzo already populates that chain transitively, so one read captures the full sequence. Only `partialAliasOf` needed the recursive treatment, since each composite carries only its immediate sub-field targets. Cycle protection via the existing reach-set dedup; cost is the per-token transitive closure depth, negligible in practice.
+
+Configs with shallow alias topology (no composite-through-primitive-through-alias chains) see no behavior change. Configs with such chains gain coverage on previously mis-culled axis pairs at the cost of running those previously-skipped probes — a correctness fix paid for in `resolver.apply` calls only on configs that needed it.

--- a/packages/core/src/alias-graph.ts
+++ b/packages/core/src/alias-graph.ts
@@ -210,10 +210,18 @@ function collectPathsWithValue(node: unknown, prefix: string, out: Set<string>):
  * Expand the reach set for a given path: add every entry from the
  * token's `aliasChain` (Terrazzo populates transitively, so one read
  * captures the full chain) plus every direct target referenced in its
- * `partialAliasOf` map. Per-path reach is the immediate neighborhood —
- * downstream callers that need cross-path closure get it via the
- * union over multiple paths' reach entries (`axisReach` does exactly
- * this), so single-hop here is sufficient for axis connectivity.
+ * `partialAliasOf` map. `partialAliasOf` is NOT transitive in
+ * Terrazzo — each composite carries only its immediate sub-field
+ * targets — so we recursively chase each target through its own
+ * `aliasChain` + `partialAliasOf` to capture the full transitive
+ * reach. Without this, a composite whose sub-field points to a token
+ * with its own onward alias chain would under-report its reach,
+ * causing the axis graph to silently mis-cull connected axis pairs.
+ *
+ * The `reach` Set doubles as a cycle guard: a recursive visit that
+ * lands on an already-reached path returns immediately, so a cyclic
+ * `partialAliasOf` (A→B→A) terminates with `reach = {A, B}` on each
+ * starting path.
  */
 function expandReach(path: string, baseline: TokenMap, reach: Set<string>): void {
   const token = baseline[path];
@@ -222,7 +230,11 @@ function expandReach(path: string, baseline: TokenMap, reach: Set<string>): void
     for (const next of token.aliasChain) reach.add(next);
   }
   if (token.partialAliasOf !== undefined) {
-    collectPartialAliasTargets(token.partialAliasOf, (next) => reach.add(next));
+    collectPartialAliasTargets(token.partialAliasOf, (next) => {
+      if (reach.has(next)) return;
+      reach.add(next);
+      expandReach(next, baseline, reach);
+    });
   }
 }
 

--- a/packages/core/test/alias-graph.test.ts
+++ b/packages/core/test/alias-graph.test.ts
@@ -69,9 +69,149 @@ describe('alias-graph', () => {
     expect(graph.reachableFromPath.get('color.fg')).toEqual(
       new Set(['color.fg', 'color.intermediate', 'color.palette.black']),
     );
+    // border.default's reach now includes color.fg's onward chain
+    // — `expandReach` recurses into partialAliasOf targets so the
+    // composite picks up its sub-field's transitive alias closure.
     expect(graph.reachableFromPath.get('border.default')).toEqual(
-      new Set(['border.default', 'color.fg']),
+      new Set(['border.default', 'color.fg', 'color.intermediate', 'color.palette.black']),
     );
+  });
+
+  it('reachableFromPath transits aliasChain through partialAliasOf targets', () => {
+    // Designer indirection pattern:
+    //   border.default → partialAliasOf.color = 'color.fg'
+    //   color.fg → aliasChain = ['color.palette.brand', 'color.palette.neutral.0']
+    // Without transitive reach, border.default's reach is {self, color.fg};
+    // a sibling axis writing color.palette.brand would be falsely classified
+    // as orthogonal because the aliasChain past color.fg never enters
+    // border.default's reach set. Transitive expansion recursively chases
+    // each partialAliasOf target through its own aliasChain + partialAliasOf.
+    const baseline: TokenMap = {
+      'border.default': {
+        $type: 'border',
+        $value: {
+          color: '#000',
+          width: { value: 1, unit: 'px' },
+          style: 'solid',
+        },
+        partialAliasOf: { color: 'color.fg' },
+      } as never,
+      'color.fg': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+        aliasOf: 'color.palette.brand',
+        aliasChain: ['color.palette.brand', 'color.palette.neutral.0'],
+      } as never,
+      'color.palette.brand': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+        aliasOf: 'color.palette.neutral.0',
+        aliasChain: ['color.palette.neutral.0'],
+      } as never,
+      'color.palette.neutral.0': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+    };
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline });
+    expect(graph.reachableFromPath.get('border.default')).toEqual(
+      new Set(['border.default', 'color.fg', 'color.palette.brand', 'color.palette.neutral.0']),
+    );
+  });
+
+  it('connectedAxes mediated by composite partialAliasOf transitivity', () => {
+    // Axis A writes only the composite token; axis B writes the
+    // terminal node of A's transitive partialAliasOf chain. Without
+    // transitive expansion, A and B classify as disconnected and the
+    // probe silently skips a real joint divergence. With transitivity,
+    // A's axisReach includes the terminal node and B intersects.
+    const axes: Axis[] = [
+      { name: 'theme', contexts: ['light', 'dark'], default: 'light', source: 'resolver' },
+      { name: 'brand', contexts: ['default', 'a'], default: 'default', source: 'resolver' },
+    ];
+    const baseline: TokenMap = {
+      'border.default': {
+        $type: 'border',
+        $value: {
+          color: '#000',
+          width: { value: 1, unit: 'px' },
+          style: 'solid',
+        },
+        partialAliasOf: { color: 'color.fg' },
+      } as never,
+      'color.fg': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+        aliasOf: 'color.palette.brand',
+        aliasChain: ['color.palette.brand'],
+      } as never,
+      'color.palette.brand': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+    };
+    const resolverModifiers = {
+      theme: {
+        default: 'light',
+        contexts: {
+          light: [],
+          dark: [
+            {
+              border: {
+                $type: 'border',
+                default: {
+                  $value: {
+                    color: '#fff',
+                    width: { value: 1, unit: 'px' },
+                    style: 'solid',
+                  },
+                },
+              },
+            },
+          ],
+        },
+      },
+      brand: {
+        default: 'default',
+        contexts: {
+          default: [],
+          a: [
+            {
+              color: {
+                $type: 'color',
+                palette: {
+                  brand: { $value: { colorSpace: 'srgb', components: [0.3, 0, 0.5] } },
+                },
+              },
+            },
+          ],
+        },
+      },
+    };
+    const graph = buildAliasGraph({ axes, resolverModifiers, baseline });
+    expect(graph.connectedAxes.get('theme')?.has('brand')).toBe(true);
+    expect(graph.connectedAxes.get('brand')?.has('theme')).toBe(true);
+  });
+
+  it('reachableFromPath handles cyclic partialAliasOf without infinite recursion', () => {
+    // Synthetic cycle: A.partialAliasOf → B, B.partialAliasOf → A.
+    // Should terminate via reach-set dedup; both paths' reach sets
+    // converge to {A, B}.
+    const baseline: TokenMap = {
+      'border.a': {
+        $type: 'border',
+        $value: { color: '#000', width: { value: 1, unit: 'px' }, style: 'solid' },
+        partialAliasOf: { color: 'border.b' },
+      } as never,
+      'border.b': {
+        $type: 'border',
+        $value: { color: '#000', width: { value: 1, unit: 'px' }, style: 'solid' },
+        partialAliasOf: { color: 'border.a' },
+      } as never,
+    };
+    const graph = buildAliasGraph({ axes: [], resolverModifiers: {}, baseline });
+    expect(graph.reachableFromPath.get('border.a')).toEqual(new Set(['border.a', 'border.b']));
+    expect(graph.reachableFromPath.get('border.b')).toEqual(new Set(['border.a', 'border.b']));
   });
 
   it('partialAliasOf handles shadow composite (array of objects)', () => {


### PR DESCRIPTION
**Milestone:** Maintenance
**Plan impact:** none

Closes #972

## Summary

Closes the alias-graph false-negative on composite-through-primitive-through-alias chains. `partialAliasOf` target traversal is now recursive; `aliasChain` traversal stays single-pass because Terrazzo already pre-flattens those chains.

## The case it fixes

```
border.default  partialAliasOf.color → color.fg
color.fg        aliasChain          → [color.palette.brand]
color.palette.brand                  (terminal)
```

Pre-fix: `border.default`'s reach = `{border.default, color.fg}` (single-hop stop at `color.fg`).
Post-fix: `border.default`'s reach = `{border.default, color.fg, color.palette.brand}` (recursed through `color.fg`'s `aliasChain`).

An axis writing only `border.default` and an axis writing only `color.palette.brand` are correctly classified as connected post-fix. Pre-fix they classify orthogonal and the probe silently skips real joint divergences.

## Correctness, not just perf

This is misframed as `perf(core)` to match the rest of the alias-graph series, but it's a correctness fix on the conservative side: pre-fix the graph could under-report reach (false-negative connectivity → silent miss). Post-fix the graph is tighter and `connectedAxes` may grow; probe coverage strictly increases on chains that needed it.

## Cycle handling

Existing reach-Set dedup doubles as cycle guard. A synthetic `A↔B` cyclic `partialAliasOf` test pins termination — both paths converge on `{A, B}`.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter='@unpunnyfuns/*'` — 37/37 green
- [x] `alias-graph.test.ts` — 13/13 (3 new transitive tests, 1 existing test's expectation widened)
- [x] reference fixture `accent.fg` joint case still detected (no behavior change on reference — its chains don't cross the composite-through-primitive boundary)
- [x] cyclic `partialAliasOf` terminates with finite reach