### PR TITLE
chore: bump qs to clear GHSA-q8mj-m7cp-5q26

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   ws: ^8.20.1
   webpack-dev-server: ^5.2.4
   brace-expansion@>=5: ^5.0.6
+  qs: ^6.15.2
 
 patchedDependencies:
   '@terrazzo/plugin-css-in-js@2.0.3': 9792500f4d6b47ecff171b57293cb888be2ff44580faa445fea7e77c1e21f63c
@@ -7658,8 +7659,8 @@ packages:
     resolution: {integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==}
     engines: {node: '>=16.0.0'}
 
-  qs@6.14.2:
-    resolution: {integrity: sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -14184,7 +14185,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -14199,7 +14200,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.2
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -15117,7 +15118,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -15152,7 +15153,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.2
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -17495,7 +17496,7 @@ snapshots:
 
   pvutils@1.1.5: {}
 
-  qs@6.14.2:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,7 @@ overrides:
   ws: ^8.20.1
   webpack-dev-server: ^5.2.4
   'brace-expansion@>=5': ^5.0.6
+  qs: ^6.15.2
 
 patchedDependencies:
   '@terrazzo/plugin-css-in-js@2.0.3': patches/@terrazzo__plugin-css-in-js@2.0.3.patch


### PR DESCRIPTION
## Summary

Clears [Dependabot alert #18](https://github.com/unpunnyfuns/swatchbook/security/dependabot/18) — [GHSA-q8mj-m7cp-5q26](https://github.com/advisories/GHSA-q8mj-m7cp-5q26).

| Field | Value |
|---|---|
| Severity | Medium |
| Package | `qs` |
| Vulnerable | `≥ 6.11.1, ≤ 6.15.1` |
| Patched | `6.15.2` |
| In tree before | `qs@6.14.2` |
| In tree after | `qs@6.15.2` |
| Direct dep? | No — transitive via `body-parser → express → webpack-dev-server → @docusaurus/core` (docs site only) |

Pinned via `pnpm-workspace.yaml#overrides`. Practical risk in our context is low (Docusaurus builds to static HTML, so `qs` only runs in the dev server), but the fix is mechanical.

## Test plan

- [x] `pnpm install` — qs resolved to 6.15.2
- [x] Full monorepo `pnpm turbo run format:check lint typecheck test` — 37/37 tasks green
- [x] 6.15.2 published 2026-05-16, ~14 days old, well past `minimumReleaseAge: 1440`

No changeset — same as #1012, devDependency / transitive override doesn't affect published-package behaviour. Pure lockfile + overrides shift.

Milestone: Maintenance

Closes #1036