### PR TITLE
docs: tighten the "Built with AI" disclosure prose

### DIFF
--- a/.changeset/built-with-ai-prose-polish.md
+++ b/.changeset/built-with-ai-prose-polish.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Tighten the "Built with AI" docs prose: drop the self-narrating opening ("This page says plainly…"), shorten "Claude, Anthropic's coding agent" to "Claude", and add one dry aside. Patch so the next release's snapshot rebuild carries it to the stable docs.

--- a/apps/docs/docs/developers/built-with-ai.mdx
+++ b/apps/docs/docs/developers/built-with-ai.mdx
@@ -7,9 +7,8 @@ sidebar_position: 3
 # Built with AI
 
 Nearly all of swatchbook's code, tests, and documentation are written by Claude,
-Anthropic's coding agent, under human direction. This page says plainly how that
-works and what every change clears before it ships, so you can judge the code on
-its merits and its safeguards rather than on who typed it.
+under human direction. Here's how that works: what a human controls, and what
+every change has to clear before it ships.
 
 The repo doesn't hide it. [`CLAUDE.md`](https://github.com/unpunnyfuns/swatchbook/blob/main/CLAUDE.md),
 the orientation file the agent reads at the start of every session, is committed
@@ -28,6 +27,8 @@ The split is clean because it has to be. This is a large surface for one
 maintainer: six published packages, browser-mode test suites, visual-regression
 CI, this docs site, an MCP server. One person can't hand-write all of it. One
 person can direct it, review all of it, and answer for it.
+
+The maintainer has a day job; the agent does not.
 
 ## What a human always gates
 

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -30,7 +30,7 @@ Not a runtime theme-switcher for production apps, not a CSS-variable framework, 
 
 ## Was this coded with AI?
 
-Yes, nearly all of it, and deliberately so. Swatchbook is a large surface for one maintainer: six published packages, browser-mode test suites, visual-regression CI, this docs site, an MCP server. It's written by Claude, Anthropic's coding agent, under human direction, which is what makes a project this size sustainable solo. A person still sets the direction, reviews every change, and is the only one who merges pull requests or cuts releases; the agent does neither on its own. More effort goes into verifying the code than building features. [Built with AI](./developers/built-with-ai.mdx) lays out the checks every change clears.
+Yes, nearly all of it, and deliberately so. Swatchbook is a large surface for one maintainer: six published packages, browser-mode test suites, visual-regression CI, this docs site, an MCP server. It's written by Claude under human direction, which is what makes a project this size sustainable solo. A person still sets the direction, reviews every change, and is the only one who merges pull requests or cuts releases; the agent does neither on its own. More effort goes into verifying the code than building features. The checks every change clears are in [Built with AI](./developers/built-with-ai.mdx).
 
 ## Installation
 


### PR DESCRIPTION
Follow-up polish on the disclosure page shipped in v0.60.9.

- Drop the self-narrating opening ("This page says plainly how that works…") — instruction-register that reads as written-to-spec.
- Shorten "Claude, Anthropic's coding agent" to "Claude" on both the intro block and the page.
- Soften the intro-block "lays out" line.
- Add one dry aside ("The maintainer has a day job; the agent does not.").

Patch changeset so the next release rebuilds the stable docs snapshot with the tightened prose.

Milestone: Maintenance

Closes #1073

Plan impact: none.