### PR TITLE
fix(blocks): restore TokenNavigator focus when the focused row is removed

### DIFF
--- a/.changeset/token-navigator-focus-repair.md
+++ b/.changeset/token-navigator-focus-repair.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+`TokenNavigator` now restores keyboard focus to the first visible row when the focused token disappears from the tree (e.g. a toolbar axis flip drops a theme-specific token, or a live token edit removes the focused row). Previously the browser orphaned focus onto `<body>`, breaking the roving-tabindex invariant until the user tabbed back in.

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -317,13 +317,29 @@ export function TokenNavigator({
     if (focusedPath === null) return;
     const node = treeItemRefs.current.get(focusedPath);
     if (node && document.activeElement !== node) {
-      // Only steal focus if it currently sits on a different treeitem
-      // inside our tree — don't yank it away from the search input or
-      // anything outside.
       const active = document.activeElement;
+      // Move focus to the repaired row in two cases:
+      // 1. Focus sits on a different treeitem inside our tree (e.g. after
+      //    Right-arrow expands a group and the queued child mounts).
+      // 2. The previously-focused row was removed (a toolbar axis flip
+      //    dropped a token, a search narrowed the tree, a live edit) and
+      //    the browser orphaned focus onto <body>. `focusedPath` has
+      //    repaired to the first visible row but `storedFocus` still names
+      //    the gone row — restore the live focus to match.
+      // Don't yank focus from the search input or anything else still
+      // legitimately focused, and don't grab it on mount (storedFocus null).
       const insideTree = active instanceof HTMLElement && active.closest('[role="tree"]');
-      if (insideTree) node.focus();
+      const orphaned = active === document.body || active === null;
+      const focusedRowRemoved = storedFocus !== null && storedFocus !== focusedPath;
+      if (insideTree || (orphaned && focusedRowRemoved)) node.focus();
     }
+    // Deps are intentionally just `focusedPath`. The repair fires when the
+    // focused row changes — including when a removed row forces the fall back
+    // to the first visible row — NOT on every `storedFocus` change (that would
+    // re-run while DOM focus sits on a descendant leaf and steal it to the
+    // group). Reading `storedFocus` from the triggering render is correct: on
+    // removal it still names the now-gone row, so `focusedRowRemoved` holds.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [focusedPath]);
 
   const handleTreeKeyDown = useCallback(

--- a/packages/blocks/test/detail-overlay-dismissal.browser.test.tsx
+++ b/packages/blocks/test/detail-overlay-dismissal.browser.test.tsx
@@ -8,7 +8,7 @@
  * `detail-overlay-focus-lifecycle.browser.test.tsx` and
  * `detail-overlay-focus-trap.browser.test.tsx`.
  */
-import { userEvent } from '@vitest/browser/context';
+import { page, userEvent } from '@vitest/browser/context';
 import { cleanup, screen } from '@testing-library/react';
 import { afterEach, expect, it } from 'vitest';
 import { renderOverlay } from './_detail-overlay-helpers.tsx';
@@ -21,16 +21,16 @@ it('calls onClose on Escape', async () => {
   expect(onClose).toHaveBeenCalledTimes(1);
 });
 
-it('calls onClose on backdrop click', () => {
-  // The backdrop sits behind the panel (right-aligned, 560px wide).
-  // `userEvent.click(backdrop)` aims at the element's bounding-box
-  // center, which the panel covers — Playwright then clicks the
-  // panel and `stopPropagation` swallows it. Click the top-left
-  // corner instead to hit the visible backdrop area, matching how a
-  // real user dismisses the overlay (anywhere outside the panel).
+it('calls onClose on backdrop click', async () => {
+  // The panel is a right-aligned slide-over (`min(560px, 100%)`), so a bare
+  // backdrop strip only exists at desktop widths — at narrow widths the panel
+  // fills the viewport and there is nothing outside it to click. Widen the
+  // viewport, then aim a real geometry click at the top-left (bare backdrop),
+  // the way a user dismisses the overlay by clicking outside the panel.
+  await page.viewport(1024, 768);
   const { onClose } = renderOverlay();
   const backdrop = screen.getByTestId('swatchbook-overlay');
-  backdrop.click();
+  await userEvent.click(backdrop, { position: { x: 8, y: 8 } });
   expect(onClose).toHaveBeenCalledTimes(1);
 });
 

--- a/packages/blocks/test/token-navigator-focus-repair.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-focus-repair.browser.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * Focus repair when the focused leaf disappears from the resolved data.
+ *
+ * The roving-tabindex effect repairs DOM focus to a visible treeitem when
+ * the previously-focused row is removed. The reachable trigger is a
+ * resolved-data change while a tree item — not the search input — holds
+ * focus: flipping a toolbar axis (or a live token edit) can drop a
+ * theme-specific token the user had arrow-navigated onto. On unmount the
+ * browser reassigns focus to <body>; the effect must move it back onto a
+ * visible row rather than leave it dead there.
+ *
+ * (The search path does NOT trigger this: typing keeps focus on the
+ * search input, where the effect correctly declines to steal it.)
+ *
+ * The fixture uses single-segment paths so each token is a top-level
+ * treeitem with no ancestor group — `onFocus` is focusin-based and bubbles,
+ * so a leaf nested under a group would hand `storedFocus` to the group on a
+ * raw `.focus()`. Top-level leaves keep `storedFocus` on the row itself,
+ * matching what arrow-key navigation produces in practice.
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { SwatchbookProvider, TokenNavigator } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+// `bravo` exists only in the Light theme; flipping to Dark drops it.
+const LIGHT: Record<string, VirtualTokenShape> = {
+  alpha: { $type: 'color', $value: { hex: '#000011' } },
+  bravo: { $type: 'color', $value: { hex: '#000022' } },
+  charlie: { $type: 'color', $value: { hex: '#000033' } },
+};
+const DARK: Record<string, VirtualTokenShape> = {
+  alpha: { $type: 'color', $value: { hex: '#111011' } },
+  charlie: { $type: 'color', $value: { hex: '#111033' } },
+};
+
+function snapshotFor(activeTheme: 'Light' | 'Dark'): ProjectSnapshot {
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light', 'Dark'], default: 'Light', source: 'synthetic' }],
+    disabledAxes: [],
+    presets: [],
+    defaultTuple: { theme: 'Light' },
+    activeTheme,
+    activeAxes: { theme: activeTheme },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = (tuple) => (tuple['theme'] === 'Dark' ? DARK : LIGHT);
+  return snap;
+}
+
+const view = (theme: 'Light' | 'Dark') => (
+  <SwatchbookProvider value={snapshotFor(theme)}>
+    <TokenNavigator searchable={false} />
+  </SwatchbookProvider>
+);
+
+afterEach(cleanup);
+
+it('restores focus to a visible treeitem when the focused leaf is removed from the data', async () => {
+  const { rerender } = render(view('Light'));
+
+  // Focus the middle leaf — its <li> onFocus records storedFocus. Wait for
+  // the roving tabindex to settle on it so the focus commit lands before the
+  // flip (as it would in real use: navigate, *then* change the theme — not
+  // both in one batched update).
+  const focused = within(screen.getByRole('tree'))
+    .getAllByRole('treeitem')
+    .find((el) => el.getAttribute('data-path') === 'bravo') as HTMLLIElement;
+  focused.focus();
+  await waitFor(() => {
+    expect(focused.getAttribute('tabindex')).toBe('0');
+  });
+  expect(document.activeElement).toBe(focused);
+
+  // Flip the theme — `bravo` is no longer resolved, so its row unmounts.
+  rerender(view('Dark'));
+
+  // Focus must not be orphaned on <body>; it lands on a visible row.
+  await waitFor(() => {
+    expect(document.activeElement).not.toBe(document.body);
+  });
+  const items = within(screen.getByRole('tree')).getAllByRole('treeitem');
+  expect(items).toContain(document.activeElement);
+});


### PR DESCRIPTION
Two focus/overlay fixes surfaced by the deep review.

## TokenNavigator focus repair (#1056)

When the row a user has arrow-navigated onto disappears — a toolbar axis flip drops a theme-specific token, or a live token edit removes it — the browser reassigns focus to `<body>`. The roving-tabindex repair effect only restored focus when the active element was already inside the tree (`closest('[role="tree"]')`), so orphaned focus stayed dead on `<body>`, breaking keyboard navigation until the user tabbed back in.

The fix detects the orphan case (`active === document.body`) **when the previously-focused row was actually removed** (`storedFocus` no longer equals the repaired `focusedPath`) and re-homes focus onto the first visible row. It deliberately does **not** grab focus on mount (storedFocus is null) or steal it from the search input (focus would be on the input, not `body`).

Notes for reviewers:
- The originally-filed fix in #1056 (`!document.body.contains(active)`) was wrong — once a focused element unmounts, `document.activeElement` *is* `body`, and `body.contains(body)` is `true`, so that guard never fires. The correct signal is `active === document.body`.
- The effect deps stay `[focusedPath]` (not `[…, storedFocus]`): the orphan trigger already changes `focusedPath`, and adding `storedFocus` would re-run the effect while DOM focus sits on a descendant leaf and steal it up to the group row.
- Adds a red/green browser regression test (verified failing without the fix). The reachable trigger is a resolved-data change, not the search input — typing keeps focus on the input where the effect correctly declines to steal.

## Overlay backdrop-click test (#1057)

Replaces the raw imperative `backdrop.click()` with `userEvent` geometry. The slide-over panel is `min(560px, 100%)`, so a bare backdrop strip to click only exists at desktop width — the test now widens the viewport, then clicks the top-left (outside the panel) the way a user dismisses the overlay.

`format:check` / `lint` / `typecheck` / `test` green on blocks (186 tests).

Milestone: Maintenance

Closes #1056
Closes #1057

Plan impact: none — bug fix plus test correction, no design changes.