### PR TITLE
fix: show a type-appropriate CSS property in the token usage snippet

### DIFF
--- a/.changeset/token-usage-snippet-type.md
+++ b/.changeset/token-usage-snippet-type.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+`TokenUsageSnippet` now emits a CSS property matching the token's `$type` instead of always `color:`. Color tokens still show `color: var(--…)`; shadow/border/font tokens show their canonical property (`box-shadow`, `border`, `font-family`, …); and types with no single canonical property (`dimension`, `number`) show the var reference prefixed with a `/* <type> */` hint rather than a misleading property.

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -73,20 +73,21 @@ export function GradientPalette({
   sortDir = 'asc',
 }: GradientPaletteProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
   const colorFormat = useColorFormat();
 
   const rows = useMemo<Row[]>(() => {
+    const projectFields = { listing, cssVarPrefix };
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'gradient') return false;
       return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
       path,
-      cssVar: resolveCssVar(path, project),
+      cssVar: resolveCssVar(path, projectFields),
       stops: asStops(token.$value),
     }));
-  }, [resolved, filter, project, sortBy, sortDir]);
+  }, [resolved, listing, cssVarPrefix, filter, sortBy, sortDir]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/internal/channel-tokens.ts
+++ b/packages/blocks/src/internal/channel-tokens.ts
@@ -98,6 +98,10 @@ function getSnapshot(): TokenSnapshot {
   return snapshot;
 }
 
+function getServerSnapshot(): TokenSnapshot {
+  return snapshot;
+}
+
 export function useTokenSnapshot(): TokenSnapshot {
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }

--- a/packages/blocks/src/token-detail/TokenUsageSnippet.tsx
+++ b/packages/blocks/src/token-detail/TokenUsageSnippet.tsx
@@ -7,10 +7,34 @@ export interface TokenUsageSnippetProps {
   path: string;
 }
 
+/**
+ * DTCG `$type`s with a single canonical CSS property. Types whose value is
+ * applied across many properties (`dimension`, `number`, `strokeStyle`,
+ * `typography`) are intentionally absent — they fall back to a commented hint.
+ */
+const CSS_PROPERTY_BY_TYPE: Record<string, string> = {
+  color: 'color',
+  shadow: 'box-shadow',
+  border: 'border',
+  fontFamily: 'font-family',
+  fontWeight: 'font-weight',
+  duration: 'transition-duration',
+  cubicBezier: 'transition-timing-function',
+  gradient: 'background',
+  transition: 'transition',
+};
+
+function usageSnippet(cssVar: string, type: string | undefined): string {
+  const property = type ? CSS_PROPERTY_BY_TYPE[type] : undefined;
+  if (property) return `${property}: ${cssVar};`;
+  if (type) return `/* ${type} */ ${cssVar};`;
+  return `${cssVar};`;
+}
+
 export function TokenUsageSnippet({ path }: TokenUsageSnippetProps): ReactElement | null {
   const { token, cssVar } = useTokenDetailData(path);
   if (!token) return null;
-  const snippet = `color: ${cssVar};`;
+  const snippet = usageSnippet(cssVar, token.$type);
   return (
     <>
       <div className="sb-token-detail__section-header">Usage</div>

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -55,9 +55,10 @@ function logPhase(label: string, startedAt: number): void {
 export async function loadProject(config: Config, cwd: string = process.cwd()): Promise<Project> {
   const loadStart = performance.now();
   const logger = new BufferedLogger({ level: 'warn' });
+  const cssVarPrefix = config.cssVarPrefix ?? DEFAULT_CSS_VAR_PREFIX;
   const configWithDefaults: Config = {
     ...config,
-    cssVarPrefix: config.cssVarPrefix ?? DEFAULT_CSS_VAR_PREFIX,
+    cssVarPrefix,
   };
   const tParse = performance.now();
   const normalized = await normalizePermutations(configWithDefaults, cwd, logger);
@@ -119,16 +120,11 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   const tListing = performance.now();
   const { listing, diagnostics: listingDiagnostics } =
     normalized.parserInput !== undefined
-      ? await computeTokenListing(
-          normalized.parserInput,
-          cwd,
-          configWithDefaults.cssVarPrefix ?? '',
-          {
-            ...(config.cssOptions !== undefined && { cssOptions: config.cssOptions }),
-            ...(config.listingOptions !== undefined && { listingOptions: config.listingOptions }),
-            ...(config.terrazzoPlugins !== undefined && { extraPlugins: config.terrazzoPlugins }),
-          },
-        )
+      ? await computeTokenListing(normalized.parserInput, cwd, cssVarPrefix, {
+          ...(config.cssOptions !== undefined && { cssOptions: config.cssOptions }),
+          ...(config.listingOptions !== undefined && { listingOptions: config.listingOptions }),
+          ...(config.terrazzoPlugins !== undefined && { extraPlugins: config.terrazzoPlugins }),
+        })
       : { listing: {}, diagnostics: [] };
   logPhase('token-listing build', tListing);
 

--- a/packages/integrations/src/css-in-js.ts
+++ b/packages/integrations/src/css-in-js.ts
@@ -94,7 +94,8 @@ function renderTheme(project: Project): string {
 }
 
 function collectPaths(project: Project): string[] {
-  return [...listPaths(project.tokenGraph)].toSorted();
+  // listPaths already returns a sorted array; copy it to a mutable string[].
+  return [...listPaths(project.tokenGraph)];
 }
 
 interface TreeNode {


### PR DESCRIPTION
Clears the low-severity cleanup nits from the deep-review batch (#1053). One user-visible fix, four internal tidy-ups:

- **`TokenUsageSnippet`** (user-visible) — emit a CSS property matching the token's `$type` instead of always `color:`. Color → `color:`, shadow → `box-shadow:`, border → `border:`, font tokens → their property; types with no single canonical property (`dimension`, `number`) show the var with a `/* <type> */` hint rather than a misleading property. Changeset included.
- **`load.ts`** — extract a typed `cssVarPrefix` local so the listing call no longer re-coalesces `cssVarPrefix ?? ''` against an already-defaulted value.
- **`css-in-js`** — drop the redundant `.toSorted()`; `listPaths()` already returns a sorted array.
- **`channel-tokens`** — give `useTokenSnapshot` a `getServerSnapshot`, matching the sibling `useChannelGlobals` hook.
- **`GradientPalette`** — depend on `{ listing, cssVarPrefix }` instead of the whole `project` object in the rows memo, mirroring `ColorPalette`.

The FLAT test-structure items also listed in #1053 are handled in #1054. Deferred from #1053 as low-priority follow-ups: the two optional test-coverage additions (`css-axis-projected-many-axes` correctness assert, layered last-wins overlapping-write case) and the `CLAUDE.md` "Current state" version staleness (v0.20.1 → v0.60.7).

`format:check` / `lint` / `typecheck` / `test` green on core, integrations, and blocks (220 + 184 tests).

Milestone: Maintenance

Closes #1053

Plan impact: none — cleanup batch, no design or plan changes.