### PR TITLE
fix(blocks): persist TokenNavigator expand/collapse state across mode switches

### DIFF
--- a/.changeset/navigator-state-persistence.md
+++ b/.changeset/navigator-state-persistence.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+`TokenNavigator` no longer resets its expand/collapse state when the active tuple changes. Previously, flipping a mode/brand/contrast in the toolbar gave `resolved` (and the derived tree) a fresh identity, which snapped the tree back to the `initiallyExpanded` default — collapsing whatever the user had opened. The expand/collapse state now persists across settings changes and is re-seeded only when the `initiallyExpanded` prop itself changes.

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -225,9 +225,17 @@ export function TokenNavigator({
   }, [tree, initiallyExpanded]);
 
   const [expanded, setExpanded] = useState<Set<string>>(initialExpanded);
+  const initiallyExpandedRef = useRef(initiallyExpanded);
   useEffect(() => {
+    // Re-seed the expand/collapse state ONLY when the `initiallyExpanded`
+    // prop itself changes — not when `initialExpanded` merely gets a fresh
+    // identity because `resolved`/`tree` churned on an axis flip. `resolved`
+    // is recomputed per active tuple, so without this guard every mode switch
+    // would snap the user's expand/collapse state back to the default.
+    if (initiallyExpandedRef.current === initiallyExpanded) return;
+    initiallyExpandedRef.current = initiallyExpanded;
     setExpanded(initialExpanded);
-  }, [initialExpanded]);
+  }, [initiallyExpanded, initialExpanded]);
 
   const [selectedPath, setSelectedPath] = useState<string | null>(null);
   const [query, setQuery] = useState('');

--- a/packages/blocks/test/token-navigator-state-persistence.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-state-persistence.browser.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Expand/collapse state must survive a settings change.
+ *
+ * `resolved` gets a fresh identity on every axis flip (it is recomputed per
+ * active tuple), so anything the navigator memoizes off it — including the
+ * derived `initialExpanded` set — churns identity on a mode switch. The
+ * expand/collapse state the user built up must NOT be reset back to the
+ * `initiallyExpanded` default when only token values change underneath.
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, expect, it } from 'vitest';
+import { SwatchbookProvider, TokenNavigator } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+// Same paths in both themes — only the values differ, as with a real mode flip.
+const LIGHT: Record<string, VirtualTokenShape> = {
+  'color.a': { $type: 'color', $value: { hex: '#000011' } },
+  'color.b': { $type: 'color', $value: { hex: '#000022' } },
+};
+const DARK: Record<string, VirtualTokenShape> = {
+  'color.a': { $type: 'color', $value: { hex: '#111011' } },
+  'color.b': { $type: 'color', $value: { hex: '#111022' } },
+};
+
+function snapshotFor(activeTheme: 'Light' | 'Dark'): ProjectSnapshot {
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light', 'Dark'], default: 'Light', source: 'synthetic' }],
+    disabledAxes: [],
+    presets: [],
+    defaultTuple: { theme: 'Light' },
+    activeTheme,
+    activeAxes: { theme: activeTheme },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = (tuple) => (tuple['theme'] === 'Dark' ? DARK : LIGHT);
+  return snap;
+}
+
+const view = (theme: 'Light' | 'Dark') => (
+  <SwatchbookProvider value={snapshotFor(theme)}>
+    {/* initiallyExpanded=0 — the `color` group starts collapsed. */}
+    <TokenNavigator initiallyExpanded={0} searchable={false} />
+  </SwatchbookProvider>
+);
+
+const group = (path: string): HTMLLIElement =>
+  within(screen.getByRole('tree'))
+    .getAllByRole('treeitem')
+    .find((el) => el.getAttribute('data-path') === path) as HTMLLIElement;
+
+afterEach(cleanup);
+
+it('keeps the user-expanded group expanded across a mode switch', async () => {
+  const { rerender } = render(view('Light'));
+
+  // Expand the `color` group (it starts collapsed at initiallyExpanded=0).
+  const color = group('color');
+  expect(color.getAttribute('aria-expanded')).toBe('false');
+  color.focus();
+  await userEvent.keyboard(' ');
+  await waitFor(() => {
+    expect(group('color').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  // Flip the theme — same paths, different values.
+  rerender(view('Dark'));
+
+  // The expansion the user built must persist, not snap back to the default.
+  expect(group('color').getAttribute('aria-expanded')).toBe('true');
+});


### PR DESCRIPTION
## Problem

`TokenNavigator` reset its expand/collapse state to the `initiallyExpanded` default on every settings change — flipping a mode/brand/contrast in the toolbar snapped the tree shut, losing whatever the user had opened.

## Root cause

`tree` is memoized on `resolved`, and `resolved` is recomputed per active tuple. A mode switch therefore gives `resolved` → `tree` → `initialExpanded` a fresh identity even though the token *paths* are unchanged, and the re-seed effect (`useEffect(() => setExpanded(initialExpanded), [initialExpanded])`) blindly snapped `expanded` back to the default.

## Fix

Re-seed `expanded` only when the `initiallyExpanded` **prop** changes, via a ref guard — not when `initialExpanded` merely gets a new identity from a `resolved`/`tree` rebuild.

## Scope

`TokenNavigator` is the only block with this anti-pattern. Verified: the addon's preview decorator does not remount the story subtree on a mode switch (provider value changes, but `<Story />` is not keyed), and `ColorTable`/`TokenTable` hold expansion/selection in plain `useState` with no re-seed effect, so they already persist.

Adds a red/green browser regression test (expand a group → flip the theme → assert it stays expanded; verified failing without the fix). `format:check` / `lint` / `typecheck` / `test` green on blocks (188 tests).

Milestone: Maintenance

Closes #1060

Plan impact: none — bug fix, no design changes.