### PR TITLE
refactor: clarify misleading internal names and remove dead fields

### DIFF
--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -23,7 +23,9 @@ export const RESOLVED_INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID = `\0${INTEGRATION_SID
 
 export const STYLE_ELEMENT_ID = 'swatchbook-tokens';
 
-/** Channel event: preview → manager, carries theme list + mode. */
+/** Channel event: preview → manager, carries the init payload:
+ * axes / presets / disabledAxes / diagnostics / cssVarPrefix /
+ * defaultTuple. */
 export const INIT_EVENT = 'swatchbook/init';
 /** Channel event: manager → preview, asks preview to re-emit INIT_EVENT.
  * Covers the race where the manager subscribes after the preview's
@@ -44,6 +46,6 @@ export const TOKENS_UPDATED_EVENT = 'swatchbook/tokens-updated';
 
 /** Custom Vite HMR event: plugin → preview. Preview forwards it to the
  * Storybook channel as {@link TOKENS_UPDATED_EVENT} so blocks can
- * update their snapshot. Kept distinct from the channel event so the
- * plugin doesn't need a Storybook-channel dependency. */
-export const HMR_EVENT = 'swatchbook/tokens-updated';
+ * update their snapshot. A distinct wire string from the channel event
+ * so the plugin doesn't need a Storybook-channel dependency. */
+export const HMR_EVENT = 'swatchbook/hmr-tokens';

--- a/packages/addon/src/globals.ts
+++ b/packages/addon/src/globals.ts
@@ -14,7 +14,7 @@ import type { ColorFormat } from '@unpunnyfuns/swatchbook-blocks';
  * - `swatchbookAxes` — active axis tuple (axis name → context name).
  * - `swatchbookColorFormat` — display-side color format for blocks. Does
  *   not affect emitted CSS.
- * - `swatchbookTheme` — legacy composed permutation ID, written in
+ * - `swatchbookTheme` — legacy composed theme name, written in
  *   lockstep with `swatchbookAxes` for back-compat with consumers that
  *   only read the composed string.
  *
@@ -35,7 +35,7 @@ export interface SwatchbookGlobals {
 export interface SwatchbookParameters {
   /** Per-story tuple override. Highest priority input. */
   axes?: Record<string, string>;
-  /** Per-story composed permutation ID. Second priority. */
+  /** Per-story composed theme name. Second priority. */
   permutation?: string;
   /** Legacy alias for `permutation`. */
   theme?: string;

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -51,8 +51,9 @@ export interface TokenInfo {
  * Storybook's preview-only hooks. Reads from the addon-provided
  * `SwatchbookContext` when present (preferred — uses the lifted
  * `resolveAt` accessor and the live active tuple); falls back to the
- * virtual module's eager `permutationsResolved` lookup keyed by the
- * default permutation name when no provider is mounted.
+ * module-scope `fallbackResolveAt` (`resolveAllAt(virtualTokenGraph,
+ * tuple)`) over the virtual module's default tuple when no provider is
+ * mounted.
  */
 export function useToken(path: TokenPath): TokenInfo {
   const snapshot = useOptionalSwatchbookData();

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -41,6 +41,7 @@ import {
   STYLE_ELEMENT_ID,
   TOKENS_UPDATED_EVENT,
 } from '#/constants.ts';
+import type { InitPayload } from '#/channel-types.ts';
 import type { StoryParameters, SwatchbookGlobals } from '#/globals.ts';
 
 // Standard visually-hidden style for the theme-flip live region.
@@ -98,7 +99,7 @@ function forEachPinnedAxis(cb: (name: string, value: string) => void): void {
 // in axis order. Used for the `ThemeContext` value the blocks read and
 // the addon-channel signals downstream consumers subscribe to. Returns
 // empty string when there are no axes (no name to write).
-function matchThemeName(tuple: Readonly<Record<string, string>>): string {
+function composeThemeName(tuple: Readonly<Record<string, string>>): string {
   if (virtualAxes.length === 0) return '';
   return tupleToName(virtualAxes, tuple);
 }
@@ -125,20 +126,11 @@ function setRootAxes(tuple: Readonly<Record<string, string>>): void {
   });
 }
 
-// Subset of an INIT_EVENT-shaped object the manager bundle needs. The
-// fields are the union of what the toolbar and panel read; named so
-// `broadcastInit` (module-level virtual exports) and the HMR re-emit
-// (`payload`-shaped) compose the same payload from the same shape.
-interface InitFieldsSource {
-  axes: typeof virtualAxes;
-  disabledAxes: typeof virtualDisabledAxes;
-  presets: typeof virtualPresets;
-  diagnostics: typeof diagnostics;
-  cssVarPrefix: string;
-  defaultTuple: typeof virtualDefaultTuple;
-}
-
-function pickInitFields(source: InitFieldsSource): InitFieldsSource {
+// Project the INIT_EVENT fields the manager bundle needs out of a wider
+// source object. Both `broadcastInit` (module-level virtual exports) and
+// the HMR re-emit (`payload`-shaped) feed it, so the two compose the same
+// `InitPayload` from the same field set.
+function toInitPayload(source: InitPayload): InitPayload {
   return {
     axes: source.axes,
     disabledAxes: source.disabledAxes,
@@ -156,7 +148,7 @@ function broadcastInit(): void {
   const channel = addons.getChannel();
   channel.emit(
     INIT_EVENT,
-    pickInitFields({
+    toInitPayload({
       axes: virtualAxes,
       disabledAxes: virtualDisabledAxes,
       presets: virtualPresets,
@@ -176,7 +168,7 @@ function defaultTuple(): Record<string, string> {
 
 // Reverse-engineer a tuple from a `Light · Brand A · Normal`-shape
 // theme name. Splits on ` · ` and zips with `virtualAxes` in declared
-// order — matches `matchThemeName`'s production direction so a
+// order — matches `composeThemeName`'s production direction so a
 // round-trip is lossless. Returns `undefined` when the segment count
 // doesn't match the axis count.
 function tupleForName(name: string): Record<string, string> | undefined {
@@ -209,7 +201,7 @@ function normalizeTuple(partial: Readonly<Record<string, string>>): Record<strin
 
 // Resolve the active tuple from all input channels, in priority order:
 //   1. `parameters.swatchbook.axes` — per-story tuple.
-//   2. `parameters.swatchbook.permutation` — per-story composed name.
+//   2. `parameters.swatchbook.permutation` — per-story composed theme name.
 //   3. `globals.swatchbookAxes` — toolbar-set tuple.
 //   4. virtual module default.
 function resolveTuple(
@@ -257,7 +249,7 @@ const themedDecorator: Decorator = (Story, context) => {
     [axesGlobal, paramSwatchbook],
   );
   const colorFormat = useMemo(() => resolveColorFormat(colorFormatGlobal), [colorFormatGlobal]);
-  const themeName = useMemo(() => matchThemeName(tuple), [tuple]);
+  const themeName = useMemo(() => composeThemeName(tuple), [tuple]);
 
   useEffect(() => {
     ensureStylesheet(css, cssVarPrefix);
@@ -345,7 +337,7 @@ export const decorators: NonNullable<Preview['decorators']> = [themedDecorator];
 export const globalTypes: NonNullable<Preview['globalTypes']> = {
   [AXES_GLOBAL_KEY]: {
     name: 'Axes',
-    description: 'Per-axis context selection — the active permutation tuple.',
+    description: 'Per-axis context selection — the active theme name tuple.',
   },
   [COLOR_FORMAT_GLOBAL_KEY]: {
     name: 'Color format',
@@ -406,9 +398,9 @@ function installGlobalAxisApplier(): void {
   const onGlobals = (payload: { globals?: SwatchbookGlobals }): void => {
     if (!payload.globals) return;
     const tuple = resolveTuple(payload.globals[AXES_GLOBAL_KEY], undefined);
-    const fingerprint = matchThemeName(tuple);
-    if (fingerprint === lastApplied) return;
-    lastApplied = fingerprint;
+    const themeKey = composeThemeName(tuple);
+    if (themeKey === lastApplied) return;
+    lastApplied = themeKey;
     apply(payload.globals);
   };
   channel.on('globalsUpdated', onGlobals);
@@ -455,7 +447,7 @@ if (import.meta.hot) {
   import.meta.hot.on(HMR_EVENT, (payload: HmrSnapshot) => {
     ensureStylesheet(payload.css, payload.cssVarPrefix);
     const channel = addons.getChannel();
-    channel.emit(INIT_EVENT, pickInitFields(payload));
+    channel.emit(INIT_EVENT, toInitPayload(payload));
     channel.emit(TOKENS_UPDATED_EVENT, payload);
   });
 }

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -5,7 +5,7 @@ import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import type { ColorFormat } from '#/format-color.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -87,14 +87,14 @@ export function BorderPreview({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No border tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-border-preview__row">

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './ColorPalette.css';
 import { useColorFormat } from '#/contexts.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -114,14 +114,14 @@ export function ColorPalette({
 
   if (totalCount === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No color tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {groups.map(([group, swatches]) => (
         <section key={group} className="sb-color-palette__group">

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -7,7 +7,7 @@ import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import type { ColorFormat, NormalizedColor } from '#/format-color.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -185,14 +185,14 @@ export function ColorTable({
 
   if (groups.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No color tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       {searchable && (
         <div className="sb-color-table__search">
           <input

--- a/packages/blocks/src/Diagnostics.tsx
+++ b/packages/blocks/src/Diagnostics.tsx
@@ -2,7 +2,7 @@ import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './Diagnostics.css';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { useProject } from '#/internal/use-project.ts';
 import type { VirtualDiagnostic } from '#/types.ts';
 
@@ -69,7 +69,7 @@ export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
   const headingText = caption ?? `Diagnostics · ${summary.text}`;
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)} data-testid="diagnostics">
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)} data-testid="diagnostics">
       <details open={summary.hasErrorsOrWarnings}>
         <summary
           className={cx(

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import './DimensionScale.css';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
 import type { DimensionKind } from '#/dimension-scale/DimensionBar.tsx';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
@@ -97,14 +97,14 @@ export function DimensionScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No dimension tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-dimension-scale__row">

--- a/packages/blocks/src/FontFamilySample.tsx
+++ b/packages/blocks/src/FontFamilySample.tsx
@@ -1,7 +1,7 @@
 import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './FontFamilySample.css';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { sortTokens } from '#/internal/sort-tokens.ts';
@@ -67,14 +67,14 @@ export function FontFamilySample({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No fontFamily tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-font-family-sample__row">

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -2,7 +2,7 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './FontWeightScale.css';
 import { cssVarAsNumber } from '#/internal/css-var-style.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -74,14 +74,14 @@ export function FontWeightScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No fontWeight tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-font-weight-scale__row">

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import './GradientPalette.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -95,14 +95,14 @@ export function GradientPalette({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No gradient tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-gradient-palette__row">

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -2,7 +2,7 @@ import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { useMemo, useState } from 'react';
 import './MotionPreview.css';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
@@ -81,14 +81,14 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No motion tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       <div className="sb-motion-preview__controls">
         <span className="sb-motion-preview__control-label">Speed</span>

--- a/packages/blocks/src/OpacityScale.tsx
+++ b/packages/blocks/src/OpacityScale.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
 import './OpacityScale.css';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -99,7 +99,7 @@ export function OpacityScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No opacity tokens match this filter.</div>
       </div>
     );
@@ -108,7 +108,7 @@ export function OpacityScale({
   const sampleColorVar = resolveCssVar(sampleColor, project);
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       <div className="sb-opacity-scale__grid">
         {rows.map((row) => (

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -5,7 +5,7 @@ import './ShadowPreview.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import type { ColorFormat } from '#/format-color.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -104,14 +104,14 @@ export function ShadowPreview({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No shadow tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-shadow-preview__row">

--- a/packages/blocks/src/StrokeStyleSample.tsx
+++ b/packages/blocks/src/StrokeStyleSample.tsx
@@ -1,7 +1,7 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
 import './StrokeStyleSample.css';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
@@ -77,14 +77,14 @@ export function StrokeStyleSample({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No strokeStyle tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-stroke-style-sample__row">

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -3,7 +3,7 @@ import type { ReactElement } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { useProject } from '#/internal/use-project.ts';
 import { AliasChain } from '#/token-detail/AliasChain.tsx';
@@ -27,11 +27,11 @@ export interface TokenDetailProps {
 export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
   const { token, cssVar, activeTheme, activeAxes, cssVarPrefix } = useTokenDetailData(path);
   const colorFormat = useColorFormat();
-  const theme = themeAttrs(cssVarPrefix, activeAxes);
+  const wrapperAttrs = blockWrapperAttrs(cssVarPrefix, activeAxes);
 
   if (!token) {
     return (
-      <div {...theme} className={cx(theme['className'], 'sb-token-detail')}>
+      <div {...wrapperAttrs} className={cx(wrapperAttrs['className'], 'sb-token-detail')}>
         <div className="sb-token-detail__missing">
           Token <code>{path}</code> not found in theme <strong>{activeTheme}</strong>.
         </div>
@@ -46,7 +46,7 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
   const outOfGamut = gamut?.outOfGamut ?? false;
 
   return (
-    <div {...theme} className={cx(theme['className'], 'sb-token-detail')}>
+    <div {...wrapperAttrs} className={cx(wrapperAttrs['className'], 'sb-token-detail')}>
       <TokenHeader path={path} {...(heading !== undefined && { heading })} />
 
       <div className="sb-token-detail__section-header">Resolved value · {activeTheme}</div>

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -5,7 +5,7 @@ import './TokenNavigator.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { EmptyState } from '#/internal/styles.tsx';
@@ -457,7 +457,7 @@ export function TokenNavigator({
 
   if (tree.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <EmptyState>
           {root
             ? `No tokens under "${root}"${typeFilter ? ` matching ${typeLabel.slice(3)}` : ''}.`
@@ -470,7 +470,7 @@ export function TokenNavigator({
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       {searchable && (
         <div className="sb-token-navigator__search">
           <input

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -5,7 +5,7 @@ import { useCallback, useDeferredValue, useMemo, useState } from 'react';
 import './TokenTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
@@ -115,14 +115,14 @@ export function TokenTable({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       {searchable && (
         <div className="sb-token-table__search">
           <input

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -2,7 +2,7 @@ import type { CSSProperties, ReactElement } from 'react';
 import { useMemo } from 'react';
 import './TypographyScale.css';
 import type { TypographyValue } from '#/internal/composite-types.ts';
-import { themeAttrs } from '#/internal/data-attr.ts';
+import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { useProject } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { sortTokens } from '#/internal/sort-tokens.ts';
@@ -112,14 +112,14 @@ export function TypographyScale({
 
   if (rows.length === 0) {
     return (
-      <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+      <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
         <div className="sb-block__empty">No typography tokens match this filter.</div>
       </div>
     );
   }
 
   return (
-    <div {...themeAttrs(cssVarPrefix, activeAxes)}>
+    <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
       {rows.map((row) => (
         <div key={row.path} className="sb-typography-scale__row">

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -139,7 +139,7 @@ export function useActiveTheme(): string {
  * Active axis tuple for the current story/docs render — `Record<axisName,
  * contextName>`. Derived from the same input as {@link ThemeContext}; split
  * out so consumers needing per-axis info (toolbar, panel, tuple-aware
- * blocks) don't have to reparse the composed permutation ID.
+ * blocks) don't have to reparse the composed theme name.
  */
 export const AxesContext = createContext<Readonly<Record<string, string>>>({});
 

--- a/packages/blocks/src/format-color.ts
+++ b/packages/blocks/src/format-color.ts
@@ -152,12 +152,12 @@ function formatHex(color: Color, alpha: number): FormatColorResult {
     const rgb = formatRgb(color, alpha);
     return { value: rgb.value, outOfGamut: true };
   }
-  const r = clamp255(coord(srgb, 0));
-  const g = clamp255(coord(srgb, 1));
-  const b = clamp255(coord(srgb, 2));
+  const r = unitToByte(coord(srgb, 0));
+  const g = unitToByte(coord(srgb, 1));
+  const b = unitToByte(coord(srgb, 2));
   const base = `#${toHexByte(r)}${toHexByte(g)}${toHexByte(b)}`;
   if (alpha >= 1) return { value: base, outOfGamut: false };
