### PR TITLE
chore(addon): apply the comment doctrine to addon comments

### DIFF
--- a/packages/addon/src/ColorFormatSelector.tsx
+++ b/packages/addon/src/ColorFormatSelector.tsx
@@ -4,21 +4,19 @@ import type { ReactElement } from 'react';
 
 export type { ColorFormat };
 
-/**
- * Storybook-addon-specific pill row for picking how color sub-values
- * render in swatchbook blocks (hex / rgb / hsl / oklch / raw). Lives in
- * the addon rather than the shared switcher because color format is a
- * blocks-rendering concern, not a theming one — the docs-site navbar
- * switcher has no consumer for it.
- *
- * Reuses the `sb-switcher__*` class names so styling stays consistent
- * with the rest of the toolbar popover. The switcher's CSS is already
- * loaded on the page because this selector only renders inside
- * `<ThemeSwitcher>`'s `footer` prop.
- *
- * Uses `React.createElement` (via `h`) to survive embedding in Storybook's
- * manager bundle, which doesn't expose `react/jsx-runtime`.
- */
+// Storybook-addon-specific pill row for picking how color sub-values
+// render in swatchbook blocks (hex / rgb / hsl / oklch / raw). Lives in
+// the addon rather than the shared switcher because color format is a
+// blocks-rendering concern, not a theming one — the docs-site navbar
+// switcher has no consumer for it.
+//
+// Reuses the `sb-switcher__*` class names so styling stays consistent
+// with the rest of the toolbar popover. The switcher's CSS is already
+// loaded on the page because this selector only renders inside
+// `<ThemeSwitcher>`'s `footer` prop.
+//
+// Uses `React.createElement` (via `h`) to survive embedding in Storybook's
+// manager bundle, which doesn't expose `react/jsx-runtime`.
 
 /**
  * Runtime list of valid color formats. Declared here (alongside

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -7,13 +7,11 @@ import { resolveAllAt } from '@unpunnyfuns/swatchbook-core/graph';
 import { makeCssVar } from '@unpunnyfuns/swatchbook-core/css-var';
 import { useActiveAxes, useOptionalSwatchbookData } from '@unpunnyfuns/swatchbook-blocks';
 
-/**
- * Module-scope `resolveAt` for the no-provider fallback path. Built
- * once from the stable virtual-module exports — mirrors what the
- * preview decorator does for its `previewResolveAt` but lives in this
- * file so the hook can be called outside the addon's preview wrapper
- * (autodocs / MDX renders).
- */
+// Module-scope `resolveAt` for the no-provider fallback path. Built
+// once from the stable virtual-module exports — mirrors what the
+// preview decorator does for its `previewResolveAt` but lives in this
+// file so the hook can be called outside the addon's preview wrapper
+// (autodocs / MDX renders).
 const fallbackResolveAt = (tuple: Record<string, string>) => resolveAllAt(virtualTokenGraph, tuple);
 
 /**

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -20,28 +20,24 @@ import {
   TOOL_ID,
 } from '#/constants.ts';
 
-/**
- * Use explicit `React.createElement` rather than JSX so the manager bundle
- * doesn't take a hard dependency on `react/jsx-runtime`. Storybook's manager
- * page injects its own React as a runtime global; `react/jsx-runtime` isn't
- * always part of that exposure, which breaks JSX with
- * "Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')".
- * Mirrors the pattern `@storybook/addon-a11y` uses in its manager.
- *
- * The imported `<ThemeSwitcher>` from `@unpunnyfuns/swatchbook-switcher`
- * compiles with classic JSX (`React.createElement`) specifically so it
- * survives embedding in the manager bundle the same way.
- */
+// Use explicit `React.createElement` rather than JSX so the manager bundle
+// doesn't take a hard dependency on `react/jsx-runtime`. Storybook's manager
+// page injects its own React as a runtime global; `react/jsx-runtime` isn't
+// always part of that exposure, which breaks JSX with
+// "Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')".
+// Mirrors the pattern `@storybook/addon-a11y` uses in its manager.
+//
+// The imported `<ThemeSwitcher>` from `@unpunnyfuns/swatchbook-switcher`
+// compiles with classic JSX (`React.createElement`) specifically so it
+// survives embedding in the manager bundle the same way.
 const h = React.createElement;
 
 const EMPTY_AXES: readonly AxisEntry[] = [];
 const EMPTY_PRESETS: readonly PresetEntry[] = [];
 
