### PR TITLE
ci: authenticate release workflow via a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,23 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      # Mint a short-lived GitHub App installation token for changesets/action
+      # and the PR-polish steps below. The default GITHUB_TOKEN is deliberately
+      # barred by GitHub from triggering further workflow runs, so when the
+      # action force-pushes `changeset-release/main` to absorb a newly-merged
+      # changeset, no CI / Chromatic / PR-lint runs spawn and the Version
+      # Packages PR's required checks stall Expected-forever (see issue #1062).
+      # Pushes made with an App installation token DO trigger workflows. The
+      # token is short-lived and scoped to the App's install permissions
+      # (Contents + Pull requests: write); OIDC trusted publishing below is
+      # unaffected — it uses the separate id-token, not this token.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Create Version Packages PR or publish
         id: changesets
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
@@ -96,7 +113,10 @@ jobs:
           commit: 'chore(release): version packages'
           title: 'chore(release): version packages'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # App-installation token (not the default GITHUB_TOKEN) so the
+          # push to `changeset-release/main` triggers the release PR's
+          # required checks — see the "Mint GitHub App token" step.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Trusted publishing is configured on npm for every published
           # fixed-group package (core, addon, blocks, switcher, mcp). No
           # NPM_TOKEN / NODE_AUTH_TOKEN needed; npm picks up the GitHub
@@ -182,7 +202,7 @@ jobs:
       - name: Polish Version Packages PR title + body
         if: steps.changesets.outputs.pullRequestNumber && steps.changesets.outputs.published != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
         run: |
           set -e
@@ -219,7 +239,7 @@ jobs:
       # one.
       - name: Close empty Version Packages PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -e
           pr_json=$(gh pr list --head changeset-release/main --state open --json number,headRefName --limit 1)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,12 @@ jobs:
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # Scope the minted token to least privilege rather than inheriting
+          # the App's full installation permissions: changesets/action only
+          # needs to push `changeset-release/main` (contents) and open/update
+          # the Version Packages PR (pull-requests).
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create Version Packages PR or publish
         id: changesets


### PR DESCRIPTION
Authenticates the release workflow's `changesets/action` with a short-lived GitHub App installation token instead of the default token, so updates to the Version Packages branch trigger the required PR checks rather than stalling. The minted token is scoped to least privilege (`contents` + `pull-requests`, write).

Depends on the `RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY` repository secrets (already configured).

Milestone: Maintenance

Closes #1062

Plan impact: none — release-workflow auth change.