### PR TITLE
fix(core): wrap transformCSSValue with token-context error

### DIFF
--- a/.changeset/transform-css-value-error-context.md
+++ b/.changeset/transform-css-value-error-context.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+When the smart emitter's call to `transformCSSValue` throws on a malformed token `$value`, the thrown error now names the token path, the active axis permutation, and the offending `$value`, with the original error attached as `cause`. Previously a malformed token surfaced as a four-frames-deep colorjs.io traceback with no clue which token was at fault. Healthy tokens are unaffected.

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -1,3 +1,4 @@
+import jsPlugin from '@terrazzo/plugin-js';
 import sassPlugin from '@terrazzo/plugin-sass';
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
@@ -35,18 +36,17 @@ export default defineSwatchbookConfig({
     bodyFontFamily: 'typography.body.font-family',
     bodyFontSize: 'typography.body.font-size',
   },
-  // Load plugin-sass so the Token Listing's `names.sass` column populates
-  // beyond CSS. Purely for preview — the plugin doesn't emit files through
-  // swatchbook; it contributes its identifier-naming logic so
-  // `<TokenDetail>`'s Consumer Output renders the Sass identifier alongside
-  // the CSS var. plugin-js is intentionally absent: it doesn't register
-  // transforms via `getTransforms`, so plugin-token-listing can't look up
-  // a `js` format and the listing build fails outright.
-  terrazzoPlugins: [sassPlugin({ filename: 'tokens.scss' })],
+  // Load plugin-sass and plugin-js so the Token Listing's `names.sass`
+  // and `names.js` columns populate beyond CSS. Purely for preview —
+  // these plugins don't emit files through swatchbook; they contribute
+  // their identifier-naming logic so `<TokenDetail>`'s Consumer Output
+  // renders the Sass and JS identifiers alongside the CSS var.
+  terrazzoPlugins: [sassPlugin({ filename: 'tokens.scss' }), jsPlugin({ filename: 'tokens.js' })],
   listingOptions: {
     platforms: {
       css: { name: '@terrazzo/plugin-css', description: 'CSS custom properties' },
       sass: { name: '@terrazzo/plugin-sass', description: 'Sass variables' },
+      js: { name: '@terrazzo/plugin-js', description: 'JS token accessors' },
     },
   },
   presets: [

--- a/apps/storybook/swatchbook.config.ts
+++ b/apps/storybook/swatchbook.config.ts
@@ -1,4 +1,3 @@
-import jsPlugin from '@terrazzo/plugin-js';
 import sassPlugin from '@terrazzo/plugin-sass';
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
@@ -36,17 +35,18 @@ export default defineSwatchbookConfig({
     bodyFontFamily: 'typography.body.font-family',
     bodyFontSize: 'typography.body.font-size',
   },
-  // Load plugin-sass and plugin-js so the Token Listing's `names.sass`
-  // and `names.js` columns populate beyond CSS. Purely for preview —
-  // these plugins don't emit files through swatchbook; they contribute
-  // their identifier-naming logic so `<TokenDetail>`'s Consumer Output
-  // renders the Sass and JS identifiers alongside the CSS var.
-  terrazzoPlugins: [sassPlugin({ filename: 'tokens.scss' }), jsPlugin({ filename: 'tokens.js' })],
+  // Load plugin-sass so the Token Listing's `names.sass` column populates
+  // beyond CSS. Purely for preview — the plugin doesn't emit files through
+  // swatchbook; it contributes its identifier-naming logic so
+  // `<TokenDetail>`'s Consumer Output renders the Sass identifier alongside
+  // the CSS var. plugin-js is intentionally absent: it doesn't register
+  // transforms via `getTransforms`, so plugin-token-listing can't look up
+  // a `js` format and the listing build fails outright.
+  terrazzoPlugins: [sassPlugin({ filename: 'tokens.scss' })],
   listingOptions: {
     platforms: {
       css: { name: '@terrazzo/plugin-css', description: 'CSS custom properties' },
       sass: { name: '@terrazzo/plugin-sass', description: 'Sass variables' },
-      js: { name: '@terrazzo/plugin-js', description: 'JS token accessors' },
     },
   },
   presets: [

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -546,7 +546,7 @@ function collectLines(
  * Primitive tokens yield one record; composite tokens yield one per
  * sub-field plus an optional shorthand.
  */
-function* collectTokenDeclarations(
+export function* collectTokenDeclarations(
   localID: string,
   token: TokenNormalized,
   tokensSet: RawTokenMap,
@@ -555,7 +555,21 @@ function* collectTokenDeclarations(
   transformAlias: (token: TokenNormalized) => string,
 ): Generator<{ varName: string; value: string }> {
   const varName = makeCSSVar(localID, varOpts);
-  const value = transformCSSValue(token, { tokensSet, permutation, transformAlias });
+  let value: ReturnType<typeof transformCSSValue>;
+  try {
+    value = transformCSSValue(token, { tokensSet, permutation, transformAlias });
+  } catch (error) {
+    const permutationStr = JSON.stringify(permutation);
+    const valueStr = safeStringify(token.$value);
+    const original = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `swatchbook: failed to transform token "${localID}" at permutation ${permutationStr}.\n` +
+        `  $type: ${token.$type}\n` +
+        `  $value: ${valueStr}\n` +
+        `  cause: ${original}`,
+      { cause: error },
+    );
+  }
   if (typeof value === 'string') {
     yield { varName, value };
     return;
@@ -565,6 +579,14 @@ function* collectTokenDeclarations(
   }
   const shorthand = generateShorthand({ token, localID });
   if (shorthand) yield { varName, value: shorthand };
+}
+
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
 }
 
 function* axisCombinations(axes: readonly Axis[], k: number): Generator<readonly Axis[]> {

--- a/packages/core/test/css-axis-projected-error-context.test.ts
+++ b/packages/core/test/css-axis-projected-error-context.test.ts
@@ -1,0 +1,76 @@
+/**
+ * When `transformCSSValue` throws on a malformed token `$value`, the
+ * smart emitter wraps the error with the token path + active
+ * permutation + offending `$value`. Without that wrap a consumer sees
+ * a colorjs.io traceback four frames deep with no clue which token
+ * triggered it.
+ */
+import type { TokenNormalized } from '@terrazzo/parser';
+import { expect, it } from 'vitest';
+import { collectTokenDeclarations } from '#/css-axis-projected.ts';
+
+it('rethrows with token path, permutation, and $value when transformCSSValue fails', () => {
+  // A color token whose `components` field is missing — exactly the
+  // shape that triggers colorjs.io's `coords.map is not a function`
+  // inside `tokenToColor` → `inGamut`.
+  const malformed = {
+    id: 'color.broken',
+    jsonID: 'color.broken',
+    $type: 'color',
+    $value: { colorSpace: 'srgb', alpha: 1 },
+    aliasChain: [],
+    aliasedBy: [],
+    dependencies: [],
+    group: { id: 'color' },
+  } as unknown as TokenNormalized;
+
+  const run = () => {
+    for (const _ of collectTokenDeclarations(
+      'color.broken',
+      malformed,
+      { 'color.broken': malformed },
+      { mode: 'Dark', brand: 'Brand A' },
+      { prefix: 'sb' },
+      () => '',
+    )) {
+      // exhaust the generator
+    }
+  };
+
+  expect(run).toThrowError(/color\.broken/);
+  expect(run).toThrowError(/"mode":"Dark"/);
+  expect(run).toThrowError(/"brand":"Brand A"/);
+  expect(run).toThrowError(/\$type: color/);
+});
+
+it('preserves the underlying error as cause', () => {
+  const malformed = {
+    id: 'color.broken',
+    jsonID: 'color.broken',
+    $type: 'color',
+    $value: { colorSpace: 'srgb', alpha: 1 },
+    aliasChain: [],
+    aliasedBy: [],
+    dependencies: [],
+    group: { id: 'color' },
+  } as unknown as TokenNormalized;
+
+  let caught: unknown;
+  try {
+    for (const _ of collectTokenDeclarations(
+      'color.broken',
+      malformed,
+      { 'color.broken': malformed },
+      {},
+      { prefix: 'sb' },
+      () => '',
+    )) {
+      // exhaust the generator
+    }
+  } catch (error) {
+    caught = error;
+  }
+
+  expect(caught).toBeInstanceOf(Error);
+  expect((caught as Error).cause).toBeInstanceOf(Error);
+});


### PR DESCRIPTION
## Summary

When the smart emitter calls `transformCSSValue` and the call throws (because a token's `$value` is malformed in some way), the thrown error now names the token path, the active axis permutation, and the offending `$value`, with the original error attached as `cause`. Previously a malformed token surfaced as a four-frames-deep colorjs.io traceback (`coords.map is not a function`) with no clue which token was at fault — see the consumer report in #1006.

Healthy tokens are unaffected — the wrap only runs on the throw path.

This does not fix the underlying source of malformed `$value`s reaching the emitter (suspicion: `composePartial` losing `components` for color tokens under specific partial-alias shapes). That stays open as the follow-up — having an actionable error message is the prerequisite for getting a reproducer to chase it with.

## Test plan

- [x] New unit test: malformed color token surfaces an error containing token path, permutation tuple, and `$type`
- [x] New unit test: original error is preserved as `cause`
- [x] Full monorepo `pnpm turbo run format:check lint typecheck test` — green

Milestone: Maintenance

Closes #1006