### PR TITLE
docs: add a "Built with AI" disclosure page

### DIFF
--- a/.changeset/built-with-ai-disclosure.md
+++ b/.changeset/built-with-ai-disclosure.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Add a "Built with AI" disclosure to the docs. A short block on the Introduction page states plainly that nearly all of swatchbook's code is written by an AI coding agent under human direction, and a new `developers/built-with-ai.mdx` page lays out who does what, what a human gates (every merge, every release), the quality machinery, and where the effort goes. Patch so the next release's snapshot rebuild picks it up.

--- a/apps/docs/docs/developers/built-with-ai.mdx
+++ b/apps/docs/docs/developers/built-with-ai.mdx
@@ -1,0 +1,72 @@
+---
+id: built-with-ai
+title: Built with AI
+sidebar_position: 3
+---
+
+# Built with AI
+
+Nearly all of swatchbook's code, tests, and documentation are written by Claude,
+Anthropic's coding agent, under human direction. This page says plainly how that
+works and what every change clears before it ships, so you can judge the code on
+its merits and its safeguards rather than on who typed it.
+
+The repo doesn't hide it. [`CLAUDE.md`](https://github.com/unpunnyfuns/swatchbook/blob/main/CLAUDE.md),
+the orientation file the agent reads at the start of every session, is committed
+alongside the code.
+
+## Who does what
+
+**The agent** writes code, tests, and docs, runs the local checks, and opens pull
+requests.
+
+**The human** sets scope and direction, reviews every diff, merges, and approves
+releases. The human also decides what "done" means: when a change is actually
+correct, when a claim is actually true.
+
+The split is clean because it has to be. This is a large surface for one
+maintainer: six published packages, browser-mode test suites, visual-regression
+CI, this docs site, an MCP server. One person can't hand-write all of it. One
+person can direct it, review all of it, and answer for it.
+
+## What a human always gates
+
+- **Every merge.** The agent never self-merges. A person reviews the diff and
+  merges it.
+- **Every release.** The publish workflow pauses behind an approval gate before
+  any package reaches npm, a deliberate second human check between "version
+  bumped" and "shipped."
+- **Direction and scope.** What gets built, and what doesn't.
+
+## How quality is kept
+
+The machinery is what any project ought to have. AI authorship just makes naming
+it worth doing.
+
+- **A pre-commit gate:** formatting, linting, type-checking, and the full test
+  suite run before every commit.
+- **Component tests in a real browser.** Focus, keyboard, and pointer behavior are
+  exercised in real Chromium rather than a jsdom approximation, so tests check the
+  browser instead of the author's mental model of it.
+- **A CI matrix** re-runs every check on each push and pull request.
+- **Visual-regression CI** (Chromatic) catches unintended rendering changes block
+  by block.
+- **Code review** on every change.
+- **Gated, provenance-attested publishing** via Changesets. The fixed-version
+  package group ships together, behind the approval gate above.
+
+## Where the effort goes
+
+Most of the effort here is not writing features. It is verifying them, and making
+sure the docs match the code. Examples on this site are run against the real
+project, not hand-written to look right. Behavior changes have to clear regression
+tests that check meaning, not just output, before they land.
+
+The real back-and-forth between the human and the agent is about correctness, not
+scope. Less "build this," more "this is wrong, here is the case that breaks it."
+
+So the bottom line is plain. An AI wrote nearly all of it. A human is accountable
+for all of it, and the evidence is public: the tests, the CI runs, the gated
+releases, the commit history. Hold swatchbook to the same standard as any
+dependency you take on. This page exists so you know exactly what you're looking
+at when you do.

--- a/apps/docs/docs/developers/index.mdx
+++ b/apps/docs/docs/developers/index.mdx
@@ -14,6 +14,7 @@ This section assumes you've already skimmed [**CONTRIBUTING.md**](https://github
 
 - [**Architecture**](./architecture.mdx) — the repo map, the one data structure everything revolves around (`Project`), and how data moves from a token file on disk to a rendered doc block. Includes the static build path, the dev/HMR path, and how the MCP server plugs in.
 - [**Sharp corners**](./sharp-corners.mdx) — the "someone will bleed on this" list. Shapes that trip newcomers. Read this after *Architecture* so the rules have context.
+- [**Built with AI**](./built-with-ai.mdx) — swatchbook is written by an AI coding agent under human direction. How that split works, what a human gates, and the checks every change clears.
 
 ## Where the source lives
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -28,6 +28,10 @@ Design-system authors with DTCG tokens, especially systems with more than one in
 
 Not a runtime theme-switcher for production apps, not a CSS-variable framework, not a token build tool. Swatchbook emits CSS variables and `data-<prefix>-*` attributes inside the Storybook preview so tokens repaint when an author flips an axis. For production theme switching, use your framework's theming tools. For production CSS / Swift / Android / etc. emission, run Terrazzo's CLI against the same DTCG sources — swatchbook is the preview side of that pipeline, not a replacement for it.
 
+## Was this coded with AI?
+
+Yes, nearly all of it, and deliberately so. Swatchbook is a large surface for one maintainer: six published packages, browser-mode test suites, visual-regression CI, this docs site, an MCP server. It's written by Claude, Anthropic's coding agent, under human direction, which is what makes a project this size sustainable solo. A person still sets the direction, reviews every change, and is the only one who merges pull requests or cuts releases; the agent does neither on its own. More effort goes into verifying the code than building features. [Built with AI](./developers/built-with-ai.mdx) lays out the checks every change clears.
+
 ## Installation
 
 Register `@unpunnyfuns/swatchbook-addon` in `.storybook/main.ts`. It pulls in `swatchbook-core`, `swatchbook-blocks`, and `swatchbook-switcher` transitively. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` resolves from any consumer file. See the [Quickstart](./quickstart.mdx) for a complete setup.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -62,7 +62,12 @@ const sidebars: SidebarsConfig = {
       ],
     },
   ],
-  developers: ['developers/developers', 'developers/architecture', 'developers/sharp-corners'],
+  developers: [
+    'developers/developers',
+    'developers/architecture',
+    'developers/sharp-corners',
+    'developers/built-with-ai',
+  ],
 };
 
 export default sidebars;


### PR DESCRIPTION
Adds an honest-disclosure note that swatchbook is written largely by an AI coding agent under human direction.

- **Introduction page** gets a short `## Was this coded with AI?` block before Installation, answering the question directly and linking onward.
- **New `developers/built-with-ai.mdx`** covers who does what, what a human always gates (every merge, every release), how quality is kept, and where the effort goes — ending on a plain verdict: hold the code to the same standard as any dependency, the evidence is public.
- Wired into the Developers sidebar and section index.

Patch changeset so the next release's snapshot rebuild carries the page to `/`, not just `/next/`.

Milestone: Maintenance

Closes #1070

Plan impact: none.