### PR TITLE
chore(core): apply the comment doctrine to core comments

### DIFF
--- a/packages/core/src/chrome.ts
+++ b/packages/core/src/chrome.ts
@@ -109,12 +109,10 @@ export function validateChrome(
   return { entries, diagnostics };
 }
 
-/**
- * A target resolves if it's either a direct token ID, or a composite
- * sub-field under one (`typography.body.font-family` under the composite
- * `typography.body`). Composite tokens emit one CSS var per sub-field,
- * so either form is a valid alias target.
- */
+// A target resolves if it's either a direct token ID, or a composite
+// sub-field under one (`typography.body.font-family` under the composite
+// `typography.body`). Composite tokens emit one CSS var per sub-field,
+// so either form is a valid alias target.
 function targetResolves(target: string, tokenIDs: ReadonlySet<string>): boolean {
   if (tokenIDs.has(target)) return true;
   const lastDot = target.lastIndexOf('.');

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -9,15 +9,13 @@ import type { Project, TokenMap } from '#/types.ts';
 import { permutationID } from '#/types.ts';
 import { valueKey } from '#/value-key.ts';
 
-/**
- * Internal alias: the raw Terrazzo-shape map this emitter passes into
- * `transformCSSValue` / `generateShorthand`. The graph stores slim
- * `SwatchbookToken` shapes (no `id`, `source`, `mode`, etc.). The CSS
- * emitter needs `token.id` (= the token path) for `transformAlias` and
- * `defaultAliasTransform`. `withSyntheticIds` injects `id: path` so
- * `transformCSSValue` can resolve alias var references correctly without
- * requiring the full Terrazzo shape in the graph.
- */
+// Internal alias: the raw Terrazzo-shape map this emitter passes into
+// `transformCSSValue` / `generateShorthand`. The graph stores slim
+// `SwatchbookToken` shapes (no `id`, `source`, `mode`, etc.). The CSS
+// emitter needs `token.id` (= the token path) for `transformAlias` and
+// `defaultAliasTransform`. `withSyntheticIds` injects `id: path` so
+// `transformCSSValue` can resolve alias var references correctly without
+// requiring the full Terrazzo shape in the graph.
 type RawTokenMap = Record<string, TokenNormalized>;
 
 function withSyntheticIds(map: TokenMap): RawTokenMap {
@@ -32,7 +30,7 @@ function asRawTokens(map: TokenMap): RawTokenMap {
   return withSyntheticIds(map);
 }
 
-/** Distinguishes a token's variance shape so the emitter can route it. */
+// Distinguishes a token's variance shape so the emitter can route it.
 type VarianceInfo =
   | {
       kind: 'baseline-only';
@@ -51,48 +49,42 @@ type VarianceInfo =
       jointCases: readonly JointCase[];
     };
 
-/**
- * One concrete partial tuple (2+ axes at non-default contexts) where
- * cascade composition would NOT produce the cartesian-correct value
- * for this token. Emitted as a compound `[data-axis="…"][…]` block.
- *
- * `tuple` carries only the non-default axes — its `Object.keys` length
- * is the joint case's arity (2 for pairs, 3 for triples, etc.).
- */
+// One concrete partial tuple (2+ axes at non-default contexts) where
+// cascade composition would NOT produce the cartesian-correct value
+// for this token. Emitted as a compound `[data-axis="…"][…]` block.
+//
+// `tuple` carries only the non-default axes — its `Object.keys` length
+// is the joint case's arity (2 for pairs, 3 for triples, etc.).
 interface JointCase {
   tuple: Record<string, string>;
   cartesianValueKey: string;
   permutationName: string;
 }
 
-/**
- * Default cap on joint-case arity probed per token. See `Config.maxJointArity`
- * in the public types for the per-project override and the failure-mode
- * tradeoffs. Per-token work scales as
- * `Σ C(|affectedBy|, k) × Π non_default_contexts` for k = 2..arity.
- * 4 covers virtually all design-system shapes (mode × brand × density ×
- * contrast is the largest real-world joint anyone tends to express);
- * beyond that, joint blocks aren't emitted and the cascade resolves to
- * whatever lower-arity composition produces.
- */
+// Default cap on joint-case arity probed per token. See `Config.maxJointArity`
+// in the public types for the per-project override and the failure-mode
+// tradeoffs. Per-token work scales as
+// `Σ C(|affectedBy|, k) × Π non_default_contexts` for k = 2..arity.
+// 4 covers virtually all design-system shapes (mode × brand × density ×
+// contrast is the largest real-world joint anyone tends to express);
+// beyond that, joint blocks aren't emitted and the cascade resolves to
+// whatever lower-arity composition produces.
 const DEFAULT_MAX_JOINT_ARITY = 4;
 
-/**
- * Classify every token in a project. Returns a Map keyed by token path.
- * Reads from `project.tokenGraph` — the sole resolution surface.
- *
- * For tokens affected by 2+ axes, probes joint divergences from arity 2
- * up to `min(|affectedBy|, MAX_JOINT_ARITY)`. Each probe checks whether
- * cascade composition (baseline + per-axis cell overlays in project axis
- * order + lower-arity joint corrections recorded for this token) produces
- * the cartesian-correct value at the candidate tuple. When it doesn't,
- * an arity-k joint case is recorded — which will become an arity-k
- * compound block at emission.
- *
- * The per-token bound on probing scope is what keeps this tractable for
- * many-axis projects: a token affected by 3 axes only ever probes within
- * those 3 axes, regardless of how many axes the project has overall.
- */
+// Classify every token in a project. Returns a Map keyed by token path.
+// Reads from `project.tokenGraph` — the sole resolution surface.
+//
+// For tokens affected by 2+ axes, probes joint divergences from arity 2
+// up to `min(|affectedBy|, MAX_JOINT_ARITY)`. Each probe checks whether
+// cascade composition (baseline + per-axis cell overlays in project axis
+// order + lower-arity joint corrections recorded for this token) produces
+// the cartesian-correct value at the candidate tuple. When it doesn't,
+// an arity-k joint case is recorded — which will become an arity-k
+// compound block at emission.
+//
+// The per-token bound on probing scope is what keeps this tractable for
+// many-axis projects: a token affected by 3 axes only ever probes within
+// those 3 axes, regardless of how many axes the project has overall.
 function analyzeProjectVariance(project: Project): Map<string, VarianceInfo> {
   const result = new Map<string, VarianceInfo>();
   const { axes, tokenGraph, defaultTuple } = project;
@@ -208,7 +200,7 @@ function analyzeProjectVariance(project: Project): Map<string, VarianceInfo> {
   return result;
 }
 
-/** True if every axis=ctx in `partial` appears the same way in `full`. */
+// True if every axis=ctx in `partial` appears the same way in `full`.
 function isPartialTupleSubset(
   partial: Record<string, string>,
   full: Record<string, string>,
@@ -323,7 +315,7 @@ export function emitAxisProjectedCss(
 
   // Pre-compute per-axis delta sets using tokenGraph walks. A path is
   // in a delta cell when its resolved value at that singleton tuple
-  // differs from the baseline — mirrors the shape buildCells produced.
+  // differs from the baseline.
   const deltaPathsByAxis: Record<string, Record<string, Set<string>>> = {};
   for (const axis of axes) {
     const axisDeltaPaths: Record<string, Set<string>> = {};
@@ -398,11 +390,9 @@ export function emitAxisProjectedCss(
 
 type VarOpts = Record<string, never> | { prefix: string };
 
-/**
- * Tells whether the given axis is in a token's touching set. Drives the
- * per-axis cell-block filter: only tokens this axis actually affects
- * appear in that axis's cell blocks.
- */
+// Tells whether the given axis is in a token's touching set. Drives the
+// per-axis cell-block filter: only tokens this axis actually affects
+// appear in that axis's cell blocks.
 function axisTouchesToken(axisName: string, info: VarianceInfo | undefined): boolean {
   if (!info) return false;
   switch (info.kind) {
@@ -426,20 +416,18 @@ interface Axis {
   default: string;
 }
 
-/**
- * Emit one compound `[data-axis="…"][…]` block per unique joint tuple
- * that any token in the project diverges at. The set of joint tuples
- * comes from `analyzeProjectVariance`'s per-token `jointCases` — no
- * cartesian enumeration over project axes is performed. For a token
- * with `affectedBy = [A, B]` the only joint tuples probed involve A
- * and B; the rest of the project's axes are irrelevant for that token.
- *
- * Blocks are emitted in arity-ascending order so cascade composition
- * resolves correctly: higher-arity blocks override lower-arity blocks
- * at the same specificity gradient (n-attribute selectors have
- * specificity (0, n, 0); a 3-axis block beats both its constituent
- * 2-axis blocks).
- */
+// Emit one compound `[data-axis="…"][…]` block per unique joint tuple
+// that any token in the project diverges at. The set of joint tuples
+// comes from `analyzeProjectVariance`'s per-token `jointCases` — no
+// cartesian enumeration over project axes is performed. For a token
+// with `affectedBy = [A, B]` the only joint tuples probed involve A
+// and B; the rest of the project's axes are irrelevant for that token.
+//
+// Blocks are emitted in arity-ascending order so cascade composition
+// resolves correctly: higher-arity blocks override lower-arity blocks
+// at the same specificity gradient (n-attribute selectors have
+// specificity (0, n, 0); a 3-axis block beats both its constituent
+// 2-axis blocks).
 function collectJointBlocks(
   project: Project,
   variance: Map<string, VarianceInfo>,
@@ -475,8 +463,8 @@ function collectJointBlocks(
 
   // Sort: arity ascending first (cascade requires lower-arity blocks before
   // higher-arity). Within an arity, by project-axis order of the involved
-  // axes; within same axes, by context iteration order. Matches the
-  // emission order the old cartesian enumerator produced.
+  // axes; within same axes, by context iteration order — a stable emission
+  // order keyed off project-axis and context declaration order.
   function emissionSortKey(tuple: Record<string, string>): string {
     const sortedAxes = Object.keys(tuple).toSorted(
       (a, b) => (projectAxisOrder.get(a) ?? 0) - (projectAxisOrder.get(b) ?? 0),
@@ -538,10 +526,8 @@ function collectJointBlocks(
   return blocks;
 }
 
-/**
- * Build a stable lookup key for a partial tuple — axis entries joined
- * in sorted key order so `{A: a, B: b}` and `{B: b, A: a}` match.
- */
+// Build a stable lookup key for a partial tuple — axis entries joined
+// in sorted key order so `{A: a, B: b}` and `{B: b, A: a}` match.
 function canonicalPartialKey(partial: Record<string, string>): string {
   return Object.entries(partial)
     .toSorted(([a], [b]) => a.localeCompare(b))
@@ -549,18 +535,16 @@ function canonicalPartialKey(partial: Record<string, string>): string {
     .join('|');
 }
 
-/**
- * Collect emitted declaration lines for a token map, filtering tokens
- * by `accept(path)`. Each line is `  --var: value;` (with leading
- * indent for embedding in a block). Composite tokens contribute one
- * line per sub-field plus an optional shorthand line; primitives
- * contribute one line.
- *
- * `tokensForAliasResolution` is the broader resolution context —
- * with delta cells, `tokens` itself only carries the delta paths,
- * so composite token sub-aliases need the full composed TokenMap
- * to resolve references to non-delta tokens.
- */
+// Collect emitted declaration lines for a token map, filtering tokens
+// by `accept(path)`. Each line is `  --var: value;` (with leading
+// indent for embedding in a block). Composite tokens contribute one
+// line per sub-field plus an optional shorthand line; primitives
+// contribute one line.
+//
+// `tokensForAliasResolution` is the broader resolution context —
+// with delta cells, `tokens` itself only carries the delta paths,
+// so composite token sub-aliases need the full composed TokenMap
+// to resolve references to non-delta tokens.
 function collectLines(
   tokens: RawTokenMap,
   tokensForAliasResolution: RawTokenMap,

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -30,17 +30,15 @@ import type { Axis, Config, Diagnostic, Permutation, Project, TokenMap } from '#
  * or set to `''` to opt out of namespacing. */
 export const DEFAULT_CSS_VAR_PREFIX = 'swatch';
 
-/**
- * Opt-in phase timing for `loadProject`. Activate with the env var
- * `SWATCHBOOK_LOG_VERBOSE=1`. Each major phase logs its duration to
- * stdout as `[swatchbook:load] <phase>: <ms>ms`. When the env var is
- * unset, the overhead is a few `performance.now()` calls per phase
- * (negligible) and no console output.
- *
- * Primary use case: a consumer reports a hung or slow `loadProject` and
- * we need to know which phase is the offender before reaching for a
- * full CPU profile.
- */
+// Opt-in phase timing for `loadProject`. Activate with the env var
+// `SWATCHBOOK_LOG_VERBOSE=1`. Each major phase logs its duration to
+// stdout as `[swatchbook:load] <phase>: <ms>ms`. When the env var is
+// unset, the overhead is a few `performance.now()` calls per phase
+// (negligible) and no console output.
+//
+// Primary use case: a consumer reports a hung or slow `loadProject` and
+// we need to know which phase is the offender before reaching for a
+// full CPU profile.
 function isVerbose(): boolean {
   return process.env['SWATCHBOOK_LOG_VERBOSE'] === '1';
 }
@@ -188,8 +186,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   })();
 
   // `validateChrome` checks targets against the project's path universe.
-  // `listPaths` returns every path present in the graph — same set the
-  // prior `permutationsResolved`-scan produced.
+  // `listPaths` returns every path present in the graph.
   const tokenIDs = new Set<string>(listPaths(tokenGraphResult.graph));
   const { entries: chrome, diagnostics: chromeDiagnostics } = validateChrome(
     config.chrome,
@@ -225,13 +222,11 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
   };
 }
 
-/**
- * Project `disabledAxes` onto the loader output: drop disabled axes from
- * the axis list, keep only the permutations whose disabled-axis values
- * equal their axis defaults, and prune `resolved` to the surviving
- * permutation names. Returns the original triple unchanged when
- * `disabled` is empty.
- */
+// Project `disabledAxes` onto the loader output: drop disabled axes from
+// the axis list, keep only the permutations whose disabled-axis values
+// equal their axis defaults, and prune `resolved` to the surviving
+// permutation names. Returns the original triple unchanged when
+// `disabled` is empty.
 function applyDisabledAxes(
   axes: Axis[],
   permutations: Permutation[],

--- a/packages/core/src/permutations/resolver.ts
+++ b/packages/core/src/permutations/resolver.ts
@@ -19,23 +19,21 @@ export interface ResolverLoadResult {
   diagnostics: Diagnostic[];
 }
 
-/**
- * Resolve a `config.resolver` value to an absolute file path.
- *
- * Resolution order:
- *
- * 1. Absolute paths pass through unchanged.
- * 2. Explicit relative paths (`./resolver.json`, `../config/resolver.json`)
- *    resolve against `cwd`.
- * 3. Anything else first tries `cwd`-relative on disk — preserves the
- *    legacy "`resolver.json` in the project root" form — and falls back
- *    to `node_modules` resolution when that file isn't present. Token
- *    packages can ship a resolver that consumers reference directly
- *    (`@scope/pkg/resolver.json`) without copying it into their tree.
- *
- * The `createRequire` anchor doesn't need to exist on disk — it only
- * fixes the starting point for the `node_modules` walk.
- */
+// Resolve a `config.resolver` value to an absolute file path.
+//
+// Resolution order:
+//
+// 1. Absolute paths pass through unchanged.
+// 2. Explicit relative paths (`./resolver.json`, `../config/resolver.json`)
+//    resolve against `cwd`.
+// 3. Anything else first tries `cwd`-relative on disk — so a bare
+//    `resolver.json` in the project root resolves — and falls back
+//    to `node_modules` resolution when that file isn't present. Token
+//    packages can ship a resolver that consumers reference directly
+//    (`@scope/pkg/resolver.json`) without copying it into their tree.
+//
+// The `createRequire` anchor doesn't need to exist on disk — it only
+// fixes the starting point for the `node_modules` walk.
 function resolveResolverInput(resolverPath: string, cwd: string): string {
   if (isAbsolute(resolverPath)) return resolverPath;
   if (resolverPath.startsWith('.')) return resolvePath(cwd, resolverPath);

--- a/packages/core/src/terrazzo-options.ts
+++ b/packages/core/src/terrazzo-options.ts
@@ -11,12 +11,10 @@ export type StrippedCssOption = 'variableName' | 'permutations' | 'filename' | '
 
 export type ForwardedCssOptions = Omit<CSSPluginOptions, StrippedCssOption>;
 
-/**
- * Deprecated plugin-css knobs that are silently inert under swatchbook's
- * permutation-based emission. Calling them out as `warn` diagnostics beats
- * the alternative — authors wonder why their `modeSelectors` don't take
- * effect and blame swatchbook.
- */
+// Deprecated plugin-css knobs that are silently inert under swatchbook's
+// permutation-based emission. Calling them out as `warn` diagnostics beats
+// the alternative — authors wonder why their `modeSelectors` don't take
+// effect and blame swatchbook.
 const INERT_DEPRECATED_KEYS = ['baseSelector', 'baseScheme', 'modeSelectors'] as const;
 
 /**

--- a/packages/core/src/token-graph/build.ts
+++ b/packages/core/src/token-graph/build.ts
@@ -22,17 +22,15 @@ const SLIM_KEYS = [
   'aliasedBy',
 ] as const;
 
-/**
- * Strip a Terrazzo-shaped token to only the fields swatchbook consumers
- * read. Terrazzo's `TokenNormalized` carries `source.node`, `mode`,
- * `group`, `originalValue`, `jsonID`, `id`, `dependencies` — none of
- * which any swatchbook consumer reads, but which together account for
- * ~530 KB of the wire payload on the reference fixture (`source.node`
- * alone is 245 KB).
- *
- * Apply at graph-build time so the in-memory graph carries only the
- * slim shape; the wire payload then naturally serializes the slim shape.
- */
+// Strip a Terrazzo-shaped token to only the fields swatchbook consumers
+// read. Terrazzo's `TokenNormalized` carries `source.node`, `mode`,
+// `group`, `originalValue`, `jsonID`, `id`, `dependencies` — none of
+// which any swatchbook consumer reads, but which together account for
+// ~530 KB of the wire payload on the reference fixture (`source.node`
+// alone is 245 KB).
+//
+// Apply at graph-build time so the in-memory graph carries only the
+// slim shape; the wire payload then naturally serializes the slim shape.
 function slimToken(token: SwatchbookToken): SwatchbookToken {
   const result: Record<string, unknown> = {};
   for (const key of SLIM_KEYS) {
@@ -126,19 +124,17 @@ function toWriteValue(
   return { kind: 'literal', value: slimToken(withType) };
 }
 
-/**
- * Walk `value` and replace any `{ $ref: '<JSON Pointer>' }` object with the
- * resolved target from `refLookup`. Terrazzo's resolver normalize pass
- * doesn't substitute cross-document `$ref` references in modifier source
- * values — they're only substituted at `resolver.apply()` time via
- * `processTokens`, which our `extractWritesFromModifiers` bypasses by
- * reading `resolver.source.modifiers` directly. This function fills that
- * gap by performing the same JSON Pointer substitution against an already-
- * resolved token snapshot (typically the resolver's baseline output).
- *
- * Unresolved pointers are left as-is — they then surface via #1014's
- * `unresolvedRefDiagnostic` (load-time) or #1007's emit-wrap (runtime).
- */
+// Walk `value` and replace any `{ $ref: '<JSON Pointer>' }` object with the
+// resolved target from `refLookup`. Terrazzo's resolver normalize pass
+// doesn't substitute cross-document `$ref` references in modifier source
+// values — they're only substituted at `resolver.apply()` time via
+// `processTokens`, which our `extractWritesFromModifiers` bypasses by
+// reading `resolver.source.modifiers` directly. This function fills that
+// gap by performing the same JSON Pointer substitution against an already-
+// resolved token snapshot (typically the resolver's baseline output).
+//
+// Unresolved pointers are left as-is — they then surface via
+// `unresolvedRefDiagnostic` (load-time) or the emit-wrap (runtime).
 function resolveRefsInValue(value: unknown, refLookup: TokenMap): unknown {
   if (Array.isArray(value)) {
     let changed = false;
@@ -289,15 +285,13 @@ function validateAliasTargets(nodes: Record<string, TokenGraphNode>): Diagnostic
   return diagnostics;
 }
 
-/**
- * Walks every literal `$value` in the graph and reports DTCG color
- * objects whose `components` field is missing or non-array — the
- * shape that crashes `colorjs.io` inside `inGamut(...)` with the
- * unactionable `coords.map is not a function` traceback. Covers
- * top-level color tokens AND color sub-fields inside composites
- * (border, gradient, shadow) uniformly: any object whose
- * `colorSpace` is a string is treated as a color and validated.
- */
+// Walks every literal `$value` in the graph and reports DTCG color
+// objects whose `components` field is missing or non-array — the
+// shape that crashes `colorjs.io` inside `inGamut(...)` with the
+// unactionable `coords.map is not a function` traceback. Covers
+// top-level color tokens AND color sub-fields inside composites
+// (border, gradient, shadow) uniformly: any object whose
+// `colorSpace` is a string is treated as a color and validated.
 function validateColorShapes(nodes: Record<string, TokenGraphNode>): Diagnostic[] {
   const diagnostics: Diagnostic[] = [];
   for (const [path, node] of Object.entries(nodes)) {
@@ -363,13 +357,11 @@ function scanValueForColorShape(
   }
 }
 
-/**
- * Returns the JSON Pointer if `value` is an unresolved DTCG `$ref` object
- * (a plain object whose only non-`$`-prefixed shape is a string `$ref`
- * member). Returns `undefined` for anything else. Used to distinguish a
- * source-side malformation from an upstream parser failing to substitute
- * a `$ref` target.
- */
+// Returns the JSON Pointer if `value` is an unresolved DTCG `$ref` object
+// (a plain object whose only non-`$`-prefixed shape is a string `$ref`
+// member). Returns `undefined` for anything else. Used to distinguish a
+// source-side malformation from an upstream parser failing to substitute
+// a `$ref` target.
 function unresolvedRefTarget(value: unknown): string | undefined {
   if (!isPlainObject(value)) return undefined;
   const ref = value['$ref'];

--- a/packages/core/src/token-listing.ts
+++ b/packages/core/src/token-listing.ts
@@ -64,7 +64,7 @@ export async function computeTokenListing(
 
     // User-supplied `platforms` overrides the default CSS entry when
     // present — otherwise the built-in `css` platform is the only one
-    // registered, matching the earlier default behavior.
+    // registered.
     const platforms = options.listingOptions?.platforms ?? {
       css: { name: '@terrazzo/plugin-css', description: 'CSS custom properties' },
     };

--- a/packages/core/src/tuple-key.ts
+++ b/packages/core/src/tuple-key.ts
@@ -3,7 +3,7 @@
  * serialization / `Map` lookups behave identically at runtime; the
  * brand catches places that pass arbitrary strings (token paths, axis
  * names, theme display names) into a context expecting a canonical
- * tuple key, which used to all compile as plain `string`.
+ * tuple key.
  *
  * Produced by {@link canonicalKey}.
  */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -151,14 +151,12 @@ export interface AxisConfig {
   default: string;
 }
 
-/**
- * Fields shared across every swatchbook config variant. The three
- * discriminated subtypes (`ResolverConfig`, `LayeredConfig`,
- * `PlainConfig`) extend this with their own load-strategy fields plus
- * `?: never` rejections of the other variants' fields, so an invalid
- * combination (`resolver` + `axes`, `axes` without `tokens`) is a
- * compile error before it ever reaches the loader's runtime checks.
- */
+// Fields shared across every swatchbook config variant. The three
+// discriminated subtypes (`ResolverConfig`, `LayeredConfig`,
+// `PlainConfig`) extend this with their own load-strategy fields plus
+// `?: never` rejections of the other variants' fields, so an invalid
+// combination (`resolver` + `axes`, `axes` without `tokens`) is a
+// compile error before it ever reaches the loader's runtime checks.
 interface CommonConfig {
   /**
    * Initial active tuple (`{ axisName: contextName }`). Any axis the tuple


### PR DESCRIPTION
Applies the comment doctrine (from #1077) to `packages/core/src`. Comment-only — verified zero non-comment lines changed.

- Converted internal `/** */` (helpers, in-body blocks, internal interfaces/types in `css-axis-projected.ts`, `build.ts`, `load.ts`, `resolver.ts`, `chrome.ts`, `terrazzo-options.ts`) to `//`. Kept `/** */` on the exported surface — including `@internal`-tagged exports and the `CommonConfig` member docs that the exported `Config` union inherits.
- History trimmed, invariants preserved:
  - emission-order comment: "matches the old cartesian enumerator" → states the stable declaration-order invariant directly.
  - dropped a removed-`buildCells` reference, the `#1014`/`#1007` issue numbers on `resolveRefsInValue` (kept the load/emit mechanism names), "legacy"/"earlier default"/"used to all compile as plain string".
- No restating-the-code trims were needed; the algorithmic "why" comments all carry real reasoning and were preserved verbatim aside from the delimiter.

Net −37 lines. Gate green: format / lint / typecheck / 222 tests. Internal-only, so no changeset.

Milestone: Maintenance

Closes #1080

Plan impact: none.
