### PR TITLE
fix(core): substitute $ref in modifier values against baseline

### DIFF
--- a/.changeset/resolve-refs-in-modifier-writes.md
+++ b/.changeset/resolve-refs-in-modifier-writes.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Substitute DTCG `$ref` objects in modifier values against the resolver's baseline output. The resolver-based loader's `extractWritesFromModifiers` was reading from `resolver.source.modifiers` directly — a pre-`processTokens` representation where cross-document `$ref` references in modifier source values (e.g. a semantic token's `components` referencing a primitive's `components` array via JSON Pointer) had not yet been resolved. The unresolved `{ $ref }` objects flowed through write values into the walker and reached emit time, where colorjs.io crashed on them. The fix performs the same JSON Pointer substitution at write-extraction time, using the already-resolved baseline as the lookup source. Unresolved pointers are left intact and continue to surface via the existing emit-time error wrap and load-time diagnostic.

--- a/packages/core/src/token-graph/build.ts
+++ b/packages/core/src/token-graph/build.ts
@@ -49,6 +49,7 @@ export function extractWritesFromModifiers(
     { contexts?: Record<string, unknown[]> | undefined; default?: string | undefined }
   >,
   axes: readonly Axis[],
+  refLookup: TokenMap = {},
 ): Record<string, Record<string, Record<string, WriteValue>>> {
   const out: Record<string, Record<string, Record<string, WriteValue>>> = {};
   for (const axis of axes) {
@@ -57,7 +58,7 @@ export function extractWritesFromModifiers(
     for (const [contextName, groupNodes] of Object.entries(modifier.contexts)) {
       if (contextName === axis.default) continue;
       for (const node of groupNodes) {
-        collectLeafWrites(node, '', axis.name, contextName, out);
+        collectLeafWrites(node, '', axis.name, contextName, out, refLookup);
       }
     }
   }
@@ -70,13 +71,14 @@ function collectLeafWrites(
   axisName: string,
   contextName: string,
   out: Record<string, Record<string, Record<string, WriteValue>>>,
+  refLookup: TokenMap,
   inheritedType?: string,
 ): void {
   if (!isPlainObject(node)) return;
   if ('$value' in node) {
     if (!prefix) return;
     const effectiveType = typeof node['$type'] === 'string' ? node['$type'] : inheritedType;
-    const write = toWriteValue(node, effectiveType);
+    const write = toWriteValue(node, effectiveType, refLookup);
     if (write) {
       (out[prefix] ??= {})[axisName] ??= {};
       out[prefix]![axisName]![contextName] = write;
@@ -87,21 +89,24 @@ function collectLeafWrites(
   for (const [key, child] of Object.entries(node)) {
     if (key.startsWith('$')) continue;
     const childPath = prefix ? `${prefix}.${key}` : key;
-    collectLeafWrites(child, childPath, axisName, contextName, out, nextInheritedType);
+    collectLeafWrites(child, childPath, axisName, contextName, out, refLookup, nextInheritedType);
   }
 }
 
 function toWriteValue(
   token: Record<string, unknown>,
   effectiveType?: string,
+  refLookup: TokenMap = {},
 ): WriteValue | undefined {
-  const value = token['$value'];
-  if (value === undefined) return undefined;
+  const rawValue = token['$value'];
+  if (rawValue === undefined) return undefined;
+  const value = resolveRefsInValue(rawValue, refLookup);
   const $type = typeof token['$type'] === 'string' ? token['$type'] : effectiveType;
+  const tokenWithSubstitutedValue = value === rawValue ? token : { ...token, $value: value };
   const withType: SwatchbookToken =
     $type !== undefined && token['$type'] === undefined
-      ? ({ ...token, $type } as SwatchbookToken)
-      : (token as SwatchbookToken);
+      ? ({ ...tokenWithSubstitutedValue, $type } as SwatchbookToken)
+      : (tokenWithSubstitutedValue as SwatchbookToken);
   if (typeof value === 'string') {
     const match = ALIAS_RE.exec(value);
     if (match) return { kind: 'alias', target: match[1]! };
@@ -119,6 +124,67 @@ function toWriteValue(
     }
   }
   return { kind: 'literal', value: slimToken(withType) };
+}
+
+/**
+ * Walk `value` and replace any `{ $ref: '<JSON Pointer>' }` object with the
+ * resolved target from `refLookup`. Terrazzo's resolver normalize pass
+ * doesn't substitute cross-document `$ref` references in modifier source
+ * values — they're only substituted at `resolver.apply()` time via
+ * `processTokens`, which our `extractWritesFromModifiers` bypasses by
+ * reading `resolver.source.modifiers` directly. This function fills that
+ * gap by performing the same JSON Pointer substitution against an already-
+ * resolved token snapshot (typically the resolver's baseline output).
+ *
+ * Unresolved pointers are left as-is — they then surface via #1014's
+ * `unresolvedRefDiagnostic` (load-time) or #1007's emit-wrap (runtime).
+ */
+function resolveRefsInValue(value: unknown, refLookup: TokenMap): unknown {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next: unknown[] = [];
+    for (const entry of value) {
+      const replaced = resolveRefsInValue(entry, refLookup);
+      if (replaced !== entry) changed = true;
+      next.push(replaced);
+    }
+    return changed ? next : value;
+  }
+  if (!isPlainObject(value)) return value;
+  const ref = value['$ref'];
+  if (typeof ref === 'string') {
+    const resolved = lookupJsonPointer(ref, refLookup);
+    if (resolved !== undefined) return resolved;
+    return value;
+  }
+  let changed = false;
+  const next: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(value)) {
+    const replaced = resolveRefsInValue(v, refLookup);
+    if (replaced !== v) changed = true;
+    next[k] = replaced;
+  }
+  return changed ? next : value;
+}
+
+function lookupJsonPointer(pointer: string, refLookup: TokenMap): unknown {
+  if (!pointer.startsWith('#/')) return undefined;
+  const parts = pointer
+    .slice(2)
+    .split('/')
+    .map((p) => p.replace(/~1/g, '/').replace(/~0/g, '~'));
+  for (let i = parts.length; i > 0; i--) {
+    const tokenID = parts.slice(0, i).join('.');
+    const token = refLookup[tokenID];
+    if (!token) continue;
+    let node: unknown = token;
+    for (const part of parts.slice(i)) {
+      if (node == null || typeof node !== 'object') return undefined;
+      node = (node as Record<string, unknown>)[part];
+    }
+    return node;
+  }
+  return undefined;
 }
 
 // Walks raw DTCG `$value` looking for `{path}`-shaped alias syntax. Used during modifier-source extraction.
@@ -157,6 +223,7 @@ export function buildTokenGraph(
   const writesByPath = extractWritesFromModifiers(
     parserInput.resolver.source?.modifiers ?? {},
     axes,
+    baseline,
   );
   // Singleton-apply sweep: each non-default (axis, ctx) tuple.
   // Records resolved values per singleton so writes-only paths

--- a/packages/core/test/token-graph/build.test.ts
+++ b/packages/core/test/token-graph/build.test.ts
@@ -159,6 +159,96 @@ describe('extractWritesFromModifiers', () => {
     expect(writes['a']?.brand).toBeUndefined();
   });
 
+  it('substitutes $ref objects in modifier values against the refLookup token map', () => {
+    // The consumer-reported failure mode: a modifier writes a color with
+    // `components: { $ref: '#/primitives/.../components' }`. Without
+    // substitution, the raw $ref object reaches the walker and crashes
+    // colorjs.io at emit. With refLookup, the substituted array is what
+    // gets stored as the write's value.
+    const refLookup = {
+      'primitives.color.gray.12': {
+        $type: 'color' as const,
+        $value: { colorSpace: 'srgb', components: [0.5, 0.5, 0.5], alpha: 1 },
+      },
+    };
+    const modifiers = {
+      'color-mode': {
+        contexts: {
+          dark: [
+            {
+              semantics: {
+                color: {
+                  emphasis: {
+                    accent: {
+                      base: {
+                        active: {
+                          $type: 'color',
+                          $value: {
+                            colorSpace: 'oklch',
+                            alpha: 0.6,
+                            components: { $ref: '#/primitives/color/gray/12/$value/components' },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        },
+        default: 'light',
+      },
+    };
+    const axes: Axis[] = [
+      {
+        name: 'color-mode',
+        contexts: ['light', 'dark'],
+        default: 'light',
+        source: 'resolver',
+      },
+    ];
+    const writes = extractWritesFromModifiers(modifiers, axes, refLookup);
+    const write = writes['semantics.color.emphasis.accent.base.active']?.['color-mode']?.dark;
+    expect(write?.kind).toBe('literal');
+    if (write?.kind === 'literal') {
+      const $value = write.value.$value as { components: unknown };
+      expect($value.components).toEqual([0.5, 0.5, 0.5]);
+    }
+  });
+
+  it('leaves $ref objects intact when the target is missing from refLookup', () => {
+    const modifiers = {
+      mode: {
+        contexts: {
+          Dark: [
+            {
+              c: {
+                $type: 'color',
+                $value: {
+                  colorSpace: 'srgb',
+                  alpha: 1,
+                  components: { $ref: '#/nonexistent/path' },
+                },
+              },
+            },
+          ],
+        },
+        default: 'Light',
+      },
+    };
+    const axes: Axis[] = [
+      { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'resolver' },
+    ];
+    const writes = extractWritesFromModifiers(modifiers, axes, {});
+    const write = writes['c']?.mode?.Dark;
+    expect(write?.kind).toBe('literal');
+    if (write?.kind === 'literal') {
+      const $value = write.value.$value as { components: unknown };
+      expect($value.components).toEqual({ $ref: '#/nonexistent/path' });
+    }
+  });
+
   it('inherits $type from a parent group node when the leaf lacks its own', () => {
     // Modifier source where `border` group declares $type, and child leaves
     // (`default`) carry only $value. Without inheritance, toWriteValue can't


### PR DESCRIPTION
## Summary

The resolver-based loader's `extractWritesFromModifiers` was reading from `resolver.source.modifiers` directly — a pre-`processTokens` representation where cross-document `$ref` references in modifier source values had not yet been resolved. The unresolved `{ $ref }` objects flowed through write values into the walker and reached emit time, where colorjs.io crashed on them. See #1017 for the full investigation and the consumer-reported failure that surfaced this.

Terrazzo CLI never hits this because it operates on `tokens` from `parse()` (which IS `resolver.apply(firstInput)`'s output, run through `processTokens` which resolves cross-doc $refs). Our path reads the raw modifier source directly for write-structure detection and stored the raw values.

## Fix

Walk modifier `$value`s for `{ $ref: '<JSON Pointer>' }` objects and substitute against the already-resolved baseline `TokenMap` before classifying writes. Same logic `processTokens` runs, scoped to write extraction. Unresolved pointers are left intact and surface through the existing emit-wrap (#1007) and load-time diagnostic (#1014).

Scope is narrow:

- Only the resolver-based path (`buildTokenGraph`). The layered path (`buildTokenGraphFromLayered`) already reads from `apply()`-resolved singleton tokens, so it has no equivalent gap.
- `refLookup` defaults to `{}` so existing tests that call `extractWritesFromModifiers` directly without a refLookup keep working — they exercise the no-$ref path, which is unaffected by the change.

## Test plan

- [x] New: modifier writes a color with `components: { $ref: '#/primitives/...' }` and the resulting write value carries the substituted array, not the raw $ref
- [x] New: modifier writes a color whose `$ref` target is missing from refLookup; the raw $ref is left intact (so #1014's diagnostic still surfaces it)
- [x] Existing: all 210 prior tests pass unchanged (reference fixture uses `{token.path}` aliases, not `$ref`, so the change is a no-op for it)
- [x] Full monorepo `pnpm turbo run format:check lint typecheck test` — 37/37 tasks green
- [x] Storybook interaction suite — 165/165 pass

Milestone: Maintenance

Closes #1017