### PR TITLE
ci: pin every action to commit SHA + add zizmor workflow audit

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -22,6 +22,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          # Chromatic doesn't upload artifacts, so the immediate
+          # leak vector zizmor's `artipacked` rule flags doesn't
+          # apply here. Setting `false` as defense-in-depth so the
+          # rule stays clean for this workflow too.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,15 +19,15 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -44,7 +44,7 @@ jobs:
         run: pnpm turbo run build:storybook --filter=@unpunnyfuns/swatchbook-storybook
 
       - name: Publish to Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@8ad69a40dea06755a3c6db290f300a39e011433b # v17.1.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: apps/storybook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
         node: [24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Don't write the GITHUB_TOKEN into .git/config of the checked-out
+          # tree. Downstream steps include actions/upload-artifact, which
+          # would otherwise ship the token in the artifact (zizmor's
+          # `artipacked` finding). No git push from this job, so we don't
+          # need credentials persisted.
+          persist-credentials: false
 
       - name: Trust workspace inside container
         # Runner UID differs from checkout owner inside containers, which

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         node: [24]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Trust workspace inside container
         # Runner UID differs from checkout owner inside containers, which
@@ -60,17 +60,17 @@ jobs:
         # cache keys.
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
 
       - name: Cache Turbo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .turbo
           key: turbo-${{ matrix.node }}-${{ github.sha }}
@@ -152,7 +152,7 @@ jobs:
       - name: Build Storybook
         run: pnpm turbo run build:storybook
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: storybook-static
           path: apps/storybook/storybook-static

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,19 +21,19 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
 
       - name: Cache Turbo
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: .turbo
           key: turbo-docs-${{ github.sha }}
@@ -50,11 +50,11 @@ jobs:
           rm -rf apps/docs/build/storybook
           cp -r apps/storybook/storybook-static apps/docs/build/storybook
 
-      - uses: actions/configure-pages@v6
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
-      - uses: actions/upload-pages-artifact@v5
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: apps/docs/build
 
       - id: deploy
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,6 +22,12 @@ jobs:
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          # Don't write the GITHUB_TOKEN into .git/config of the checked-out
+          # tree. The deploy-pages step uses actions/upload-pages-artifact
+          # which would otherwise ship the token in the artifact
+          # (zizmor's `artipacked` finding). No git push from this job.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:

--- a/.github/workflows/mirror-playwright.yml
+++ b/.github/workflows/mirror-playwright.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -64,7 +64,7 @@ jobs:
     steps:
       - name: Detect code-vs-docs-only changes
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             code:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,15 @@ jobs:
       # needed. Also covers provenance attestation (sigstore).
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:
           run_install: false
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -55,7 +55,7 @@ jobs:
 
       - name: Create Version Packages PR or publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
         with:
           # `pnpm run <script>` disambiguates from pnpm's built-ins
           # (`pnpm version` would hit the built-in and silently no-op).

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,27 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor (workflow static analysis)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # Required for zizmor to read the GitHub API for cross-repo
+      # reference resolution (e.g., confirming pinned-SHA tags exist).
+      security-events: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
## Summary

Two changes that reinforce each other — see [Astral's security post](https://astral.sh/blog/open-source-security-at-astral) for the broader framing.

**Pin every action `uses:` reference to a commit SHA.** All 13 unique actions across our 6 workflow files now pinned to 40-char SHAs with a trailing version comment for human readability + Dependabot consumption (Dependabot understands and bumps this format automatically).

| Action | Pinned to |
|---|---|
| `actions/checkout` | `de0fac2…` # v6 |
| `actions/setup-node` | `48b55a0…` # v6 |
| `actions/cache` | `27d5ce7…` # v5 |
| `actions/upload-artifact` | `043fb46…` # v7 |
| `actions/upload-pages-artifact` | `fc324d3…` # v5 |
| `actions/configure-pages` | `45bfe01…` # v6 |
| `actions/deploy-pages` | `cd2ce8f…` # v5 |
| `amannn/action-semantic-pull-request` | `e32d7e6…` # v5 |
| `docker/login-action` | `c94ce9f…` # v3 |
| `pnpm/action-setup` | `fc06bc1…` # v5 |
| `changesets/action` | `63a615b…` # v1.8.0 |
| `dorny/paths-filter` | `d1c1ffe…` # v3 |
| `chromaui/action` | `8ad69a4…` # v17.1.0 (was `@latest` — worst pin) |

**Add zizmor workflow audit.** `.github/workflows/security.yml` runs `zizmor` (Rust-based static analysis for GitHub Actions, by Trail of Bits' William Woodruff) on every push and on PRs that touch workflows. Catches future regressions: unpinned-uses, dangerous triggers, template injection (`${{ secrets.X }}` flowing into shell), excessive permissions, impostor commits. Findings surface in the repo's Security tab via SARIF, alongside CodeQL.

## Why this matters

Tag hijack is a live supply-chain vector. `tj-actions/changed-files` was compromised in 2025 — the attacker moved the `@v1` tag to a malicious commit; every CI run that pulled `@v1` between the move and the disclosure exfiltrated repository secrets. For swatchbook the worst case is the npm OIDC token from `release.yml` leaking, which would let an attacker publish a malicious version. The pinning eliminates this class of risk; zizmor keeps future workflow changes from quietly reintroducing it.

## Test plan

- [x] `grep` confirms no unpinned `uses:` remain
- [x] All SHAs resolved from GitHub's actual repos via `git ls-remote` (annotated-tag-aware)
- [x] Comment trailers in Dependabot-compatible format
- [x] zizmor workflow itself uses pinned actions (`checkout` + `zizmor-action` both SHA-pinned)
- [x] zizmor workflow runs only on workflow-file changes for PRs (path filter) to avoid noise on unrelated PRs
- [x] No source/test changes — pure CI hardening

No changeset (CI-only, no published-package surface change).

Milestone: Maintenance

Closes #1038