### PR TITLE
refactor: remove dead internal code (naming audit, bucket E)

### DIFF
--- a/packages/addon/src/ColorFormatSelector.tsx
+++ b/packages/addon/src/ColorFormatSelector.tsx
@@ -38,7 +38,7 @@ const COLOR_FORMAT_OPTIONS: readonly { id: ColorFormat; label: string }[] = [
 
 const h = React.createElement;
 
-export interface ColorFormatSelectorProps {
+interface ColorFormatSelectorProps {
   active: ColorFormat;
   onSelect(next: ColorFormat): void;
 }

--- a/packages/addon/src/channel-types.ts
+++ b/packages/addon/src/channel-types.ts
@@ -7,34 +7,12 @@
  * type-only imports (`import type`) erase before the bundler sees them
  * under `verbatimModuleSyntax`, so the canonical shapes can come
  * directly from core for the fields that aren't blocks-narrowed.
- *
- * `VirtualToken` and the wire-cells / wire-jointOverrides shapes that
- * reference it stay local — those carry a narrower token shape than
- * core's `TokenMap` so the channel payload doesn't drag Terrazzo's full
- * `TokenNormalized` into the wire surface.
  */
-import type { Axis, Diagnostic, DiagnosticSeverity, Preset } from '@unpunnyfuns/swatchbook-core';
+import type { Axis, Diagnostic, Preset } from '@unpunnyfuns/swatchbook-core';
 
-export type { DiagnosticSeverity };
 export type VirtualAxis = Axis;
 export type VirtualPreset = Preset;
 export type VirtualDiagnostic = Diagnostic;
-
-export interface VirtualToken {
-  $type?: string | undefined;
-  $value?: unknown;
-  $description?: string | undefined;
-  aliasOf?: string | undefined;
-  aliasChain?: readonly string[] | undefined;
-  aliasedBy?: readonly string[] | undefined;
-  /**
-   * Per-sub-field alias map for composite tokens — same shape as
-   * `blocks/contexts.ts`'s `VirtualTokenShape.partialAliasOf`. Typed as
-   * `unknown` because the structure varies per composite `$type`; the
-   * block narrows it at the consumer.
-   */
-  partialAliasOf?: unknown;
-}
 
 /**
  * The full INIT_EVENT payload. Preview emits it whole via

--- a/packages/blocks/src/internal/styles.tsx
+++ b/packages/blocks/src/internal/styles.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, ReactElement, ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 
 /**
  * Chrome-style primitives shared across every block. Kept as JS exports
@@ -8,28 +8,13 @@ import type { CSSProperties, ReactElement, ReactNode } from 'react';
  * empty-state — lives in `styles.css` and is applied via class names.
  */
 
-export const TEXT_DEFAULT = 'var(--swatchbook-text-default, CanvasText)';
 export const TEXT_MUTED = 'var(--swatchbook-text-muted, CanvasText)';
 
-export const SURFACE_DEFAULT = 'var(--swatchbook-surface-default, Canvas)';
 export const SURFACE_RAISED = 'var(--swatchbook-surface-raised, Canvas)';
 export const SURFACE_MUTED = 'var(--swatchbook-surface-muted, rgba(128,128,128,0.15))';
 
-export const BORDER_DEFAULT = `1px solid var(--swatchbook-border-default, rgba(128,128,128,0.2))`;
 export const BORDER_FAINT = `1px solid var(--swatchbook-border-default, rgba(128,128,128,0.15))`;
 export const BORDER_STRONG = `1px solid var(--swatchbook-border-default, rgba(128,128,128,0.3))`;
-
-export const SIZE_PILL = 10;
-
-export const typePillStyle = {
-  display: 'inline-block',
-  padding: '2px 6px',
-  borderRadius: 4,
-  fontSize: SIZE_PILL,
-  letterSpacing: 0.5,
-  textTransform: 'uppercase',
-  background: SURFACE_MUTED,
-} satisfies CSSProperties;
 
 /**
  * Inner content for a block's "nothing to render" state. Call sites wrap

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -40,12 +40,6 @@ export interface ProjectData {
    */
   varianceByPath: VirtualVarianceByPathShape;
   /**
-   * Pre-built token graph. JSON-safe; nodes carry per-axis writes
-   * plus alias edges. The hook backs `resolveAt` and `varianceByPath`
-   * from this graph.
-   */
-  tokenGraph: VirtualTokenGraph;
-  /**
    * Compose the resolved `TokenMap` for any tuple of axis selections.
    * Backed browser-side by `resolveAllAt` over the `tokenGraph`.
    */
@@ -159,7 +153,6 @@ export function useProject(): ProjectData {
       cssVarPrefix: cssVarPrefix ?? '',
       listing: listing ?? {},
       varianceByPath: derivedVarianceByPath,
-      tokenGraph: tokenGraph ?? { nodes: {}, axes: [], axisDefaults: {}, axisContexts: {} },
       resolveAt,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -239,7 +232,6 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
       cssVarPrefix: tokens.cssVarPrefix,
       listing: tokens.listing,
       varianceByPath: fallbackVarianceByPath,
-      tokenGraph: tokens.tokenGraph,
       resolveAt,
     }),
     [
@@ -250,7 +242,6 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
       tokens.cssVarPrefix,
       tokens.listing,
       fallbackVarianceByPath,
-      tokens.tokenGraph,
       resolveAt,
     ],
   );

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -28,7 +28,7 @@ import type { Axis, Config, Diagnostic, Permutation, Project, TokenMap } from '#
  * swatchbook output doesn't collide with whatever else the consumer has
  * claimed in `:root`. Override in config to use a project-specific prefix
  * or set to `''` to opt out of namespacing. */
