### PR TITLE
test(core): cover layered last-wins + at-scale variance routing

### DIFF
--- a/packages/core/test/css-axis-projected-many-axes.test.ts
+++ b/packages/core/test/css-axis-projected-many-axes.test.ts
@@ -19,7 +19,9 @@
 import { afterAll, expect, it } from 'vitest';
 import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
 import { buildTokenGraphFromLayered } from '#/token-graph/build.ts';
+import { permutationID } from '#/types.ts';
 import type { Axis, Project } from '#/types.ts';
+import { extractBlock } from './_helpers.ts';
 
 it('emit completes promptly when the project has 8 axes × 5 contexts each (no cartesian enumeration)', () => {
   const axes: Axis[] = Array.from({ length: 8 }, (_, i) => ({
@@ -43,17 +45,18 @@ it('emit completes promptly when the project has 8 axes × 5 contexts each (no c
   // axis0=a writes color.token-0 → some other value
   // axis1=a writes color.token-0 → yet another value
   // (so token-0 is touched by axis0 and axis1; nothing touched by axis2..7)
+  // Keyed via permutationID (Object.values join) so the singleton lookup in
+  // buildTokenGraphFromLayered actually finds these — otherwise the writes
+  // never register and the test degrades to timing a baseline-only emit.
   const perSingletonResolved: Record<string, Record<string, { $type: string; $value: string }>> = {
-    'axis0=a|axis1=default|axis2=default|axis3=default|axis4=default|axis5=default|axis6=default|axis7=default':
-      {
-        ...baseline,
-        'color.token-0': { $type: 'color', $value: '#111111' },
-      },
-    'axis0=default|axis1=a|axis2=default|axis3=default|axis4=default|axis5=default|axis6=default|axis7=default':
-      {
-        ...baseline,
-        'color.token-0': { $type: 'color', $value: '#222222' },
-      },
+    [permutationID({ ...defaultTuple, axis0: 'a' })]: {
+      ...baseline,
+      'color.token-0': { $type: 'color', $value: '#111111' },
+    },
+    [permutationID({ ...defaultTuple, axis1: 'a' })]: {
+      ...baseline,
+      'color.token-0': { $type: 'color', $value: '#222222' },
+    },
   };
 
   const { graph } = buildTokenGraphFromLayered(
@@ -92,6 +95,78 @@ it('emit completes promptly when the project has 8 axes × 5 contexts each (no c
   // Per-token variance with one token touching 2 axes does O(1) probes
   // total. Generous 5s wall-clock budget.
   expect(elapsedMs).toBeLessThan(5000);
+});
+
+it('routes per-token variance correctly at scale — touched tokens land in their axis cells, constants stay in :root', () => {
+  // Correctness counterpart to the timing guard above. Five axes; only
+  // color.token-0 is touched, by two independent single-axis writes
+  // (axis0=a and axis1=a). tokens 1..4 are baseline-only. Per-token variance
+  // must route token-0 into exactly the axis0 and axis1 cells, emit no cell
+  // for the untouched axes, and keep constants in :root — a cartesian
+  // regression would spray cells for axes nothing is affected by.
+  const axes: Axis[] = Array.from({ length: 5 }, (_, i) => ({
+    name: `axis${i}`,
+    contexts: ['default', 'a'],
+    default: 'default',
+    source: 'layered',
+  }));
+
+  const defaultTuple: Record<string, string> = {};
+  for (const axis of axes) defaultTuple[axis.name] = axis.default;
+
+  const baseline = Object.fromEntries(
+    Array.from({ length: 5 }, (_, i) => [
+      `color.token-${i}`,
+      { $type: 'color', $value: '#000000' },
+    ]),
+  );
+
+  const perSingletonResolved: Record<string, Record<string, { $type: string; $value: string }>> = {
+    [permutationID({ ...defaultTuple, axis0: 'a' })]: {
+      ...baseline,
+      'color.token-0': { $type: 'color', $value: '#111111' },
+    },
+    [permutationID({ ...defaultTuple, axis1: 'a' })]: {
+      ...baseline,
+      'color.token-0': { $type: 'color', $value: '#222222' },
+    },
+  };
+
+  const { graph } = buildTokenGraphFromLayered(axes, baseline, perSingletonResolved, defaultTuple);
+
+  const project: Project = {
+    config: { cssVarPrefix: 'sb' },
+    axes,
+    disabledAxes: [],
+    presets: [],
+    chrome: {},
+    defaultTokens: baseline,
+    defaultTuple,
+    resolveAt: () => ({}),
+    tokenGraph: graph,
+    sourceFiles: [],
+    cwd: '',
+    listing: {},
+    diagnostics: [],
+  };
+
+  const css = emitAxisProjectedCss(project);
+
+  // The touched token lands in exactly the two axis cells that write it.
+  expect(extractBlock(css, '[data-sb-axis0="a"]')).toMatch(/--sb-color-token-0:/);
+  expect(extractBlock(css, '[data-sb-axis1="a"]')).toMatch(/--sb-color-token-0:/);
+
+  // Untouched axes emit no cell at all — variance routing, not cartesian.
+  for (const i of [2, 3, 4]) {
+    expect(css).not.toContain(`[data-sb-axis${i}="a"]`);
+  }
+
+  // Baseline-only tokens live in :root and never leak into a cell.
+  expect(extractBlock(css, ':root')).toMatch(/--sb-color-token-3:/);
+  const cells = css.split('\n\n').filter((b) => b.startsWith('[data-sb-'));
+  for (const cell of cells) {
+    expect(cell).not.toMatch(/--sb-color-token-3:/);
+  }
 });
 
 afterAll(() => {

--- a/packages/core/test/load-layered.test.ts
+++ b/packages/core/test/load-layered.test.ts
@@ -69,6 +69,24 @@ describe('loadProject — layered axes', () => {
     expect(tokens['color.accent']?.$value).toMatchObject({ components: [0.9, 0.2, 0.2] });
   });
 
+  it('last-axis-in-declaration-order wins when two axes write the same path', () => {
+    // `color.text` is written by BOTH axes — mode=Dark → {color.white} and
+    // brand=Brand A → {color.red}. Axes are declared mode-then-brand, so the
+    // later axis (brand) wins at the joint tuple → red. The single-axis-write
+    // assertions above only exercise paths touched by one axis, so a
+    // regression in axis-order precedence on an overlapping write would be
+    // silent without this case.
+    const joint = project.resolveAt({ mode: 'Dark', brand: 'Brand A' });
+    expect(joint['color.text']?.$value).toMatchObject({ components: [0.9, 0.2, 0.2] });
+    // Each single-axis view still resolves to that axis's own write.
+    expect(
+      project.resolveAt({ mode: 'Dark', brand: 'Default' })['color.text']?.$value,
+    ).toMatchObject({ components: [1, 1, 1] });
+    expect(
+      project.resolveAt({ mode: 'Light', brand: 'Brand A' })['color.text']?.$value,
+    ).toMatchObject({ components: [0.9, 0.2, 0.2] });
+  });
+
   it('empty context arrays are legal (no-override case)', async () => {
     const config: Config = {
       tokens: ['base/*.json'],


### PR DESCRIPTION
Closes two test-coverage gaps from the code review (deferred from #1053).

- **Layered overlapping-write precedence** — `load-layered.test.ts` now asserts that when two axes write the same path (`color.text`: mode=Dark → white, brand=Brand A → red), the later-declared axis (brand) wins at the joint tuple. The existing multi-axis assertions only exercised single-axis-write paths, so an axis-order precedence regression would have been silent.
- **At-scale variance routing** — `css-axis-projected-many-axes.test.ts` gains a correctness case: a touched token lands in exactly its axis cells, untouched axes emit no cell, and constants stay in `:root` (the variance-routing counterpart to the existing timing guard).

Also fixes a latent bug in that file: the `perSingletonResolved` keys used a `name=ctx|…` shape that doesn't match `permutationID`'s `value · value` join, so the singleton lookup never matched and the writes never registered — the perf test was timing a baseline-only emit, not the variance path. Both tests now key via `permutationID`, so the perf guard is meaningful too.

Test-only; full core gate green (format/lint/typecheck/test).

Milestone: Maintenance

Closes #1066

Plan impact: none — test coverage, no source changes.