### PR TITLE
ci: gate release on deployment environment with required approval

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
     # changesets/action handles its own re-entry via the Version Packages PR.
     if: github.repository == 'unpunnyfuns/swatchbook'
     runs-on: ubuntu-latest
+    # Gates `changeset publish` on a deployment environment that requires
+    # human approval (configured under repo Settings → Environments → release).
+    # Defends against the compromised-maintainer-account scenario: if a
+    # malicious commit lands on main and squeaks a changeset through, the
+    # publish step still pauses for a second human's review before the
+    # OIDC token is exchanged for an npm publish.
+    environment: release
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,14 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          # Don't write GITHUB_TOKEN into .git/config. changesets/action
+          # below authenticates via the GITHUB_TOKEN env var (not via
+          # .git/config), and `gh pr edit` / `gh pr close` use GH_TOKEN.
+          # `git fetch origin changeset-release/main` in the title-polish
+          # step works without auth on a public repo. So persisted
+          # credentials aren't actually needed by anything downstream —
+          # disabling closes zizmor's `artipacked` finding.
+          persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         with:

--- a/apps/docs/docs/developers/sharp-corners.mdx
+++ b/apps/docs/docs/developers/sharp-corners.mdx
@@ -150,6 +150,12 @@ See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, di
 
 **Rule:** don't prune those entries from the `build` inputs. If you add a new versioned docs artifact, include it too.
 
+### Release publishes through a deployment environment that requires human approval
+
+**Shape:** the release workflow (`.github/workflows/release.yml`) declares `environment: release`. Merging the Version Packages PR triggers a deployment that pauses for an approver before `changeset publish` runs. The approver list lives under repo Settings → Environments → release. Required reviewers ≥ 1.
+
+**Rule:** when a release stalls after the Version Packages PR merges, check the Actions tab for a pending deployment review. A privileged org member needs to approve the deployment to release. This is intentional — the gate defends against the compromised-maintainer-account scenario where a malicious commit lands on main and a publish would otherwise proceed unattended.
+
 ## MCP
 
 ### stderr for logs, stdout reserved for protocol frames


### PR DESCRIPTION
## Summary

Adds `environment: release` to the release job in `.github/workflows/release.yml`. Combined with a repo-level GitHub Environment configured with required reviewers (≥1 privileged org member), this gates `changeset publish` on human approval after the Version Packages PR merges.

Inspired by [Astral's open-source security post](https://astral.sh/blog/open-source-security-at-astral). Defends against the compromised-maintainer-account scenario: even if a malicious commit lands on main and a changeset squeaks through, the publish step still requires a second human's approval before the OIDC token is exchanged for an npm publish.

## What this does today

The PR adds the workflow-side line. The deployment gate only activates once the `release` environment is created at the repo level (Settings → Environments → New environment → name: `release` → add required reviewers). Until then, the workflow runs through the environment without an approval prompt (effectively a no-op).

## Docs change

Updates `developers/sharp-corners.mdx` so the next release author knows to look for a pending deployment review when a release stalls.

## Stacking

Based on #1043 (release-no-cache), which is based on #1042 (pin-actions-zizmor). The release.yml line being added sits adjacent to the cache disable from #1043, so this PR stacks cleanly on it.

## Test plan

- [x] release.yml YAML parses cleanly (existing workflow + `environment:` line)
- [x] sharp-corners.mdx documents the gate
- [x] Docs build clean
- [ ] **Org-config step (out of PR scope)**: configure the `release` environment with required reviewers before this lands, or the gate is a no-op

Milestone: Maintenance

Closes #1039