### PR TITLE
chore(mcp): apply the comment doctrine to mcp comments

### DIFF
--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -1,13 +1,11 @@
 #!/usr/bin/env node
-/**
- * Stdio entry for `npx @unpunnyfuns/swatchbook-mcp --config <path>`.
- *
- * Parses `--config <path>`, optional `--cwd <path>`, loads the project, and
- * binds an MCP server to stdio. Watches the resolved source files + config
- * file so token edits land in subsequent tool calls without restarting the
- * transport. Pass `--no-watch` to opt out (e.g. CI). Loader / watcher errors
- * print to stderr — stdout is reserved for MCP protocol frames.
- */
+// Stdio entry for `npx @unpunnyfuns/swatchbook-mcp --config <path>`.
+//
+// Parses `--config <path>`, optional `--cwd <path>`, loads the project, and
+// binds an MCP server to stdio. Watches the resolved source files + config
+// file so token edits land in subsequent tool calls without restarting the
+// transport. Pass `--no-watch` to opt out (e.g. CI). Loader / watcher errors
+// print to stderr — stdout is reserved for MCP protocol frames.
 import { watch as fsWatch } from 'node:fs';
 import type { FSWatcher } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve } from 'node:path';
@@ -66,17 +64,15 @@ Tools exposed:
   return out;
 }
 
