### PR TITLE
fix(core): validate color token $value shape at load time

### DIFF
--- a/.changeset/validate-color-shape-at-load.md
+++ b/.changeset/validate-color-shape-at-load.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Validate color token `$value` shape at load time. The graph builder now walks every literal value and reports DTCG color objects whose `components` field is missing or non-array — the shape that crashes `colorjs.io` inside `inGamut(...)` with the unactionable `coords.map is not a function` traceback. Covers top-level color tokens and color sub-fields inside composites uniformly: any object whose `colorSpace` is a string is treated as a color and validated. Healthy fixtures see no new diagnostics; the validator finds problems, it doesn't create them.

--- a/packages/core/src/token-graph/build.ts
+++ b/packages/core/src/token-graph/build.ts
@@ -3,7 +3,11 @@ import { permutationID } from '#/types.ts';
 import type { TokenGraph, TokenGraphNode, WriteValue } from '#/token-graph/types.ts';
 import { valueKey } from '#/value-key.ts';
 import { isPlainObject } from '#/token-graph/internal-utils.ts';
-import { aliasCycleDiagnostic, unresolvableAliasDiagnostic } from '#/token-graph/diagnostics.ts';
+import {
+  aliasCycleDiagnostic,
+  malformedColorShapeDiagnostic,
+  unresolvableAliasDiagnostic,
+} from '#/token-graph/diagnostics.ts';
 
 const COMPOSITE_TYPES = new Set(['border', 'typography', 'transition', 'gradient', 'shadow']);
 
@@ -217,6 +221,74 @@ function validateAliasTargets(nodes: Record<string, TokenGraphNode>): Diagnostic
   return diagnostics;
 }
 
+/**
+ * Walks every literal `$value` in the graph and reports DTCG color
+ * objects whose `components` field is missing or non-array — the
+ * shape that crashes `colorjs.io` inside `inGamut(...)` with the
+ * unactionable `coords.map is not a function` traceback. Covers
+ * top-level color tokens AND color sub-fields inside composites
+ * (border, gradient, shadow) uniformly: any object whose
+ * `colorSpace` is a string is treated as a color and validated.
+ */
+function validateColorShapes(nodes: Record<string, TokenGraphNode>): Diagnostic[] {
+  const diagnostics: Diagnostic[] = [];
+  for (const [path, node] of Object.entries(nodes)) {
+    if (node.baselineKind === 'literal') {
+      scanValueForColorShape(path, node.baselineValue.$value, '', diagnostics);
+    } else if (node.baselineKind === 'partial-alias') {
+      scanValueForColorShape(path, node.baselineValue.$value, '', diagnostics);
+    }
+    for (const axisWrites of Object.values(node.writes)) {
+      for (const write of Object.values(axisWrites)) {
+        if (write.kind === 'literal') {
+          scanValueForColorShape(path, write.value.$value, '', diagnostics);
+        } else if (write.kind === 'partial-alias') {
+          scanValueForColorShape(path, write.baseValue.$value, '', diagnostics);
+        }
+      }
+    }
+  }
+  return diagnostics;
+}
+
+function scanValueForColorShape(
+  tokenPath: string,
+  value: unknown,
+  fieldPath: string,
+  out: Diagnostic[],
+): void {
+  if (Array.isArray(value)) {
+    value.forEach((entry, i) => {
+      const nextPath = fieldPath ? `${fieldPath}.${i}` : String(i);
+      scanValueForColorShape(tokenPath, entry, nextPath, out);
+    });
+    return;
+  }
+  if (!isPlainObject(value)) return;
+  if (typeof value['colorSpace'] === 'string') {
+    const components = value['components'];
+    if (components === undefined) {
+      out.push(
+        malformedColorShapeDiagnostic(tokenPath, fieldPath, '`components` field is missing'),
+      );
+    } else if (!Array.isArray(components)) {
+      out.push(
+        malformedColorShapeDiagnostic(
+          tokenPath,
+          fieldPath,
+          `\`components\` must be an array of numbers (got ${typeof components})`,
+        ),
+      );
+    }
+    return;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (key.startsWith('$')) continue;
+    const nextPath = fieldPath ? `${fieldPath}.${key}` : key;
+    scanValueForColorShape(tokenPath, child, nextPath, out);
+  }
+}
+
 function detectAliasCycles(nodes: Record<string, TokenGraphNode>): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   const reportedCycles = new Set<string>();
@@ -298,6 +370,7 @@ function assembleGraph(
 
   const aliasDiagnostics = validateAliasTargets(nodes);
   const cycleDiagnostics = detectAliasCycles(nodes);
+  const colorShapeDiagnostics = validateColorShapes(nodes);
 
   computeAffectedBy(
     nodes,
@@ -306,7 +379,7 @@ function assembleGraph(
 
   return {
     graph: { nodes, axes: axes.map((a) => a.name), axisDefaults, axisContexts },
-    diagnostics: [...aliasDiagnostics, ...cycleDiagnostics],
+    diagnostics: [...aliasDiagnostics, ...cycleDiagnostics, ...colorShapeDiagnostics],
   };
 }
 

--- a/packages/core/src/token-graph/diagnostics.ts
+++ b/packages/core/src/token-graph/diagnostics.ts
@@ -28,3 +28,16 @@ export function aliasCycleDiagnostic(path: string, chain: readonly string[]): Di
     message: `Alias cycle starting at \`${path}\` (chain: ${chain.join(' → ')} → ${path}). Walker returns baseline literal at cycle entry.`,
   };
 }
