### PR TITLE
ci: gate release environment only on publish runs

### DIFF
--- a/.changeset/release-gate-publish-only.md
+++ b/.changeset/release-gate-publish-only.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+The release workflow's `release` environment now gates only on publish runs (the Version Packages PR's squash-merge), not on every push to main. Previously every changeset-PR merge would pause for approval even though no publish was about to happen — the action would just open a VP PR. Now the gate fires only when `github.event.head_commit.message` starts with `chore(release):` — i.e., the VP PR was just merged and `changeset publish` is about to run. Routine pushes proceed unattended. Documented in `developers/sharp-corners.mdx`. No published-package behaviour change.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,16 @@ jobs:
     # malicious commit lands on main and squeaks a changeset through, the
     # publish step still pauses for a second human's review before the
     # OIDC token is exchanged for an npm publish.
-    environment: release
+    #
+    # Conditional so the gate only fires on the Version Packages PR's merge
+    # commit (the one that actually triggers `changeset publish`), not on
+    # every push to main. The Changesets release workflow runs in two
+    # modes: (1) open/update the Version Packages PR when changesets are
+    # pending — no publish, no gate; (2) publish when the VP PR was just
+    # merged — gated. The VP PR's squash-merge always starts with
+    # `chore(release):` (either the default `chore(release): version packages`
+    # or our customized `chore(release): vX.Y.Z`).
+    environment: ${{ startsWith(github.event.head_commit.message, 'chore(release):') && 'release' || '' }}
     permissions:
       contents: write
       pull-requests: write

--- a/apps/docs/docs/developers/sharp-corners.mdx
+++ b/apps/docs/docs/developers/sharp-corners.mdx
@@ -152,9 +152,9 @@ See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, di
 
 ### Release publishes through a deployment environment that requires human approval
 
-**Shape:** the release workflow (`.github/workflows/release.yml`) declares `environment: release`. Merging the Version Packages PR triggers a deployment that pauses for an approver before `changeset publish` runs. The approver list lives under repo Settings → Environments → release. Required reviewers ≥ 1.
+**Shape:** the release workflow (`.github/workflows/release.yml`) gates the `release` environment behind a conditional — `environment: ${{ startsWith(github.event.head_commit.message, 'chore(release):') && 'release' || '' }}`. The expression resolves to `release` only when the head commit's message starts with `chore(release):` — i.e., the Version Packages PR's squash-merge. Every other push to main (feature merges, changeset-only PR merges) runs without the gate, because those don't publish — they only open or update the Version Packages PR. The approver list lives under repo Settings → Environments → release. Required reviewers ≥ 1.
 
-**Rule:** when a release stalls after the Version Packages PR merges, check the Actions tab for a pending deployment review. A privileged org member needs to approve the deployment to release. This is intentional — the gate defends against the compromised-maintainer-account scenario where a malicious commit lands on main and a publish would otherwise proceed unattended.
+**Rule:** when a release stalls after the Version Packages PR merges, check the Actions tab for a pending deployment review. A privileged org member needs to approve the deployment to release. This is intentional — the gate defends against the compromised-maintainer-account scenario where a malicious commit lands on main and a publish would otherwise proceed unattended. Routine merges (anything that isn't a Version Packages PR) don't fire the gate.
 
 ## MCP
 


### PR DESCRIPTION
## Summary

Refines the deployment-approval gate from #1044 so it fires only on the actual publish run, not on every push to main. Previously every changeset-PR merge (or any other push to main) would pause for approval even when no publish was about to happen — the action would just open a Version Packages PR. That's friction without security value.

## Fix

Makes the environment conditional on the head commit message:

\`\`\`yaml
environment: \${{ startsWith(github.event.head_commit.message, 'chore(release):') && 'release' || '' }}
\`\`\`

The Version Packages PR's squash-merge always starts with \`chore(release):\` (either Changesets' default \`chore(release): version packages\` or our customized \`chore(release): vX.Y.Z\` from the title-polish step). When the head commit matches, the expression resolves to \`release\` and the gate fires. Every other push resolves to an empty string and runs without the gate.

Security posture: unchanged. The publish path is still gated, and that's the path that actually exchanges the OIDC token for npm publish access. The non-publish path (opening a VP PR) doesn't touch secrets — there's nothing to gate.

## Docs

\`developers/sharp-corners.mdx\` updated to reflect the conditional shape and the "routine merges don't fire the gate" property.

## Test plan

- Merging this PR: should run the workflow WITHOUT pausing (head commit message doesn't start with \`chore(release):\`).
- Resulting VP PR's merge: SHOULD pause (head commit message starts with \`chore(release):\`).

This PR's own merge thus serves as the first test of the new behavior. If the workflow pauses on this PR's merge, the conditional isn't working correctly.

Milestone: Maintenance

Closes #1049