### PR TITLE
ci: gate the publish on a dedicated always-gated job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,58 +7,40 @@ on:
 # Prevent concurrent release runs — we don't want two Version Packages PRs
 # racing or a publish triggering while another is mid-flight.
 #
-# `cancel-in-progress: true`: when a newer push arrives (most importantly
-# the Version Packages PR's merge commit right after a sibling feature
-# merge), cancel any earlier in-flight run. The earlier run was only going
-# to regenerate the VP PR from a pre-consumption snapshot of `.changeset/`
-# and would spawn a ghost PR (see issue #361 post-0.3.0 for the symptom).
-# The workflow is idempotent — publishing a version that's already shipped
-# is a no-op on npm, and re-updating the VP PR is free — so cancellation
-# loses no work.
+# `cancel-in-progress: true`: when a newer push arrives, cancel any earlier
+# in-flight run. The earlier run was only going to regenerate the VP PR from a
+# pre-consumption snapshot of `.changeset/` and would spawn a ghost PR (see
+# issue #361 post-0.3.0 for the symptom). Cancellation is safe even when a
+# `publish` job is waiting on its approval gate: the publish decision is
+# re-derived from "is this version on npm yet?" on every run, so a cancelled
+# pending publish simply re-queues — still gated — on the next run rather than
+# being lost or slipping through ungated. `changeset publish` is idempotent.
 concurrency:
   group: release
   cancel-in-progress: true
 
 jobs:
-  release:
-    # Skip on the Changesets bot's own commits to avoid recursion; the
-    # changesets/action handles its own re-entry via the Version Packages PR.
+  # ── Prepare ──────────────────────────────────────────────────────────────
+  # Opens/updates the Version Packages PR (version mode only — never
+  # publishes) and decides whether a publish is now due. Ungated: opening a PR
+  # is harmless, and gating it would force an approval click on every merge to
+  # main. The actual publish lives in the gated `publish` job below.
+  prepare:
+    # Skip on forks; the action handles its own re-entry via the VP PR.
     if: github.repository == 'unpunnyfuns/swatchbook'
     runs-on: ubuntu-latest
-    # Gates `changeset publish` on a deployment environment that requires
-    # human approval (configured under repo Settings → Environments → release).
-    # Defends against the compromised-maintainer-account scenario: if a
-    # malicious commit lands on main and squeaks a changeset through, the
-    # publish step still pauses for a second human's review before the
-    # OIDC token is exchanged for an npm publish.
-    #
-    # Conditional so the gate only fires on the Version Packages PR's merge
-    # commit (the one that actually triggers `changeset publish`), not on
-    # every push to main. The Changesets release workflow runs in two
-    # modes: (1) open/update the Version Packages PR when changesets are
-    # pending — no publish, no gate; (2) publish when the VP PR was just
-    # merged — gated. The VP PR's squash-merge always starts with
-    # `chore(release):` (either the default `chore(release): version packages`
-    # or our customized `chore(release): vX.Y.Z`).
-    environment: ${{ startsWith(github.event.head_commit.message, 'chore(release):') && 'release' || '' }}
+    outputs:
+      should-publish: ${{ steps.detect.outputs.should-publish }}
     permissions:
       contents: write
       pull-requests: write
