### PR TITLE
chore: patch changeset to trigger release verifying the new approval gate

### DIFF
--- a/.changeset/security-infrastructure-snapshot.md
+++ b/.changeset/security-infrastructure-snapshot.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Internal release: ships the security-infrastructure documentation added in #1044 into the current minor's docs snapshot. No published-package behaviour change. The recent CI hardening landed across #1042 (pin GitHub Actions to commit SHAs + add zizmor workflow audit), #1043 (disable Actions cache during release for cache-poisoning defense), #1044 (gate release on deployment environment with required approval), and #1046 (fix template-injection findings in mirror-playwright). The release-approval gate is documented under `developers/sharp-corners.mdx`.


### PR DESCRIPTION
## Summary

Single-file PR adding a patch changeset. Two purposes:

1. **Snapshot fix:** #1044 added a section to `developers/sharp-corners.mdx` documenting the new release-approval gate, but went out without a changeset. Per the docs-only-PR convention, docs changes need a patch changeset so `scripts/snapshot-docs-version.mjs` rebuilds the current minor's docs snapshot. Without one the change only reaches `/next/`. This PR fills that gap.

2. **End-to-end verification of the new release-approval gate:** none of the recent security PRs (#1042, #1043, #1044, #1046) carry changesets — they're CI/infrastructure, no published-package surface change. So nothing on main has been triggering a release naturally, and the new approval gate in #1044 hasn't actually been exercised. Merging this opens a Version Packages PR; merging that triggers the release workflow, which should now pause for deployment approval before `changeset publish` runs.

## What to watch when this releases

- ✅ **Workflow pauses at the deployment-approval gate** after the Version Packages PR merges. Visible in the Actions tab as "Deployment pending review."
- ✅ Approval button appears for the configured required reviewer.
- ✅ After approval, publish runs normally — same as previous releases except for the pause.
- ✅ Tag created via GitHub Release; tag ruleset doesn't block (GitHub Release-created tags are a separate code path from `git push --tags`).
- ⚠️ Anything other than "pause for approval" indicates the gate isn't wired correctly and needs investigation.

## Out of scope

No package source changes. No version bump beyond the patch. The release ships the doc snapshot + (implicitly) the security-infrastructure changes already on main.

Milestone: Maintenance