### PR TITLE
chore: patch changeset to land docs audit fixes in 0.60.1 snapshot

### DIFF
--- a/.changeset/docs-audit-snapshot.md
+++ b/.changeset/docs-audit-snapshot.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Patch release to ship the docs audit fixes from PR #1002 into the stable docs snapshot. The fixes (corrected import paths, removed broken anchors, jargon swapped for plain language, prose register tightened) only reached `/next/` after the original PR — this release rebuilds the `version-0.60/` snapshot so they reach `/` too. No package source changes.


### PR DESCRIPTION
## Summary

Patch changeset across all six published packages. Triggers a 0.60.1 release whose snapshot script rebuilds \`apps/docs/versioned_docs/version-0.60/\` from current \`apps/docs/docs/\`, bringing the PR #1002 audit fixes onto \`/\`. No package source changes.

Closes #1003

## Test plan

- [x] Confirm changeset file is parseable and bumps the fixed-version group consistently.
- [ ] After merge: Changesets opens the \`chore(release): v0.60.1\` PR; merge that to fire the release and rebuild the docs snapshot.