### PR TITLE
fix: stop typography-aliasing-typography tokens from breaking the listing

### DIFF
--- a/packages/core/test/fixtures/typography-alias/tokens/tokens.json
+++ b/packages/core/test/fixtures/typography-alias/tokens/tokens.json
@@ -1,0 +1,22 @@
+{
+  "color": {
+    "$type": "color",
+    "ink": { "$value": "#1a1a1a" }
+  },
+  "font": {
+    "$type": "fontFamily",
+    "sans": { "$value": ["Inter", "sans-serif"] }
+  },
+  "typography": {
+    "$type": "typography",
+    "base": {
+      "$value": {
+        "fontFamily": "{font.sans}",
+        "fontSize": "16px",
+        "fontWeight": 400,
+        "lineHeight": "1.5"
+      }
+    },
+    "body": { "$value": "{typography.base}" }
+  }
+}

--- a/packages/core/test/token-listing.test.ts
+++ b/packages/core/test/token-listing.test.ts
@@ -1,7 +1,10 @@
+import { fileURLToPath } from 'node:url';
 import { resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 import { describe, expect, it } from 'vitest';
 import { loadProject } from '#/load.ts';
 import { fixtureCwd, loadWithPrefix } from './_helpers.ts';
+
+const typographyAliasCwd = fileURLToPath(new URL('./fixtures/typography-alias', import.meta.url));
 
 describe('Token Listing integration', () => {
   it('populates project.listing for resolver-backed projects', async () => {
@@ -38,6 +41,17 @@ describe('Token Listing integration', () => {
     const preview = entry?.$extensions['app.terrazzo.listing'].previewValue;
     expect(typeof preview).toBe('string');
     expect(preview).toMatch(/^#[0-9a-fA-F]{6,8}$/);
+  });
+
+  it('survives a typography token aliasing another typography token', async () => {
+    // token-tools hands plugin-token-listing a mode-less `{ id }` stub for a
+    // typography→typography alias; an unpatched plugin derefs `.mode` on it and
+    // throws, zeroing the whole listing. Patched, the listing builds and the
+    // other tokens keep their previews.
+    const project = await loadProject({ tokens: ['tokens/**/*.json'] }, typographyAliasCwd);
+    expect(project.diagnostics.filter((d) => d.group === 'swatchbook/listing')).toHaveLength(0);
+    expect(project.listing['typography.body']).toBeDefined();
+    expect(project.listing['color.ink']?.$extensions['app.terrazzo.listing'].previewValue).toBe('#1a1a1a');
   });
 
   it('surfaces a swatchbook/listing warn diagnostic when a terrazzoPlugin throws', async () => {

--- a/patches/@terrazzo__plugin-token-listing@0.1.0-alpha.1.patch
+++ b/patches/@terrazzo__plugin-token-listing@0.1.0-alpha.1.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/index.js b/dist/index.js
+index 49e2dc1f44c81cbc19e7c3c1b179442280eba886..af85edf15faa26bc348e0e614169bb291f252e9b 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -4115,6 +4115,7 @@ function isCompositeTypography(computed) {
+ }
+ function computePreviewValue({ tokensSet, token, mode, logger }) {
+ 	const recursiveNoAliasTransform = (rToken) => {
++		if (!rToken || !rToken.mode) return "";
+ 		const computed = transformCSSValue(rToken, {
+ 			mode: mode && mode in rToken.mode ? mode : ".",
+ 			tokensSet,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
 
 patchedDependencies:
   '@terrazzo/plugin-css-in-js@2.0.3': 9792500f4d6b47ecff171b57293cb888be2ff44580faa445fea7e77c1e21f63c
+  '@terrazzo/plugin-token-listing@0.1.0-alpha.1': a7b4e8e4b68164907d800eb10588124d1d41e1567e114c62ab19bdab56a61544
 
 importers:
 
@@ -330,7 +331,7 @@ importers:
         version: 2.0.3(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.18)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))(@terrazzo/parser@2.0.3(yaml-to-momoa@0.0.9))
       '@terrazzo/plugin-token-listing':
         specifier: 0.1.0-alpha.1
-        version: 0.1.0-alpha.1(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.18)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
+        version: 0.1.0-alpha.1(patch_hash=a7b4e8e4b68164907d800eb10588124d1d41e1567e114c62ab19bdab56a61544)(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.18)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))
       '@terrazzo/token-tools':
         specifier: ^2.0.3
         version: 2.0.3
@@ -13357,7 +13358,7 @@ snapshots:
       '@terrazzo/token-tools': 2.1.0
       colorjs.io: 0.6.1
 
-  '@terrazzo/plugin-token-listing@0.1.0-alpha.1(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.18)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))':
+  '@terrazzo/plugin-token-listing@0.1.0-alpha.1(patch_hash=a7b4e8e4b68164907d800eb10588124d1d41e1567e114c62ab19bdab56a61544)(@terrazzo/cli@2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.18)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1))':
     dependencies:
       '@terrazzo/cli': 2.0.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@25.6.0)(esbuild@0.27.7)(hono@4.12.18)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
       '@terrazzo/token-tools': 2.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,3 +25,4 @@ overrides:
 
 patchedDependencies:
   '@terrazzo/plugin-css-in-js@2.0.3': patches/@terrazzo__plugin-css-in-js@2.0.3.patch
+  '@terrazzo/plugin-token-listing@0.1.0-alpha.1': patches/@terrazzo__plugin-token-listing@0.1.0-alpha.1.patch


### PR DESCRIPTION
A typography token whose `$value` aliases another typography token crashed the in-memory token-listing build:

```
WARN  Token listing build failed: Cannot use 'in' operator to search for '.' in undefined.
swatchbook/listing
```

`token-tools/css/typography.ts` resolves a typography-to-typography alias by handing `transformAlias` a synthetic, mode-less `{ id }` stub. The published `@terrazzo/plugin-token-listing`'s `recursiveNoAliasTransform` then evaluates `mode in rToken.mode` with `mode === '.'` and `rToken.mode === undefined`, throwing. Because `computeTokenListing` wraps the whole build in one try/catch, a single such token zeroes `Project.listing`, degrading every block's previews at once.

The fix patches the installed plugin so `recursiveNoAliasTransform` returns an empty preview for a mode-less stub. The listing builds; only the aliasing token loses its computed preview while the rest keep theirs. A regression fixture and test exercise the alias and assert no `swatchbook/listing` diagnostic, so the test goes red if the patch is dropped or the dependency bumped without the upstream fix.

The bug also lives in the Terrazzo fork source; this patch fixes our workspace and dogfood until that is fixed upstream and republished, after which the patch can be dropped. Published swatchbook packages do not carry the patch, so consumers still need the upstream fix.

Milestone: Maintenance

Closes #1088

Plan impact: none.
