### PR TITLE
docs: drop scoping-large-modifier-spaces section from axes reference

### DIFF
--- a/apps/docs/docs/reference/axes.mdx
+++ b/apps/docs/docs/reference/axes.mdx
@@ -87,15 +87,6 @@ Omit an axis and it falls back to that axis's default. Invalid axis keys or cont
 
 A resolver may declare more modifiers than a given Storybook wants to surface. List the axis name in `config.disabledAxes` and the project behaves as if that axis didn't exist for this session: no toolbar dropdown, no extra CSS blocks, the axis pinned to its `default` context in the active tuple. The Design Tokens panel shows a faint pinned indicator so the suppression isn't invisible. See the [`disabledAxes`](./config.mdx#disabledaxes) field for details.
 
-## Scoping large modifier spaces
-
-`loadProject` enumerates `1 + Σ(axes × (contexts - 1))` singleton tuples per project — the default tuple plus one per non-default cell on each axis. Bounded by axis cardinality, independent of the cartesian product, so a resolver with 20 axes × 5 contexts loads ~80 tuples regardless of whether the underlying cartesian is hundreds or 15 million. The toolbar surfaces every axis, the smart CSS emitter writes per-axis cell blocks plus compound blocks only for tokens with genuine joint divergence, and runtime CSS composition lands the right value at any multi-axis selector.
-
-The loader can't blow up on a large cartesian because it doesn't materialize the cartesian in the first place. Two scoping levers remain, both presentational:
-
-- **`presets`** — author named tuples for the handful of themes that matter (`Default Light`, `Brand A Dark`, `A11y High Contrast`). Toolbar surfaces them as quick-select pills; emit pipelines can fan out on `'presets'` instead of every axis-attribute combination. The right answer when only a handful of tuples are presentational.
-- **`disabledAxes`** — pin state-space modifiers (locale, density, motion-pref, …) to their defaults. They vanish from the toolbar, drop from the project's axis list, and don't contribute to emitted CSS. The right answer when an axis exists in the resolver but doesn't represent presentational variation.
-
 ## See also
 
 - [Config reference](./config.mdx) — the `resolver` / `axes` / `default` / `disabledAxes` / `presets` fields.


### PR DESCRIPTION
## Summary

- Remove the \`Scoping large modifier spaces\` section from \`apps/docs/docs/reference/axes.mdx\`. Implementation-detail math + unverified scale claims + redundant coverage of \`presets\` / \`disabledAxes\` that are already documented in \`config.mdx\` and the \`Disabling an axis\` section right above.

No changeset (docs-only, no published-package surface change).

Closes #999

## Test plan

- [x] \`pnpm --filter swatchbook-docs build\` — clean, no broken links.