### PR TITLE
chore(switcher): apply the comment doctrine to switcher comments

### DIFF
--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -102,11 +102,9 @@ interface OptionPillProps {
   title?: string;
   onClick(): void;
   trailing?: ReactElement | null;
-  /**
-   * Optional accessible-label prefix — disambiguates pills that share a
-   * label across sections (e.g. `Default` appears on both `mode` and
-   * `brand`). The full accessible name becomes `"<label> <ariaLabelSuffix>"`.
-   */
+  // Optional accessible-label prefix — disambiguates pills that share a
+  // label across sections (e.g. `Default` appears on both `mode` and
+  // `brand`). The full accessible name becomes `"<label> <ariaLabelSuffix>"`.
   ariaLabelSuffix?: string;
 }
 
@@ -213,12 +211,10 @@ function AxisSection({ axis, active, onSelect }: AxisSectionProps): ReactElement
   );
 }
 
-/**
- * Treat the `{ name: 'theme', source: 'synthetic' }` axis — the one core
- * fabricates for single-theme projects with no resolver — as a special case
- * that reads as "Permutation". Authored single-axis resolvers keep their real
- * name (e.g. `mode`, `brand`).
- */
+// Treat the `{ name: 'theme', source: 'synthetic' }` axis — the one core
+// fabricates for single-theme projects with no resolver — as a special case
+// that reads as "Permutation". Authored single-axis resolvers keep their real
+// name (e.g. `mode`, `brand`).
 function displayLabelFor(axis: SwitcherAxis): string {
   if (axis.source === 'synthetic' && axis.name === 'theme') return 'Permutation';
   return axis.name;

--- a/packages/switcher/src/types.ts
+++ b/packages/switcher/src/types.ts
@@ -1,9 +1,7 @@
-/**
- * Structural types the switcher consumes. Mirror the shapes produced by
- * `@unpunnyfuns/swatchbook-core` and by the addon's preview INIT payload —
- * re-declared here so the switcher stays framework-agnostic and doesn't pull
- * core / addon as runtime deps.
- */
+// Structural types the switcher consumes. Mirror the shapes produced by
+// `@unpunnyfuns/swatchbook-core` and by the addon's preview INIT payload —
+// re-declared here so the switcher stays framework-agnostic and doesn't pull
+// core / addon as runtime deps.
 
 export interface SwitcherAxis {
   name: string;


### PR DESCRIPTION
Applies the comment doctrine (from #1077) to `packages/switcher/src`. Comment-only — verified zero non-comment lines changed.

- Converted 3 internal `/** */` to `//`: the `types.ts` module header, `OptionPillProps.ariaLabelSuffix` (internal interface property), and `displayLabelFor` (internal helper).
- Kept `/** */` on the exported `ThemeSwitcher` and `ThemeSwitcherProps` (and its property docs) and on the exported `presetTuple`.
- No history trims needed; the cross-reference notes ("Mirrors the addon preview decorator's own fallback logic") are current rationale.

Gate green: format / lint / typecheck / test. Internal-only, so no changeset.

This completes the comment-doctrine sweep across all six published packages (integrations #1077, addon #1079, core #1081, blocks #1083, mcp #1085, and this).

Milestone: Maintenance

Closes #1086

Plan impact: none.