-      # Required for npm trusted publishing — GitHub's OIDC token is
-      # exchanged for a short-lived publish token; no NPM_TOKEN secret
-      # needed. Also covers provenance attestation (sigstore).
-      id-token: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
-          # Don't write GITHUB_TOKEN into .git/config. changesets/action
-          # below authenticates via the GITHUB_TOKEN env var (not via
-          # .git/config), and `gh pr edit` / `gh pr close` use GH_TOKEN.
-          # `git fetch origin changeset-release/main` in the title-polish
-          # step works without auth on a public repo. So persisted
-          # credentials aren't actually needed by anything downstream —
-          # disabling closes zizmor's `artipacked` finding.
+          # Don't write a token into .git/config. changesets/action below
+          # authenticates via the GITHUB_TOKEN env var, and `gh pr edit` /
+          # `gh pr close` use GH_TOKEN. Closes zizmor's `artipacked` finding.
           persist-credentials: false
 
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
@@ -68,13 +50,161 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
-          # Cache deliberately disabled during release: GitHub Actions
-          # cache poisoning is a documented release-time vector — a
-          # malicious PR populates the cache; a subsequent release run
-          # picks it up and the published artifact carries the payload.
-          # The few seconds saved on cold installs aren't worth the
-          # additional attack surface for a workflow that publishes to
-          # npm with the OIDC token.
+
+      - run: pnpm install --frozen-lockfile
+
+      # Mint a short-lived GitHub App installation token. The default
+      # GITHUB_TOKEN is deliberately barred by GitHub from triggering further
+      # workflow runs, so a push to `changeset-release/main` under it would
+      # leave the VP PR's required checks stalled Expected-forever (issue
+      # #1062). Pushes made with an App token DO trigger workflows. Scoped to
+      # least privilege (Contents + Pull requests: write); publishing below
+      # uses the separate OIDC id-token, never this token.
+      - name: Mint GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      # Decide whether a publish is due — BEFORE the version step mutates the
+      # working tree — from a signal an attacker can't forge: is the committed
+      # `core` version already on npm? This replaces the old commit-message
+      # gate (`startsWith(head_commit.message, 'chore(release):')`), which a
+      # non-release push could route around to publish ungated.
+      #
+      #   - VP PR just merged  → version is bumped + unpublished → publish due.
+      #   - changesets pending → version on main is still the published one →
+      #                          not due (we wait for the VP PR to merge).
+      #   - any other push     → version already on npm → not due (no spurious
+      #                          approval prompts on ordinary merges).
+      - name: Decide whether a publish is due
+        id: detect
+        run: |
+          set -e
+          version=$(jq -r .version packages/core/package.json)
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "Could not read packages/core/package.json#version." >&2
+            exit 1
+          fi
+          on_npm=$(npm view "@unpunnyfuns/swatchbook-core@$version" version \
+            --registry https://registry.npmjs.org 2>/dev/null || true)
+          if [ "$on_npm" = "$version" ]; then
+            echo "core@$version already on npm — no publish due."
+            echo "should-publish=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "core@$version not on npm — a publish is due (gated)."
+            echo "should-publish=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or update the Version Packages PR
+        id: changesets
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
+        with:
+          # `version` only — NO `publish:` input. This job is structurally
+          # incapable of publishing; that is the gated `publish` job's job.
+          # `pnpm run version` → `changeset version` + docs snapshot.
+          version: pnpm run version
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          # App-installation token (not the default GITHUB_TOKEN) so the push
+          # to `changeset-release/main` triggers the VP PR's required checks.
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # The action opens the VP PR with a static title and a boilerplate-led
+      # body. Retitle with the computed next version and trim the boilerplate
+      # so the PR (and its eventual squash-merge commit) reads informatively.
+      - name: Polish Version Packages PR title + body
+        if: steps.changesets.outputs.pullRequestNumber
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
+        run: |
+          set -e
+          git fetch origin changeset-release/main
+          next_version=$(git show origin/changeset-release/main:packages/core/package.json | jq -r .version)
+          if [ -z "$next_version" ] || [ "$next_version" = "null" ]; then
+            echo "Could not read next version — leaving PR #$PR_NUMBER alone."
+            exit 0
+          fi
+
+          echo "Retitling PR #$PR_NUMBER to v$next_version"
+
+          current_body=$(gh pr view "$PR_NUMBER" --json body --jq .body)
+          # Drop everything before the "# Releases" heading changesets emits —
+          # the preceding paragraph is the boilerplate we want gone. Fall back
+          # to the original body if the heading isn't present (defensive).
+          trimmed_body=$(printf '%s\n' "$current_body" | awk 'found{print; next} /^# Releases[[:space:]]*$/{found=1; print}')
+          if [ -z "$trimmed_body" ]; then
+            trimmed_body="$current_body"
+          fi
+
+          gh pr edit "$PR_NUMBER" \
+            --title "chore(release): v$next_version" \
+            --body "$trimmed_body"
+
+      # When the VP branch's diff vs main collapses to nothing (all changesets
+      # consumed, nothing new pending), close the stale PR so the next real
+      # changeset opens a fresh, accurate one.
+      - name: Close empty Version Packages PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -e
+          pr_json=$(gh pr list --head changeset-release/main --state open --json number,headRefName --limit 1)
+          pr_number=$(echo "$pr_json" | jq -r '.[0].number // empty')
+          if [ -z "$pr_number" ]; then
+            echo "No open Version Packages PR to check."
+            exit 0
+          fi
+          diff_stat=$(git fetch origin changeset-release/main && git diff --stat origin/main..origin/changeset-release/main | tail -n 1)
+          if [ -z "$diff_stat" ]; then
+            echo "Version Packages PR #$pr_number has no diff vs main — closing."
+            gh pr close "$pr_number" --delete-branch --comment 'Closed automatically: no changesets pending. The next real changeset on main will open a fresh PR.'
+          else
+            echo "Version Packages PR #$pr_number has real changes — leaving open."
+          fi
+
+  # ── Publish ──────────────────────────────────────────────────────────────
+  # Runs ONLY when `prepare` determined a version is bumped-but-unpublished,
+  # and ALWAYS behind the `release` environment's approval gate — regardless
+  # of which commit triggered the run. This is the fix for the old
+  # commit-message-conditioned gate: there is now exactly one publish path and
+  # it is unconditionally gated, so no push can route a publish around it.
+  publish:
+    needs: prepare
+    if: needs.prepare.outputs.should-publish == 'true'
+    runs-on: ubuntu-latest
+    # Requires human approval (repo Settings → Environments → release).
+    # Defends against the compromised-maintainer scenario: a malicious commit
+    # that squeaks a version bump through still pauses for a second human
+    # before the OIDC token is exchanged for an npm publish.
+    environment: release
+    permissions:
+      contents: read
+      # npm trusted publishing: the OIDC token is exchanged for a short-lived
+      # publish token — no NPM_TOKEN secret. Also covers provenance.
+      id-token: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+        with:
+          run_install: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          # Cache deliberately disabled during publish: Actions cache
+          # poisoning is a documented release-time vector. The few seconds
+          # saved aren't worth the attack surface on a workflow that publishes
+          # to npm with the OIDC token.
           registry-url: https://registry.npmjs.org
 
       # Node 24 ships npm 10.x; trusted publishing needs >= 11.5.1.
@@ -83,68 +213,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
-      # Mint a short-lived GitHub App installation token for changesets/action
-      # and the PR-polish steps below. The default GITHUB_TOKEN is deliberately
-      # barred by GitHub from triggering further workflow runs, so when the
-      # action force-pushes `changeset-release/main` to absorb a newly-merged
-      # changeset, no CI / Chromatic / PR-lint runs spawn and the Version
-      # Packages PR's required checks stall Expected-forever (see issue #1062).
-      # Pushes made with an App installation token DO trigger workflows. The
-      # token is short-lived and scoped to the App's install permissions
-      # (Contents + Pull requests: write); OIDC trusted publishing below is
-      # unaffected — it uses the separate id-token, not this token.
-      - name: Mint GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          # Scope the minted token to least privilege rather than inheriting
-          # the App's full installation permissions: changesets/action only
-          # needs to push `changeset-release/main` (contents) and open/update
-          # the Version Packages PR (pull-requests).
-          permission-contents: write
-          permission-pull-requests: write
-
-      - name: Create Version Packages PR or publish
-        id: changesets
-        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b # v1.8.0
-        with:
-          # `pnpm run <script>` disambiguates from pnpm's built-ins
-          # (`pnpm version` would hit the built-in and silently no-op).
-          # `version` → `changeset version`; `release` builds the
-          # fixed-group packages and runs `changeset publish`.
-          publish: pnpm run release
-          version: pnpm run version
-          commit: 'chore(release): version packages'
-          title: 'chore(release): version packages'
+      - name: Build + publish
+        run: pnpm run release
         env:
-          # App-installation token (not the default GITHUB_TOKEN) so the
-          # push to `changeset-release/main` triggers the release PR's
-          # required checks — see the "Mint GitHub App token" step.
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          # Trusted publishing is configured on npm for every published
-          # fixed-group package (core, addon, blocks, switcher, mcp). No
-          # NPM_TOKEN / NODE_AUTH_TOKEN needed; npm picks up the GitHub
-          # OIDC token via id-token: write and exchanges it for a
-          # short-lived publish token at publish time.
           NPM_CONFIG_PROVENANCE: true
 
       # Post-publish verification — catches silent partial publishes.
-      #
-      # Failure mode this guards against: `changeset publish` reports
-      # success even if a member of the fixed group never made it to npm
-      # (e.g. its `dist/` was never built because the release script's
-      # turbo filter omitted it, as happened for `integrations` pre-0.50).
-      # The action's `published` output is true if ANY package shipped,
-      # so this is the only place that asserts the fixed group is whole.
-      #
-      # For each fixed-group package, ask npm whether
-      # `<pkg>@<version>` resolves. Any miss fails the workflow with a
-      # punch-list of which packages are unpublished, so the release can
-      # be re-run (idempotent) or the missing package bootstrapped.
+      # `changeset publish` reports success even if a fixed-group member never
+      # made it to npm (e.g. its `dist/` wasn't built because a turbo filter
+      # omitted it, as happened for `integrations` pre-0.50). Assert the whole
+      # fixed group resolves at the published version.
       - name: Verify fixed-group publish completeness
-        if: steps.changesets.outputs.published == 'true'
         env:
           NPM_REGISTRY: https://registry.npmjs.org
         run: |
@@ -159,8 +238,7 @@ jobs:
 
           missing=()
           # npm propagates new versions through its CDN within a few seconds
-          # but not always instantly; give each lookup a couple of retries
-          # before declaring it missing.
+          # but not always instantly; retry each lookup before declaring a miss.
           for pkg in \
             @unpunnyfuns/swatchbook-core \
             @unpunnyfuns/swatchbook-addon \
@@ -196,68 +274,3 @@ jobs:
           fi
 
           echo "All six fixed-group packages confirmed at v$version."
-
-      # The action opens the Version Packages PR with a static title
-      # ("chore(release): version packages") and a body that leads with a
-      # "This PR was opened by the Changesets release GitHub action…"
-      # boilerplate paragraph. Neither carries the proposed version, and
-      # the boilerplate is static noise once you've seen it once. Retitle
-      # with the computed next version and trim the boilerplate so the PR
-      # (and the eventual squash-merge commit on main) is informative at
-      # a glance.
-      - name: Polish Version Packages PR title + body
-        if: steps.changesets.outputs.pullRequestNumber && steps.changesets.outputs.published != 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PR_NUMBER: ${{ steps.changesets.outputs.pullRequestNumber }}
-        run: |
-          set -e
-          git fetch origin changeset-release/main
-          next_version=$(git show origin/changeset-release/main:packages/core/package.json | jq -r .version)
-          if [ -z "$next_version" ] || [ "$next_version" = "null" ]; then
-            echo "Could not read next version — leaving PR #$PR_NUMBER alone."
-            exit 0
-          fi
-
-          echo "Retitling PR #$PR_NUMBER to v$next_version"
-
-          current_body=$(gh pr view "$PR_NUMBER" --json body --jq .body)
-          # Drop everything before the "# Releases" heading that
-          # changesets always emits — the preceding paragraph is the
-          # boilerplate we want gone. Fall back to the original body if
-          # the heading isn't present (defensive; it always is today).
-          trimmed_body=$(printf '%s\n' "$current_body" | awk 'found{print; next} /^# Releases[[:space:]]*$/{found=1; print}')
-          if [ -z "$trimmed_body" ]; then
-            trimmed_body="$current_body"
-          fi
-
-          gh pr edit "$PR_NUMBER" \
-            --title "chore(release): v$next_version" \
-            --body "$trimmed_body"
-
-      # changesets/action maintains a `changeset-release/main` branch and
-      # keeps the Version Packages PR open across runs. When the branch's
-      # diff vs main collapses to nothing (all changesets consumed, nothing
-      # new pending), the PR sticks around with a stale body — misleads at a
-      # glance ("0.3.0 is already shipped, why is it proposing 0.3.0 again?"
-      # — because the body was regenerated from consumed changesets). Close
-      # any empty VP PR so the next real changeset opens a fresh, accurate
-      # one.
-      - name: Close empty Version Packages PR
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          set -e
-          pr_json=$(gh pr list --head changeset-release/main --state open --json number,headRefName --limit 1)
-          pr_number=$(echo "$pr_json" | jq -r '.[0].number // empty')
-          if [ -z "$pr_number" ]; then
-            echo "No open Version Packages PR to check."
-            exit 0
-          fi
-          diff_stat=$(git fetch origin changeset-release/main && git diff --stat origin/main..origin/changeset-release/main | tail -n 1)
-          if [ -z "$diff_stat" ]; then
-            echo "Version Packages PR #$pr_number has no diff vs main — closing."
-            gh pr close "$pr_number" --delete-branch --comment 'Closed automatically: no changesets pending. The next real changeset on main will open a fresh PR.'
-          else
-            echo "Version Packages PR #$pr_number has real changes — leaving open."
-          fi


### PR DESCRIPTION
Splits the release workflow so publishing is its own job that **always** carries the `environment: release` approval gate, regardless of which commit triggered the run.

Previously the gate was applied to the single release job via an `environment:` expression conditioned on the triggering commit's message. Since a publish can be triggered by commits other than the Version Packages merge, a publish could run without passing through the gate.

- **`prepare`** (ungated) — opens/updates the Version Packages PR in version-only mode (no `publish:` input, so it cannot publish) and decides whether a publish is due from a forge-proof signal: is the committed `core` version already on npm?
- **`publish`** (`environment: release`, always gated) — runs only when `prepare` reports a bumped-but-unpublished version, and always behind approval.

One publish path, unconditionally gated. Ordinary merges (version already on npm) never reach the publish job, so no spurious approval prompts; only real publishes prompt. OIDC trusted publishing and the fixed-group completeness verifier are unchanged, moved into the publish job. `cancel-in-progress` is now safe even mid-approval — a cancelled pending publish re-queues, still gated.

Milestone: Maintenance

Closes #1064

Plan impact: none — release-workflow hardening, no product changes.