### PR TITLE
chore: gitignore .playwright-mcp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ npm-debug.log*
 pnpm-debug.log*
 .vitest-attachments/
 __screenshots__/
+.playwright-mcp/
 
 # Superpowers local working artifacts (specs/plans not meant to ship)
 docs/superpowers/


### PR DESCRIPTION
## Summary

- Add \`.playwright-mcp/\` to the root \`.gitignore\` alongside \`.vitest-attachments/\` and \`__screenshots__/\`. Per-run trace and snapshot artifacts from the playwright MCP browser tools; not meant to be tracked.

Closes #984

## Test plan

- [x] After running any playwright MCP command, \`git status\` no longer shows \`.playwright-mcp/\` as untracked.