### PR TITLE
fix(core): specific diagnostic for unresolved $ref in color components

### DIFF
--- a/.changeset/unresolved-ref-diagnostic.md
+++ b/.changeset/unresolved-ref-diagnostic.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+When the color-shape validator encounters `components` carrying an unresolved DTCG `$ref` object (a plain object with a string `$ref` member), the emitted diagnostic now names the JSON Pointer and identifies the upstream parser's failure to substitute the target — rather than the generic "`components` must be an array of numbers" message, which sends consumers hunting for source-side errors when the source is usually correct. Non-`$ref` non-array components keep the existing generic message.

--- a/packages/core/src/token-graph/build.ts
+++ b/packages/core/src/token-graph/build.ts
@@ -7,6 +7,7 @@ import {
   aliasCycleDiagnostic,
   malformedColorShapeDiagnostic,
   unresolvableAliasDiagnostic,
+  unresolvedRefDiagnostic,
 } from '#/token-graph/diagnostics.ts';
 
 const COMPOSITE_TYPES = new Set(['border', 'typography', 'transition', 'gradient', 'shadow']);
@@ -272,13 +273,19 @@ function scanValueForColorShape(
         malformedColorShapeDiagnostic(tokenPath, fieldPath, '`components` field is missing'),
       );
     } else if (!Array.isArray(components)) {
-      out.push(
-        malformedColorShapeDiagnostic(
-          tokenPath,
-          fieldPath,
-          `\`components\` must be an array of numbers (got ${typeof components})`,
-        ),
-      );
+      const refTarget = unresolvedRefTarget(components);
+      const componentsField = fieldPath ? `${fieldPath}.components` : 'components';
+      if (refTarget !== undefined) {
+        out.push(unresolvedRefDiagnostic(tokenPath, componentsField, refTarget));
+      } else {
+        out.push(
+          malformedColorShapeDiagnostic(
+            tokenPath,
+            fieldPath,
+            `\`components\` must be an array of numbers (got ${typeof components})`,
+          ),
+        );
+      }
     }
     return;
   }
@@ -287,6 +294,20 @@ function scanValueForColorShape(
     const nextPath = fieldPath ? `${fieldPath}.${key}` : key;
     scanValueForColorShape(tokenPath, child, nextPath, out);
   }
+}
+
+/**
+ * Returns the JSON Pointer if `value` is an unresolved DTCG `$ref` object
+ * (a plain object whose only non-`$`-prefixed shape is a string `$ref`
+ * member). Returns `undefined` for anything else. Used to distinguish a
+ * source-side malformation from an upstream parser failing to substitute
+ * a `$ref` target.
+ */
+function unresolvedRefTarget(value: unknown): string | undefined {
+  if (!isPlainObject(value)) return undefined;
+  const ref = value['$ref'];
+  if (typeof ref !== 'string') return undefined;
+  return ref;
 }
 
 function detectAliasCycles(nodes: Record<string, TokenGraphNode>): Diagnostic[] {

--- a/packages/core/src/token-graph/diagnostics.ts
+++ b/packages/core/src/token-graph/diagnostics.ts
@@ -41,3 +41,12 @@ export function malformedColorShapeDiagnostic(
     message: `Color value at \`${where}\` is structurally invalid: ${reason}. CSS emission will fail for any context that resolves to this token.`,
   };
 }
+
+export function unresolvedRefDiagnostic(path: string, fieldPath: string, ref: string): Diagnostic {
+  const where = fieldPath ? `${path} (at \`${fieldPath}\`)` : path;
+  return {
+    severity: 'warn',
+    group: 'swatchbook/token-graph',
+    message: `Unresolved \`$ref\` at \`${where}\`: \`${ref}\`. The upstream DTCG parser did not substitute the target value, so this field will reach CSS emission as a \`{ $ref }\` object literal. Check that the JSON Pointer resolves and that the parser version handles \`$ref\` into non-Object targets (arrays, scalars).`,
+  };
+}