+
+export function malformedColorShapeDiagnostic(
+  path: string,
+  fieldPath: string,
+  reason: string,
+): Diagnostic {
+  const where = fieldPath ? `${path} (at \`${fieldPath}\`)` : path;
+  return {
+    severity: 'warn',
+    group: 'swatchbook/token-graph',
+    message: `Color value at \`${where}\` is structurally invalid: ${reason}. CSS emission will fail for any context that resolves to this token.`,
+  };
+}

--- a/packages/core/test/token-graph/build.test.ts
+++ b/packages/core/test/token-graph/build.test.ts
@@ -399,4 +399,81 @@ describe('diagnostic emission', () => {
     const { diagnostics } = buildTokenGraphFromLayered(axes, baseline, perSingletonResolved, defaultTuple);
     expect(diagnostics).toHaveLength(0);
   });
+
+  it('emits malformedColorShapeDiagnostic when a color token has object $value with no components', () => {
+    const axes: Axis[] = [];
+    const baseline = {
+      'color.broken': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', alpha: 0.5 },
+      },
+    };
+    const { diagnostics } = buildTokenGraphFromLayered(axes, baseline, {}, {});
+    const match = diagnostics.find(
+      (d) =>
+        d.group === 'swatchbook/token-graph' &&
+        d.severity === 'warn' &&
+        d.message.includes('color.broken') &&
+        d.message.includes('components'),
+    );
+    expect(match).toBeDefined();
+  });
+
+  it('emits malformedColorShapeDiagnostic for object components on a color token', () => {
+    const axes: Axis[] = [];
+    const baseline = {
+      'color.broken': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: { r: 1, g: 0, b: 0 } as unknown as number[] },
+      },
+    };
+    const { diagnostics } = buildTokenGraphFromLayered(axes, baseline, {}, {});
+    const match = diagnostics.find(
+      (d) =>
+        d.group === 'swatchbook/token-graph' &&
+        d.message.includes('color.broken') &&
+        d.message.includes('must be an array'),
+    );
+    expect(match).toBeDefined();
+  });
+
+  it('emits malformedColorShapeDiagnostic for a malformed color sub-field in a border token', () => {
+    const axes: Axis[] = [];
+    const baseline = {
+      'border.thin': {
+        $type: 'border',
+        $value: {
+          color: { colorSpace: 'srgb', alpha: 1 },
+          style: 'solid',
+          width: '1px',
+        },
+      },
+    };
+    const { diagnostics } = buildTokenGraphFromLayered(axes, baseline, {}, {});
+    const match = diagnostics.find(
+      (d) =>
+        d.group === 'swatchbook/token-graph' &&
+        d.message.includes('border.thin') &&
+        d.message.includes('color') &&
+        d.message.includes('components'),
+    );
+    expect(match).toBeDefined();
+  });
+
+  it('does not emit malformedColorShapeDiagnostic for a well-formed color token', () => {
+    const axes: Axis[] = [];
+    const baseline = {
+      'color.ok': {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [1, 0, 0], alpha: 1 },
+      },
+      'color.string-form': {
+        $type: 'color',
+        $value: '#ff0000',
+      },
+    };
+    const { diagnostics } = buildTokenGraphFromLayered(axes, baseline, {}, {});
+    const colorShapeDiags = diagnostics.filter((d) => d.message.includes('structurally invalid'));
+    expect(colorShapeDiags).toHaveLength(0);
+  });
 });


### PR DESCRIPTION
## Summary

The graph builder now walks every literal value in `Project.tokenGraph` and reports DTCG color objects whose `components` field is missing or non-array — the shape that crashes `colorjs.io` inside `inGamut(...)` with the unactionable `coords.map is not a function` traceback first surfaced in #1006.

Catches the same condition as the emit-time wrap from #1007 but earlier, so the Design Tokens panel surfaces the issue before any block tries to render the offending token. Top-level color tokens and color sub-fields inside composites are validated uniformly: any object whose `colorSpace` is a string is treated as a color and checked.

Healthy fixtures see no new diagnostics — the validator finds problems, it doesn't create them. Reference fixture's `tokenGraph` build still emits zero diagnostics (verified by the existing pin at `build.test.ts:338`), and the `DiagnosticsClean` storybook story still passes.

## Test plan

- [x] New: malformed color (no `components`) emits diagnostic naming token + missing field
- [x] New: object-shaped `components` (not array) emits diagnostic naming type seen
- [x] New: malformed color sub-field inside a border token emits diagnostic with sub-field path
- [x] New: well-formed color in both string and object form produces no new diagnostic
- [x] Existing: reference fixture still emits zero diagnostics
- [x] Existing: `DiagnosticsClean` storybook story still asserts zero warnings
- [x] Full monorepo `pnpm turbo run format:check lint typecheck test` — green

Milestone: Maintenance

Closes #1008