-/**
- * Root toolbar glyph — a split-circle ("yinyang") mark: a faint filled
- * disc for the full-swatch silhouette, with a darker half-and-inset-disc
- * path reading as a pair of theme variants swapped in place.
- */
+// Root toolbar glyph — a split-circle ("yinyang") mark: a faint filled
+// disc for the full-swatch silhouette, with a darker half-and-inset-disc
+// path reading as a pair of theme variants swapped in place.
 function SwatchbookIcon(): ReactElement {
   return h(
     'svg',
@@ -71,12 +67,10 @@ function AxesToolbar(): ReactElement {
     const channel = addons.getChannel();
     const onInit = (next: InitPayload): void => setPayload(next);
     channel.on(INIT_EVENT, onInit);
-    /**
-     * Ask the preview to (re-)emit INIT_EVENT in case it already broadcast
-     * before this effect subscribed. Without this request, a late-mounting
-     * manager (story navigation, docs reload) can stay in "loading…" until
-     * the user triggers a globals change.
-     */
+    // Ask the preview to (re-)emit INIT_EVENT in case it already broadcast
+    // before this effect subscribed. Without this request, a late-mounting
+    // manager (story navigation, docs reload) can stay in "loading…" until
+    // the user triggers a globals change.
     channel.emit(INIT_REQUEST_EVENT);
     return () => {
       channel.off(INIT_EVENT, onInit);
@@ -154,11 +148,9 @@ function AxesToolbar(): ReactElement {
     }
   }, []);
 
-  /**
-   * Escape closes even when focus hasn't entered the popover yet (e.g. the
-   * user opened it via click and the mouse is still over the canvas). We
-   * attach a document-level listener when open.
-   */
+  // Escape closes even when focus hasn't entered the popover yet (e.g. the
+  // user opened it via click and the mouse is still over the canvas). We
+  // attach a document-level listener when open.
   useEffect(() => {
     if (!open) return;
     const onDocKey = (e: KeyboardEvent): void => {
@@ -168,12 +160,10 @@ function AxesToolbar(): ReactElement {
     return () => document.removeEventListener('keydown', onDocKey);
   }, [open]);
 
-  /**
-   * `WithTooltip`'s built-in `closeOnOutsideClick` misses some cases
-   * (portaled popover + manager iframe boundaries). Belt-and-suspenders:
-   * close when the user mouses down anywhere that isn't the trigger wrapper
-   * or the popover body.
-   */
+  // `WithTooltip`'s built-in `closeOnOutsideClick` misses some cases
+  // (portaled popover + manager iframe boundaries). Belt-and-suspenders:
+  // close when the user mouses down anywhere that isn't the trigger wrapper
+  // or the popover body.
   useEffect(() => {
     if (!open) return;
     const onDocMouseDown = (e: MouseEvent): void => {
@@ -183,12 +173,10 @@ function AxesToolbar(): ReactElement {
       if (target.closest('[data-testid="swatchbook-switcher"]')) return;
       setOpen(false);
     };
-    /**
-     * The manager's document-level listener above can't see mousedowns
-     * inside the preview iframe. Preview emits PREVIEW_MOUSEDOWN_EVENT on
-     * every mousedown over its own document; listen for it here so
-     * clicking the canvas / docs page also closes the popover.
-     */
+    // The manager's document-level listener above can't see mousedowns
+    // inside the preview iframe. Preview emits PREVIEW_MOUSEDOWN_EVENT on
+    // every mousedown over its own document; listen for it here so
+    // clicking the canvas / docs page also closes the popover.
     const channel = addons.getChannel();
     const onPreviewMouseDown = (): void => setOpen(false);
     document.addEventListener('mousedown', onDocMouseDown);
@@ -223,19 +211,17 @@ function AxesToolbar(): ReactElement {
       tooltip: label,
       pressed: open,
       onClick: () => setOpen((prev) => !prev),
-      /**
-       * Screen-reader disclosure semantics for the popover trigger. We
-       * don't set `aria-controls` because the popover is portaled by
-       * Storybook's `WithTooltip` with a dynamically-generated id we
-       * don't have a stable handle on; `aria-haspopup` + `aria-expanded`
-       * is the practical subset of the disclosure pattern.
-       *
-       * `aria-haspopup="true"` (generic) rather than `"dialog"`: the
-       * switcher body is `role="group"` (it's a settings panel of
-       * independent controls, not a modal dialog), so promising
-       * `"dialog"` would misalign the trigger with what AT finds when
-       * focus enters the popover.
-       */
+      // Screen-reader disclosure semantics for the popover trigger. We
+      // don't set `aria-controls` because the popover is portaled by
+      // Storybook's `WithTooltip` with a dynamically-generated id we
+      // don't have a stable handle on; `aria-haspopup` + `aria-expanded`
+      // is the practical subset of the disclosure pattern.
+      //
+      // `aria-haspopup="true"` (generic) rather than `"dialog"`: the
+      // switcher body is `role="group"` (it's a settings panel of
+      // independent controls, not a modal dialog), so promising
+      // `"dialog"` would misalign the trigger with what AT finds when
+      // focus enters the popover.
       'aria-haspopup': true as const,
       'aria-expanded': open,
     },
@@ -251,12 +237,10 @@ function AxesToolbar(): ReactElement {
     onAxisChange: setAxis,
     onPresetApply: applyPreset,
     onKeyDown: handleKeyDown,
-    /**
-     * Color format is addon-local chrome — drives how swatchbook blocks
-     * stringify colors inside stories and docs. Slotted through the
-     * switcher's `footer` escape hatch so shared theming UI stays free
-     * of this concern.
-     */
+    // Color format is addon-local chrome — drives how swatchbook blocks
+    // stringify colors inside stories and docs. Slotted through the
+    // switcher's `footer` escape hatch so shared theming UI stays free
+    // of this concern.
     footer: h(ColorFormatSelector, {
       active: activeColorFormat,
       onSelect: (next: ColorFormat) => updateGlobals({ [COLOR_FORMAT_GLOBAL_KEY]: next }),

--- a/packages/addon/src/preset.ts
+++ b/packages/addon/src/preset.ts
@@ -11,7 +11,7 @@ import type { AddonOptions } from '#/options.ts';
 import { swatchbookTokensPlugin } from '#/virtual/plugin.ts';
 
 interface PresetOptions extends AddonOptions {
-  /** Storybook injects this — the `.storybook` directory absolute path. */
+  // Storybook injects this — the `.storybook` directory absolute path.
   configDir: string;
 }
 

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -43,12 +43,10 @@ import {
 } from '#/constants.ts';
 import type { StoryParameters, SwatchbookGlobals } from '#/globals.ts';
 
-/**
- * Standard visually-hidden style for the theme-flip live region.
- * Keeps the announcement element discoverable by SR but out of visual
- * + pointer flow. The clip-path / `position: absolute` combination is
- * the canonical sr-only pattern.
- */
+// Standard visually-hidden style for the theme-flip live region.
+// Keeps the announcement element discoverable by SR but out of visual
+// + pointer flow. The clip-path / `position: absolute` combination is
+// the canonical sr-only pattern.
 const SR_ONLY_STYLE: CSSProperties = {
   position: 'absolute',
   width: 1,
@@ -61,12 +59,10 @@ const SR_ONLY_STYLE: CSSProperties = {
   border: 0,
 };
 
-/**
- * The `html, body { ... }` rules that paint the iframe's own chrome
- * (outside any decorator wrapper — Docs mode, autodocs, empty gutters)
- * with the active theme's surface + text vars. Composed alongside the
- * emitted token CSS so both load through the same `<style>` element.
- */
+// The `html, body { ... }` rules that paint the iframe's own chrome
+// (outside any decorator wrapper — Docs mode, autodocs, empty gutters)
+// with the active theme's surface + text vars. Composed alongside the
+// emitted token CSS so both load through the same `<style>` element.
 function iframeChromeRules(prefix: string): string {
   const surface = prefix ? `--${prefix}-color-surface-default` : '--color-surface-default';
   const text = prefix ? `--${prefix}-color-text-default` : '--color-text-default';
@@ -79,23 +75,18 @@ html, body {
 `;
 }
 
-/**
- * Inject the per-theme stylesheet plus the iframe-chrome block. Shared
- * with the HMR re-emit path below so a token refresh updates the
- * iframe's chrome rules from the same source.
- */
+// Inject the per-theme stylesheet plus the iframe-chrome block. Shared
+// with the HMR re-emit path below so a token refresh updates the
+// iframe's chrome rules from the same source.
 function ensureStylesheet(cssText: string, prefix: string): void {
   ensureStyleElement(STYLE_ELEMENT_ID, `${cssText}\n${iframeChromeRules(prefix)}`);
 }
 
-/**
- * Apply `cb(axisName, value)` for every pinned (disabled) axis whose
- * default-tuple value is set. `virtualDefaultTuple` carries the
- * post-filter axis defaults; disabled axes don't appear in
- * `virtualAxes` but their pinned context value still lives here, so
- * sampling it gives the same result the old "first permutation's
- * input" lookup did.
- */
+// Apply `cb(axisName, value)` for every pinned (disabled) axis whose
+// default-tuple value is set. `virtualDefaultTuple` carries the
+// post-filter axis defaults; disabled axes don't appear in
+// `virtualAxes` but their pinned context value still lives here, so
+// sampling it yields each pinned axis's active context.
 function forEachPinnedAxis(cb: (name: string, value: string) => void): void {
   for (const name of virtualDisabledAxes) {
     const value = virtualDefaultTuple[name];
@@ -103,24 +94,20 @@ function forEachPinnedAxis(cb: (name: string, value: string) => void): void {
   }
 }
 
-/**
- * Compose a stable theme name from a tuple — `axisValues.join(' · ')`
- * in axis order. Used for the `ThemeContext` value the blocks read and
- * the addon-channel signals downstream consumers subscribe to. Returns
- * empty string when there are no axes (no name to write).
- */
+// Compose a stable theme name from a tuple — `axisValues.join(' · ')`
+// in axis order. Used for the `ThemeContext` value the blocks read and
+// the addon-channel signals downstream consumers subscribe to. Returns
+// empty string when there are no axes (no name to write).
 function matchThemeName(tuple: Readonly<Record<string, string>>): string {
   if (virtualAxes.length === 0) return '';
   return tupleToName(virtualAxes, tuple);
 }
 
-/**
- * Write one `data-<prefix>-<axis>=<context>` per axis on `<html>`.
- * The smart CSS emitter targets these single-axis selectors (and
- * joint compounds across multiple) — that's the actual scoping
- * surface the cascade resolves through. Prefix follows `cssVarPrefix`
- * so attr namespace and emitted selectors stay in lockstep.
- */
+// Write one `data-<prefix>-<axis>=<context>` per axis on `<html>`.
+// The smart CSS emitter targets these single-axis selectors (and
+// joint compounds across multiple) — that's the actual scoping
+// surface the cascade resolves through. Prefix follows `cssVarPrefix`
+// so attr namespace and emitted selectors stay in lockstep.
 function setRootAxes(tuple: Readonly<Record<string, string>>): void {
   if (typeof document === 'undefined') return;
   const root = document.documentElement;
@@ -138,12 +125,10 @@ function setRootAxes(tuple: Readonly<Record<string, string>>): void {
   });
 }
 
-/**
- * Subset of an INIT_EVENT-shaped object the manager bundle needs. The
- * fields are the union of what the toolbar and panel read; named so
- * `broadcastInit` (module-level virtual exports) and the HMR re-emit
- * (`payload`-shaped) compose the same payload from the same shape.
- */
+// Subset of an INIT_EVENT-shaped object the manager bundle needs. The
+// fields are the union of what the toolbar and panel read; named so
+// `broadcastInit` (module-level virtual exports) and the HMR re-emit
+// (`payload`-shaped) compose the same payload from the same shape.
 interface InitFieldsSource {
   axes: typeof virtualAxes;
   disabledAxes: typeof virtualDisabledAxes;
@@ -164,11 +149,9 @@ function pickInitFields(source: InitFieldsSource): InitFieldsSource {
   };
 }
 
-/**
- * Emit the full virtual-module payload to the manager over Storybook's
- * channel so the toolbar + panel (which run in the manager bundle and
- * can't import our virtual module) can render from it.
- */
+// Emit the full virtual-module payload to the manager over Storybook's
+// channel so the toolbar + panel (which run in the manager bundle and
+// can't import our virtual module) can render from it.
 function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(
@@ -184,20 +167,18 @@ function broadcastInit(): void {
   );
 }
 
-/** Axis-default tuple, used as the baseline before overrides. */
+// Axis-default tuple, used as the baseline before overrides.
 function defaultTuple(): Record<string, string> {
   const out: Record<string, string> = {};
   for (const axis of virtualAxes) out[axis.name] = axis.default;
   return out;
 }
 
-/**
- * Reverse-engineer a tuple from a `Light · Brand A · Normal`-shape
- * theme name. Splits on ` · ` and zips with `virtualAxes` in declared
- * order — matches `matchThemeName`'s production direction so a
- * round-trip is lossless. Returns `undefined` when the segment count
- * doesn't match the axis count.
- */
+// Reverse-engineer a tuple from a `Light · Brand A · Normal`-shape
+// theme name. Splits on ` · ` and zips with `virtualAxes` in declared
+// order — matches `matchThemeName`'s production direction so a
+// round-trip is lossless. Returns `undefined` when the segment count
+// doesn't match the axis count.
 function tupleForName(name: string): Record<string, string> | undefined {
   if (!name) return undefined;
   const parts = name.split(' · ');
@@ -212,11 +193,9 @@ function tupleForName(name: string): Record<string, string> | undefined {
   return out;
 }
 
-/**
- * Merge a partial tuple onto the axis defaults, dropping keys for axes that
- * don't exist and silently falling back to the default for contexts that
- * aren't listed on the axis.
- */
+// Merge a partial tuple onto the axis defaults, dropping keys for axes that
+// don't exist and silently falling back to the default for contexts that
+// aren't listed on the axis.
 function normalizeTuple(partial: Readonly<Record<string, string>>): Record<string, string> {
   const out = defaultTuple();
   for (const axis of virtualAxes) {
@@ -228,13 +207,11 @@ function normalizeTuple(partial: Readonly<Record<string, string>>): Record<strin
   return out;
 }
 
-/**
- * Resolve the active tuple from all input channels, in priority order:
- *   1. `parameters.swatchbook.axes` — per-story tuple.
- *   2. `parameters.swatchbook.permutation` — per-story composed name.
- *   3. `globals.swatchbookAxes` — toolbar-set tuple.
- *   4. virtual module default.
- */
+// Resolve the active tuple from all input channels, in priority order:
+//   1. `parameters.swatchbook.axes` — per-story tuple.
+//   2. `parameters.swatchbook.permutation` — per-story composed name.
+//   3. `globals.swatchbookAxes` — toolbar-set tuple.
+//   4. virtual module default.
 function resolveTuple(
   axesGlobal: SwatchbookGlobals[typeof AXES_GLOBAL_KEY],
   paramSwatchbook: StoryParameters['swatchbook'],
@@ -260,14 +237,12 @@ function resolveColorFormat(raw: SwatchbookGlobals[typeof COLOR_FORMAT_GLOBAL_KE
   return 'hex';
 }
 
-/**
- * Single shared `resolveAt` instance for the lifetime of the preview
- * iframe. `virtualTokenGraph` is a module-level virtual-module export
- * with stable identity, so this closure never needs to rebuild;
- * downstream `ProjectSnapshot` consumers can key memos on the snapshot
- * wrapper without worrying about `resolveAt` churning when Storybook
- * recreates `context.globals`.
- */
+// Single shared `resolveAt` instance for the lifetime of the preview
+// iframe. `virtualTokenGraph` is a module-level virtual-module export
+// with stable identity, so this closure never needs to rebuild;
+// downstream `ProjectSnapshot` consumers can key memos on the snapshot
+// wrapper without worrying about `resolveAt` churning when Storybook
+// recreates `context.globals`.
 const previewResolveAt = (tuple: Record<string, string>): TokenMap =>
   resolveAllAt(virtualTokenGraph, tuple);
 
@@ -389,35 +364,29 @@ export const initialGlobals: NonNullable<Preview['initialGlobals']> = {
   [COLOR_FORMAT_GLOBAL_KEY]: 'hex',
 };
 
-/**
- * Module-level channel subscription: writes the active tuple's attributes
- * onto `<html>` regardless of whether a story decorator is rendering.
- *
- * The {@link themedDecorator} already sets these inside story renders, but
- * it never runs on MDX docs pages that embed blocks without `<Story />`.
- * Without attrs on an ancestor, the per-tuple CSS selectors
- * (`[data-mode="Dark"][data-brand="…"]`) don't match and everything falls
- * back to the `:root` default tuple — so colors stay defaults even after
- * the toolbar switches axes. Subscribing globally fixes MDX docs at the
- * cost of one idempotent redundant write per story render.
- */
+// Module-level channel subscription: writes the active tuple's attributes
+// onto `<html>` regardless of whether a story decorator is rendering.
+//
+// The themedDecorator already sets these inside story renders, but it
+// never runs on MDX docs pages that embed blocks without `<Story />`.
+// Without attrs on an ancestor, the per-tuple CSS selectors
+// (`[data-mode="Dark"][data-brand="…"]`) don't match and everything falls
+// back to the `:root` default tuple — so colors stay defaults even after
+// the toolbar switches axes. Subscribing globally fixes MDX docs at the
+// cost of one idempotent redundant write per story render.
 function installGlobalAxisApplier(): void {
   if (typeof document === 'undefined') return;
   const channel = addons.getChannel();
-  /**
-   * Inject the stylesheet and emit the init payload once on module load so
-   * the manager's toolbar populates and CSS vars are available even when no
-   * story/decorator ever runs (bare MDX docs pages). Without these, the
-   * toolbar sits in its disabled "loading…" state and nothing is styled.
-   */
+  // Inject the stylesheet and emit the init payload once on module load so
+  // the manager's toolbar populates and CSS vars are available even when no
+  // story/decorator ever runs (bare MDX docs pages). Without these, the
+  // toolbar sits in its disabled "loading…" state and nothing is styled.
   ensureStylesheet(css, cssVarPrefix);
   broadcastInit();
-  /**
-   * If the manager subscribes to INIT_EVENT after our initial broadcast,
-   * it misses the payload and the toolbar stays in its "loading…" state
-   * until something else re-fires it. Honor an explicit request event so
-   * a late-mounting manager can ask for the payload.
-   */
+  // If the manager subscribes to INIT_EVENT after our initial broadcast,
+  // it misses the payload and the toolbar stays in its "loading…" state
+  // until something else re-fires it. Honor an explicit request event so
+  // a late-mounting manager can ask for the payload.
   channel.on(INIT_REQUEST_EVENT, broadcastInit);
   const apply = (globals: SwatchbookGlobals): void => {
     ensureStylesheet(css, cssVarPrefix);
@@ -449,13 +418,11 @@ function installGlobalAxisApplier(): void {
 
 installGlobalAxisApplier();
 
-/**
- * Bridge `mousedown` inside the preview iframe to the manager via a
- * dedicated channel event. The toolbar popover's outside-click listener
- * runs on the manager's document, which can't observe mousedowns inside
- * the preview; without this bridge, clicking the canvas leaves the
- * popover open. Idempotent: fires at most once per real mousedown.
- */
+// Bridge `mousedown` inside the preview iframe to the manager via a
+// dedicated channel event. The toolbar popover's outside-click listener
+// runs on the manager's document, which can't observe mousedowns inside
+// the preview; without this bridge, clicking the canvas leaves the
+// popover open. Idempotent: fires at most once per real mousedown.
 function installPreviewMouseDownBridge(): void {
   if (typeof document === 'undefined') return;
   const channel = addons.getChannel();
@@ -466,15 +433,13 @@ function installPreviewMouseDownBridge(): void {
 
 installPreviewMouseDownBridge();
 
-/**
- * Wire the dev-time token-refresh HMR path. The plugin emits `HMR_EVENT`
- * with the fresh virtual-module payload whenever a watched source file
- * changes; we re-inject the stylesheet and forward to the Storybook
- * channel so the toolbar re-renders and blocks can re-subscribe with
- * the new snapshot — no full preview reload, so args / scroll / open
- * overlays survive the refresh. No-ops in production where
- * `import.meta.hot` is undefined.
- */
+// Wire the dev-time token-refresh HMR path. The plugin emits `HMR_EVENT`
+// with the fresh virtual-module payload whenever a watched source file
+// changes; we re-inject the stylesheet and forward to the Storybook
+// channel so the toolbar re-renders and blocks can re-subscribe with
+// the new snapshot — no full preview reload, so args / scroll / open
+// overlays survive the refresh. No-ops in production where
+// `import.meta.hot` is undefined.
 interface HmrSnapshot {
   axes: typeof virtualAxes;
   disabledAxes: typeof virtualDisabledAxes;

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -22,15 +22,14 @@ export interface SwatchbookPluginOptions {
   integrations?: readonly SwatchbookIntegration[];
   /**
    * Pre-loaded project to use for the first `buildStart` instead of
-   * calling `loadProject` again. Lets `preset.viteFinal` share its
-   * single `loadProject` call (originally needed for codegen) with the
-   * plugin, eliminating a redundant parse pass at Storybook startup.
-   * HMR-triggered reloads still call `loadProject` directly.
+   * calling `loadProject` again. Shares `preset.viteFinal`'s single
+   * `loadProject` call with the plugin so Storybook startup doesn't parse
+   * twice. HMR-triggered reloads still call `loadProject` directly.
    */
   initialProject?: Project;
 }
 
-/** `\0<virtualId>` — Vite convention for resolved virtual module IDs. */
+// `\0<virtualId>` — Vite convention for resolved virtual module IDs.
 function resolvedId(virtualId: string): string {
   return `\0${virtualId}`;
 }
@@ -55,9 +54,9 @@ export function swatchbookTokensPlugin({
     css = emitAxisProjectedCss(project);
   }
 
-  /** Map of resolvedId → integration, indexed once. */
+  // Map of resolvedId → integration, indexed once.
   const integrationById = new Map<string, SwatchbookIntegration>();
-  /** Virtual IDs the preview auto-imports as side effects (global CSS). */
+  // Virtual IDs the preview auto-imports as side effects (global CSS).
   const autoInjectIds: string[] = [];
   for (const integration of integrations) {
     const vm = integration.virtualModule;
@@ -70,20 +69,18 @@ export function swatchbookTokensPlugin({
     name: 'swatchbook:virtual-tokens',
     enforce: 'pre',
 
-    /**
-     * Vite uses esbuild for `optimizeDeps` pre-bundling (development
-     * mode), and esbuild doesn't see Rollup-style `resolveId` hooks.
-     * Without this exclusion, a preview file that imports
-     * `virtual:swatchbook/tokens` (directly or via the addon's
-     * `useToken` hook) can get pulled into pre-bundling, hitting
-     * esbuild with no resolver registered and failing with
-     * `Could not resolve "virtual:swatchbook/tokens"`.
-     *
-     * Excluding the virtual IDs tells Vite to route them through the
-     * Rollup-style pipeline at request time — our `resolveId` / `load`
-     * hooks above handle the resolution. Build mode is unaffected
-     * (build uses Rollup throughout).
-     */
+    // Vite uses esbuild for `optimizeDeps` pre-bundling (development
+    // mode), and esbuild doesn't see Rollup-style `resolveId` hooks.
+    // Without this exclusion, a preview file that imports
+    // `virtual:swatchbook/tokens` (directly or via the addon's
+    // `useToken` hook) can get pulled into pre-bundling, hitting
+    // esbuild with no resolver registered and failing with
+    // `Could not resolve "virtual:swatchbook/tokens"`.
+    //
+    // Excluding the virtual IDs tells Vite to route them through the
+    // Rollup-style pipeline at request time — our `resolveId` / `load`
+    // hooks above handle the resolution. Build mode is unaffected
+    // (build uses Rollup throughout).
     config() {
       return {
         optimizeDeps: {
@@ -153,12 +150,10 @@ export function swatchbookTokensPlugin({
       // and saves to any `$ref` target silently drop.
       if (!project) await refresh();
 
-      /**
-       * Editors typically emit two or three filesystem events per save
-       * (atomic rename + rewrite + metadata). A 100 ms trailing debounce
-       * coalesces those into a single reload while staying well under
-       * user-perceptible latency.
-       */
+      // Editors typically emit two or three filesystem events per save
+      // (atomic rename + rewrite + metadata). A 100 ms trailing debounce
+      // coalesces those into a single reload while staying well under
+      // user-perceptible latency.
       let pending: ReturnType<typeof setTimeout> | null = null;
       const invalidate = (): void => {
         if (pending) clearTimeout(pending);
@@ -182,14 +177,12 @@ export function swatchbookTokensPlugin({
               const m = server.moduleGraph.getModuleById(resolvedIntegrationId);
               if (m) server.moduleGraph.invalidateModule(m);
             }
-            /**
-             * Send the fresh snapshot as a custom HMR event instead of a
-             * full-reload. The preview subscribes and re-broadcasts to
-             * blocks via the Storybook channel so the React tree
-             * re-renders in place without losing toolbar / args / scroll
-             * state. Field shape matches the INIT_EVENT payload so the
-             * preview can hand it straight through.
-             */
+            // Send the fresh snapshot as a custom HMR event instead of a
+            // full-reload. The preview subscribes and re-broadcasts to
+            // blocks via the Storybook channel so the React tree
+            // re-renders in place without losing toolbar / args / scroll
+            // state. Field shape matches the INIT_EVENT payload so the
+            // preview can hand it straight through.
             server.ws.send({
               type: 'custom',
               event: HMR_EVENT,
@@ -199,18 +192,16 @@ export function swatchbookTokensPlugin({
         }, 100);
       };
 
-      /**
-       * Watch each source file's *parent directory* rather than the file
-       * itself. File-level `fs.watch` is fragile: atomic-save editors
-       * unlink the old inode and write a new one, so the original
-       * watcher either fires a one-shot 'rename' and goes deaf, or on
-       * some platforms loops on ghost events for the old inode. Watching
-       * the dir sidesteps both — the dir inode is stable across the
-       * rename dance — and filename filtering keeps event volume low.
-       *
-       * Vite's `server.watcher` still wouldn't carry these events across
-       * pnpm symlink boundaries, so we keep running our own watchers.
-       */
+      // Watch each source file's *parent directory* rather than the file
+      // itself. File-level `fs.watch` is fragile: atomic-save editors
+      // unlink the old inode and write a new one, so the original
+      // watcher either fires a one-shot 'rename' and goes deaf, or on
+      // some platforms loops on ghost events for the old inode. Watching
+      // the dir sidesteps both — the dir inode is stable across the
+      // rename dance — and filename filtering keeps event volume low.
+      //
+      // Vite's `server.watcher` still wouldn't carry these events across
+      // pnpm symlink boundaries, so we keep running our own watchers.
       const byDir = new Map<string, Set<string>>();
       for (const file of project?.sourceFiles ?? []) {
         const dir = dirname(file);
@@ -246,8 +237,9 @@ export function swatchbookTokensPlugin({
  * absent, use the resolver file + every `$ref` target it pulled in, as
  * tracked on `project.sourceFiles` — which stays correct as the resolver
  * evolves without requiring a parallel `tokens` glob.
+ *
+ * @internal Exported for tests; not part of the public API.
  */
-/** @internal Exported for tests; not part of the public API. */
 export function collectWatchPaths(
   config: Config,
   project: Project | undefined,


### PR DESCRIPTION
Applies the comment doctrine (from #1077) to `packages/addon/src`. Comment-only — verified zero non-comment lines changed.

- Converted ~26 internal `/** */` (helpers, in-body rationale blocks, internal interfaces) to `//`; kept `/** */` on the exported surface (`swatchbookTokensPlugin`, `useToken`, `decorators`, `COLOR_FORMATS`, etc.).
- Dropped two history smells: `forEachPinnedAxis` no longer compares itself to "the old lookup"; `initialProject` no longer says "originally needed for codegen" (states the current parse-once purpose).
- Merged `collectWatchPaths`' two stacked `/** */` blocks into one.
- `constants.ts`, `channel-types.ts`, `globals.ts`, `options.ts`, `index.ts`, `hooks/index.ts`, `virtual.d.ts`: no changes — already correct.

Net −63 lines. Gate green: format / lint / typecheck / 37 tests. Internal-only, so no changeset.

Milestone: Maintenance

Closes #1078

Plan impact: none.