--- a/packages/core/test/token-graph/build.test.ts
+++ b/packages/core/test/token-graph/build.test.ts
@@ -476,4 +476,55 @@ describe('diagnostic emission', () => {
     const colorShapeDiags = diagnostics.filter((d) => d.message.includes('structurally invalid'));
     expect(colorShapeDiags).toHaveLength(0);
   });
+
+  it('emits unresolvedRefDiagnostic when color components carry an unresolved $ref object', () => {
+    const axes: Axis[] = [];
+    const baseline = {
+      'color.via-ref': {
+        $type: 'color',
+        $value: {
+          colorSpace: 'srgb',
+          components: { $ref: '#/primitives/color/gray/12/$value/components' } as unknown as number[],
+          alpha: 1,
+        },
+      },
+    };
+    const { diagnostics } = buildTokenGraphFromLayered(axes, baseline, {}, {});
+    const match = diagnostics.find(
+      (d) =>
+        d.group === 'swatchbook/token-graph' &&
+        d.severity === 'warn' &&
+        d.message.includes('Unresolved `$ref`') &&
+        d.message.includes('color.via-ref') &&
+        d.message.includes('#/primitives/color/gray/12/$value/components'),
+    );
+    expect(match).toBeDefined();
+
+    // The generic "must be an array" diagnostic should NOT also fire — the
+    // $ref-specific message replaces it.
+    const generic = diagnostics.filter((d) => d.message.includes('must be an array of numbers'));
+    expect(generic).toHaveLength(0);
+  });
+
+  it('still emits generic malformedColorShapeDiagnostic for non-$ref non-array components', () => {
+    const axes: Axis[] = [];
+    const baseline = {
+      'color.bad-shape': {
+        $type: 'color',
+        $value: {
+          colorSpace: 'srgb',
+          components: { r: 1, g: 0, b: 0 } as unknown as number[],
+          alpha: 1,
+        },
+      },
+    };
+    const { diagnostics } = buildTokenGraphFromLayered(axes, baseline, {}, {});
+    const match = diagnostics.find(
+      (d) =>
+        d.group === 'swatchbook/token-graph' &&
+        d.message.includes('color.bad-shape') &&
+        d.message.includes('must be an array of numbers'),
+    );
+    expect(match).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary

Refines the color-shape validator from #1010. When `components` is a `{ $ref: '<JSON Pointer>' }` object — the shape that arises when an upstream DTCG parser leaves an in-`$value` `$ref` unsubstituted — the emitted diagnostic now identifies the failure as an unresolved `$ref` and includes the literal pointer:

```
Unresolved `$ref` at `color.via-ref` (at `components`): `#/primitives/color/gray/12/$value/components`. The upstream DTCG parser did not substitute the target value, so this field will reach CSS emission as a `{ $ref }` object literal. Check that the JSON Pointer resolves and that the parser version handles `$ref` into non-Object targets (arrays, scalars).
```

The previous generic message ("`components` must be an array of numbers (got object)") read as a source-side complaint and pointed consumers at their own tokens. The truth in this case is usually different — DTCG 2025.10's `$ref` form allows JSON Pointers into sub-fields of another token's `$value`, and parsers that retrofit `$ref` onto a whole-token-alias resolver can miss the sub-field case. A `$ref`-aware message redirects the consumer at the actual issue.

Non-`$ref` non-array `components` (a string, a number, an object without `$ref`) keeps the existing generic message — that case really is a source malformation.

## Scope

Diagnostic-only. We do not resolve `$ref` ourselves — that's the parser's job. Same "preview host, not transformer" framing as the rest of the validator.

## Test plan

- [x] New: `components = { $ref: '<pointer>' }` emits `$ref`-specific diagnostic with the pointer
- [x] New: the generic "must be an array" diagnostic does NOT fire alongside it
- [x] New: non-`$ref` non-array `components` (object literal) still emits the generic message
- [x] Existing: reference fixture still emits zero diagnostics
- [x] Existing: `DiagnosticsClean` storybook story still asserts zero warnings
- [x] Full monorepo `pnpm turbo run format:check lint typecheck test` — green

Milestone: Maintenance

Closes #1013