### PR TITLE
chore(blocks): apply the comment doctrine to blocks comments

### DIFF
--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -49,10 +49,8 @@ interface Swatch {
   outOfGamut: boolean;
 }
 
-/**
- * Count segments in the filter before the first glob (`*` / `**`).
- * `color.*` → 2; `color.surface.*` → 3; `color` → 1; undefined → 0.
- */
+// Count segments in the filter before the first glob (`*` / `**`).
+// `color.*` → 2; `color.surface.*` → 3; `color` → 1; undefined → 0.
 function fixedPrefixLength(filter: string | undefined): number {
   if (!filter) return 0;
   const segments = filter.split('.');

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -63,7 +63,7 @@ export interface ColorTableProps {
    *
    * Single-member groups render as plain rows (no pill selector). Empty
    * map (default) disables grouping entirely; each token renders as its
-   * own row, identical to the pre-grouping behavior.
+   * own row.
    */
   variants?: Record<string, string>;
 }
@@ -72,10 +72,10 @@ interface Variant {
   label: string;
   path: string;
   cssVar: string;
-  /** The display value in the currently-active color format. */
+  // The display value in the currently-active color format.
   value: string;
   outOfGamut: boolean;
-  /** Hex / HSL / OKLCH breakdown — retained for the expanded sub-table. */
+  // Hex / HSL / OKLCH breakdown — retained for the expanded sub-table.
   hex: string;
   hsl: string;
   oklch: string;
@@ -464,13 +464,11 @@ function ValueCell({
 
 type FormatColorResult = ReturnType<typeof formatColor>;
 
-/**
- * Pick the value + gamut flag to display in the single Value column based
- * on the active color-format context. We pre-compute hex/hsl/oklch for the
- * expanded sub-table regardless; the extras (`rgb`, `raw`) take a fresh
- * `formatColor` pass. Keeps the hot path fast while staying honest about
- * out-of-gamut warnings per-format.
- */
+// Pick the value + gamut flag to display in the single Value column based
+// on the active color-format context. We pre-compute hex/hsl/oklch for the
+// expanded sub-table regardless; the extras (`rgb`, `raw`) take a fresh
+// `formatColor` pass. Keeps the hot path fast while staying honest about
+// out-of-gamut warnings per-format.
 function pickActiveFormat(
   raw: NormalizedColor,
   colorFormat: ColorFormat,
@@ -498,9 +496,9 @@ interface VariantEntry {
 }
 
 interface VariantDefs {
-  /** Match iteration order — longest suffix first. */
+  // Match iteration order — longest suffix first.
   matchOrder: readonly VariantEntry[];
-  /** Display iteration order — preserves the caller's declared order. */
+  // Display iteration order — preserves the caller's declared order.
   displayOrder: readonly string[];
 }
 
@@ -517,31 +515,27 @@ function buildVariantDefs(variants: Record<string, string> | undefined): Variant
   return { matchOrder, displayOrder };
 }
 
-/**
- * Position of a label within a group — the `base` entry always sorts first,
- * then declared labels in the order the caller wrote them in the `variants`
- * prop. Unknown labels (shouldn't happen in practice) fall to the end.
- */
+// Position of a label within a group — the `base` entry always sorts first,
+// then declared labels in the order the caller wrote them in the `variants`
+// prop. Unknown labels (shouldn't happen in practice) fall to the end.
 function orderIndex(label: string, defs: VariantDefs): number {
   if (label === BASE_LABEL) return -1;
   const idx = defs.displayOrder.indexOf(label);
   return idx >= 0 ? idx : Number.POSITIVE_INFINITY;
 }
 
-/**
- * Resolve the variant label + base path for a token, if any. The leaf
- * (last dot-segment) must either equal the suffix outright (dot-segment
- * form: `hi.disabled` matches suffix `disabled`) or end in `-<suffix>`
- * (hyphen-tail form: `hi-d` matches `d`). The leading hyphen is required
- * for the tail form so suffix `0` can't hit `neutral-900` by character.
- *
- * Returned `basePath` is what gets used as the grouping key:
- * - Dot-segment match → parent path (drop the last dot-segment)
- * - Hyphen-tail match → same dot-depth, leaf with `-<suffix>` stripped
- *
- * Entries in `matchOrder` are pre-sorted longest-first, so `h-dark` wins
- * over `dark` for a path ending in `-h-dark`.
- */
+// Resolve the variant label + base path for a token, if any. The leaf
+// (last dot-segment) must either equal the suffix outright (dot-segment
+// form: `hi.disabled` matches suffix `disabled`) or end in `-<suffix>`
+// (hyphen-tail form: `hi-d` matches `d`). The leading hyphen is required
+// for the tail form so suffix `0` can't hit `neutral-900` by character.
+//
+// Returned `basePath` is what gets used as the grouping key:
+// - Dot-segment match → parent path (drop the last dot-segment)
+// - Hyphen-tail match → same dot-depth, leaf with `-<suffix>` stripped
+//
+// Entries in `matchOrder` are pre-sorted longest-first, so `h-dark` wins
+// over `dark` for a path ending in `-h-dark`.
 function matchVariant(
   path: string,
   matchOrder: readonly VariantEntry[],

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -150,16 +150,14 @@ function collectLeafPaths(nodes: TreeNode[], out: string[]): void {
   }
 }
 
-/**
- * Flatten the currently-visible treeitems into the order screen-reader
- * users + arrow-key users navigate them: depth-first, only descending
- * into expanded groups. Each entry carries enough metadata for the
- * keyboard handler to compute parent / first-child / next / prev.
- */
+// Flatten the currently-visible treeitems into the order screen-reader
+// users + arrow-key users navigate them: depth-first, only descending
+// into expanded groups. Each entry carries enough metadata for the
+// keyboard handler to compute parent / first-child / next / prev.
 interface FlatTreeItem {
   path: string;
   kind: 'group' | 'leaf';
-  /** Dot-path of the parent group, or `null` for top-level entries. */
+  // Dot-path of the parent group, or `null` for top-level entries.
   parentPath: string | null;
 }
 
@@ -177,11 +175,9 @@ function flattenVisible(
   }
 }
 
-/**
- * Return a pruned copy of the tree keeping only leaves whose path is in
- * `matches`, plus the groups on the way to them. Every surviving group's
- * path is added to `expandOut` so callers can force those groups open.
- */
+// Return a pruned copy of the tree keeping only leaves whose path is in
+// `matches`, plus the groups on the way to them. Every surviving group's
+// path is added to `expandOut` so callers can force those groups open.
 function pruneTreeForMatches(
   nodes: TreeNode[],
   matches: ReadonlySet<string>,
@@ -544,11 +540,11 @@ interface TreeNodeRowProps {
   onToggle(path: string): void;
   onFocusPath(path: string): void;
   onLeafClick(path: string): void;
-  /** 1-indexed depth in the tree (top-level = 1). */
+  // 1-indexed depth in the tree (top-level = 1).
   level: number;
-  /** Number of siblings at this level (including self). */
+  // Number of siblings at this level (including self).
   setsize: number;
-  /** 1-indexed position among siblings. */
+  // 1-indexed position among siblings.
   posinset: number;
 }
 
@@ -643,11 +639,11 @@ interface LeafRowProps {
   registerTreeItem(path: string): (el: HTMLLIElement | null) => void;
   onFocusPath(path: string): void;
   onLeafClick(path: string): void;
-  /** 1-indexed depth in the tree (top-level = 1). */
+  // 1-indexed depth in the tree (top-level = 1).
   level: number;
-  /** Number of siblings at this level (including self). */
+  // Number of siblings at this level (including self).
   setsize: number;
-  /** 1-indexed position among siblings. */
+  // 1-indexed position among siblings.
   posinset: number;
 }
 

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -8,11 +8,9 @@ import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 
-/**
- * Dimension sub-values in DTCG 2025.10 use a `{ value, unit }` envelope
- * — narrow once here so the local `asDimension` helper doesn't need
- * to re-validate keys at every read.
- */
+// Dimension sub-values in DTCG 2025.10 use a `{ value, unit }` envelope
+// — narrow once here so the local `asDimension` helper doesn't need
+// to re-validate keys at every read.
 interface DimensionLike {
   value?: unknown;
   unit?: unknown;

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -39,12 +39,10 @@ const styles = {
   } satisfies CSSProperties,
 };
 
-/**
- * Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
- * purpose of deciding whether to cap the rendered bar. Returns `NaN` for
- * units we can't reasonably approximate (ex / ch / %), which the caller
- * treats as "render at cssVar but don't cap".
- */
+// Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
+// purpose of deciding whether to cap the rendered bar. Returns `NaN` for
+// units we can't reasonably approximate (ex / ch / %), which the caller
+// treats as "render at cssVar but don't cap".
 function toPixels(raw: unknown): number {
   if (raw == null || typeof raw !== 'object') return Number.NaN;
   const v = raw as { value?: unknown; unit?: unknown };

--- a/packages/blocks/src/format-color.ts
+++ b/packages/blocks/src/format-color.ts
@@ -113,10 +113,8 @@ function hexToComponents(hex: string): number[] {
   return [r, g, b];
 }
 
-/**
- * Map Terrazzo's canonical CSS Color 4 space identifiers to the shorter
- * identifiers colorjs.io registers. Only the ones that differ need an entry.
- */
+// Map Terrazzo's canonical CSS Color 4 space identifiers to the shorter
+// identifiers colorjs.io registers. Only the ones that differ need an entry.
 const COLORJS_SPACE_ALIASES: Record<string, string> = {
   'display-p3': 'p3',
   'a98-rgb': 'a98rgb',

--- a/packages/blocks/src/internal/DetailOverlay.tsx
+++ b/packages/blocks/src/internal/DetailOverlay.tsx
@@ -20,12 +20,10 @@ export interface DetailOverlayProps {
   testId?: string;
 }
 
-/**
- * Selector for elements the trap considers focus stops. Mirrors the
- * "tabbable" set most focus-trap libraries use; the `:not(...)` clauses
- * skip the panel wrapper itself (we focus it manually on mount via its
- * own ref) and any explicitly-detabbed descendants.
- */
+// Selector for elements the trap considers focus stops. Mirrors the
+// "tabbable" set most focus-trap libraries use; the `:not(...)` clauses
+// skip the panel wrapper itself (we focus it manually on mount via its
+// own ref) and any explicitly-detabbed descendants.
 const FOCUSABLE_SELECTOR = [
   'a[href]',
   'button:not([disabled])',
@@ -88,11 +86,9 @@ export function DetailOverlay({
     return () => window.removeEventListener('keydown', onKey);
   }, [onClose]);
 
-  /**
-   * Wrap Tab inside the panel: from the last focusable, jump to the first;
-   * from the first (or from the panel itself), Shift+Tab jumps to the last.
-   * Defers to the browser otherwise.
-   */
+  // Wrap Tab inside the panel: from the last focusable, jump to the first;
+  // from the first (or from the panel itself), Shift+Tab jumps to the last.
+  // Defers to the browser otherwise.
   const onPanelKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>): void => {
     if (e.key !== 'Tab') return;
     const panel = panelRef.current;
@@ -149,12 +145,10 @@ export function DetailOverlay({
   );
 }
 
-/**
- * Walk up from `node` to the direct child of `<body>` that contains it.
- * Returns `null` when the node isn't attached to the document (mid-mount,
- * post-unmount). Used to identify which top-level branch to *not* mark
- * inert when the overlay opens.
- */
+// Walk up from `node` to the direct child of `<body>` that contains it.
+// Returns `null` when the node isn't attached to the document (mid-mount,
+// post-unmount). Used to identify which top-level branch to *not* mark
+// inert when the overlay opens.
 function findBodyChildContaining(node: HTMLElement): HTMLElement | null {
   let cursor: HTMLElement | null = node;
   while (cursor && cursor.parentElement !== document.body) {

--- a/packages/blocks/src/internal/channel-globals.ts
+++ b/packages/blocks/src/internal/channel-globals.ts
@@ -48,9 +48,8 @@ function ensureSubscribed(): void {
   // initial URL-persisted globals; `updateGlobals` is the toolbar
   // signal; `globalsUpdated` is the cross-frame echo. The handler runs
   // for each but content-deduplicates: we only update the shared
-  // snapshot when axes or format actually shifted (the previous
-  // identity-based spread guard fired three times per tick because each
-  // spread produced a new object identity even with unchanged content).
+  // snapshot when axes or format actually shifted, so the three events
+  // per tick don't each trigger a re-render.
   let lastFingerprint = '';
   const onGlobals = (payload: { globals?: SwatchbookGlobalsPayload }): void => {
     const globals = payload.globals;
@@ -71,11 +70,9 @@ function ensureSubscribed(): void {
   channel.on('setGlobals', onGlobals);
 }
 
-/**
- * Subscribe at module load so the `SET_GLOBALS` emission from preview init
- * lands in our snapshot before any block renders. Running `useSyncExternalStore`'s
- * `subscribe` lazily on first hook call would miss the event in most cases.
- */
+// Subscribe at module load so the `SET_GLOBALS` emission from preview init
+// lands in our snapshot before any block renders. Running `useSyncExternalStore`'s
+// `subscribe` lazily on first hook call would miss the event in most cases.
 ensureSubscribed();
 
 function subscribe(cb: () => void): () => void {

--- a/packages/blocks/src/internal/data-attr.ts
+++ b/packages/blocks/src/internal/data-attr.ts
@@ -7,14 +7,12 @@ import { dataAttr } from '@unpunnyfuns/swatchbook-core/data-attr';
  */
 export const BLOCK_ATTR = 'data-swatchbook-block';
 
-/**
- * Opt-out class that Storybook's `.sbdocs` stylesheet uses to self-exclude
- * on MDX docs pages — every `.sbdocs` house rule is wrapped in
- * `:not(.sb-unstyled, .sb-unstyled *)`, so any descendant of a `.sb-unstyled`
- * container is left alone. Stamped onto every block wrapper so blocks
- * render identically in MDX docs and regular stories without fighting
- * cascade specificity.
- */
+// Opt-out class that Storybook's `.sbdocs` stylesheet uses to self-exclude
+// on MDX docs pages — every `.sbdocs` house rule is wrapped in
+// `:not(.sb-unstyled, .sb-unstyled *)`, so any descendant of a `.sb-unstyled`
+// container is left alone. Stamped onto every block wrapper so blocks
+// render identically in MDX docs and regular stories without fighting
+// cascade specificity.
 const WRAPPER_CLASSES = 'sb-unstyled sb-block';
 
 /**

--- a/packages/blocks/src/internal/prefers-reduced-motion.ts
+++ b/packages/blocks/src/internal/prefers-reduced-motion.ts
@@ -1,13 +1,11 @@
 import { useEffect, useState } from 'react';
 
-/**
- * True when rendering inside Chromatic's snapshot runner. Chromatic's
- * browser ships a recognisable user-agent string; checked here so
- * motion-looping components can fall back to their static state for
- * deterministic snapshots. Per-component detection rather than the
- * global `chromatic.prefersReducedMotion: true` parameter — that
- * parameter is incompatible with Chromatic's verification parser.
- */
+// True when rendering inside Chromatic's snapshot runner. Chromatic's
+// browser ships a recognisable user-agent string; checked here so
+// motion-looping components can fall back to their static state for
+// deterministic snapshots. Per-component detection rather than the
+// global `chromatic.prefersReducedMotion: true` parameter — that
+// parameter is incompatible with Chromatic's verification parser.
 function isChromatic(): boolean {
   if (typeof navigator === 'undefined') return false;
   return navigator.userAgent.includes('Chromatic');

--- a/packages/blocks/src/internal/sort-tokens.ts
+++ b/packages/blocks/src/internal/sort-tokens.ts
@@ -11,31 +11,28 @@ export interface SortOptions {
 
 type Entry = readonly [string, VirtualToken];
 
-/**
- * Stable sort for a filtered `[path, token][]` list.
- *
- * `sortBy: 'path'` — lexicographic on the dot-path (locale-aware, numeric).
- * `sortBy: 'value'` — per-`$type` ordering:
- *   - `dimension` / `duration` → numeric pixels / ms (via `toMagnitude`).
- *   - `fontWeight` / `opacity` / `number` / `lineHeight` → numeric.
- *   - `color` → perceptual by oklch L → C → H.
- *   - `fontFamily` / `strokeStyle` (string form) → lexicographic.
- *   - Composites (`typography`, `shadow`, `border`, `gradient`, `transition`) →
- *     fall back to path-alpha. No useful single-axis order.
- * `sortBy: 'none'` — preserve input order (still respects `sortDir: 'desc'`
- *   as a reverse).
- */
-/**
- * Pre-computed per-token sort key — one of three shapes depending on
- * `$type`. The comparator looks the key up by token-reference once
- * per pair instead of recomputing on every comparison (Schwartzian
- * transform).
- *
- * For N tokens, sort does O(N log N) comparisons; per-call cost for
- * colors was an Oklch conversion (a `new Color()` + `to('oklch')`)
- * which dominates wall time on real fixtures. Pre-computing brings
- * that down to O(N) keys + O(N log N) cheap lookups.
- */
+// Stable sort for a filtered `[path, token][]` list.
+//
+// `sortBy: 'path'` — lexicographic on the dot-path (locale-aware, numeric).
+// `sortBy: 'value'` — per-`$type` ordering:
+//   - `dimension` / `duration` → numeric pixels / ms (via `toMagnitude`).
+//   - `fontWeight` / `opacity` / `number` / `lineHeight` → numeric.
+//   - `color` → perceptual by oklch L → C → H.
+//   - `fontFamily` / `strokeStyle` (string form) → lexicographic.
+//   - Composites (`typography`, `shadow`, `border`, `gradient`, `transition`) →
+//     fall back to path-alpha. No useful single-axis order.
+// `sortBy: 'none'` — preserve input order (still respects `sortDir: 'desc'`
+//   as a reverse).
+
+// Pre-computed per-token sort key — one of three shapes depending on
+// `$type`. The comparator looks the key up by token-reference once
+// per pair instead of recomputing on every comparison (Schwartzian
+// transform).
+//
+// For N tokens, sort does O(N log N) comparisons; per-call cost for
+// colors is an Oklch conversion (a `new Color()` + `to('oklch')`)
+// which dominates wall time on real fixtures. Pre-computing brings
+// that down to O(N) keys + O(N log N) cheap lookups.
 type SortKey =
   | { kind: 'numeric'; value: number; valid: boolean }
   | { kind: 'color'; key: { l: number; c: number; h: number } | null }
@@ -162,11 +159,9 @@ function toMagnitude(v: unknown): number {
   return Number.NaN;
 }
 
-/**
- * Coerce a possibly-null/undefined number to 0 — `coords` returns
- * `(number | null)[]` and `noUncheckedIndexedAccess` adds `undefined`
- * on top. `typeof` narrows the union for the comparator below.
- */
+// Coerce a possibly-null/undefined number to 0 — `coords` returns
+// `(number | null)[]` and `noUncheckedIndexedAccess` adds `undefined`
+// on top. `typeof` narrows the union for the comparator below.
 function safeNumber(v: number | null | undefined): number {
   return typeof v === 'number' && Number.isFinite(v) ? v : 0;
 }

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -62,13 +62,11 @@ function defaultTuple(axes: readonly VirtualAxis[]): Record<string, string> {
   return out;
 }
 
-/**
- * Build a `resolveAt` accessor backed by the token graph. Returns an
- * empty resolver when no graph is present (test stubs, partial
- * snapshots). Stable identity when memoized on `tokenGraph` — the
- * graph is a module-level virtual-module export so its reference stays
- * constant for the lifetime of the iframe.
- */
+// Build a `resolveAt` accessor backed by the token graph. Returns an
+// empty resolver when no graph is present (test stubs, partial
+// snapshots). Stable identity when memoized on `tokenGraph` — the
+// graph is a module-level virtual-module export so its reference stays
+// constant for the lifetime of the iframe.
 function makeResolveAt(
   graph: VirtualTokenGraph | undefined,
 ): (tuple: Record<string, string>) => ResolvedTokens {
@@ -76,14 +74,12 @@ function makeResolveAt(
   return (tuple) => resolveAllAt(graph, tuple) as unknown as ResolvedTokens;
 }
 
-/**
- * Build the `resolveAt` accessor for a snapshot. Prefers the
- * snapshot's own `resolveAt` (the addon's preview decorator
- * pre-builds one at module load — see `previewResolveAt` in
- * `packages/addon/src/preview.tsx`), otherwise builds one from
- * `tokenGraph`. Hand-built snapshots can omit `resolveAt`;
- * the graph-backed fallback covers them.
- */
+// Build the `resolveAt` accessor for a snapshot. Prefers the
+// snapshot's own `resolveAt` (the addon's preview decorator
+// pre-builds one at module load — see `previewResolveAt` in
+// `packages/addon/src/preview.tsx`), otherwise builds one from
+// `tokenGraph`. Hand-built snapshots can omit `resolveAt`;
+// the graph-backed fallback covers them.
 function snapshotResolveAt(
   snapshot: ProjectSnapshot,
 ): (tuple: Record<string, string>) => ResolvedTokens {
@@ -187,13 +183,11 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
   const contextPermutation = useActiveTheme();
   const contextAxes = useActiveAxes();
   const channelGlobals = useChannelGlobals();
-  /**
-   * Subscribe to the live token snapshot rather than reading the virtual
-   * module's module-level exports directly. Initial values come from
-   * `virtual:swatchbook/tokens` at load time; subsequent dev-time edits
-   * flow through the addon's HMR channel and update this snapshot in
-   * place so blocks re-render without a full preview reload.
-   */
+  // Subscribe to the live token snapshot rather than reading the virtual
+  // module's module-level exports directly. Initial values come from
+  // `virtual:swatchbook/tokens` at load time; subsequent dev-time edits
+  // flow through the addon's HMR channel and update this snapshot in
+  // place so blocks re-render without a full preview reload.
   const tokens = useTokenSnapshot();
 
   useEffect(() => {

--- a/packages/blocks/src/token-detail/CompositeBreakdown.tsx
+++ b/packages/blocks/src/token-detail/CompositeBreakdown.tsx
@@ -223,12 +223,10 @@ function formatDimensionValue(v: unknown): string | null {
   return JSON.stringify(v);
 }
 
-/**
- * Route sub-value colors through `formatColor` so they honor the active
- * color-format dropdown, just like the standalone `<ColorPalette />` and
- * `<TokenDetail />` top-line do. Returns `null` for a missing field so
- * the key/value row drops out entirely.
- */
+// Route sub-value colors through `formatColor` so they honor the active
+// color-format dropdown, just like the standalone `<ColorPalette />` and
+// `<TokenDetail />` top-line do. Returns `null` for a missing field so
+// the key/value row drops out entirely.
 function formatColorSubValue(v: unknown, format: ColorFormat): string | null {
   if (v == null) return null;
   return formatColor(v, format).value;
@@ -244,11 +242,9 @@ function pickArrayAliases(v: unknown): Record<string, string | undefined>[] | un
   return v as Record<string, string | undefined>[];
 }
 
-/**
- * Walk the alias chain starting from an immediate sub-value alias target.
- * `aliasTarget` is the path the sub-value directly references; the target
- * token's own `aliasChain` continues the walk to the primitive.
- */
+// Walk the alias chain starting from an immediate sub-value alias target.
+// `aliasTarget` is the path the sub-value directly references; the target
+// token's own `aliasChain` continues the walk to the primitive.
 function subValueChain(
   aliasTarget: string | undefined,
   resolved: Record<string, DetailToken> | undefined,

--- a/packages/blocks/src/token-detail/ConsumerOutput.tsx
+++ b/packages/blocks/src/token-detail/ConsumerOutput.tsx
@@ -21,8 +21,7 @@ export function ConsumerOutput({ path }: ConsumerOutputProps): ReactElement | nu
   // Platforms beyond `css`. Populated only when the consumer has loaded
   // extra plugins (`@terrazzo/plugin-swift`, `-android`, `-sass`, …) via
   // `config.terrazzoPlugins` + `config.listingOptions.platforms`. Always
-  // empty otherwise — the row set falls back to Path + CSS exactly like
-  // before listing adoption.
+  // empty otherwise — the row set falls back to Path + CSS.
   const names = listing[path]?.names ?? {};
   const extraPlatforms = Object.keys(names)
     .filter((platform) => platform !== 'css' && names[platform])

--- a/packages/blocks/src/token-detail/TokenUsageSnippet.tsx
+++ b/packages/blocks/src/token-detail/TokenUsageSnippet.tsx
@@ -7,11 +7,9 @@ export interface TokenUsageSnippetProps {
   path: string;
 }
 
-/**
- * DTCG `$type`s with a single canonical CSS property. Types whose value is
- * applied across many properties (`dimension`, `number`, `strokeStyle`,
- * `typography`) are intentionally absent — they fall back to a commented hint.
- */
+// DTCG `$type`s with a single canonical CSS property. Types whose value is
+// applied across many properties (`dimension`, `number`, `strokeStyle`,
+// `typography`) are intentionally absent — they fall back to a commented hint.
 const CSS_PROPERTY_BY_TYPE: Record<string, string> = {
   color: 'color',
   shadow: 'box-shadow',


### PR DESCRIPTION
Applies the comment doctrine (from #1077) to `packages/blocks/src`. Comment-only — verified zero non-comment lines changed.

- Converted 16 internal `/** */` blocks across 12 files (internal helpers, internal interfaces/types, in-body rationale) to `//`. Kept `/** */` on all exported components, hooks, and Props interfaces (and their property docs).
- History trimmed, live rationale preserved:
  - `ConsumerOutput.tsx`: dropped "exactly like before listing adoption" (kept the live fallback constraint).
  - `channel-globals.ts`: dropped the parenthetical about the previous identity-based spread guard (restated as the current per-tick reason).
  - `ColorTable.tsx`: dropped "identical to the pre-grouping behavior" on the exported `variants` prop.
  - `sort-tokens.ts`: tense fix ("was an Oklch conversion" → "is").
- Deliberately kept: TokenNavigator's focus-repair "previously-focused row was removed" (a live runtime scenario, not code history) and `composite-types.ts`'s "legacy hex / older channels alias" (currently-accepted input shapes).

Net −49 lines. Gate green: format / lint / typecheck / 188 tests (Chromium + Firefox). Internal-only, so no changeset.

Milestone: Maintenance

Closes #1082

Plan impact: none.