-export const DEFAULT_CSS_VAR_PREFIX = 'swatch';
+const DEFAULT_CSS_VAR_PREFIX = 'swatch';
 
 // Opt-in phase timing for `loadProject`. Activate with the env var
 // `SWATCHBOOK_LOG_VERBOSE=1`. Each major phase logs its duration to
@@ -108,7 +108,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
       const id = permutationID(tuple);
       if (filteredResolved[id]) continue;
       filteredResolved[id] = normalized.parserInput.resolver.apply(tuple);
-      filteredPermutations.push({ name: id, input: tuple, sources: [] });
+      filteredPermutations.push({ name: id, input: tuple });
     }
     logPhase(`apply ${presets.length} preset tuple(s)`, tPresets);
   }

--- a/packages/core/src/permutations/layered.ts
+++ b/packages/core/src/permutations/layered.ts
@@ -117,7 +117,7 @@ export async function loadLayeredPermutations(
   const sourceSet = new Set<string>();
   for (const { input, allFiles, tokens } of perTuple) {
     const id = permutationID(input);
-    permutations.push({ name: id, input: { ...input }, sources: allFiles });
+    permutations.push({ name: id, input: { ...input } });
     resolved[id] = tokens;
     for (const f of allFiles) sourceSet.add(f);
   }

--- a/packages/core/src/permutations/resolver.ts
+++ b/packages/core/src/permutations/resolver.ts
@@ -121,7 +121,7 @@ export async function loadResolverPermutations(
     const name = 'default';
     return {
       axes: [{ name: 'theme', contexts: [name], default: name, source: 'synthetic' }],
-      permutations: [{ name, input: { theme: name }, sources: tokenFiles }],
+      permutations: [{ name, input: { theme: name } }],
       resolved: { [name]: parsed.tokens },
       sourceFiles: tokenFiles,
       parserInput: {
@@ -177,7 +177,7 @@ export async function loadResolverPermutations(
   const defaultInput: Record<string, string> = {};
   for (const axis of axes) defaultInput[axis.name] = axis.default;
   const defaultId = permutationID(defaultInput);
-  permutations.push({ name: defaultId, input: defaultInput, sources: [] });
+  permutations.push({ name: defaultId, input: defaultInput });
   resolved[defaultId] = resolver.apply(defaultInput);
 
   for (const axis of axes) {
@@ -186,7 +186,7 @@ export async function loadResolverPermutations(
       const cellInput = { ...defaultInput, [axis.name]: ctx };
       const id = permutationID(cellInput);
       if (resolved[id] !== undefined) continue;
-      permutations.push({ name: id, input: cellInput, sources: [] });
+      permutations.push({ name: id, input: cellInput });
       resolved[id] = resolver.apply(cellInput);
     }
   }

--- a/packages/core/src/token-graph/build.ts
+++ b/packages/core/src/token-graph/build.ts
@@ -514,9 +514,7 @@ function extractPartialAliasFields(partialAliasOf: unknown): Record<string, stri
 // (max alias-chain depth) iterations — 1000 covers any realistic project.
 const AFFECTED_BY_FIXPOINT_BOUND = 1000;
 
-export function computeAliasTargets(
-  nodes: Record<string, TokenGraphNode>,
-): Record<string, Set<string>> {
+function computeAliasTargets(nodes: Record<string, TokenGraphNode>): Record<string, Set<string>> {
   const out: Record<string, Set<string>> = {};
   for (const [path, node] of Object.entries(nodes)) {
     const targets = new Set<string>(node.aliases);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -108,8 +108,6 @@ export interface Permutation {
   name: string;
   /** The resolver input tuple (e.g. `{ theme: 'Light' }` or `{ mode: 'Dark', brand: 'Brand A' }`). */
   input: Readonly<Record<string, string>>;
-  /** Source files this tuple was parsed from (layered loader populates; resolver mode leaves empty). */
-  sources: readonly string[];
 }
 
 /**


### PR DESCRIPTION
Removes confirmed-dead **internal** code from the dead-code audit (bucket E). No exported/documented surface touched — no breaking change, no changeset. Full gate green (format / lint / typecheck / tests, incl. 188 blocks browser-mode tests).

These survive `noUnusedLocals` (which already bars unused locals and dead non-exported functions); what's left is the shape the type checker can't see — unread fields, dead `export` keywords, and unimported exports.

- **core**: deleted the unread `Permutation.sources` field (+ its 5 write sites); dropped the dead `export` on `computeAliasTargets` and `DEFAULT_CSS_VAR_PREFIX` (both used only in their own file).
- **blocks**: removed four dead style constants (`TEXT_DEFAULT`, `SURFACE_DEFAULT`, `BORDER_DEFAULT`, `typePillStyle` + its only feeder `SIZE_PILL`) with zero references; dropped the surfaced-but-unread `ProjectData.tokenGraph` field from the `useProject()` return (kept the internal local that derives `resolveAt`/`varianceByPath`).
- **addon**: removed the unimported `VirtualToken` interface and the dead `DiagnosticSeverity` re-export from `channel-types.ts`; un-exported `ColorFormatSelectorProps`.

### Deliberately NOT included
- The dead `theme` param + `swatchbookTheme` global: they're dead in code, but `addon.mdx` documents them (and even claims `swatchbookTheme` is "written in lockstep" — which no longer happens). Documented public surface, so they go with the `permutation`→`themeName` rename in a single planned breaking change (rename + delete the dead pair + correct the docs + changeset + migration note).
- `PARAM_KEY`, `ProjectSnapshot.presets`/`disabledAxes`, `Diagnostic.column`: dead/unused but on the published surface → deferred to the same break.
- Library public API with no internal callers (`TupleKey`, `ResolveAt`, `Config` union arms, …) is intended API, not dead — left alone.

Milestone: Maintenance

Closes #1093

Plan impact: none.