-/**
- * Watch the project's source files + config path for edits. Debounces
- * filesystem events (editors fire 2-3 per save) into a single reload per
- * 100 ms burst; on each settle, calls `loadFromConfig` again and swaps the
- * fresh project into the already-connected MCP server.
- *
- * Watches parent directories rather than files themselves. Atomic-save
- * editors unlink + recreate the target inode, which kills file-level
- * watchers on the first save; a dir watcher with filename filtering
- * survives that dance. Mirrors the addon's plugin strategy.
- */
+// Watch the project's source files + config path for edits. Debounces
+// filesystem events (editors fire 2-3 per save) into a single reload per
+// 100 ms burst; on each settle, calls `loadFromConfig` again and swaps the
+// fresh project into the already-connected MCP server.
+//
+// Watches parent directories rather than files themselves. Atomic-save
+// editors unlink + recreate the target inode, which kills file-level
+// watchers on the first save; a dir watcher with filename filtering
+// survives that dance. Mirrors the addon's plugin strategy.
 function setupReload(
   initialSourceFiles: readonly string[],
   configPath: string,

--- a/packages/mcp/src/contrast.ts
+++ b/packages/mcp/src/contrast.ts
@@ -1,16 +1,14 @@
 import Color from 'colorjs.io';
 
-/**
- * Pair-wise contrast between two DTCG color `$value`s. Wraps
- * `colorjs.io`'s contrast primitives with pass/fail grids for the
- * thresholds agents typically reason against (WCAG 2.1 AA/AAA
- * normal/large; APCA body / large text / non-text).
- *
- * Kept separate from `format-color.ts` even though both build
- * `Color` instances from the same DTCG shape — the color-format
- * formatter stringifies, this one does arithmetic, and they're
- * called from different tool paths.
- */
+// Pair-wise contrast between two DTCG color `$value`s. Wraps
+// `colorjs.io`'s contrast primitives with pass/fail grids for the
+// thresholds agents typically reason against (WCAG 2.1 AA/AAA
+// normal/large; APCA body / large text / non-text).
+//
+// Kept separate from `format-color.ts` even though both build
+// `Color` instances from the same DTCG shape — the color-format
+// formatter stringifies, this one does arithmetic, and they're
+// called from different tool paths.
 
 interface ColorInput {
   colorSpace?: string;
@@ -81,13 +79,11 @@ export function computeContrast(
     };
   }
 
-  /**
-   * APCA thresholds from the Silver draft guidance. These are the
-   * "body text / large text / non-text" bronze tier thresholds most
-   * tooling settles on; the full table has more gradations but
-   * agents rarely need them. Non-text = icons, focus rings, UI
-   * borders.
-   */
+  // APCA thresholds from the Silver draft guidance. These are the
+  // "body text / large text / non-text" bronze tier thresholds most
+  // tooling settles on; the full table has more gradations but
+  // agents rarely need them. Non-text = icons, focus rings, UI
+  // borders.
   const lc = fg.contrast(bg, 'APCA');
   const absLc = Math.abs(lc);
   return {

--- a/packages/mcp/src/format-color.ts
+++ b/packages/mcp/src/format-color.ts
@@ -1,14 +1,12 @@
 import Color from 'colorjs.io';
 
-/**
- * Convert a DTCG color `$value` into the same format menu the
- * addon's toolbar exposes — hex / rgb / hsl / oklch / raw JSON. Mirrors
- * the narrower version in `@unpunnyfuns/swatchbook-blocks/format-color.ts`
- * without pulling blocks (and React) into the MCP server.
- *
- * Out-of-gamut colours still stringify — the caller gets both the
- * rendered string and an `outOfGamut` flag so agents can warn.
- */
+// Convert a DTCG color `$value` into the same format menu the
+// addon's toolbar exposes — hex / rgb / hsl / oklch / raw JSON. Mirrors
+// the narrower version in `@unpunnyfuns/swatchbook-blocks/format-color.ts`
+// without pulling blocks (and React) into the MCP server.
+//
+// Out-of-gamut colours still stringify — the caller gets both the
+// rendered string and an `outOfGamut` flag so agents can warn.
 
 export type ColorFormat = 'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw';
 

--- a/packages/mcp/src/load-config.ts
+++ b/packages/mcp/src/load-config.ts
@@ -36,14 +36,12 @@ export async function loadFromConfig(
 }
 
 async function loadTsConfig(absolute: string): Promise<Config> {
-  /**
-   * jiti's first arg is a directory-shaped "from" URL it uses to resolve
-   * the target's relative imports. Passing a file URL leaves jiti
-   * unsure whether to treat the path as a dir, which on some Node
-   * versions falls through to a plain JSON read and surfaces as
-   * `Unexpected token 'i', "import { d"...`. A trailing slash on a
-   * directory URL avoids the ambiguity.
-   */
+  // jiti's first arg is a directory-shaped "from" URL it uses to resolve
+  // the target's relative imports. Passing a file URL leaves jiti
+  // unsure whether to treat the path as a dir, which on some Node
+  // versions falls through to a plain JSON read and surfaces as
+  // `Unexpected token 'i', "import { d"...`. A trailing slash on a
+  // directory URL avoids the ambiguity.
   const fromUrl = new URL('./', pathToFileURL(absolute));
   const jiti = createJiti(fromUrl.href, {
     interopDefault: true,

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -44,22 +44,18 @@ export function createServer(initial: Project): McpServer & {
     defaultThemeName = tupleToName(next.axes, next.defaultTuple);
   };
 
-  /**
-   * Resolve tokens for a `theme` name parameter. Falls back to the
-   * project's default tuple when the name doesn't match any known
-   * theme (also covers the no-theme-provided path).
-   */
+  // Resolve tokens for a `theme` name parameter. Falls back to the
+  // project's default tuple when the name doesn't match any known
+  // theme (also covers the no-theme-provided path).
   const tokensForTheme = (themeName: string | undefined): TokenMap => {
     const tuple =
       (themeName !== undefined ? tupleByName.get(themeName) : undefined) ?? project.defaultTuple;
     return project.resolveAt(tuple);
   };
 
-  /**
-   * Iterate every `(themeName, tuple)` pair the project surfaces —
-   * default + singletons + presets. Order is insertion order of
-   * `tupleByName` (default first, then singletons per axis, then presets).
-   */
+  // Iterate every `(themeName, tuple)` pair the project surfaces —
+  // default + singletons + presets. Order is insertion order of
+  // `tupleByName` (default first, then singletons per axis, then presets).
   const eachTheme = function* (): Generator<{ name: string; tuple: Record<string, string> }> {
     for (const [name, tuple] of tupleByName) yield { name, tuple };
   };
@@ -569,13 +565,11 @@ export function createServer(initial: Project): McpServer & {
   return server;
 }
 
-/**
- * Build a `Map<themeName, axisTuple>` covering the same set the
- * resolver loader's singleton enumeration produces: default tuple +
- * one per non-default cell on each axis + each preset. Bounded by
- * `1 + Σ(axes × (contexts - 1)) + presets.length` — linear in axis
- * cardinality, independent of the cartesian product.
- */
+// Build a `Map<themeName, axisTuple>` covering the same set the
+// resolver loader's singleton enumeration produces: default tuple +
+// one per non-default cell on each axis + each preset. Bounded by
+// `1 + Σ(axes × (contexts - 1)) + presets.length` — linear in axis
+// cardinality, independent of the cartesian product.
 function buildTupleByName(project: Project): Map<string, Record<string, string>> {
   const out = new Map<string, Record<string, string>>();
   for (const { name, tuple } of enumerateThemes(project)) {


### PR DESCRIPTION
Applies the comment doctrine (from #1077) to `packages/mcp/src`. Comment-only — verified zero non-comment lines changed.

- Converted 9 internal `/** */` blocks (module headers, internal helpers `setupReload`/`tokensForTheme`/`eachTheme`/`buildTupleByName`, in-body rationale) to `//`. Kept `/** */` on the exported surface (`loadFromConfig`, `createServer`, `ContrastResult.ratio`).
- No history trims needed; cross-package "Mirrors the addon's plugin strategy" notes are current-constraint rationale and were preserved.
- MCP tool description strings (runtime data) untouched.

Net −18 lines. Gate green: format / lint / typecheck / 67 tests. Internal-only, so no changeset.

Milestone: Maintenance

Closes #1084

Plan impact: none.
