### PR TITLE
feat(core): opt-in phase-bounded load timing log

### DIFF
--- a/.changeset/verbose-load-timing.md
+++ b/.changeset/verbose-load-timing.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+`loadProject` now emits phase-bounded timing to stdout when the `SWATCHBOOK_LOG_VERBOSE=1` environment variable is set. Lines look like `[swatchbook:load] graph build: 380ms`, with one entry per major phase (parse + normalize, preset apply sweep when presets are configured, token-listing build, graph build, total). When the env var is unset, behaviour is unchanged — no console output, only a few `performance.now()` calls per load (negligible overhead). Intended use: a consumer reports a hung or slow load and we need to know which phase is the offender before reaching for a full CPU profile.

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -30,13 +30,38 @@ import type { Axis, Config, Diagnostic, Permutation, Project, TokenMap } from '#
  * or set to `''` to opt out of namespacing. */
 export const DEFAULT_CSS_VAR_PREFIX = 'swatch';
 
+/**
+ * Opt-in phase timing for `loadProject`. Activate with the env var
+ * `SWATCHBOOK_LOG_VERBOSE=1`. Each major phase logs its duration to
+ * stdout as `[swatchbook:load] <phase>: <ms>ms`. When the env var is
+ * unset, the overhead is a few `performance.now()` calls per phase
+ * (negligible) and no console output.
+ *
+ * Primary use case: a consumer reports a hung or slow `loadProject` and
+ * we need to know which phase is the offender before reaching for a
+ * full CPU profile.
+ */
+function isVerbose(): boolean {
+  return process.env['SWATCHBOOK_LOG_VERBOSE'] === '1';
+}
+
+function logPhase(label: string, startedAt: number): void {
+  if (!isVerbose()) return;
+  const ms = performance.now() - startedAt;
+  // biome-ignore lint/suspicious/noConsole: opt-in debug output, gated behind env var
+  console.log(`[swatchbook:load] ${label}: ${ms.toFixed(0)}ms`);
+}
+
 export async function loadProject(config: Config, cwd: string = process.cwd()): Promise<Project> {
+  const loadStart = performance.now();
   const logger = new BufferedLogger({ level: 'warn' });
   const configWithDefaults: Config = {
     ...config,
     cssVarPrefix: config.cssVarPrefix ?? DEFAULT_CSS_VAR_PREFIX,
   };
+  const tParse = performance.now();
   const normalized = await normalizePermutations(configWithDefaults, cwd, logger);
+  logPhase('parse + normalize', tParse);
 
   const { names: disabledAxes, diagnostics: disabledDiagnostics } = validateDisabledAxes(
     config.disabledAxes,
@@ -78,6 +103,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   // Resolver-backed projects only — layered presets without a
   // resolver can't apply() on demand.
   if (normalized.parserInput?.resolver && presets.length > 0) {
+    const tPresets = performance.now();
     for (const preset of presets) {
       const tuple = fillPresetTuple(preset.axes, filteredAxes);
       const id = permutationID(tuple);
@@ -85,10 +111,12 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
       filteredResolved[id] = normalized.parserInput.resolver.apply(tuple);
       filteredPermutations.push({ name: id, input: tuple, sources: [] });
     }
+    logPhase(`apply ${presets.length} preset tuple(s)`, tPresets);
   }
 
   const { diagnostics: cssOptionsDiagnostics } = validateCssOptions(config.cssOptions);
 
+  const tListing = performance.now();
   const { listing, diagnostics: listingDiagnostics } =
     normalized.parserInput !== undefined
       ? await computeTokenListing(
@@ -102,6 +130,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
           },
         )
       : { listing: {}, diagnostics: [] };
+  logPhase('token-listing build', tListing);
 
   // `defaultTuple` here is the post-disabledAxes-filter version.
   const projectDefaultTuple: Record<string, string> = {};
@@ -110,6 +139,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   // Build the token graph. Resolver-backed projects build from the live
   // Resolver; layered / plain-parse projects infer writes by diffing
   // per-singleton resolved maps.
+  const tGraph = performance.now();
   let tokenGraphResult: BuildTokenGraphResult;
   try {
     if (normalized.parserInput?.resolver) {
@@ -126,6 +156,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
         projectDefaultTuple,
       );
     }
+    logPhase('graph build', tGraph);
   } catch (error) {
     const detail = error instanceof Error ? error.message : String(error);
     tokenGraphResult = {
@@ -168,6 +199,8 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     config.chrome,
     tokenIDs,
   );
+
+  logPhase('total', loadStart);
 
   return {
     config: configWithDefaults,

--- a/packages/core/test/verbose-load-timing.test.ts
+++ b/packages/core/test/verbose-load-timing.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Phase-bounded load timing is opt-in via `SWATCHBOOK_LOG_VERBOSE=1`.
+ * When unset, `loadProject` produces no `[swatchbook:load]` output —
+ * silence is the contract for the default path. When set, each phase
+ * logs a single line so a consumer hitting a hung or slow load can
+ * identify which phase is the offender without instrumenting the code.
+ */
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { loadProject } from '#/load.ts';
+import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
+import { dirname } from 'node:path';
+import { tokensDir } from '@unpunnyfuns/swatchbook-tokens';
+
+const fixtureCwd = dirname(tokensDir);
+
+const baseConfig = {
+  tokens: ['tokens/**/*.json'],
+  resolver: resolverPath,
+  default: { mode: 'Light', brand: 'Default', contrast: 'Normal' },
+};
+
+beforeEach(() => {
+  delete process.env['SWATCHBOOK_LOG_VERBOSE'];
+});
+
+afterEach(() => {
+  delete process.env['SWATCHBOOK_LOG_VERBOSE'];
+  vi.restoreAllMocks();
+});
+
+it('produces no [swatchbook:load] output when SWATCHBOOK_LOG_VERBOSE is unset', async () => {
+  const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  await loadProject(baseConfig, fixtureCwd);
+  const loadLines = consoleSpy.mock.calls
+    .map((args) => String(args[0] ?? ''))
+    .filter((line) => line.startsWith('[swatchbook:load]'));
+  expect(loadLines).toEqual([]);
+}, 30_000);
+
+it('logs a phase line per major load phase when SWATCHBOOK_LOG_VERBOSE=1', async () => {
+  process.env['SWATCHBOOK_LOG_VERBOSE'] = '1';
+  const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  await loadProject(baseConfig, fixtureCwd);
+  const loadLines = consoleSpy.mock.calls
+    .map((args) => String(args[0] ?? ''))
+    .filter((line) => line.startsWith('[swatchbook:load]'));
+  expect(loadLines.length).toBeGreaterThan(0);
+  // Each phase line carries a millisecond-tagged duration.
+  for (const line of loadLines) {
+    expect(line).toMatch(/^\[swatchbook:load\] .+: \d+ms$/);
+  }
+  // The known phases should all be present at least once.
+  const labels = loadLines.map((line) => line.match(/\] (.+): /)?.[1] ?? '');
+  expect(labels).toContain('parse + normalize');
+  expect(labels).toContain('token-listing build');
+  expect(labels).toContain('graph build');
+  expect(labels).toContain('total');
+}, 30_000);
+
+it('ignores any value other than literal "1" for SWATCHBOOK_LOG_VERBOSE', async () => {
+  process.env['SWATCHBOOK_LOG_VERBOSE'] = 'true';
+  const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  await loadProject(baseConfig, fixtureCwd);
+  const loadLines = consoleSpy.mock.calls
+    .map((args) => String(args[0] ?? ''))
+    .filter((line) => line.startsWith('[swatchbook:load]'));
+  expect(loadLines).toEqual([]);
+}, 30_000);


### PR DESCRIPTION
## Summary

`loadProject` now emits phase-bounded timing to stdout when the `SWATCHBOOK_LOG_VERBOSE=1` environment variable is set:

```
[swatchbook:load] parse + normalize: 1240ms
[swatchbook:load] apply 3 preset tuple(s): 18ms
[swatchbook:load] token-listing build: 2840ms
[swatchbook:load] graph build: 380ms
[swatchbook:load] total: 4478ms
```

When the env var is unset, behaviour is unchanged — no console output, only a few `performance.now()` calls per load (negligible overhead).

## Why

A consumer reported a load that hangs for >1h with no error, no OOM, and no Storybook ever booting. Without phase-bounded timing we cannot tell whether the offender is parse, the graph build, a validator, the token-listing build, or the preset apply sweep. Currently the only diagnostic path is to ask the consumer to instrument the code by hand, which doesn't scale across consumer reports.

A small env-var-gated logger is the cheapest observability addition that pays itself back the next time someone says "it just never loads."

## Why an env var, not a config field

Config-shape changes carry API stability implications (TypeScript inference, snapshot serialization, downstream consumers). An env var is opt-in, doesn't widen the public surface, and is the conventional shape for debug-time observability in Node tooling.

## Test plan

- [x] New: with `SWATCHBOOK_LOG_VERBOSE` unset, no `[swatchbook:load]` lines emitted on the reference fixture load.
- [x] New: with `SWATCHBOOK_LOG_VERBOSE=1`, every known phase logs a line in the `[swatchbook:load] <label>: <ms>ms` format. `total` line present.
- [x] New: any value other than the literal `"1"` is treated as unset (no log output for `SWATCHBOOK_LOG_VERBOSE=true`).
- [x] Existing: full monorepo `pnpm turbo run format:check lint typecheck test` — 37/37 tasks green.

## Follow-up

A docs note describing the env var, the output format, and when to reach for `node --cpu-prof` instead belongs on the diagnostics reference page (#1021). Will add as a separate small docs PR once #1021 merges to avoid stacking.

Milestone: Maintenance

Closes #1024