### PR TITLE
fix(addon): exclude virtual modules from Vite optimizeDeps pre-bundling

### DIFF
--- a/.changeset/optimize-deps-exclude-virtuals.md
+++ b/.changeset/optimize-deps-exclude-virtuals.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+The addon's Vite plugin now excludes its virtual module IDs (`virtual:swatchbook/tokens`, `virtual:swatchbook/integration-side-effects`) from Vite's `optimizeDeps` pre-bundling. Vite uses esbuild for pre-bundling, and esbuild doesn't see Rollup-style `resolveId` hooks — a preview file that gets pulled into pre-bundling and imports one of our virtuals would fail with `Could not resolve "virtual:swatchbook/tokens"`. The exclusion routes the virtuals through the dev-time plugin pipeline where `resolveId` / `load` handle them. Build mode is unaffected (Rollup throughout).

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -70,6 +70,28 @@ export function swatchbookTokensPlugin({
     name: 'swatchbook:virtual-tokens',
     enforce: 'pre',
 
+    /**
+     * Vite uses esbuild for `optimizeDeps` pre-bundling (development
+     * mode), and esbuild doesn't see Rollup-style `resolveId` hooks.
+     * Without this exclusion, a preview file that imports
+     * `virtual:swatchbook/tokens` (directly or via the addon's
+     * `useToken` hook) can get pulled into pre-bundling, hitting
+     * esbuild with no resolver registered and failing with
+     * `Could not resolve "virtual:swatchbook/tokens"`.
+     *
+     * Excluding the virtual IDs tells Vite to route them through the
+     * Rollup-style pipeline at request time — our `resolveId` / `load`
+     * hooks above handle the resolution. Build mode is unaffected
+     * (build uses Rollup throughout).
+     */
+    config() {
+      return {
+        optimizeDeps: {
+          exclude: [VIRTUAL_MODULE_ID, INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID],
+        },
+      };
+    },
+
     async buildStart() {
       // Skip the redundant load when preset.viteFinal already supplied
       // a freshly-loaded project via `initialProject`. The first HMR

--- a/packages/addon/test/virtual-plugin.test.ts
+++ b/packages/addon/test/virtual-plugin.test.ts
@@ -6,7 +6,7 @@
 // of the cost.
 import type { Config, Project } from '@unpunnyfuns/swatchbook-core';
 import { expect, it } from 'vitest';
-import { collectWatchPaths } from '#/virtual/plugin.ts';
+import { collectWatchPaths, swatchbookTokensPlugin } from '#/virtual/plugin.ts';
 
 const CWD = '/project';
 
@@ -64,4 +64,26 @@ it('handles absolute paths untouched', () => {
   const config: Config = { tokens: ['/abs/tokens/**/*.json'] };
   const paths = collectWatchPaths(config, undefined, CWD);
   expect(paths).toEqual(['/abs/tokens']);
+});
+
+it('excludes the addon virtual IDs from Vite optimizeDeps pre-bundling', () => {
+  // Vite uses esbuild for optimizeDeps, which doesn't see Rollup-style
+  // `resolveId` hooks. The config hook tells Vite to route the virtuals
+  // through the dev-time plugin pipeline instead of esbuild's bundler.
+  const plugin = swatchbookTokensPlugin({
+    config: { tokens: ['tokens/**/*.json'] },
+    cwd: '/project',
+  });
+  const configResult =
+    typeof plugin.config === 'function'
+      ? plugin.config({}, { command: 'serve', mode: 'development' })
+      : undefined;
+  const exclude =
+    configResult && 'optimizeDeps' in configResult ? configResult.optimizeDeps?.exclude : undefined;
+  expect(exclude).toEqual(
+    expect.arrayContaining([
+      'virtual:swatchbook/tokens',
+      'virtual:swatchbook/integration-side-effects',
+    ]),
+  );
 });


### PR DESCRIPTION
## Summary

A consumer reported `Could not resolve "virtual:swatchbook/tokens"` running `storybook dev` (while `storybook build` succeeded). Root cause: the addon's virtual plugin had no `config` hook excluding its virtual IDs from Vite's `optimizeDeps` pre-bundling.

Vite uses **esbuild** for `optimizeDeps` pre-bundling (development mode). esbuild doesn't see Rollup-style `resolveId` hooks — only Rollup / Vite's full plugin pipeline does. When Vite scans the dependency graph during pre-bundling and encounters `import 'virtual:swatchbook/tokens'`, esbuild has no resolver registered for that ID.

Build mode uses Rollup all the way through, no esbuild pre-bundle, which is why `storybook build` succeeds.

## Fix

Add a `config` hook to the virtual plugin that registers our virtual IDs with `optimizeDeps.exclude`. Tells Vite "don't pre-bundle these; route through the plugin pipeline." Canonical pattern for any Vite plugin owning a virtual module.

## Why this is a pre-existing latent issue

The addon's virtual plugin has never had this exclusion. Our own dogfood's preview-side files come through Storybook's own discovery, not Vite's pre-bundling entry scanner, so we never hit it. Consumer setups whose preview imports get pulled into pre-bundling (a story file that imports `useToken`, an `optimizeDeps.entries` glob that catches a preview file, etc.) do hit it.

## Test plan

- [x] New unit test asserts the plugin's `config` hook returns `{ optimizeDeps: { exclude: [...] } }` containing both virtual IDs.
- [x] Existing tests unchanged (the new behavior is additive).
- [x] Full monorepo `pnpm turbo run format:check lint typecheck test` — 37/37 tasks green.

Milestone: Maintenance

Closes #1031