-  const a = clamp255(alpha);
+  const a = unitToByte(alpha);
   return { value: `${base}${toHexByte(a)}`, outOfGamut: false };
 }
 
@@ -194,7 +194,7 @@ function formatOklch(color: Color, alpha: number): FormatColorResult {
   return { value, outOfGamut: false };
 }
 
-function clamp255(n: number): number {
+function unitToByte(n: number): number {
   return Math.max(0, Math.min(255, Math.round(n * 255)));
 }
 

--- a/packages/blocks/src/internal/data-attr.ts
+++ b/packages/blocks/src/internal/data-attr.ts
@@ -31,7 +31,7 @@ const WRAPPER_CLASSES = 'sb-unstyled sb-block';
  *   MDX docs house styles self-exclude the subtree, plus `sb-block`
  *   which carries the shared chrome from `internal/styles.css`.
  */
-export function themeAttrs(
+export function blockWrapperAttrs(
   prefix: string,
   tuple: Readonly<Record<string, string>>,
 ): Record<string, string> {

--- a/packages/blocks/src/internal/styles.tsx
+++ b/packages/blocks/src/internal/styles.tsx
@@ -33,7 +33,7 @@ export const typePillStyle = {
 
 /**
  * Inner content for a block's "nothing to render" state. Call sites wrap
- * it in their own block wrapper (which already carries `themeAttrs`), so
+ * it in their own block wrapper (which already carries `blockWrapperAttrs`), so
  * the message itself just needs the muted type.
  */
 export function EmptyState({ children }: { children: ReactNode }): ReactElement {

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -180,7 +180,7 @@ export function useProject(): ProjectData {
 }
 
 function useVirtualModuleFallback(enabled: boolean): ProjectData {
-  const contextPermutation = useActiveTheme();
+  const contextThemeName = useActiveTheme();
   const contextAxes = useActiveAxes();
   const channelGlobals = useChannelGlobals();
   // Subscribe to the live token snapshot rather than reading the virtual
@@ -206,7 +206,7 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
     return hasContextAxes ? { ...contextAxes } : (channelGlobals.axes ?? defaultTuple(tokens.axes));
   }, [contextAxes, channelGlobals.axes, tokens.axes]);
 
-  const activeTheme = contextPermutation || tupleToName(tokens.axes, activeAxes);
+  const activeTheme = contextThemeName || tupleToName(tokens.axes, activeAxes);
 
   // `resolveAllAt` is a pure function over the graph; the only memo
   // we need is for the outer closure so React's reference equality

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -6,7 +6,6 @@ import { dataAttr } from '#/data-attr.ts';
 import { listPaths } from '#/token-graph/queries.ts';
 import { resolveAliasAllAt, resolveAllAt } from '#/token-graph/walk.ts';
 import type { Project, TokenMap } from '#/types.ts';
-import { permutationID } from '#/types.ts';
 import { valueKey } from '#/value-key.ts';
 
 // Internal alias: the raw Terrazzo-shape map this emitter passes into
@@ -24,10 +23,6 @@ function withSyntheticIds(map: TokenMap): RawTokenMap {
     out[path] = { ...token, id: path } as unknown as TokenNormalized;
   }
   return out;
-}
-
-function asRawTokens(map: TokenMap): RawTokenMap {
-  return withSyntheticIds(map);
 }
 
 // Distinguishes a token's variance shape so the emitter can route it.
@@ -58,7 +53,6 @@ type VarianceInfo =
 interface JointCase {
   tuple: Record<string, string>;
   cartesianValueKey: string;
-  permutationName: string;
 }
 
 // Default cap on joint-case arity probed per token. See `Config.maxJointArity`
@@ -183,7 +177,6 @@ function analyzeProjectVariance(project: Project): Map<string, VarianceInfo> {
             jointCases.push({
               tuple: { ...partialTuple },
               cartesianValueKey: cartesianKey,
-              permutationName: permutationID(fullTuple),
             });
           }
         }
@@ -301,7 +294,7 @@ export function emitAxisProjectedCss(
   //    Baseline-only tokens never appear elsewhere; all other variance
   //    kinds also need a baseline value to start the cascade from.
   {
-    const baselineRaw = asRawTokens(baselineTokens);
+    const baselineRaw = withSyntheticIds(baselineTokens);
     const lines = collectLines(
       baselineRaw,
       baselineRaw,
@@ -347,8 +340,8 @@ export function emitAxisProjectedCss(
       const deltaPaths = deltaPathsByAxis[axis.name]?.[ctx] ?? new Set<string>();
 
       const lines = collectLines(
-        asRawTokens(cellTokens),
-        asRawTokens(cellTokensForAliases),
+        withSyntheticIds(cellTokens),
+        withSyntheticIds(cellTokensForAliases),
         (path) => deltaPaths.has(path) && axisTouchesToken(axis.name, variance.get(path)),
         cellTuple,
         varOpts,
@@ -494,7 +487,7 @@ function collectJointBlocks(
     const entry = grouped.get(key);
     if (!entry) continue;
     const fullTuple = { ...defaultTuple, ...entry.tuple };
-    const fullTokens = asRawTokens(resolveAliasAllAt(tokenGraph, fullTuple));
+    const fullTokens = withSyntheticIds(resolveAliasAllAt(tokenGraph, fullTuple));
 
     // Selector order: project axis order, not the order the entry's
     // tuple happens to be keyed in.
@@ -576,14 +569,14 @@ function collectLines(
  * sub-field plus an optional shorthand.
  */
 export function* collectTokenDeclarations(
-  localID: string,
+  path: string,
   token: TokenNormalized,
   tokensSet: RawTokenMap,
   permutation: Record<string, string>,
   varOpts: VarOpts,
   transformAlias: (token: TokenNormalized) => string,
 ): Generator<{ varName: string; value: string }> {
-  const varName = makeCSSVar(localID, varOpts);
+  const varName = makeCSSVar(path, varOpts);
   let value: ReturnType<typeof transformCSSValue>;
   try {
     value = transformCSSValue(token, { tokensSet, permutation, transformAlias });
@@ -592,7 +585,7 @@ export function* collectTokenDeclarations(
     const valueStr = safeStringify(token.$value);
     const original = error instanceof Error ? error.message : String(error);
     throw new Error(
-      `swatchbook: failed to transform token "${localID}" at permutation ${permutationStr}.\n` +
+      `swatchbook: failed to transform token "${path}" at permutation ${permutationStr}.\n` +
         `  $type: ${token.$type}\n` +
         `  $value: ${valueStr}\n` +
         `  cause: ${original}`,
@@ -604,9 +597,9 @@ export function* collectTokenDeclarations(
     return;
   }
   for (const [subKey, subVal] of Object.entries(value)) {
-    yield { varName: makeCSSVar(`${localID}.${subKey}`, varOpts), value: subVal };
+    yield { varName: makeCSSVar(`${path}.${subKey}`, varOpts), value: subVal };
   }
-  const shorthand = generateShorthand({ token, localID });
+  const shorthand = generateShorthand({ token, localID: path });
   if (shorthand) yield { varName, value: shorthand };
 }
 

--- a/packages/core/src/themes.ts
+++ b/packages/core/src/themes.ts
@@ -35,6 +35,11 @@ export interface ThemeEnumPreset {
  * by ` · ` in axis declaration order. Same form the
  * `data-<prefix>-theme` attribute holds. Falls back to each axis's
  * `default` when the tuple omits it.
+ *
+ * Not interchangeable with `permutationID` (types.ts): this is the
+ * axis-order display name that fills omitted axes from defaults, whereas
+ * `permutationID` is the insertion-order internal wire key with no default
+ * fallback.
  */
 export function tupleToName(
   axes: readonly { readonly name: string; readonly default: string }[],

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -420,6 +420,11 @@ export interface ParserInput {
  * tuples stringify to the context value alone (`{ theme: 'Light' }` →
  * `"Light"`); multi-axis tuples join context values with ` · ` in
  * insertion order (`{ mode: 'Dark', brand: 'Brand A' }` → `"Dark · Brand A"`).
+ *
+ * Not interchangeable with `tupleToName` (themes.ts): this is the
+ * insertion-order internal wire key with no default fallback, whereas
+ * `tupleToName` builds the axis-order display name and fills omitted axes
+ * from their defaults.
  */
 export function permutationID(input: Record<string, string>): string {
   const values = Object.values(input);

--- a/packages/integrations/src/tailwind.ts
+++ b/packages/integrations/src/tailwind.ts
@@ -83,16 +83,15 @@ export default function tailwindIntegration(
 
 function renderTailwindTheme(project: Project, roles: RoleMap): string {
   const prefix = project.config.cssVarPrefix ?? '';
-  const sourcePrefix = prefix ? `${prefix}-` : '';
-  const scopePrefix = prefix ? `${prefix}-` : '';
+  const varPrefix = prefix ? `${prefix}-` : '';
 
   const entries: string[] = [];
   for (const [scale, names] of Object.entries(roles)) {
     if (names.length === 0) continue;
     entries.push(`  /* ${scale} */`);
     for (const [themeKey, sourcePath] of names) {
-      const sourceVar = `--${sourcePrefix}${sourcePath.replaceAll('.', '-')}`;
-      const themeVar = `--${scale}-${scopePrefix}${themeKey}`;
+      const sourceVar = `--${varPrefix}${sourcePath.replaceAll('.', '-')}`;
+      const themeVar = `--${scale}-${varPrefix}${themeKey}`;
       entries.push(`  ${themeVar}: var(${sourceVar});`);
     }
     entries.push('');

--- a/packages/mcp/src/format-color.ts
+++ b/packages/mcp/src/format-color.ts
@@ -21,7 +21,6 @@ interface NormalizedColor {
   components?: readonly (number | null)[];
   channels?: readonly (number | null)[];
   alpha?: number;
-  hex?: string;
 }
 
 export function formatColor(raw: unknown, format: ColorFormat): FormatColorResult | null {


### PR DESCRIPTION
Actions the safe, internal-only findings from the naming audit (buckets A, B, D). No exported symbols renamed, so no breaking change and no changeset. Public-API renames (bucket C) are deferred to a planned break. Full gate green (format / lint / typecheck / tests, incl. 188 blocks browser-mode tests).

### A — internal renames (name fought behaviour)
- core: `localID` → `path` (`collectTokenDeclarations`); removed the `asRawTokens` alias in favour of `withSyntheticIds`.
- blocks: local `theme` → `wrapperAttrs` (`TokenDetail`); `themeAttrs` → `blockWrapperAttrs` (per-axis attrs, nothing theme-specific; 15 call sites); `clamp255` → `unitToByte` (it scales 0–1 → 0–255, not a plain clamp); `contextPermutation` → `contextThemeName` (it holds a theme name).
- addon: `matchThemeName` → `composeThemeName` (it composes, doesn't match); `fingerprint` → `themeKey`; `pickInitFields` → `toInitPayload`, returning the exported `InitPayload` and dropping the structurally-identical internal `InitFieldsSource`.
- integrations: collapsed the always-equal `sourcePrefix` + `scopePrefix` into one `varPrefix`.

### B — dead fields + a wire-string footgun
- core: deleted the never-read `JointCase.permutationName` field (and its now-unused `permutationID` import).
- mcp: deleted the never-read `NormalizedColor.hex` field.
- addon: `HMR_EVENT` had the **identical** wire string as `TOKENS_UPDATED_EVENT` (`'swatchbook/tokens-updated'`) despite a comment claiming they were distinct; gave the Vite-HMR event its own value `'swatchbook/hmr-tokens'` (constant name unchanged; emit + listener both reference the constant, so the change is symmetric).

### D — stale doc comments (no rename)
- addon: corrected `INIT_EVENT`'s doc (it does not carry "theme list + mode"); fixed a `use-token` JSDoc that referenced a removed `permutationsResolved` mechanism; normalised "composed permutation ID" → "composed theme name" prose in `globals.ts` / `preview.tsx`.
- blocks: same "permutation ID" → "theme name" prose fix in `contexts.ts`.

### Notably NOT changed
- `tokensSet` (core) — left as-is; it's a property key passed to Terrazzo's `transformCSSValue`, not a free local.
- `permutationID` / `tupleToName` — kept as two functions (different contracts: insertion-order wire key vs axis-order display name); added a cross-reference doc to each so they're not mistaken for duplicates and merged.
- The `tuple` / `permutation` / `theme` vocabulary — left intact; it's load-bearing and documented.

Milestone: Maintenance

Closes #1090

Plan impact: none.
