### PR TITLE
chore(core): align alias-graph comments with current cull rule

### DIFF
--- a/packages/core/src/alias-graph.ts
+++ b/packages/core/src/alias-graph.ts
@@ -19,9 +19,12 @@ import type { Axis, TokenMap } from '#/types.ts';
  * Composing the two: axis A's "reach" is `⋃ over non-default contexts
  * c of writes[A][c] ∪ reachableFromPath[P] for P in writes[A][c]`.
  * Two axes are `connected` iff their reach sets intersect.
- * `isAxisComboConnected` extends to arity N: every axis in the combo
- * must connect to at least one other axis in the combo (conservative
- * — errs toward keeping the combo, never drops a real divergence).
+ * `isAxisComboConnected` extends to arity N by requiring the combo's
+ * induced subgraph (axis nodes, edges restricted to in-combo
+ * endpoints) to be a single connected component — a combo that
+ * spans two disjoint clusters can't produce a joint divergence and
+ * is safely culled. Stays conservative: false orthogonals would drop
+ * a real divergence; false connecteds just probe an extra tuple.
  *
  * `probeJointOverrides` accepts an optional graph and skips
  * combinations the graph reports as orthogonal. Without one, it
@@ -126,9 +129,9 @@ export function buildAliasGraph(input: BuildAliasGraphInput): AliasGraph {
         connectedAxes.get(b.name)!.add(a.name);
         continue;
       }
-      const reachA = axisReach.get(a.name);
-      const reachB = axisReach.get(b.name);
-      if (!reachA || !reachB || reachA.size === 0 || reachB.size === 0) continue;
+      const reachA = axisReach.get(a.name)!;
+      const reachB = axisReach.get(b.name)!;
+      if (reachA.size === 0 || reachB.size === 0) continue;
       if (setsIntersect(reachA, reachB)) {
         connectedAxes.get(a.name)!.add(b.name);
         connectedAxes.get(b.name)!.add(a.name);

--- a/packages/core/src/joint-overrides.ts
+++ b/packages/core/src/joint-overrides.ts
@@ -132,10 +132,11 @@ export function probeJointOverrides(
     const composer = buildResolveAt(axes, cells, [...overrides.entries()], defaultTuple);
 
     for (const axisCombo of axisCombinations(axes, arity)) {
-      // Graph cull: every axis must have an in-combo connection, or
-      // the combo is provably orthogonal and can't contribute a
-      // joint divergence. Skipped entirely on resolvers without
-      // source data (test mocks); production flow always has it.
+      // Graph cull: the combo's induced subgraph must be a single
+      // connected component, or it spans disjoint clusters whose
+      // cross-cluster cartesian can't produce a joint divergence.
+      // Skipped entirely on resolvers without source data (test
+      // mocks); production flow always has it.
       if (aliasGraph && !isAxisComboConnected(aliasGraph, axisCombo)) continue;
       for (const partialTuple of contextProducts(axisCombo)) {
         const fullTuple = { ...defaultTuple, ...partialTuple };


### PR DESCRIPTION
## Summary

- File-level JSDoc on `alias-graph.ts` and the cull-site comment in `joint-overrides.ts` described the pre-#978 "every axis has ≥1 in-combo partner" rule; the check has since tightened to a strict connected-component BFS. Bring prose in line.
- Drop the unreachable `!reachA`/`!reachB` branch — `axisReach` is constructed with an empty `Set` for every axis, so `.get(a.name)` never returns `undefined`.

No behavior change. Surfaced by a focused audit of the alias-graph subsystem after v0.59.1.

Closes #981

Milestone: Maintenance

Plan impact: none.

## Test plan

- [x] `pnpm turbo run format:check lint typecheck test --filter=@unpunnyfuns/swatchbook-core` — 183/183 pass, types clean