### PR TITLE
docs: doc-review follow-ups (accuracy, README rewrites, em-dash purge)

### DIFF
--- a/.changeset/doc-review-fixes.md
+++ b/.changeset/doc-review-fixes.md
@@ -1,0 +1,17 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Documentation review follow-ups.
+
+- Accuracy: drop the stale `Diagnostic.column` field, correct the `useSwatchbookData()` return shape and the `Project` field list (no `css`), remove the bogus `OpacityScale` filter default, fix the `useToken` import path (`/hooks` subpath), and point a guide at the public `useSwatchbookData()` instead of internal `useProject()`.
+- READMEs: refresh `core`'s README for the current `tokenGraph` API (drop `jointOverrideKey`, the `resolve-at` subpath, and `cells`/`jointOverrides`/`varianceByPath`), and rewrite the `apps/docs` and `apps/storybook` scaffold READMEs into real, on-convention pages.
+- Storybook dogfood: fix the Motion demo filter (`cubicBezier.**`) and add the missing `color.text` variants.
+- Prose: remove em-dashes from all documentation prose (code samples untouched).
+
+Patch so the release snapshot rebuilds with the corrected docs.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If your stories already style with CSS variables, they pick up the toolbar's axi
 npm install -D @unpunnyfuns/swatchbook-addon
 ```
 
-One package pulls the whole React surface — toolbar, preview decorator, MDX doc blocks, `ThemeSwitcher`, `useToken()`. See the [Quickstart](https://unpunnyfuns.github.io/swatchbook/quickstart) for configuration.
+One package pulls the whole React surface: toolbar, preview decorator, MDX doc blocks, `ThemeSwitcher`, `useToken()`. See the [Quickstart](https://unpunnyfuns.github.io/swatchbook/quickstart) for configuration.
 
 ## Packages
 
@@ -28,7 +28,7 @@ One package pulls the whole React surface — toolbar, preview decorator, MDX do
 | [`@unpunnyfuns/swatchbook-integrations`](./packages/integrations) | Tailwind v4 and CSS-in-JS adapters for the addon. |
 | [`@unpunnyfuns/swatchbook-mcp`](./packages/mcp) | Model Context Protocol server for AI agents. |
 
-Most consumers only install the addon; the rest travel transitively. Each sub-package is publishable on its own for slice-only use (e.g. the switcher in a Docusaurus navbar).
+Most consumers only install the addon; the rest travel transitively. Each sub-package is publishable on its own for slice-only use (for example, the switcher in a Docusaurus navbar).
 
 ## Development
 
@@ -42,7 +42,7 @@ pnpm turbo run lint typecheck test build
 
 ## Credits
 
-Parses DTCG tokens through [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) — its parser, resolver evaluation, and alias resolution are the foundation.
+Parses DTCG tokens through [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp). Its parser, resolver evaluation, and alias resolution are the foundation.
 
 ## License
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -1,41 +1,19 @@
-# Website
+# swatchbook docs
 
-This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
+The swatchbook documentation site, built on [Docusaurus](https://docusaurus.io/). It hosts the concepts, guides, and API reference published at [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/).
 
-## Installation
+Private workspace package. Not published.
 
-```bash
-yarn
+## Develop
+
+```sh
+pnpm start          # local dev server with live reload
+pnpm build          # static build into ./build
+pnpm serve          # serve the built site
 ```
 
-## Local Development
+`prestart` / `prebuild` regenerate the dogfood tokens via `pnpm build:tokens` first.
 
-```bash
-yarn start
-```
+## Documentation
 
-This command starts a local development server and opens up a browser window. Most changes are reflected live without having to restart the server.
-
-## Build
-
-```bash
-yarn build
-```
-
-This command generates static content into the `build` directory and can be served using any static contents hosting service.
-
-## Deployment
-
-Using SSH:
-
-```bash
-USE_SSH=true yarn deploy
-```
-
-Not using SSH:
-
-```bash
-GIT_USER=<Your GitHub username> yarn deploy
-```
-
-If you are using GitHub pages for hosting, this command is a convenient way to build the website and push to the `gh-pages` branch.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) is the live site this package produces.

--- a/apps/docs/docs/developers/architecture.mdx
+++ b/apps/docs/docs/developers/architecture.mdx
@@ -6,20 +6,20 @@ sidebar_position: 1
 
 # Architecture
 
-Map of the repo, the one data structure everything revolves around, and how data moves from a DTCG token file on disk to a rendered doc block. Written for contributors — if you're consuming swatchbook as a user, the [Reference](../reference/core.mdx) section is the right door.
+Map of the repo, the one data structure everything revolves around, and how data moves from a DTCG token file on disk to a rendered doc block. Written for contributors; if you're consuming swatchbook as a user, the [Reference](../reference/core.mdx) section is the right door.
 
 ## Repo map
 
 Monorepo under `@unpunnyfuns`. pnpm workspaces + Turborepo orchestration. Every package is `"type": "module"` and ships ESM only (`tsdown` builds).
 
-### Published packages (fixed-version group — always release together)
+### Published packages (fixed-version group, always release together)
 
 | Package | Role | Depends on |
 | --- | --- | --- |
-| `@unpunnyfuns/swatchbook-core` | Framework-free DTCG loader. Parses a resolver, normalizes axes, builds a token graph, resolves themes, emits CSS and diagnostics. | — |
+| `@unpunnyfuns/swatchbook-core` | Framework-free DTCG loader. Parses a resolver, normalizes axes, builds a token graph, resolves themes, emits CSS and diagnostics. | none |
 | `@unpunnyfuns/swatchbook-addon` | Storybook 10 addon. Toolbar, preview decorator, Vite plugin that publishes a virtual module. Re-exports `-blocks` + `-switcher`. | core, blocks, switcher |
-| `@unpunnyfuns/swatchbook-blocks` | MDX doc blocks + the `SwatchbookProvider` + hooks. Pure React, framework-agnostic beyond Storybook. | — (peer: storybook) |
-| `@unpunnyfuns/swatchbook-switcher` | Framework-agnostic axis / preset popover UI. Used by the addon toolbar and the docs-site navbar. | — |
+| `@unpunnyfuns/swatchbook-blocks` | MDX doc blocks + the `SwatchbookProvider` + hooks. Pure React, framework-agnostic beyond Storybook. | none (peer: storybook) |
+| `@unpunnyfuns/swatchbook-switcher` | Framework-agnostic axis / preset popover UI. Used by the addon toolbar and the docs-site navbar. | none |
 | `@unpunnyfuns/swatchbook-mcp` | Model Context Protocol server exposing a project to AI agents. Runs without Storybook. | core |
 
 ### Apps (private workspaces, not published)
@@ -33,7 +33,7 @@ Monorepo under `@unpunnyfuns`. pnpm workspaces + Turborepo orchestration. Every 
 
 | Path | Role |
 | --- | --- |
-| `packages/tokens` | Multi-axis DTCG reference fixture — colors, sizes, type, motion, borders, shadows, gradients. The demo Storybook renders against this. |
+| `packages/tokens` | Multi-axis DTCG reference fixture: colors, sizes, type, motion, borders, shadows, gradients. The demo Storybook renders against this. |
 
 ## The Project snapshot
 
@@ -59,12 +59,12 @@ interface Project {
 
 Properties:
 
-- **`tokenGraph` is the primary resolution surface.** A JSON-serializable `Record<path, TokenGraphNode>` plus axis metadata. Each node carries its baseline value, per-(axis, context) write declarations, alias edges, and a precomputed `affectedBy` index. The graph walker (`resolveAt` in `/graph`) traverses this structure at query time — no resolver calls after build. Browser consumers read the same graph via the [`/graph`](../reference/core.mdx#graph-queries) subpath.
+- **`tokenGraph` is the primary resolution surface.** A JSON-serializable `Record<path, TokenGraphNode>` plus axis metadata. Each node carries its baseline value, per-(axis, context) write declarations, alias edges, and a precomputed `affectedBy` index. The graph walker (`resolveAt` in `/graph`) traverses this structure at query time, with no resolver calls after build. Browser consumers read the same graph via the [`/graph`](../reference/core.mdx#graph-queries) subpath.
 - **`sourceFiles` is the canonical watch set.** The addon's Vite plugin and the MCP server both use it to decide what to watch for HMR / live-reload.
-- **Diagnostics flow as data, not exceptions.** Parse errors, unresolved aliases, invalid preset axis values — all land in `project.diagnostics` with a severity. The `<Diagnostics />` block renders them.
+- **Diagnostics flow as data, not exceptions.** Parse errors, unresolved aliases, invalid preset axis values all land in `project.diagnostics` with a severity. The `<Diagnostics />` block renders them.
 - **One axis type.** `Axis.source` is `'resolver'` (DTCG resolver modifier), `'layered'` (authored per-axis layer globs), or `'synthetic'` (single-axis fallback for projects without a resolver or layers). Everything downstream treats them uniformly.
 
-`ProjectSnapshot` (in `packages/blocks/src/types.ts`) is the JSON-safe slice of `Project` that the addon's virtual module and provider deal in. It's intentionally pruned — no raw Terrazzo `TokenNormalized` shapes, just the fields blocks need.
+`ProjectSnapshot` (in `packages/blocks/src/types.ts`) is the JSON-safe slice of `Project` that the addon's virtual module and provider deal in. It's intentionally pruned: no raw Terrazzo `TokenNormalized` shapes, just the fields blocks need.
 
 ## Display-side integrations
 
@@ -80,11 +80,11 @@ interface SwatchbookIntegration {
 }
 ```
 
-The addon's Vite plugin iterates `integrations[]`, resolves each `virtualId`, serves whatever `render(project)` produces, and invalidates every integration-contributed module on HMR alongside `virtual:swatchbook/tokens`. The addon itself learns nothing about Tailwind, emotion, or anything else — integrations own their library-specific logic.
+The addon's Vite plugin iterates `integrations[]`, resolves each `virtualId`, serves whatever `render(project)` produces, and invalidates every integration-contributed module on HMR alongside `virtual:swatchbook/tokens`. The addon itself learns nothing about Tailwind, emotion, or anything else; integrations own their library-specific logic.
 
-The `Project` snapshot passed to `render` carries everything: axes, `tokenGraph`, presets, `defaultTokens`, `resolveAt`, `config` — which carries `cssVarPrefix`, `terrazzoPlugins`, etc. See the [Integrations guide](../guides/integrations/index.mdx) for factory usage.
+The `Project` snapshot passed to `render` carries everything: axes, `tokenGraph`, presets, `defaultTokens`, `resolveAt`, and `config` (which carries `cssVarPrefix`, `terrazzoPlugins`, etc.). See the [Integrations guide](../guides/integrations/index.mdx) for factory usage.
 
-## Data flow — static build path
+## Data flow: static build path
 
 The simpler of the two flows. Applies to the docs site, emitted CSS for consumers, and the MCP server at startup.
 
@@ -104,14 +104,14 @@ tokens/resolver.json
 
 The same `Project` also feeds:
 
-- `project.resolveAt(tuple)` — compose the resolved TokenMap for any axis tuple
-- `project.defaultTokens` — the default-tuple snapshot for global views
-- `getVariance(project.tokenGraph, path)` from [`/graph`](../reference/core.mdx#graph-queries) — per-token variance classification
-- `project.diagnostics` — the `<Diagnostics />` block reads this
+- `project.resolveAt(tuple)`: compose the resolved TokenMap for any axis tuple
+- `project.defaultTokens`: the default-tuple snapshot for global views
+- `getVariance(project.tokenGraph, path)` from [`/graph`](../reference/core.mdx#graph-queries): per-token variance classification
+- `project.diagnostics`: the `<Diagnostics />` block reads this
 - the MCP server's tool handlers (all fourteen read straight from the project)
 - TypeScript type emission (via Terrazzo's token-tools; not currently exposed as a CLI)
 
-## Data flow — dev / HMR path
+## Data flow: dev / HMR path
 
 Inside Storybook, the pipeline grows two links so edits to token files re-render blocks without a full preview reload.
 
@@ -137,12 +137,12 @@ Key points:
 
 - **Watchers live on parent directories, not on files.** Atomic-save editors (VS Code, vim, Zed) unlink + recreate the file inode, which kills file-level watchers. Dir-level + filename filter survives the dance. Same pattern in the MCP server's bin.
 - **The addon publishes a channel event rather than a full reload.** A full reload would drop toolbar state, `args`, scroll position. Broadcasting a snapshot through Storybook's channel lets blocks re-render in place via `useSyncExternalStore`.
-- **Outside the preview iframe, the channel never fires.** The docs site renders blocks against the virtual module's baked-at-build values — correct behavior for static docs.
+- **Outside the preview iframe, the channel never fires.** The docs site renders blocks against the virtual module's baked-at-build values, which is correct behavior for static docs.
 - **MCP mirrors the pattern.** `packages/mcp/src/bin.ts` watches the same sourceFiles, reloads via `loadFromConfig`, and calls `setProject(next)` on the already-connected MCP server.
 
 ## The reactivity model
 
-Separately from token-file edits, swatchbook reacts to user actions — the toolbar axis popover, the color-format menu.
+Separately from token-file edits, swatchbook reacts to user actions: the toolbar axis popover, the color-format menu.
 
 Path:
 
@@ -162,8 +162,8 @@ blocks re-render with new active theme / resolved tokens
 
 Two paths through `useProject`:
 
-- **Inside story renders** — the addon's preview decorator mounts `SwatchbookProvider` around every story, seeding context from the virtual module. `useOptionalSwatchbookData()` finds it, and the hook is cheap.
-- **MDX doc blocks + autodocs** — no story render is active, so no provider. The hook falls back to `useVirtualModuleFallback(enabled=true)` which reads the virtual module directly and subscribes to `globalsUpdated` via the channel. `useGlobals()` from `storybook/preview-api` wouldn't work here — it throws outside a story render.
+- **Inside story renders.** The addon's preview decorator mounts `SwatchbookProvider` around every story, seeding context from the virtual module. `useOptionalSwatchbookData()` finds it, and the hook is cheap.
+- **MDX doc blocks + autodocs.** No story render is active, so no provider. The hook falls back to `useVirtualModuleFallback(enabled=true)` which reads the virtual module directly and subscribes to `globalsUpdated` via the channel. `useGlobals()` from `storybook/preview-api` wouldn't work here; it throws outside a story render.
 
 Why the channel instead of `useGlobals`: MDX doc blocks render in a context where Storybook's preview `HooksContext` isn't mounted. The channel is the one communication surface that works in both story render and MDX contexts.
 
@@ -192,11 +192,11 @@ Fourteen tools, all stateless reads against the in-memory `Project`:
 
 ## Where to read next
 
-- `packages/core/src/load.ts` — the loader entry. Start here.
-- `packages/core/src/types.ts` — every shape flowing through the rest.
-- `packages/addon/src/virtual/plugin.ts` — the HMR plumbing.
-- `packages/addon/src/preview.tsx` — how the preview decorator wires the provider + channel.
-- `packages/blocks/src/internal/use-project.ts` — the hook every block pulls state through.
-- `packages/mcp/src/server.ts` — the fourteen MCP tools in one file.
+- `packages/core/src/load.ts`: the loader entry. Start here.
+- `packages/core/src/types.ts`: every shape flowing through the rest.
+- `packages/addon/src/virtual/plugin.ts`: the HMR plumbing.
+- `packages/addon/src/preview.tsx`: how the preview decorator wires the provider + channel.
+- `packages/blocks/src/internal/use-project.ts`: the hook every block pulls state through.
+- `packages/mcp/src/server.ts`: the fourteen MCP tools in one file.
 
 And the companion [Sharp corners](./sharp-corners.mdx) page for the "don't step there" list.

--- a/apps/docs/docs/developers/index.mdx
+++ b/apps/docs/docs/developers/index.mdx
@@ -6,15 +6,15 @@ sidebar_position: 0
 
 # For developers
 
-You're reading the right section if you want to **work on swatchbook's code** — fix bugs, add blocks, extend the MCP tool set, rewrite how HMR flows. If you want to *use* swatchbook in your own Storybook, the [Quickstart](../quickstart.mdx) and [Reference](../reference/core.mdx) are the right doors.
+You're reading the right section if you want to **work on swatchbook's code**: fix bugs, add blocks, extend the MCP tool set, rewrite how HMR flows. If you want to *use* swatchbook in your own Storybook, the [Quickstart](../quickstart.mdx) and [Reference](../reference/core.mdx) are the right doors.
 
-This section assumes you've already skimmed [**CONTRIBUTING.md**](https://github.com/unpunnyfuns/swatchbook/blob/main/CONTRIBUTING.md) on GitHub, which covers dev setup, checks, commit conventions, and the release flow. What lives here is the *how-does-the-code-work* reference — the kind of thing a new contributor needs to build a mental model before making their first real change.
+This section assumes you've already skimmed [**CONTRIBUTING.md**](https://github.com/unpunnyfuns/swatchbook/blob/main/CONTRIBUTING.md) on GitHub, which covers dev setup, checks, commit conventions, and the release flow. What lives here is the *how-does-the-code-work* reference: the kind of thing a new contributor needs to build a mental model before making their first real change.
 
 ## What's in this section
 
-- [**Architecture**](./architecture.mdx) — the repo map, the one data structure everything revolves around (`Project`), and how data moves from a token file on disk to a rendered doc block. Includes the static build path, the dev/HMR path, and how the MCP server plugs in.
-- [**Sharp corners**](./sharp-corners.mdx) — the "someone will bleed on this" list. Shapes that trip newcomers. Read this after *Architecture* so the rules have context.
-- [**Built with AI**](./built-with-ai.mdx) — swatchbook is written by an AI coding agent under human direction. How that split works, what a human gates, and the checks every change clears.
+- [**Architecture**](./architecture.mdx): the repo map, the one data structure everything revolves around (`Project`), and how data moves from a token file on disk to a rendered doc block. Includes the static build path, the dev/HMR path, and how the MCP server plugs in.
+- [**Sharp corners**](./sharp-corners.mdx): the "someone will bleed on this" list. Shapes that trip newcomers. Read this after *Architecture* so the rules have context.
+- [**Built with AI**](./built-with-ai.mdx): swatchbook is written by an AI coding agent under human direction. How that split works, what a human gates, and the checks every change clears.
 
 ## Where the source lives
 
@@ -32,9 +32,9 @@ This section assumes you've already skimmed [**CONTRIBUTING.md**](https://github
 └── packages/tokens/ # Multi-axis DTCG reference fixture
 ```
 
-## Quick orientation — typical work shapes
+## Quick orientation: typical work shapes
 
-- **Fixing a block's rendering** — start in `packages/blocks/src/<BlockName>.tsx`. Look at `packages/blocks/test/<block>.test.tsx` for the existing assertions. Add your story under `apps/storybook/src/stories/`.
-- **Changing how tokens load** — `packages/core/src/load.ts` is the entry; `packages/core/src/themes/` has the resolver and layered paths; `packages/core/src/types.ts` is the shape that flows out.
-- **Adding an MCP tool** — `packages/mcp/src/server.ts` — one file, one `server.registerTool(…)` call per tool. The MCP server is stateless beyond its in-memory `Project` reference.
-- **Tweaking HMR behavior** — `packages/addon/src/virtual/plugin.ts` is the addon-side watcher + channel broadcaster. `packages/mcp/src/bin.ts` mirrors the pattern for the MCP server. Keep them in lockstep.
+- **Fixing a block's rendering.** Start in `packages/blocks/src/<BlockName>.tsx`. Look at `packages/blocks/test/<block>.test.tsx` for the existing assertions. Add your story under `apps/storybook/src/stories/`.
+- **Changing how tokens load.** `packages/core/src/load.ts` is the entry; `packages/core/src/themes/` has the resolver and layered paths; `packages/core/src/types.ts` is the shape that flows out.
+- **Adding an MCP tool.** `packages/mcp/src/server.ts`, one file, one `server.registerTool(…)` call per tool. The MCP server is stateless beyond its in-memory `Project` reference.
+- **Tweaking HMR behavior.** `packages/addon/src/virtual/plugin.ts` is the addon-side watcher + channel broadcaster. `packages/mcp/src/bin.ts` mirrors the pattern for the MCP server. Keep them in lockstep.

--- a/apps/docs/docs/developers/sharp-corners.mdx
+++ b/apps/docs/docs/developers/sharp-corners.mdx
@@ -14,7 +14,7 @@ The "someone will bleed on this" list. Shapes that trip newcomers and sometimes 
 
 **Shape:** the Storybook manager bundle runs React 18 and doesn't expose `react/jsx-runtime`'s React-19 dispatcher. JSX in manager code crashes with `Cannot read properties of undefined (reading 'recentlyCreatedOwnerStacks')`.
 
-**Rule:** use `React.createElement` (or a local `h` alias) in every file under `packages/addon/src/manager/`. Preview code is fine with JSX — it runs on the consumer's React.
+**Rule:** use `React.createElement` (or a local `h` alias) in every file under `packages/addon/src/manager/`. Preview code is fine with JSX; it runs on the consumer's React.
 
 ### Register manager tools with `render: () => h(Component)`, not `render: Component`
 
@@ -32,7 +32,7 @@ The "someone will bleed on this" list. Shapes that trip newcomers and sometimes 
 
 **Shape:** the manager can't import preview-side Vite virtual modules. The preview can't import manager-side React either.
 
-**Rule:** `addons.getChannel()` + `emit`/`on`. Named events only — see `packages/addon/src/constants.ts` for the roster.
+**Rule:** `addons.getChannel()` + `emit`/`on`. Named events only; see `packages/addon/src/constants.ts` for the roster.
 
 ## HMR / file watching
 
@@ -46,7 +46,7 @@ The "someone will bleed on this" list. Shapes that trip newcomers and sometimes 
 
 **Shape:** `server.watcher.add(file)` works fine for files inside the Vite root, but tokens often live in a sibling workspace package reached through a pnpm symlink. Vite's watcher silently drops events across the symlink boundary.
 
-**Rule:** run your own `fs.watch` — don't try to bolt onto Vite's watcher for token files.
+**Rule:** run your own `fs.watch`; don't try to bolt onto Vite's watcher for token files.
 
 ### Debounce the reload
 
@@ -64,7 +64,7 @@ The "someone will bleed on this" list. Shapes that trip newcomers and sometimes 
 
 ### Hook the channel, not the Storybook `preview-api` hooks, from MDX
 
-See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, different angle.
+See *MDX doc blocks cannot use Storybook preview hooks* above; same shape, different angle.
 
 ## Virtual module + provider
 
@@ -84,9 +84,9 @@ See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, di
 
 ### Always carry the on-disk extension
 
-**Shape:** every import in this repo names the file extension — `.ts`, `.tsx`, `.css`, `.json`, `.svg`. No inference, no "fake `.js`".
+**Shape:** every import in this repo names the file extension: `.ts`, `.tsx`, `.css`, `.json`, `.svg`. No inference, no "fake `.js`".
 
-**Rule:** `import { loadProject } from '#/load.ts'` — not `'#/load'` or `'../load'`. Vite, Vitest, tsdown, and Node strip-types all resolve TS-extension specifiers natively.
+**Rule:** `import { loadProject } from '#/load.ts'`, not `'#/load'` or `'../load'`. Vite, Vitest, tsdown, and Node strip-types all resolve TS-extension specifiers natively.
 
 ### Use `#/*` for internal paths
 
@@ -146,15 +146,15 @@ See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, di
 
 ### Turbo's `build` task inputs include versioned snapshots
 
-**Shape:** `turbo.json`'s `build` inputs list `versioned_docs/**`, `versioned_sidebars/**`, `versions.json`. This is load-bearing for the remote cache — a fresh minor snapshot invalidates cache entries for downstream builds that depend on it.
+**Shape:** `turbo.json`'s `build` inputs list `versioned_docs/**`, `versioned_sidebars/**`, `versions.json`. This is load-bearing for the remote cache: a fresh minor snapshot invalidates cache entries for downstream builds that depend on it.
 
 **Rule:** don't prune those entries from the `build` inputs. If you add a new versioned docs artifact, include it too.
 
 ### Release publishes through a deployment environment that requires human approval
 
-**Shape:** the release workflow (`.github/workflows/release.yml`) gates the `release` environment behind a conditional — `environment: ${{ startsWith(github.event.head_commit.message, 'chore(release):') && 'release' || '' }}`. The expression resolves to `release` only when the head commit's message starts with `chore(release):` — i.e., the Version Packages PR's squash-merge. Every other push to main (feature merges, changeset-only PR merges) runs without the gate, because those don't publish — they only open or update the Version Packages PR. The approver list lives under repo Settings → Environments → release. Required reviewers ≥ 1.
+**Shape:** the release workflow (`.github/workflows/release.yml`) gates the `release` environment behind a conditional: `environment: ${{ startsWith(github.event.head_commit.message, 'chore(release):') && 'release' || '' }}`. The expression resolves to `release` only when the head commit's message starts with `chore(release):`, i.e. the Version Packages PR's squash-merge. Every other push to main (feature merges, changeset-only PR merges) runs without the gate, because those don't publish; they only open or update the Version Packages PR. The approver list lives under repo Settings → Environments → release. Required reviewers ≥ 1.
 
-**Rule:** when a release stalls after the Version Packages PR merges, check the Actions tab for a pending deployment review. A privileged org member needs to approve the deployment to release. This is intentional — the gate defends against the compromised-maintainer-account scenario where a malicious commit lands on main and a publish would otherwise proceed unattended. Routine merges (anything that isn't a Version Packages PR) don't fire the gate.
+**Rule:** when a release stalls after the Version Packages PR merges, check the Actions tab for a pending deployment review. A privileged org member needs to approve the deployment to release. This is intentional: the gate defends against the compromised-maintainer-account scenario where a malicious commit lands on main and a publish would otherwise proceed unattended. Routine merges (anything that isn't a Version Packages PR) don't fire the gate.
 
 ## MCP
 
@@ -168,13 +168,13 @@ See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, di
 
 **Shape:** MCP tools registered by a connected server don't have their schemas loaded into the agent's prompt by default. The agent sees tool names only and has to call `ToolSearch` to fetch schemas before invoking.
 
-**Rule:** design tool descriptions to be self-sufficient — the description is what makes the agent decide to fetch the schema. Be specific, list the shape of the return value in prose.
+**Rule:** design tool descriptions to be self-sufficient; the description is what makes the agent decide to fetch the schema. Be specific, list the shape of the return value in prose.
 
 ## Plan + issue governance
 
 ### Every PR links an issue
 
-**Shape:** project convention — every PR body has a `Closes: #N` line, milestone assignment, and `Plan impact` note.
+**Shape:** project convention; every PR body has a `Closes: #N` line, milestone assignment, and `Plan impact` note.
 
 **Rule:** file the issue first (`gh issue create --milestone "Maintenance" --title "…"`). Merging the PR auto-closes the issue.
 
@@ -182,4 +182,4 @@ See *MDX doc blocks cannot use Storybook preview hooks* above — same shape, di
 
 **Shape:** imperative verb as first word; lowercase even for proper nouns; scope matches a package slug.
 
-**Rule:** `fix(blocks): hoist navigator hooks above empty-state early return` — not `Fix(Blocks): TokenNavigator hooks run before empty-state early return`.
+**Rule:** `fix(blocks): hoist navigator hooks above empty-state early return`, not `Fix(Blocks): TokenNavigator hooks run before empty-state early return`.

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -6,7 +6,7 @@ sidebar_position: 2
 
 # Authoring doc stories
 
-The doc blocks from `@unpunnyfuns/swatchbook-blocks` are React components that render against the active token graph. Use them in MDX stories to compose reference pages — a `ColorPalette`, a `TypographyScale`, a `TokenTable` filtered to a subpath — all of which update live as the toolbar changes axes.
+The doc blocks from `@unpunnyfuns/swatchbook-blocks` are React components that render against the active token graph. Use them in MDX stories to compose reference pages (a `ColorPalette`, a `TypographyScale`, a `TokenTable` filtered to a subpath), all of which update live as the toolbar changes axes.
 
 ## Prerequisite
 
@@ -41,11 +41,11 @@ import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-bl
 <TokenTable filter="color.**" type="color" />
 ```
 
-`ColorTable` groups variants under their base path — `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
+`ColorTable` groups variants under their base path: `color.accent.bg` + `color.accent.bg-hover` collapse to one `accent.bg` row with a `default` / `hover` pill selector, and each row expands inline to show all variants side-by-side. `<TokenTable>` is the flat view for comparison. Visit `Docs / Colors`; swatches and values update as you flip the toolbar.
 
 ## A dashboard composition
 
-One page with diagnostics, tree, and table gives a top-to-bottom view — project health, browsable hierarchy, searchable lookup:
+One page with diagnostics, tree, and table gives a top-to-bottom view: project health, browsable hierarchy, searchable lookup:
 
 ```tsx title="src/docs/tokens.mdx"
 import { Meta } from '@storybook/addon-docs/blocks';
@@ -70,7 +70,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 
 | Block | What it renders |
 | --- | --- |
-| `TokenDetail` | A single token's full picture — alias chain, aliased-by tree, per-axis variance, composite preview. |
+| `TokenDetail` | A single token's full picture: alias chain, aliased-by tree, per-axis variance, composite preview. |
 | `TokenTable` | Filterable table of tokens. Supports path glob and `$type` filters. |
 | `TokenNavigator` | Expandable tree; scope to a subtree or `$type`. |
 | `ColorPalette` | Swatch grid grouped by sub-path. |
@@ -112,7 +112,7 @@ The toolbar still reflects the story's active tuple, so readers see what they're
 
 ## What MDX can't do
 
-Storybook's preview hooks (`useGlobals`, `useArgs`, `useChannel`) throw when called from an MDX doc block — the preview `HooksContext` only exists while a story is rendering. The blocks in this package subscribe to Storybook's channel directly instead. If you write a custom block for your project, same pattern:
+Storybook's preview hooks (`useGlobals`, `useArgs`, `useChannel`) throw when called from an MDX doc block; the preview `HooksContext` only exists while a story is rendering. The blocks in this package subscribe to Storybook's channel directly instead. If you write a custom block for your project, same pattern:
 
 ```ts
 import { addons } from 'storybook/preview-api';
@@ -125,6 +125,6 @@ channel.on('globalsUpdated', (payload) => {
 
 ## See also
 
-- [Reference: blocks](../reference/blocks/index.mdx) — every block's props.
-- [Reference: addon](../reference/addon.mdx) — the `useToken` hook and its types.
-- [Live Storybook](pathname:///storybook/) — doc stories you can steal from.
+- [Reference: blocks](../reference/blocks/index.mdx): every block's props.
+- [Reference: addon](../reference/addon.mdx): the `useToken` hook and its types.
+- [Live Storybook](pathname:///storybook/): doc stories you can steal from.

--- a/apps/docs/docs/guides/consuming-the-active-theme.mdx
+++ b/apps/docs/docs/guides/consuming-the-active-theme.mdx
@@ -8,11 +8,11 @@ sidebar_position: 5
 
 Swatchbook's toolbar flips the active tuple. Stories that render under it need a way to pick up the change. Three paths, in order of ergonomic preference:
 
-1. **CSS variables** — zero-code, recommended for any component reading tokens through `var(--…)`.
-2. **The React hook `useActiveAxes()`** — inside the Storybook preview, the addon already publishes a React context the blocks and decorators use; story code can read from it directly.
-3. **DOM observation** — the framework-agnostic fallback for Vue / Angular / Svelte / plain HTML, or for React trees outside the preview's provider.
+1. **CSS variables**: zero-code, recommended for any component reading tokens through `var(--…)`.
+2. **The React hook `useActiveAxes()`**: inside the Storybook preview, the addon already publishes a React context the blocks and decorators use; story code can read from it directly.
+3. **DOM observation**: the framework-agnostic fallback for Vue / Angular / Svelte / plain HTML, or for React trees outside the preview's provider.
 
-## CSS variables — recommended
+## CSS variables (recommended)
 
 Swatchbook emits CSS custom properties keyed on the active tuple. A component reading those variables updates automatically when the toolbar flips an axis:
 
@@ -24,9 +24,9 @@ Swatchbook emits CSS custom properties keyed on the active tuple. A component re
 }
 ```
 
-No JavaScript, no subscriptions, no observers. The cascade does the work. If your stories already use CSS variables for theming, you're done — the rest of this page is for component libraries that read their theme as a JS object at render time.
+No JavaScript, no subscriptions, no observers. The cascade does the work. If your stories already use CSS variables for theming, you're done; the rest of this page is for component libraries that read their theme as a JS object at render time.
 
-For CSS-in-JS libraries whose theme values can be `var(--…)` strings (styled-components, emotion with a `var(...)`-based theme), see the [CSS-in-JS integration](./integrations/css-in-js.mdx) — it publishes a ready-made theme accessor without either of the paths below.
+For CSS-in-JS libraries whose theme values can be `var(--…)` strings (styled-components, emotion with a `var(...)`-based theme), see the [CSS-in-JS integration](./integrations/css-in-js.mdx); it publishes a ready-made theme accessor without either of the paths below.
 
 ## React hook inside the preview
 
@@ -42,13 +42,13 @@ function ThemeBridge({ children }: { children: ReactNode }) {
 }
 ```
 
-`useActiveAxes()` reads from the same React context the blocks package publishes. It's populated by swatchbook's preview decorator, so anything inside a story tree sees it. Reactive — components re-render when the toolbar flips an axis; no observer, no manual subscription.
+`useActiveAxes()` reads from the same React context the blocks package publishes. It's populated by swatchbook's preview decorator, so anything inside a story tree sees it. It's reactive: components re-render when the toolbar flips an axis; no observer, no manual subscription.
 
 `useActiveTheme()` gives the composed tuple string (`"Dark · Brand A · Normal"`); `useColorFormat()` gives the active color-format selection. Same shape, same context.
 
-## DOM observation — for everything else
+## DOM observation (for everything else)
 
-The hooks above require React and the preview's provider tree. When your consumer is neither — a Vue / Angular / Svelte app, plain HTML, or a React tree outside swatchbook's provider — subscribe to the active tuple via `MutationObserver` on the DOM contract instead:
+The hooks above require React and the preview's provider tree. When your consumer is neither (a Vue / Angular / Svelte app, plain HTML, or a React tree outside swatchbook's provider), subscribe to the active tuple via `MutationObserver` on the DOM contract instead:
 
 ```ts
 function readAxes(): Record<string, string> {
@@ -83,34 +83,34 @@ function useSwatchbookAxes(): Record<string, string> {
 }
 ```
 
-Inside the preview, prefer `useActiveAxes()` — it's reactive without the observer cost and pools updates with the blocks' own re-renders.
+Inside the preview, prefer `useActiveAxes()`; it's reactive without the observer cost and pools updates with the blocks' own re-renders.
 
 ## What the DOM contract guarantees
 
-1. **`data-<prefix>-<axisName>="<context>"` attributes on `<html>`** — one per active axis. `<prefix>` follows your `cssVarPrefix` config (default `swatch`).
+1. **`data-<prefix>-<axisName>="<context>"` attributes on `<html>`**: one per active axis. `<prefix>` follows your `cssVarPrefix` config (default `swatch`).
 2. **The same attributes on each story's wrapper element.** Redundant with `<html>` in most cases, but useful if your story iframe hosts multiple wrappers.
-3. **Per-tuple CSS** emitted under compound attribute selectors — `[data-<prefix>-mode="Dark"][data-<prefix>-brand="Brand A"] { … }`. One block per tuple, with the default tuple's values in `:root` as the fallback.
-4. **Attributes update on toolbar flip.** Synchronously, before the next paint — observers fire on the microtask queue.
+3. **Per-tuple CSS** emitted under compound attribute selectors, e.g. `[data-<prefix>-mode="Dark"][data-<prefix>-brand="Brand A"] { … }`. One block per tuple, with the default tuple's values in `:root` as the fallback.
+4. **Attributes update on toolbar flip.** Synchronously, before the next paint; observers fire on the microtask queue.
 
 Any change to this shape is a breaking change. The DOM is the API.
 
 ## What swatchbook doesn't ship
 
-- **No Vue, Angular, or Svelte bindings.** React is the only framework with shipped hooks (`useActiveAxes` / `useActiveTheme` / `useColorFormat`), because swatchbook's blocks are React and the addon's preview decorator publishes a React context. Other frameworks consume the DOM contract directly — ten lines of observer code, pick the idiom (`ref`, signal, store) that fits.
-- **No recipes per component library.** MUI, Chakra, Mantine, styled-components, emotion, Tailwind class-mode — each has its own theming model. The CSS-variable and DOM-attribute contracts above are the starting points; your component library's theming docs are the rest.
+- **No Vue, Angular, or Svelte bindings.** React is the only framework with shipped hooks (`useActiveAxes` / `useActiveTheme` / `useColorFormat`), because swatchbook's blocks are React and the addon's preview decorator publishes a React context. Other frameworks consume the DOM contract directly: ten lines of observer code, pick the idiom (`ref`, signal, store) that fits.
+- **No recipes per component library.** MUI, Chakra, Mantine, styled-components, emotion, Tailwind class-mode: each has its own theming model. The CSS-variable and DOM-attribute contracts above are the starting points; your component library's theming docs are the rest.
 
 ## Known gotchas
 
-**Component library theme is a JS object — can it read the `--<prefix>-*` CSS variables directly?**
+**Component library theme is a JS object: can it read the `--<prefix>-*` CSS variables directly?**
 Only if the library consumes CSS variables natively. Tailwind v4 does (see the [Tailwind integration](./integrations/tailwind.mdx)); any provider whose theme values are `var(--…)` strings does (see the [CSS-in-JS integration](./integrations/css-in-js.mdx)). If the theme is a JS object *read* at render time (MUI's `createTheme`, Chakra, Mantine), use `useActiveAxes()` in React, or the DOM-observation path elsewhere, to rebuild the theme object on axis flips.
 
 **Tailwind's `dark:` variant isn't responding to swatchbook.**
-Tailwind looks for `.dark` on an ancestor, or `data-theme="dark"` in its attribute mode. Swatchbook writes `data-<prefix>-mode="Dark"` — the attribute shape and name don't match. Either configure Tailwind to key on swatchbook's attribute (`@custom-variant dark (&:where([data-<prefix>-mode=Dark], [data-<prefix>-mode=Dark] *));`), or have the preview decorator mirror a `.dark` class via the DOM-observation path.
+Tailwind looks for `.dark` on an ancestor, or `data-theme="dark"` in its attribute mode. Swatchbook writes `data-<prefix>-mode="Dark"`, so the attribute shape and name don't match. Either configure Tailwind to key on swatchbook's attribute (`@custom-variant dark (&:where([data-<prefix>-mode=Dark], [data-<prefix>-mode=Dark] *));`), or have the preview decorator mirror a `.dark` class via the DOM-observation path.
 
 **Storybook's own manager theme (light/dark chrome around the preview) doesn't flip.**
-That's `@storybook/theming`, which controls Storybook's UI chrome — a separate concern. See [Storybook's manager theming docs](https://storybook.js.org/docs/configure/user-interface/theming).
+That's `@storybook/theming`, which controls Storybook's UI chrome, a separate concern. See [Storybook's manager theming docs](https://storybook.js.org/docs/configure/user-interface/theming).
 
 ## See also
 
-- [Axes reference](../reference/axes.mdx) — the runtime model for tuples and attribute composition.
-- [Integrations](./integrations/index.mdx) — zero-code paths for Tailwind and CSS-in-JS.
+- [Axes reference](../reference/axes.mdx): the runtime model for tuples and attribute composition.
+- [Integrations](./integrations/index.mdx): zero-code paths for Tailwind and CSS-in-JS.

--- a/apps/docs/docs/guides/integrations/css-in-js.mdx
+++ b/apps/docs/docs/guides/integrations/css-in-js.mdx
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 # CSS-in-JS
 
-`@unpunnyfuns/swatchbook-integrations/css-in-js` exposes a typed JS accessor whose leaves are `var(--<cssVarPrefix>-*)` string references. Drop-in for any `ThemeProvider` that passes its theme through as-is — emotion, styled-components, or a hand-rolled provider. The toolbar flips every value at once via CSS cascade.
+`@unpunnyfuns/swatchbook-integrations/css-in-js` exposes a typed JS accessor whose leaves are `var(--<cssVarPrefix>-*)` string references. Drop-in for any `ThemeProvider` that passes its theme through as-is (emotion, styled-components, or a hand-rolled provider). The toolbar flips every value at once via CSS cascade.
 
 ## Install
 
@@ -14,7 +14,7 @@ sidebar_position: 3
 npm install -D @unpunnyfuns/swatchbook-integrations
 ```
 
-No additional Vite plugins — the virtual module is plain JavaScript.
+No additional Vite plugins needed; the virtual module is plain JavaScript.
 
 ## Configure
 
@@ -64,7 +64,7 @@ export const space = {
 export const theme = { color, space, radius, shadow, typography };
 ```
 
-Values are stable across tuples. The toolbar flipping `data-sb-mode="Dark"` doesn't change any value in this module — it changes what `--sb-color-surface-default` resolves to at the CSS level. One theme object, any number of tuples, runtime switching via cascade.
+Values are stable across tuples. The toolbar flipping `data-sb-mode="Dark"` doesn't change any value in this module; it changes what `--sb-color-surface-default` resolves to at the CSS level. One theme object, any number of tuples, runtime switching via cascade.
 
 ## Usage
 
@@ -103,6 +103,6 @@ import { color, space } from 'virtual:swatchbook/theme';
 
 ## What this doesn't do
 
-- Doesn't produce a resolved-value theme. Leaves are `var()` references, not literal colours. For libraries that derive dependent slots at factory time (MUI's `createTheme` computing `palette.primary.light` / `contrastText`), you need literal values — run [Terrazzo](https://terrazzo.app/)'s CLI with `@terrazzo/plugin-js`.
+- Doesn't produce a resolved-value theme. Leaves are `var()` references, not literal colours. For libraries that derive dependent slots at factory time (MUI's `createTheme` computing `palette.primary.light` / `contrastText`), you need literal values: run [Terrazzo](https://terrazzo.app/)'s CLI with `@terrazzo/plugin-js`.
 - Doesn't handle composite tokens structurally. A DTCG `typography` composite lives as a single `var()` reference, not as `{ fontFamily, fontSize, … }`. If your library needs the sub-fields, same caveat.
 - Doesn't auto-inject a `ThemeProvider`. You wire it yourself.

--- a/apps/docs/docs/guides/integrations/index.mdx
+++ b/apps/docs/docs/guides/integrations/index.mdx
@@ -8,8 +8,8 @@ sidebar_position: 1
 
 Preview-side adapters that let stories use third-party styling libraries against swatchbook's tokens. Two integrations ship today, both under [`@unpunnyfuns/swatchbook-integrations`](https://www.npmjs.com/package/@unpunnyfuns/swatchbook-integrations):
 
-- [**Tailwind**](./tailwind.mdx) — alias Tailwind v4 utility scales to your DTCG tokens, so `bg-sb-surface-default` / `p-sb-md` work in stories.
-- [**CSS-in-JS**](./css-in-js.mdx) — a typed JS theme accessor for emotion, styled-components, or any `ThemeProvider` consuming a plain object.
+- [**Tailwind**](./tailwind.mdx): alias Tailwind v4 utility scales to your DTCG tokens, so `bg-sb-surface-default` / `p-sb-md` work in stories.
+- [**CSS-in-JS**](./css-in-js.mdx): a typed JS theme accessor for emotion, styled-components, or any `ThemeProvider` consuming a plain object.
 
 Both are preview-only. They let utility classes and theme accessors resolve correctly inside Storybook; they don't replace your production build. For production artifacts, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources. Keep both pipelines in step with [shared Terrazzo options](../sharing-terrazzo-options.mdx).
 
@@ -35,7 +35,7 @@ export default defineMain({
 });
 ```
 
-Tailwind contributes a global `@theme` block the addon auto-injects into the preview. CSS-in-JS exposes named JS exports stories import explicitly. Token-file edits flow through HMR — each integration's output stays in lockstep without a server restart.
+Tailwind contributes a global `@theme` block the addon auto-injects into the preview. CSS-in-JS exposes named JS exports stories import explicitly. Token-file edits flow through HMR, so each integration's output stays in lockstep without a server restart.
 
 ## Writing your own integration
 

--- a/apps/docs/docs/guides/integrations/tailwind.mdx
+++ b/apps/docs/docs/guides/integrations/tailwind.mdx
@@ -75,7 +75,7 @@ At runtime the toolbar flips `data-sb-mode` / `data-sb-brand` / `data-sb-contras
 
 ## The `sb-` prefix
 
-Every `@theme` entry is nested under your project's `cssVarPrefix`. Tailwind's default scales (`--color-red-500`, `--spacing-4`, `--container-md`) stay intact — `bg-red-500` works alongside `bg-sb-surface-default`, `p-4` alongside `p-sb-md`.
+Every `@theme` entry is nested under your project's `cssVarPrefix`. Tailwind's default scales (`--color-red-500`, `--spacing-4`, `--container-md`) stay intact: `bg-red-500` works alongside `bg-sb-surface-default`, `p-4` alongside `p-sb-md`.
 
 This matters because Tailwind v4's `max-w-<name>` / `w-<name>` / `size-<name>` utilities read from the `--spacing-*` namespace. Without the prefix, an entry named `--spacing-sm` would shadow Tailwind's default `--container-sm`, making `max-w-sm` tiny. The double-prefix sidesteps that.
 
@@ -92,7 +92,7 @@ Zero-config: the integration walks your project's default-theme token graph at r
 | `shadow` | any | `shadow` | path minus `shadow.` prefix |
 | `fontFamily` | any | `font` | path minus `font.` / `font.family.` / `fontFamily.` prefix |
 
-Font-size-ish dimensions (`font.size.*`, `text.*`) are skipped — Tailwind's `--text-*` entries want size+line-height pairs this integration doesn't synthesize.
+Font-size-ish dimensions (`font.size.*`, `text.*`) are skipped, because Tailwind's `--text-*` entries want size+line-height pairs this integration doesn't synthesize.
 
 Pass a `roles` map to replace the derivation outright when you want a curated subset, explicit names for non-standard paths, or scales the derivation doesn't cover (`--animate-*`, etc.):
 
@@ -113,4 +113,4 @@ Tailwind scale names are keys; each entry is `[tailwindEntryName, dtcgPath]`.
 
 - Doesn't produce production CSS. Run Tailwind's CLI / Vite plugin against your own `@theme` source for that.
 - Doesn't enable `@tailwindcss/vite` outside Storybook. Your app's own build is independent.
-- Doesn't proxy Tailwind's plugin system. Variants, plugins, `darkMode` config, arbitrary values — all pass through to Tailwind untouched.
+- Doesn't proxy Tailwind's plugin system. Variants, plugins, `darkMode` config, arbitrary values: all pass through to Tailwind untouched.

--- a/apps/docs/docs/guides/sharing-terrazzo-options.mdx
+++ b/apps/docs/docs/guides/sharing-terrazzo-options.mdx
@@ -114,18 +114,18 @@ apps/
     … consumes the built tokens from packages/tokens/dist/
 ```
 
-If the shared module imports from other workspace packages, make sure your bundler (tsdown / rolldown / whatever `pnpm -r build` runs) resolves those imports in source form — or publish the shared module alongside the tokens package itself.
+If the shared module imports from other workspace packages, make sure your bundler (tsdown / rolldown / whatever `pnpm -r build` runs) resolves those imports in source form, or publish the shared module alongside the tokens package itself.
 
 ## Why this pattern, not a "read my Terrazzo config" field
 
-Swatchbook accepts plugin objects via `terrazzoPlugins` rather than ingesting a constructed `terrazzo.config.ts`. The reason is that plugin options live inside each plugin's closure once the factory runs — there's no general way for swatchbook to read `legacyHex` (or any other constructor argument) back out of a `cssPlugin({ legacyHex: true })` call. A `config.terrazzo: TerrazzoConfig` field could only inherit `tokens` + `plugins` and would silently ignore everything in `cssOptions`, which is the field most consumers expect alignment for. The shared-module pattern handles every option symmetrically and works the same way `tsconfig.json` `extends` or `vite.config` / `vitest.config` factoring does.
+Swatchbook accepts plugin objects via `terrazzoPlugins` rather than ingesting a constructed `terrazzo.config.ts`. The reason is that plugin options live inside each plugin's closure once the factory runs; there's no general way for swatchbook to read `legacyHex` (or any other constructor argument) back out of a `cssPlugin({ legacyHex: true })` call. A `config.terrazzo: TerrazzoConfig` field could only inherit `tokens` + `plugins` and would silently ignore everything in `cssOptions`, which is the field most consumers expect alignment for. The shared-module pattern handles every option symmetrically and works the same way `tsconfig.json` `extends` or `vite.config` / `vitest.config` factoring does.
 
-## Drift symptoms — why this matters
+## Drift symptoms: why this matters
 
 Without alignment, the docs and production diverge in subtle ways. Concretely:
 
 - A `<ColorTable>` cell shows `color(display-p3 0.24 0.56 0.89)` because swatchbook's default `plugin-css` produces the modern `color()` form. Your production CSS passes `legacyHex: true` and ships `#3d8fe4`. Designers QA the docs, sign off on the modern form, and the rollout looks different than expected.
-- `<TokenUsageSnippet>` emits `var(--ds-colour-surface-default)` using a British-spelling `variableName` policy you configured in production — but swatchbook's default policy emits `--ds-color-surface-default`. Consumer-facing code reads fine; docs snippets are wrong.
+- `<TokenUsageSnippet>` emits `var(--ds-colour-surface-default)` using a British-spelling `variableName` policy you configured in production, but swatchbook's default policy emits `--ds-color-surface-default`. Consumer-facing code reads fine; docs snippets are wrong.
 - A future per-platform column in a block you write renders `colorSurfaceDefault` for Swift, but production Swift ships `ColorSurfaceDefault` because `@terrazzo/plugin-swift` wasn't loaded in the swatchbook build.
 
 The shared-options module above closes each of these gaps in one place.
@@ -134,31 +134,31 @@ The shared-options module above closes each of these gaps in one place.
 
 Five fields are stripped at the type level. They're load-bearing for how swatchbook emits CSS and publishes the listing; letting consumers override them breaks the preview model.
 
-- **`cssOptions.variableName`** — swatchbook routes naming through `@terrazzo/token-tools`' `makeCSSVar` with your `cssVarPrefix`, so every variable carries the prefix and kebab-cases consistently with what the listing records under `names.css`. A custom policy would make the listing's `names.css` disagree with the emitted stylesheet, which is worse than the default.
-- **`cssOptions.permutations`** (the internal Terrazzo field that controls per-theme CSS blocks) — swatchbook synthesizes one entry per resolver theme (or per layered tuple) so the emitted stylesheet declares each theme under a compound `data-<prefix>-<axis>` selector. Overriding this defeats axis-aware rendering.
-- **`cssOptions.filename`** — the internal stylesheet is captured in memory, never written to disk.
-- **`cssOptions.skipBuild`** — setting `true` nulls out the listing's `previewValue` derivation, breaking every block that displays a value.
-- **`listingOptions.filename`** — the listing is captured in memory; the `outputFile` handler finds the entry by filename, and swatchbook owns that handshake.
+- **`cssOptions.variableName`**: swatchbook routes naming through `@terrazzo/token-tools`' `makeCSSVar` with your `cssVarPrefix`, so every variable carries the prefix and kebab-cases consistently with what the listing records under `names.css`. A custom policy would make the listing's `names.css` disagree with the emitted stylesheet, which is worse than the default.
+- **`cssOptions.permutations`** (the internal Terrazzo field that controls per-theme CSS blocks): swatchbook synthesizes one entry per resolver theme (or per layered tuple) so the emitted stylesheet declares each theme under a compound `data-<prefix>-<axis>` selector. Overriding this defeats axis-aware rendering.
+- **`cssOptions.filename`**: the internal stylesheet is captured in memory, never written to disk.
+- **`cssOptions.skipBuild`**: setting `true` nulls out the listing's `previewValue` derivation, breaking every block that displays a value.
+- **`listingOptions.filename`**: the listing is captured in memory; the `outputFile` handler finds the entry by filename, and swatchbook owns that handshake.
 
 Everything else passes through untouched.
 
 ### Soft-inert knobs (type-accepted, runtime-ignored)
 
-Three `plugin-css` options pass the type check but swatchbook ignores them — `permutations`-based emission supersedes them:
+Three `plugin-css` options pass the type check but swatchbook ignores them, because `permutations`-based emission supersedes them:
 
 - `baseSelector`
 - `baseScheme`
 - `modeSelectors`
 
-Setting any of these doesn't hit a type error because they're still part of `CSSPluginOptions`, but swatchbook always drives emission through the `permutations` API, so they do nothing in the preview. Load emits a `swatchbook/css-options` warn diagnostic listing the offending keys — visible in the preview's diagnostic overlay and on `Project.diagnostics` for programmatic consumers — so the "my setting isn't taking effect" failure mode turns into an explicit signal.
+Setting any of these doesn't hit a type error because they're still part of `CSSPluginOptions`, but swatchbook always drives emission through the `permutations` API, so they do nothing in the preview. Load emits a `swatchbook/css-options` warn diagnostic listing the offending keys (visible in the preview's diagnostic overlay and on `Project.diagnostics` for programmatic consumers), so the "my setting isn't taking effect" failure mode turns into an explicit signal.
 
 ## Per-platform identifier display
 
-Swatchbook isn't a replacement for `@terrazzo/cli`, `tz build`, or Style Dictionary. What it does, through the listing, is *display* the identifiers those transformers produce, so the docs line up with what production ships. The transformation happens in the user-configured plugin — swatchbook just reads its output.
+Swatchbook isn't a replacement for `@terrazzo/cli`, `tz build`, or Style Dictionary. What it does, through the listing, is *display* the identifiers those transformers produce, so the docs line up with what production ships. The transformation happens in the user-configured plugin; swatchbook just reads its output.
 
 The Token Listing records `names.<platform>` for every platform registered in `listingOptions.platforms`, using the named plugin's own identifier-naming logic. Blocks read these without duplicating any rules.
 
-Load the plugin in `terrazzoPlugins`, name it in `listingOptions.platforms`, and `listing[path].names.swift` (or `.android`, `.js`, `.sass`, …) populates automatically. `<TokenDetail>` / `<ConsumerOutput>` pick up the extra platforms and render one row per platform in the Consumer Output section — no block-writing required for the common display case. The names match production only when the plugin invocations match: pass `plugin-swift({ /* your prod options */ })`, not `plugin-swift()`, or the rows show a plausible default rather than your production identifier. The shared-options module above is the way to keep both sides identical in one place.
+Load the plugin in `terrazzoPlugins`, name it in `listingOptions.platforms`, and `listing[path].names.swift` (or `.android`, `.js`, `.sass`, …) populates automatically. `<TokenDetail>` / `<ConsumerOutput>` pick up the extra platforms and render one row per platform in the Consumer Output section, with no block-writing required for the common display case. The names match production only when the plugin invocations match: pass `plugin-swift({ /* your prod options */ })`, not `plugin-swift()`, or the rows show a plausible default rather than your production identifier. The shared-options module above is the way to keep both sides identical in one place.
 
 For custom blocks, the data is on the project snapshot:
 
@@ -169,17 +169,17 @@ const swiftName = project.listing?.[path]?.names?.swift;
 
 See [`useSwatchbookData`](../reference/blocks/hooks.mdx#useswatchbookdata) for the `ProjectSnapshot.listing` shape in the block context.
 
-The output files those plugins produce (`tokens.swift`, `tokens.xml`, …) land in the in-memory output set and are discarded. Swatchbook doesn't write them to disk — `terrazzoPlugins` runs plugins purely for their *naming contribution* to the listing, not for file emission.
+The output files those plugins produce (`tokens.swift`, `tokens.xml`, …) land in the in-memory output set and are discarded. Swatchbook doesn't write them to disk; `terrazzoPlugins` runs plugins purely for their *naming contribution* to the listing, not for file emission.
 
 ## Per-knob notes
 
 ### `cssOptions.legacyHex`, `cssOptions.transform`
 
-Value-formatting changes flow both into the emitted stylesheet and into `listing[path].previewValue` (since `@terrazzo/plugin-token-listing` derives preview values by asking plugin-css for its CSS output). Setting `legacyHex: true` flips both simultaneously — the swatch CSS uses `#3d8fe4`, and every block that displays a value (`<TokenTable>`, `<TokenDetail>`, `<ColorTable>`) shows the same hex string.
+Value-formatting changes flow both into the emitted stylesheet and into `listing[path].previewValue` (since `@terrazzo/plugin-token-listing` derives preview values by asking plugin-css for its CSS output). Setting `legacyHex: true` flips both simultaneously: the swatch CSS uses `#3d8fe4`, and every block that displays a value (`<TokenTable>`, `<TokenDetail>`, `<ColorTable>`) shows the same hex string.
 
 ### `cssOptions.include` / `cssOptions.exclude`
 
-Glob-based filters on which tokens reach the emitted CSS. Useful when production ships only a subset (say, excluding brand-internal tokens). Swatchbook still parses all tokens — the listing still enumerates them, the blocks still display them — but the injected stylesheet carries only the filtered set. If a story uses a filtered-out token via CSS var, it'll read as unset.
+Glob-based filters on which tokens reach the emitted CSS. Useful when production ships only a subset (say, excluding brand-internal tokens). Swatchbook still parses all tokens (the listing still enumerates them, the blocks still display them), but the injected stylesheet carries only the filtered set. If a story uses a filtered-out token via CSS var, it'll read as unset.
 
 ### `cssOptions.utility`
 
@@ -191,7 +191,7 @@ A hook that can override the auto-computed preview string per token. Useful if p
 
 ### `listingOptions.subtype`
 
-A hook that classifies a token's intent (`bgColor`, `fgColor`, `borderColor`, `padding`, …). Reserved for future per-`subtype` block defaults — currently unused by blocks but worth setting so the metadata is in place.
+A hook that classifies a token's intent (`bgColor`, `fgColor`, `borderColor`, `padding`, …). Reserved for future per-`subtype` block defaults; currently unused by blocks but worth setting so the metadata is in place.
 
 ### `listingOptions.modes`
 
@@ -222,7 +222,7 @@ export default {
 };
 ```
 
-The shared piece is the source tree. Alignment ends there — swatchbook computes its own CSS variable names using Terrazzo's naming rules, while Style Dictionary uses its own transform chain. Names *won't* match character-for-character unless you hand-tune both sides.
+The shared piece is the source tree. Alignment ends there: swatchbook computes its own CSS variable names using Terrazzo's naming rules, while Style Dictionary uses its own transform chain. Names *won't* match character-for-character unless you hand-tune both sides.
 
 For a preview-only tool that's usually fine. The swatchbook-rendered block shows what the tokens *are*; your apps ship what Style Dictionary emits. As long as both read the same DTCG input, token identity is preserved across pipelines even when naming differs.
 
@@ -231,29 +231,29 @@ For a preview-only tool that's usually fine. The swatchbook-rendered block shows
 This is harder. Style Dictionary's `transforms` (`name/cti/kebab`, `name/cti/camel`, custom naming transforms) produce a naming scheme that doesn't round-trip through Terrazzo's `@terrazzo/token-tools/css.makeCSSVar`. Two routes:
 
 1. **Loosen the naming contract.** Treat DTCG dot-paths as the canonical identifier; display those in blocks via `<TokenDetail path="…">`; let each build name CSS variables however it wants. The `path` is always stable across pipelines.
-2. **Write a thin adapter.** Expose the CSS variable names Style Dictionary computes as a lookup map, read them through a custom block via `useProject()`, and render them next to Terrazzo's names. Requires block-writing work; the addon doesn't ship this.
+2. **Write a thin adapter.** Expose the CSS variable names Style Dictionary computes as a lookup map, read them through a custom block via `useSwatchbookData()`, and render them next to Terrazzo's names. Requires block-writing work; the addon doesn't ship this.
 
 ### When to use Style Dictionary *and* Terrazzo side-by-side
 
-Some teams use Terrazzo for CSS + JS targets (because `@terrazzo/plugin-css` integrates natively with swatchbook) and Style Dictionary for platform targets Terrazzo doesn't cover (some legacy XML formats, Flutter, specific design-tool round-trips). This works — both read the DTCG source tree, both emit to their own `dist/`. Swatchbook aligns with Terrazzo's side; Style Dictionary's side stays unaligned but also stays out of swatchbook's view.
+Some teams use Terrazzo for CSS + JS targets (because `@terrazzo/plugin-css` integrates natively with swatchbook) and Style Dictionary for platform targets Terrazzo doesn't cover (some legacy XML formats, Flutter, specific design-tool round-trips). This works: both read the DTCG source tree, both emit to their own `dist/`. Swatchbook aligns with Terrazzo's side; Style Dictionary's side stays unaligned but also stays out of swatchbook's view.
 
-If you're weighing whether to add Terrazzo to an SD-only pipeline, the pragmatic answer is: if you want swatchbook's per-platform `names.*` columns populated with Swift/Android/etc. identifiers, add the Terrazzo plugin for that platform (`plugin-swift`, `plugin-android`) to the swatchbook build via `terrazzoPlugins`. The plugin runs in-memory only — nothing's written to disk, no parallel production artifact is produced — just the naming contribution to the listing.
+If you're weighing whether to add Terrazzo to an SD-only pipeline, the pragmatic answer is: if you want swatchbook's per-platform `names.*` columns populated with Swift/Android/etc. identifiers, add the Terrazzo plugin for that platform (`plugin-swift`, `plugin-android`) to the swatchbook build via `terrazzoPlugins`. The plugin runs in-memory only (nothing's written to disk, no parallel production artifact is produced), just the naming contribution to the listing.
 
 ## Common pitfalls
 
-- **`cssVarPrefix` drift** — swatchbook's `cssVarPrefix` is independent of the prefix plugin-css would pick if you set `variableName` yourself. Since swatchbook owns `variableName`, setting `cssVarPrefix: 'sb'` is the only lever you need for prefix control on the swatchbook side. Production's prefix lives in its own plugin-css call (or in a `variableName` policy you ship). Both sides should pick the same prefix — the guide's "one shared module" pattern doesn't cover prefix because swatchbook takes it from a top-level field; double-check that `cssVarPrefix: 'ds'` in swatchbook matches whatever `--ds-*` your production stylesheet emits.
-- **Resolver vs `tokens` divergence** — if your production build reads a flat `tokens.json` but swatchbook reads a DTCG resolver, the two pipelines see different theme sets. The listing will only reflect swatchbook's resolver view. Keep both on the same shape; if production needs flat output, emit it with Terrazzo's `plugin-js` or similar driven from the resolver's themes.
-- **Plugin loaded but not listed** — a plugin in `terrazzoPlugins` without a matching entry in `listingOptions.platforms` runs but doesn't contribute to `names.*`. Conversely, a platform entry in `listingOptions.platforms` whose plugin isn't in `terrazzoPlugins` will fail at listing time. Both sides or neither.
-- **Plugins that write to disk** — swatchbook captures `outputFile` calls in memory. A plugin that writes via `fs` directly (bypassing the Terrazzo build API) will try to write files relative to the Storybook preview's cwd during HMR. Prefer plugins that use the supported `outputFile` hook.
-- **`@terrazzo/cli` vs `@terrazzo/parser`'s `defineConfig`** — `@terrazzo/cli` is what a `tz build` consumer already has installed; `@terrazzo/parser` exports a lower-level `defineConfig` that takes a `cwd` option. Prefer the cli export in user-facing config files.
+- **`cssVarPrefix` drift**: swatchbook's `cssVarPrefix` is independent of the prefix plugin-css would pick if you set `variableName` yourself. Since swatchbook owns `variableName`, setting `cssVarPrefix: 'sb'` is the only lever you need for prefix control on the swatchbook side. Production's prefix lives in its own plugin-css call (or in a `variableName` policy you ship). Both sides should pick the same prefix; the guide's "one shared module" pattern doesn't cover prefix because swatchbook takes it from a top-level field; double-check that `cssVarPrefix: 'ds'` in swatchbook matches whatever `--ds-*` your production stylesheet emits.
+- **Resolver vs `tokens` divergence**: if your production build reads a flat `tokens.json` but swatchbook reads a DTCG resolver, the two pipelines see different theme sets. The listing will only reflect swatchbook's resolver view. Keep both on the same shape; if production needs flat output, emit it with Terrazzo's `plugin-js` or similar driven from the resolver's themes.
+- **Plugin loaded but not listed**: a plugin in `terrazzoPlugins` without a matching entry in `listingOptions.platforms` runs but doesn't contribute to `names.*`. Conversely, a platform entry in `listingOptions.platforms` whose plugin isn't in `terrazzoPlugins` will fail at listing time. Both sides or neither.
+- **Plugins that write to disk**: swatchbook captures `outputFile` calls in memory. A plugin that writes via `fs` directly (bypassing the Terrazzo build API) will try to write files relative to the Storybook preview's cwd during HMR. Prefer plugins that use the supported `outputFile` hook.
+- **`@terrazzo/cli` vs `@terrazzo/parser`'s `defineConfig`**: `@terrazzo/cli` is what a `tz build` consumer already has installed; `@terrazzo/parser` exports a lower-level `defineConfig` that takes a `cwd` option. Prefer the cli export in user-facing config files.
 
 ## When you don't need any of this
 
-If you don't run a production token build alongside swatchbook — the tokens exist only for the docs site and Storybook — leave `cssOptions`, `listingOptions`, and `terrazzoPlugins` unset. Swatchbook loads `plugin-css` with defaults and `plugin-token-listing` with a single `css` platform. Drift isn't a concern when there's only one pipeline.
+If you don't run a production token build alongside swatchbook (the tokens exist only for the docs site and Storybook), leave `cssOptions`, `listingOptions`, and `terrazzoPlugins` unset. Swatchbook loads `plugin-css` with defaults and `plugin-token-listing` with a single `css` platform. Drift isn't a concern when there's only one pipeline.
 
 ## See also
 
-- [Config reference: `cssOptions` / `listingOptions` / `terrazzoPlugins`](../reference/config.mdx) — the prop-by-prop contract.
-- [The token pipeline](../reference/token-pipeline.mdx) — how swatchbook's virtual module differs from a file-emitting build.
-- [`@terrazzo/plugin-token-listing` source](https://github.com/terrazzoapp/terrazzo/tree/main/packages/plugin-token-listing) — the listing format swatchbook consumes.
-- [Style Dictionary docs](https://styledictionary.com/) — DTCG support landed in 4.0; alignment-friendly configurations start there.
+- [Config reference: `cssOptions` / `listingOptions` / `terrazzoPlugins`](../reference/config.mdx): the prop-by-prop contract.
+- [The token pipeline](../reference/token-pipeline.mdx): how swatchbook's virtual module differs from a file-emitting build.
+- [`@terrazzo/plugin-token-listing` source](https://github.com/terrazzoapp/terrazzo/tree/main/packages/plugin-token-listing): the listing format swatchbook consumes.
+- [Style Dictionary docs](https://styledictionary.com/): DTCG support landed in 4.0; alignment-friendly configurations start there.

--- a/apps/docs/docs/intro.mdx
+++ b/apps/docs/docs/intro.mdx
@@ -12,7 +12,7 @@ A Storybook addon and MDX doc blocks for visualising [DTCG design tokens](https:
 Two things in one package:
 
 - **Doc blocks.** React components for MDX: `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, and per-type previews for motion, shadow, border, gradient, stroke style.
-- **A toolbar theme switcher.** One dropdown per modifier axis in your DTCG resolver. Flip mode, brand, contrast, density — whatever your system has — and tokens repaint live.
+- **A toolbar theme switcher.** One dropdown per modifier axis in your DTCG resolver. Flip mode, brand, contrast, density (whatever your system has) and tokens repaint live.
 
 If your existing stories already style with CSS variables, they'll pick up the switcher's flips automatically. That's mostly what the tool does.
 
@@ -26,7 +26,7 @@ Design-system authors with DTCG tokens, especially systems with more than one in
 
 ## What it isn't
 
-Not a runtime theme-switcher for production apps, not a CSS-variable framework, not a token build tool. Swatchbook emits CSS variables and `data-<prefix>-*` attributes inside the Storybook preview so tokens repaint when an author flips an axis. For production theme switching, use your framework's theming tools. For production CSS / Swift / Android / etc. emission, run Terrazzo's CLI against the same DTCG sources — swatchbook is the preview side of that pipeline, not a replacement for it.
+Not a runtime theme-switcher for production apps, not a CSS-variable framework, not a token build tool. Swatchbook emits CSS variables and `data-<prefix>-*` attributes inside the Storybook preview so tokens repaint when an author flips an axis. For production theme switching, use your framework's theming tools. For production CSS / Swift / Android / etc. emission, run Terrazzo's CLI against the same DTCG sources: swatchbook is the preview side of that pipeline, not a replacement for it.
 
 ## Was this coded with AI?
 
@@ -34,9 +34,9 @@ Yes, nearly all of it, and deliberately so. Swatchbook is a large surface for on
 
 ## Installation
 
-Register `@unpunnyfuns/swatchbook-addon` in `.storybook/main.ts`. It pulls in `swatchbook-core`, `swatchbook-blocks`, and `swatchbook-switcher` transitively. `import { TokenTable, ThemeSwitcher, useToken } from '@unpunnyfuns/swatchbook-addon'` resolves from any consumer file. See the [Quickstart](./quickstart.mdx) for a complete setup.
+Register `@unpunnyfuns/swatchbook-addon` in `.storybook/main.ts`. It pulls in `swatchbook-core`, `swatchbook-blocks`, and `swatchbook-switcher` transitively. `import { TokenTable, ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` resolves from any consumer file, and `import { useToken } from '@unpunnyfuns/swatchbook-addon/hooks'` exposes the token-lookup hook. See the [Quickstart](./quickstart.mdx) for a complete setup.
 
-Each sub-package is also publishable on its own — the switcher in a Docusaurus navbar, the core loader in a build script without React.
+Each sub-package is also publishable on its own: the switcher in a Docusaurus navbar, the core loader in a build script without React.
 
 ## No external build step
 
@@ -44,23 +44,23 @@ The addon publishes tokens to the preview through a Vite virtual module, recompu
 
 ## For AI agents
 
-The optional [`@unpunnyfuns/swatchbook-mcp`](./reference/mcp.mdx) package ships a stdio [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes the token graph — paths, axes, alias chains, diagnostics, per-theme resolved values — to any MCP-capable AI assistant. Fourteen read-only tools; live-reloads on token edits.
+The optional [`@unpunnyfuns/swatchbook-mcp`](./reference/mcp.mdx) package ships a stdio [Model Context Protocol](https://modelcontextprotocol.io/) server that exposes the token graph (paths, axes, alias chains, diagnostics, per-theme resolved values) to any MCP-capable AI assistant. Fourteen read-only tools; live-reloads on token edits.
 
 ## See it live
 
-The [live Storybook](pathname:///storybook/) runs the addon against this repo's reference fixture — a multi-file DTCG token set with resolver-driven `mode × brand × contrast` axes.
+The [live Storybook](pathname:///storybook/) runs the addon against this repo's reference fixture: a multi-file DTCG token set with resolver-driven `mode × brand × contrast` axes.
 
 ## How to read these docs
 
-- **[Quickstart](./quickstart.mdx)** — install, configure, run.
-- **[Guides](./guides/authoring-doc-stories.mdx)** — MDX doc-story composition, consuming the active theme from stories, third-party library integrations, aligning with a production Terrazzo build.
-- **[Reference](./reference/addon.mdx)** — API surface for each published package, [concepts](./reference/concepts.mdx) and the axis model, the token-pipeline mechanism, the config shape, and the [diagnostics catalog](./reference/diagnostics.mdx) when an error fires.
-- **[Developers](./developers/index.mdx)** — contributing to swatchbook itself: architecture and sharp corners.
+- **[Quickstart](./quickstart.mdx)**: install, configure, run.
+- **[Guides](./guides/authoring-doc-stories.mdx)**: MDX doc-story composition, consuming the active theme from stories, third-party library integrations, aligning with a production Terrazzo build.
+- **[Reference](./reference/addon.mdx)**: API surface for each published package, [concepts](./reference/concepts.mdx) and the axis model, the token-pipeline mechanism, the config shape, and the [diagnostics catalog](./reference/diagnostics.mdx) when an error fires.
+- **[Developers](./developers/index.mdx)**: contributing to swatchbook itself, architecture and sharp corners.
 
 ## Migrating from `@storybook/addon-themes`
 
-If you're coming from `@storybook/addon-themes` and have one or two flat theme IDs, translate each ID to an axes tuple — `"brand-a-dark"` becomes `{ brand: 'Brand A', mode: 'Dark' }` — then declare `mode` and `brand` as resolver modifiers. The axes model composes every combination of axes automatically, so no enumerating all combinations. See [axes reference](./reference/axes.mdx) for details.
+If you're coming from `@storybook/addon-themes` and have one or two flat theme IDs, translate each ID to an axes tuple (`"brand-a-dark"` becomes `{ brand: 'Brand A', mode: 'Dark' }`), then declare `mode` and `brand` as resolver modifiers. The axes model composes every combination of axes automatically, so no enumerating all combinations. See [axes reference](./reference/axes.mdx) for details.
 
 ## What these docs assume
 
-You're comfortable with Storybook (CSF, decorators, MDX docs). For DTCG itself, you've skimmed the [2025.10 spec](https://www.designtokens.org/TR/2025.10/) or at least seen `$value` / `$type` / alias syntax — we don't re-teach the spec.
+You're comfortable with Storybook (CSF, decorators, MDX docs). For DTCG itself, you've skimmed the [2025.10 spec](https://www.designtokens.org/TR/2025.10/) or at least seen `$value` / `$type` / alias syntax. We don't re-teach the spec.

--- a/apps/docs/docs/quickstart.mdx
+++ b/apps/docs/docs/quickstart.mdx
@@ -10,7 +10,7 @@ Assumes an existing Storybook 10 project with the Vite builder. Install, registe
 
 ## Install
 
-One package pulls the whole surface — toolbar, preview decorator, `useToken()`, every MDX doc block, the standalone `ThemeSwitcher`:
+One package pulls the whole surface: toolbar, preview decorator, `useToken()`, every MDX doc block, the standalone `ThemeSwitcher`:
 
 ```bash
 npm install -D @unpunnyfuns/swatchbook-addon
@@ -22,14 +22,14 @@ Peer requirements: Storybook 10.3+ on the Vite builder, React 18+, Node 24+.
 
 ### Terrazzo dependencies
 
-Swatchbook is built on [Terrazzo](https://terrazzo.app/)'s parser. `@terrazzo/parser`, `@terrazzo/plugin-css`, and `@terrazzo/plugin-token-listing` come along with `swatchbook-core` transitively — you don't install them separately for the default setup. `swatchbook-core` publishes `@terrazzo/parser` and `@terrazzo/plugin-css` as peer deps on top of its own deps, so pnpm hoists to a single shared parser instance across our internal build and any Terrazzo plugins you add yourself.
+Swatchbook is built on [Terrazzo](https://terrazzo.app/)'s parser. `@terrazzo/parser`, `@terrazzo/plugin-css`, and `@terrazzo/plugin-token-listing` come along with `swatchbook-core` transitively, so you don't install them separately for the default setup. `swatchbook-core` publishes `@terrazzo/parser` and `@terrazzo/plugin-css` as peer deps on top of its own deps, so pnpm hoists to a single shared parser instance across our internal build and any Terrazzo plugins you add yourself.
 
 Two cases where you'll install more packages explicitly:
 
 - **You already run `@terrazzo/cli` in production.** Pin matching versions of `@terrazzo/cli`, `plugin-css`, etc. in your own `package.json` so both pipelines agree on options. See [Aligning with your token build](./guides/sharing-terrazzo-options.mdx) for the shared-options module pattern.
 - **You want per-platform names (Swift, Android, Sass, JS, …) shown in doc blocks.** Install `@terrazzo/plugin-swift` / `-android` / `-sass` / `-js` at a version compatible with swatchbook's peer range, then load them via `config.terrazzoPlugins` + `config.listingOptions.platforms`. `<TokenDetail>`'s Consumer Output picks them up automatically.
 
-When in doubt, skip this section — the zero-config install is enough for everything on this page.
+When in doubt, skip this section; the zero-config install is enough for everything on this page.
 
 ## Configure
 
@@ -65,16 +65,16 @@ export default definePreview({
 });
 ```
 
-Inline `config` is the primary path. If you'd rather keep the config in its own file (useful when the same config is consumed by a CLI or CI lint outside Storybook), write a `swatchbook.config.ts` and point at it with `options.configPath: '../swatchbook.config.ts'` — see [config reference](./reference/config.mdx) for details.
+Inline `config` is the primary path. If you'd rather keep the config in its own file (useful when the same config is consumed by a CLI or CI lint outside Storybook), write a `swatchbook.config.ts` and point at it with `options.configPath: '../swatchbook.config.ts'`; see [config reference](./reference/config.mdx) for details.
 
 ### If your stories use Tailwind or a CSS-in-JS library
 
-Stories that already use CSS variables need no extra wiring — the swatchbook toolbar flips `--<prefix>-*` vars via cascade and the stories repaint automatically. Two library-specific shortcuts for everything else:
+Stories that already use CSS variables need no extra wiring: the swatchbook toolbar flips `--<prefix>-*` vars via cascade and the stories repaint automatically. Two library-specific shortcuts for everything else:
 
 - **Tailwind v4.** Add [`@unpunnyfuns/swatchbook-integrations/tailwind`](./guides/integrations/tailwind.mdx) to the addon's `integrations[]` and `@tailwindcss/vite` to Storybook's Vite plugins. Utility classes like `bg-<prefix>-surface-default` / `p-<prefix>-md` resolve through swatchbook's tokens automatically.
 - **emotion / styled-components / any `ThemeProvider`.** Add [`@unpunnyfuns/swatchbook-integrations/css-in-js`](./guides/integrations/css-in-js.mdx) to `integrations[]`. Stories `import { theme } from 'virtual:swatchbook/theme'` and hand it to their provider.
 
-Both integrations are preview-only — they let utility classes and theme accessors resolve correctly inside Storybook, nothing else. See the [Integrations guide](./guides/integrations/index.mdx) for the full picture.
+Both integrations are preview-only: they let utility classes and theme accessors resolve correctly inside Storybook, nothing else. See the [Integrations guide](./guides/integrations/index.mdx) for the full picture.
 
 Start Storybook:
 
@@ -121,18 +121,18 @@ import {
 
 Each block takes filter/scoping props so you can pick what shows up:
 
-- **`<ColorPalette filter="…" />`** — swatch grid grouped by sub-path. Filter by a glob (`"color.palette.*"`, `"color.brand.*"`).
-- **`<TokenTable filter="…" type="…" />`** — searchable two-column table (path + value). Filter by path glob, scope by DTCG `$type`.
-- **`<TokenNavigator root="…" type="…" initiallyExpanded={0..∞} />`** — expandable tree. Scope to a subtree (`root="color"`) and/or a `$type`; `initiallyExpanded={0}` opens fully collapsed.
-- **`<TokenDetail path="…" />`** — alias chain, per-theme values, CSS var reference, and `useToken` snippet for one token.
-- **`<Diagnostics />`** — collapsible list of parser / resolver / validation warnings. Auto-opens when anything's non-zero.
-- **`<TypographyScale>`, `<DimensionScale>`, `<FontFamilyPreview>`, `<FontWeightScale>`, `<BorderPreview>`, `<ShadowPreview>`, `<GradientPalette>`, `<MotionPreview>`, `<StrokeStylePreview>`** — type-specific blocks with built-in samples. Filter by path glob when you want a subset.
+- **`<ColorPalette filter="…" />`**: swatch grid grouped by sub-path. Filter by a glob (`"color.palette.*"`, `"color.brand.*"`).
+- **`<TokenTable filter="…" type="…" />`**: searchable two-column table (path + value). Filter by path glob, scope by DTCG `$type`.
+- **`<TokenNavigator root="…" type="…" initiallyExpanded={0..∞} />`**: expandable tree. Scope to a subtree (`root="color"`) and/or a `$type`; `initiallyExpanded={0}` opens fully collapsed.
+- **`<TokenDetail path="…" />`**: alias chain, per-theme values, CSS var reference, and `useToken` snippet for one token.
+- **`<Diagnostics />`**: collapsible list of parser / resolver / validation warnings. Auto-opens when anything's non-zero.
+- **`<TypographyScale>`, `<DimensionScale>`, `<FontFamilyPreview>`, `<FontWeightScale>`, `<BorderPreview>`, `<ShadowPreview>`, `<GradientPalette>`, `<MotionPreview>`, `<StrokeStylePreview>`**: type-specific blocks with built-in samples. Filter by path glob when you want a subset.
 
 The [blocks reference](./reference/blocks/index.mdx) has the full prop list for each. The [authoring guide](./guides/authoring-doc-stories.mdx) walks through composing them in real pages.
 
 ## Theme the block chrome against your tokens
 
-The MDX doc blocks read their surfaces, text, and accent colours from a fixed `--swatchbook-*` CSS-variable namespace. By default, those variables fall back to light/dark literals that flip with the active `color-scheme`, which means the blocks render legibly before you wire anything up. To have them reflect your own tokens, supply a `chrome` map — one entry per role, each pointing at a token path in your project:
+The MDX doc blocks read their surfaces, text, and accent colours from a fixed `--swatchbook-*` CSS-variable namespace. By default, those variables fall back to light/dark literals that flip with the active `color-scheme`, which means the blocks render legibly before you wire anything up. To have them reflect your own tokens, supply a `chrome` map with one entry per role, each pointing at a token path in your project:
 
 ```ts title=".storybook/main.ts"
 {
@@ -158,7 +158,7 @@ The MDX doc blocks read their surfaces, text, and accent colours from a fixed `-
 },
 ```
 
-With a `chrome` map in place the blocks track every toolbar flip — switch brand or contrast and the block chrome repaints alongside your stories. The closed set of roles (and what each maps to internally) is in the [`chrome` config reference](./reference/config.mdx#chrome).
+With a `chrome` map in place the blocks track every toolbar flip: switch brand or contrast and the block chrome repaints alongside your stories. The closed set of roles (and what each maps to internally) is in the [`chrome` config reference](./reference/config.mdx#chrome).
 
 ## No resolver yet?
 

--- a/apps/docs/docs/reference/addon.mdx
+++ b/apps/docs/docs/reference/addon.mdx
@@ -14,13 +14,13 @@ Published as `@unpunnyfuns/swatchbook-addon`. Storybook addon. Loads your config
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
-This gives you the toolbar, preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `Diagnostics`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks` — install it alongside if you want them. See the [authoring guide](../guides/authoring-doc-stories.mdx) for MDX composition patterns.
+This gives you the toolbar, preview decorator, and the `useToken()` hook. The MDX doc blocks (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `Diagnostics`, `SwatchbookProvider`, block-side hooks) live in `@unpunnyfuns/swatchbook-blocks`; install it alongside if you want them. See the [authoring guide](../guides/authoring-doc-stories.mdx) for MDX composition patterns.
 
 Peer requirements: Storybook 10.3+ on the Vite builder, React 18+.
 
 ## Registration
 
-Register the addon in `main.ts#addons` with your config (inline `config` preferred; `configPath` also works — see the [config reference](./config.mdx)):
+Register the addon in `main.ts#addons` with your config (inline `config` preferred; `configPath` also works, see the [config reference](./config.mdx)):
 
 ```ts title=".storybook/main.ts"
 import { defineMain } from '@storybook/react-vite/node';
@@ -54,10 +54,10 @@ export default definePreview({
 
 ## What it registers
 
-- **Preview decorator** — reads the active axis tuple, writes one `data-<prefix>-<axis>="<context>"` attribute per axis on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager. The prefix follows `cssVarPrefix` (default `swatch`).
-- **Toolbar tool** — a single Swatchbook `IconButton`. Clicking opens a popover containing preset pills, one dropdown per axis, and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`). Escape and outside-click close it.
+- **Preview decorator**: reads the active axis tuple, writes one `data-<prefix>-<axis>="<context>"` attribute per axis on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager. The prefix follows `cssVarPrefix` (default `swatch`).
+- **Toolbar tool**: a single Swatchbook `IconButton`. Clicking opens a popover containing preset pills, one dropdown per axis, and a color-format picker (`hex` / `rgb` / `hsl` / `oklch` / `raw`). Escape and outside-click close it.
 
-For a browsable tree + diagnostics surface, compose `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />` on an MDX page — see the [authoring guide](../guides/authoring-doc-stories.mdx)'s dashboard example. The [Diagnostics reference](./diagnostics.mdx) catalogs every group and message that can appear in the Design Tokens panel.
+For a browsable tree + diagnostics surface, compose `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />` on an MDX page. See the [authoring guide](../guides/authoring-doc-stories.mdx)'s dashboard example. The [Diagnostics reference](./diagnostics.mdx) catalogs every group and message that can appear in the Design Tokens panel.
 
 ## Globals
 
@@ -88,7 +88,7 @@ The addon exposes exactly one hook, under `@unpunnyfuns/swatchbook-addon/hooks`.
 
 ### `useToken(path)`
 
-Typed lookup. Returns `{ value, cssVar, type?, description? }` for the given path — the `value` is typed as `unknown`; `type` and `description` come from the token's `$type` / `$description` if present. Reactive to axis changes.
+Typed lookup. Returns `{ value, cssVar, type?, description? }` for the given path; the `value` is typed as `unknown`, `type` and `description` come from the token's `$type` / `$description` if present. Reactive to axis changes.
 
 ```tsx
 import { useToken } from '@unpunnyfuns/swatchbook-addon/hooks';
@@ -103,7 +103,7 @@ Paths autocomplete from the generated `.swatchbook/tokens.d.ts`. Add `"include":
 
 ### Block-side hooks live in `@unpunnyfuns/swatchbook-blocks`
 
-`useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the contexts that back them (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) live canonically in `@unpunnyfuns/swatchbook-blocks` — see the [blocks reference](./blocks/index.mdx). They're also re-exported from the addon's main entry (`import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon'` works) so consumers picking up the addon don't need a separate blocks dependency for the common hook surface.
+`useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the contexts that back them (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) live canonically in `@unpunnyfuns/swatchbook-blocks`; see the [blocks reference](./blocks/index.mdx). They're also re-exported from the addon's main entry (`import { useActiveTheme } from '@unpunnyfuns/swatchbook-addon'` works) so consumers picking up the addon don't need a separate blocks dependency for the common hook surface.
 
 The preview decorator mounts a `SwatchbookProvider` (from blocks) that populates every context, so the hooks resolve wherever the addon is registered.
 
@@ -123,7 +123,7 @@ Useful when wiring the addon into custom tooling or writing interaction tests th
 
 ## `AddonOptions`
 
-Typed shape of the `options` object passed to the Storybook `addons` entry — what the preset reads at preview start.
+Typed shape of the `options` object passed to the Storybook `addons` entry: what the preset reads at preview start.
 
 ```ts
 import type { AddonOptions } from '@unpunnyfuns/swatchbook-addon';
@@ -150,4 +150,4 @@ interface AddonOptions {
 - ✅ Use `useToken` for typed lookups when you need the resolved value at runtime (aria labels, conditional rendering).
 - ✅ Prefer `var(--…)` in CSS; `useToken().cssVar` gives you the right string programmatically.
 - ❌ Don't import from `virtual:swatchbook/tokens` directly in consumer code. Go through `useToken` / the panel / the doc blocks so the API stays stable.
-- ❌ Don't combine `parameters.swatchbook.themeName` *and* the toolbar for the same story — the parameter wins and the toolbar change won't stick.
+- ❌ Don't combine `parameters.swatchbook.themeName` *and* the toolbar for the same story: the parameter wins and the toolbar change won't stick.

--- a/apps/docs/docs/reference/axes.mdx
+++ b/apps/docs/docs/reference/axes.mdx
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 # Axes
 
-An **axis** is one independent dimension of your theming model — `mode`, `brand`, `density`, `contrast`, whatever fits your system. Each axis has a set of named **contexts** (one of which is the default), and at any moment exactly one context is selected per axis.
+An **axis** is one independent dimension of your theming model: `mode`, `brand`, `density`, `contrast`, whatever fits your system. Each axis has a set of named **contexts** (one of which is the default), and at any moment exactly one context is selected per axis.
 
 The axis shape is the alternative to a flat string-ID model (`"light"`, `"dark"`, `"brand-a-dark-compact"`). One dimension becomes two; two become four. Modelling each dimension independently keeps the combination-counting out of your theme names and into composition at runtime. If your system has exactly one dimension and no plans for more, [`@storybook/addon-themes`](https://storybook.js.org/addons/@storybook/addon-themes)' single-string-ID model is simpler and a better fit.
 
@@ -28,7 +28,7 @@ When a tuple is active, the preview decorator writes one `data-<prefix>-<axisNam
 <html data-swatch-mode="Dark" data-swatch-brand="Brand A">
 ```
 
-CSS emission matches those attributes with compound selectors. Each non-default tuple gets its own flat block — every var redeclared — with `:root` carrying the default:
+CSS emission matches those attributes with compound selectors. Each non-default tuple gets its own flat block (every var redeclared) with `:root` carrying the default:
 
 ```css
 :root {
@@ -42,7 +42,7 @@ CSS emission matches those attributes with compound selectors. Each non-default 
 }
 ```
 
-Flat emission avoids collision-detection — DTCG allows multiple modifiers to write to the same token path, and flat blocks let the last-written tuple win cleanly.
+Flat emission avoids collision-detection: DTCG allows multiple modifiers to write to the same token path, and flat blocks let the last-written tuple win cleanly.
 
 These attributes and CSS vars are swatchbook's preview scaffolding, not a public styling API. Consumer components shouldn't key production theming off `data-swatch-*` selectors.
 
@@ -89,5 +89,5 @@ A resolver may declare more modifiers than a given Storybook wants to surface. L
 
 ## See also
 
-- [Config reference](./config.mdx) — the `resolver` / `axes` / `default` / `disabledAxes` / `presets` fields.
-- [Consuming the active theme](../guides/consuming-the-active-theme.mdx) — how stories pick up axis flips.
+- [Config reference](./config.mdx): the `resolver` / `axes` / `default` / `disabledAxes` / `presets` fields.
+- [Consuming the active theme](../guides/consuming-the-active-theme.mdx): how stories pick up axis flips.

--- a/apps/docs/docs/reference/blocks/hooks.mdx
+++ b/apps/docs/docs/reference/blocks/hooks.mdx
@@ -8,13 +8,13 @@ sidebar_position: 6
 
 Context-reading hooks for authoring custom blocks. Source of truth lives in `@unpunnyfuns/swatchbook-blocks`; `@unpunnyfuns/swatchbook-addon` re-exports everything so a one-stop `import { useSwatchbookData } from '@unpunnyfuns/swatchbook-addon'` works too. Either entry reads from the nearest `SwatchbookProvider` (mounted automatically by the addon's preview decorator inside Storybook).
 
-Outside Storybook, wrap the tree in `SwatchbookProvider` and pass a `ProjectSnapshot` so the hooks have something to resolve against — see the [blocks intro](./index.mdx) for the wiring.
+Outside Storybook, wrap the tree in `SwatchbookProvider` and pass a `ProjectSnapshot` so the hooks have something to resolve against. See the [blocks intro](./index.mdx) for the wiring.
 
 ## `useSwatchbookData()`
 
-Returns the full `ProjectSnapshot` the provider is holding (themes, axes, presets, tokens, diagnostics, listing, …). Useful for custom blocks that need graph-level information the canned blocks don't expose.
+Returns the full `ProjectSnapshot` the provider is holding (`axes`, `activeTheme`, `activeAxes`, `cssVarPrefix`, `diagnostics`, `css`, `listing`, `tokenGraph`, `defaultTuple`, `resolveAt`). Useful for custom blocks that need graph-level information the canned blocks don't expose.
 
-The snapshot's `listing?: Readonly<Record<string, VirtualTokenListingShape>>` field carries per-token metadata from `@terrazzo/plugin-token-listing` — authoritative CSS variable names (`names.css`), preview values, source file + line references. Empty for layered / plain-parse projects; read-it-when-present, fall back gracefully. Blocks that need a token's CSS var reference use `resolveCssVar(path, project)` internally — an internal helper in `packages/blocks/src/internal/use-project.ts` that reads `listing[path].names.css` first and falls back to `makeCssVar(path, cssVarPrefix)` from `@unpunnyfuns/swatchbook-core/css-var` when a listing entry is absent.
+The snapshot's `listing?: Readonly<Record<string, VirtualTokenListingShape>>` field carries per-token metadata from `@terrazzo/plugin-token-listing`: authoritative CSS variable names (`names.css`), preview values, source file + line references. Empty for layered / plain-parse projects; read-it-when-present, fall back gracefully. Blocks that need a token's CSS var reference use `resolveCssVar(path, project)` internally, an internal helper in `packages/blocks/src/internal/use-project.ts` that reads `listing[path].names.css` first and falls back to `makeCssVar(path, cssVarPrefix)` from `@unpunnyfuns/swatchbook-core/css-var` when a listing entry is absent.
 
 Throws when no `SwatchbookProvider` is mounted above. For code paths that need to handle the no-provider case (MDX doc blocks rendered without a preview decorator, conditional fallbacks), use [`useOptionalSwatchbookData`](#useoptionalswatchbookdata) instead.
 
@@ -32,8 +32,8 @@ Returns the active tuple as `Readonly<Record<string, string>>`.
 
 ## `useColorFormat()`
 
-Returns the active color format (`'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw'`) — the display setting toggled from the toolbar popover. Pair with `formatColor(value, format)` (also exported) to render colors the same way the built-in blocks do. `hex` falls back to space-separated `rgb()` for out-of-gamut colors, marked with a ⚠ warning.
+Returns the active color format (`'hex' | 'rgb' | 'hsl' | 'oklch' | 'raw'`), the display setting toggled from the toolbar popover. Pair with `formatColor(value, format)` (also exported) to render colors the same way the built-in blocks do. `hex` falls back to space-separated `rgb()` for out-of-gamut colors, marked with a ⚠ warning.
 
 ## Reactivity
 
-Hook consumers re-render on the same Storybook `globalsUpdated` channel event the built-in blocks subscribe to, so the active axis tuple and color format both stay in sync without a story re-render. This works both inside story renders and inside MDX doc blocks (where the preview HooksContext isn't available — we use the channel directly).
+Hook consumers re-render on the same Storybook `globalsUpdated` channel event the built-in blocks subscribe to, so the active axis tuple and color format both stay in sync without a story re-render. This works both inside story renders and inside MDX doc blocks (where the preview HooksContext isn't available, so we use the channel directly).

--- a/apps/docs/docs/reference/blocks/index.mdx
+++ b/apps/docs/docs/reference/blocks/index.mdx
@@ -14,7 +14,7 @@ Published as `@unpunnyfuns/swatchbook-blocks`. MDX-embeddable doc blocks. Each b
 npm install -D @unpunnyfuns/swatchbook-blocks
 ```
 
-Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these blocks — its preview decorator mounts a `SwatchbookProvider` (exported from this package) that the blocks read from. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly.
+Inside Storybook, register `@unpunnyfuns/swatchbook-addon` alongside these blocks; its preview decorator mounts a `SwatchbookProvider` (exported from this package) that the blocks read from. Outside Storybook, wrap your tree in `SwatchbookProvider` and pass a `ProjectSnapshot` directly.
 
 `SwatchbookProvider`, `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`, and the backing contexts (`SwatchbookContext`, `ThemeContext`, `AxesContext`, `ColorFormatContext`) live in `@unpunnyfuns/swatchbook-blocks`. `@unpunnyfuns/swatchbook-addon` re-exports them verbatim, so either import path works depending on which packages your consumer already pulls in.
 
@@ -35,7 +35,7 @@ The addon's preview decorator wraps every story and docs render in a `Swatchbook
 
 ### Using blocks outside Storybook
 
-Blocks are pure presentation. Given a `ProjectSnapshot` — the shape the addon internally publishes into `virtual:swatchbook/tokens` — they render in any React tree: unit tests, standalone docs apps, custom tooling.
+Blocks are pure presentation. Given a `ProjectSnapshot` (the shape the addon internally publishes into `virtual:swatchbook/tokens`), they render in any React tree: unit tests, standalone docs apps, custom tooling.
 
 ```tsx
 import { SwatchbookProvider, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
@@ -50,28 +50,28 @@ export function TokenDocs() {
 }
 ```
 
-`SwatchbookProvider` is the canonical entry point. The `virtual:swatchbook/tokens` module is the Storybook addon's internal wiring — do not import from it directly in consumer code.
+`SwatchbookProvider` is the canonical entry point. The `virtual:swatchbook/tokens` module is the Storybook addon's internal wiring; do not import from it directly in consumer code.
 
 ## Groups
 
 Four groups by shape of use:
 
-- [**Overview blocks**](./overview.mdx) — survey many tokens at once. `TokenNavigator`, `TokenTable`, `ColorTable`, plus the per-type scales and palettes.
-- [**Inspector blocks**](./inspector.mdx) — single-token deep-dive. `TokenDetail` and its subparts.
-- [**Sample blocks**](./samples.mdx) — one-token visual atoms you can drop inline.
-- [**Utility blocks**](./utility.mdx) — `Diagnostics`.
+- [**Overview blocks**](./overview.mdx): survey many tokens at once. `TokenNavigator`, `TokenTable`, `ColorTable`, plus the per-type scales and palettes.
+- [**Inspector blocks**](./inspector.mdx): single-token deep-dive. `TokenDetail` and its subparts.
+- [**Sample blocks**](./samples.mdx): one-token visual atoms you can drop inline.
+- [**Utility blocks**](./utility.mdx): `Diagnostics`.
 
 Most overview blocks take `filter?` (path glob), `sortBy?`, `sortDir?`, and `caption?`.
 
-For authoring custom blocks against the same provider the built-ins read from, see the [**Hooks reference**](./hooks.mdx) — `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`.
+For authoring custom blocks against the same provider the built-ins read from, see the [**Hooks reference**](./hooks.mdx): `useSwatchbookData`, `useActiveTheme`, `useActiveAxes`, `useColorFormat`.
 
 ## Reactivity
 
-All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render when the active axis tuple or color format changes. This works both inside story renders and inside MDX doc blocks (where the preview HooksContext isn't available — we use the channel directly).
+All blocks subscribe to Storybook's `globalsUpdated` channel event and re-render when the active axis tuple or color format changes. This works both inside story renders and inside MDX doc blocks (where the preview HooksContext isn't available, so we use the channel directly).
 
 ## Do / don't
 
 - ✅ Use blocks in MDX `*.mdx` docs pages for token reference tables.
-- ✅ Filter aggressively — `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
+- ✅ Filter aggressively. `<TokenTable filter="color.**" type="color" />` beats unfiltered tables for browsability.
 - ✅ Use blocks outside Storybook by wrapping the tree in `SwatchbookProvider` and passing a `ProjectSnapshot`. The blocks themselves are framework-free.
-- ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source — the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.
+- ✅ Either `@unpunnyfuns/swatchbook-blocks` or `@unpunnyfuns/swatchbook-addon` works as an import source: the addon re-exports the blocks surface so you don't have to pin a second dependency in consumer projects that already have the addon.

--- a/apps/docs/docs/reference/blocks/inspector.mdx
+++ b/apps/docs/docs/reference/blocks/inspector.mdx
@@ -56,7 +56,7 @@ Forward alias chain (`color.accent.bg → color.palette.blue.700`). Renders noth
 <AliasedBy path="color.palette.blue.500" />
 ```
 
-Backward alias tree — every token that transitively aliases this one. Truncates at depth 6.
+Backward alias tree: every token that transitively aliases this one. Truncates at depth 6.
 
 ## AxisVariance
 
@@ -82,6 +82,6 @@ Copy-ready `color: var(--…);` reference snippet.
 
 Summary rows for the token's **Path** and **CSS var** with copy-to-clipboard on each. Shows the active axis tuple above the rows when more than one axis is in play.
 
-When the project's Terrazzo build loads additional plugins (`@terrazzo/plugin-swift`, `-android`, `-sass`, `-js`, …) alongside the default `plugin-css` — wired via `config.terrazzoPlugins` and named in `config.listingOptions.platforms` — one extra row appears per platform, carrying that plugin's authoritative identifier for the token (`Color.accentBg`, `@color/accent_bg`, `$accent-bg`, …). See [Aligning with your token build](../../guides/sharing-terrazzo-options.mdx) for the setup pattern.
+When the project's Terrazzo build loads additional plugins (`@terrazzo/plugin-swift`, `-android`, `-sass`, `-js`, …) alongside the default `plugin-css` (wired via `config.terrazzoPlugins` and named in `config.listingOptions.platforms`), one extra row appears per platform, carrying that plugin's authoritative identifier for the token (`Color.accentBg`, `@color/accent_bg`, `$accent-bg`, …). See [Aligning with your token build](../../guides/sharing-terrazzo-options.mdx) for the setup pattern.
 
-**The displayed names are whatever your plugin config produces.** Swatchbook doesn't transform tokens — it displays the identifiers the plugins you configured emit. If you pass `sassPlugin()` with defaults, you see default Sass naming; if you pass `sassPlugin(yourProductionOptions)`, you see the names your production build ships. The shared-options module pattern is how you keep the two in lockstep — otherwise the row labelled `Sass` is showing *a* plausible identifier, not *your* identifier.
+**The displayed names are whatever your plugin config produces.** Swatchbook doesn't transform tokens; it displays the identifiers the plugins you configured emit. If you pass `sassPlugin()` with defaults, you see default Sass naming; if you pass `sassPlugin(yourProductionOptions)`, you see the names your production build ships. The shared-options module pattern is how you keep the two in lockstep; otherwise the row labelled `Sass` is showing *a* plausible identifier, not *your* identifier.

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -10,10 +10,10 @@ Survey many tokens at once. The first two work across every `$type` in the graph
 
 Most blocks in this group take:
 
-- `filter?: string` — path glob (see [`matchPath`](../core.mdx#browser-safe-subpaths) in the `/match-path` subpath).
-- `sortBy?: 'path' | 'value' | 'none'` — default `'path'` (exceptions noted per block).
-- `sortDir?: 'asc' | 'desc'` — default `'asc'`.
-- `caption?: string` — override the default summary caption.
+- `filter?: string`: path glob (see [`matchPath`](../core.mdx#browser-safe-subpaths) in the `/match-path` subpath).
+- `sortBy?: 'path' | 'value' | 'none'`: default `'path'` (exceptions noted per block).
+- `sortDir?: 'asc' | 'desc'`: default `'asc'`.
+- `caption?: string`: override the default summary caption.
 
 ## Across types
 
@@ -23,15 +23,15 @@ Most blocks in this group take:
 <TokenNavigator root="color" />
 ```
 
-Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A fuzzy-search input at the top filters leaves by path — case-insensitive, out-of-order terms, single-character typo tolerance. Matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
+Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A fuzzy-search input at the top filters leaves by path: case-insensitive, out-of-order terms, single-character typo tolerance. Matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
 Props:
 
-- `root?: string` — mount at this subtree (e.g. `"color"`, `"typography"`). Omit to show everything.
-- `type?: string | readonly string[]` — restrict to one DTCG `$type` (`type="color"`) or a small-multiples set (`type={['duration', 'cubicBezier', 'transition']}`). Composes with `root` — both constraints must hold.
-- `initiallyExpanded?: number` — depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
-- `searchable?: boolean` — render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
-- `onSelect?(path: string): void` — receives a leaf's full dot-path on click; suppresses the built-in overlay.
+- `root?: string`: mount at this subtree (e.g. `"color"`, `"typography"`). Omit to show everything.
+- `type?: string | readonly string[]`: restrict to one DTCG `$type` (`type="color"`) or a small-multiples set (`type={['duration', 'cubicBezier', 'transition']}`). Composes with `root`; both constraints must hold.
+- `initiallyExpanded?: number`: depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
+- `searchable?: boolean`: render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
+- `onSelect?(path: string): void`: receives a leaf's full dot-path on click; suppresses the built-in overlay.
 
 ### TokenTable
 
@@ -39,17 +39,17 @@ Props:
 <TokenTable type="color" />
 ```
 
-Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). A fuzzy-search input at the top narrows rows by path, type, or value — case-insensitive, out-of-order terms, single-character typo tolerance. Each value cell has a hover-revealed copy-to-clipboard button. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
+Compact two-column table: **Path** and **Value** (with inline type pill + color swatch). A fuzzy-search input at the top narrows rows by path, type, or value: case-insensitive, out-of-order terms, single-character typo tolerance. Each value cell has a hover-revealed copy-to-clipboard button. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
 
 Props:
 
-- `filter?: string` — path glob.
-- `type?: string` — DTCG `$type` filter (`"color"`, `"dimension"`, …).
-- `caption?: string` — override the caption.
-- `sortBy?: 'path' | 'value' | 'none'` — default `'path'`.
-- `sortDir?: 'asc' | 'desc'` — default `'asc'`.
-- `searchable?: boolean` — render a runtime search input above the table. Defaults to `true`.
-- `onSelect?(path: string): void` — suppress the built-in drawer.
+- `filter?: string`: path glob.
+- `type?: string`: DTCG `$type` filter (`"color"`, `"dimension"`, …).
+- `caption?: string`: override the caption.
+- `sortBy?: 'path' | 'value' | 'none'`: default `'path'`.
+- `sortDir?: 'asc' | 'desc'`: default `'asc'`.
+- `searchable?: boolean`: render a runtime search input above the table. Defaults to `true`.
+- `onSelect?(path: string): void`: suppress the built-in drawer.
 
 ## Per-type
 
@@ -71,9 +71,9 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 
 Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
 
-Clicking a row expands it inline — the detail panel surfaces `$description`, the token's alias chain, and (for grouped variants) a sub-table comparing every variant's HEX / HSL / OKLCH at once. That side-by-side comparison is the one place per-format density earns its weight; the collapsed row only shows the format the user already picked.
+Clicking a row expands it inline: the detail panel surfaces `$description`, the token's alias chain, and (for grouped variants) a sub-table comparing every variant's HEX / HSL / OKLCH at once. That side-by-side comparison is the one place per-format density earns its weight; the collapsed row only shows the format the user already picked.
 
-**Variant grouping** — pass a `variants` map to collapse sibling tokens that share a base path into a single row with a pill selector. Clicking a pill swaps the displayed values to that variant:
+**Variant grouping**: pass a `variants` map to collapse sibling tokens that share a base path into a single row with a pill selector. Clicking a pill swaps the displayed values to that variant:
 
 ```tsx
 <ColorTable
@@ -82,17 +82,17 @@ Clicking a row expands it inline — the detail panel surfaces `$description`, t
 />
 ```
 
-Given tokens like `color.bg.hi` / `color.bg.hi.hover` / `color.bg.hi.disabled`, the table emits one row for `color.bg.hi` with three pills (`base`, `hover`, `disabled`). The same map also handles Backmarket-style hyphen tails — `color.bg.hi-h` with `variants={{ hover: 'h' }}` groups identically. Suffix matching is longest-wins and requires a real segment boundary, so `variants={{ zero: '0' }}` will not spuriously hit `neutral-900`.
+Given tokens like `color.bg.hi` / `color.bg.hi.hover` / `color.bg.hi.disabled`, the table emits one row for `color.bg.hi` with three pills (`base`, `hover`, `disabled`). The same map also handles Backmarket-style hyphen tails: `color.bg.hi-h` with `variants={{ hover: 'h' }}` groups identically. Suffix matching is longest-wins and requires a real segment boundary, so `variants={{ zero: '0' }}` will not spuriously hit `neutral-900`.
 
 Props:
 
-- `filter?: string` — path glob. Defaults to every `$type: color` token.
-- `caption?: string` — override the caption.
-- `sortBy?: 'path' | 'value' | 'none'` — default `'path'`. `'value'` orders perceptually (oklch L → C → H).
-- `sortDir?: 'asc' | 'desc'` — default `'asc'`.
-- `searchable?: boolean` — render a fuzzy-search input above the table. Defaults to `true`.
-- `onSelect?(path: string): void` — replaces the expand-in-place default with a consumer-driven callback, invoked with the currently-selected variant's path.
-- `variants?: Record<string, string>` — label-to-suffix map for grouping. Accepts both DTCG dot-segment (`hi.disabled`) and Backmarket hyphen-tail (`hi-d`) conventions. Single-member groups render as plain rows; empty / omitted map disables grouping entirely.
+- `filter?: string`: path glob. Defaults to every `$type: color` token.
+- `caption?: string`: override the caption.
+- `sortBy?: 'path' | 'value' | 'none'`: default `'path'`. `'value'` orders perceptually (oklch L → C → H).
+- `sortDir?: 'asc' | 'desc'`: default `'asc'`.
+- `searchable?: boolean`: render a fuzzy-search input above the table. Defaults to `true`.
+- `onSelect?(path: string): void`: replaces the expand-in-place default with a consumer-driven callback, invoked with the currently-selected variant's path.
+- `variants?: Record<string, string>`: label-to-suffix map for grouping. Accepts both DTCG dot-segment (`hi.disabled`) and Backmarket hyphen-tail (`hi-d`) conventions. Single-member groups render as plain rows; empty / omitted map disables grouping entirely.
 
 ### TypographyScale
 
@@ -108,9 +108,9 @@ One sample line per `typography` composite, rendered with the token's own `fontF
 <DimensionScale visual="length" />
 ```
 
-Width-driven bar (default), radius-sample square, or size-sample square per `dimension` token. Defaults to `sortBy: 'value'` — ordered numerically by the rendered pixel size.
+Width-driven bar (default), radius-sample square, or size-sample square per `dimension` token. Defaults to `sortBy: 'value'`, ordered numerically by the rendered pixel size.
 
-- `visual?: 'length' | 'radius' | 'size'` — visualization mode (default `'length'`).
+- `visual?: 'length' | 'radius' | 'size'`: visualization mode (default `'length'`).
 
 ### FontFamilyPreview
 
@@ -126,7 +126,7 @@ Pangram rendered per `fontFamily` primitive. `sample?: string` overrides the tex
 <FontWeightScale />
 ```
 
-Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: 'value'` — ordered 100 → 900.
+Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: 'value'`, ordered 100 → 900.
 
 ### OpacityScale
 
@@ -134,11 +134,11 @@ Same sample text rendered at each `fontWeight` primitive. Defaults to `sortBy: '
 <OpacityScale filter="number.opacity.**" />
 ```
 
-One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up — non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.
+One card per opacity token: the sample colour rendered at that opacity over a checkerboard backdrop, so the transparency reads visually. Only `$type: 'number'` (or `'opacity'`) tokens whose `$value` is a finite number in `[0, 1]` are picked up; non-opacity `number` siblings (`line-height`, `z-index`) fall out naturally.
 
-- `filter?: string` — path glob; defaults to `'**.opacity.*'` so common layouts (`number.opacity.*`, `opacity.*`) work without configuration.
-- `type?: 'number' | 'opacity'` — default `'number'`.
-- `sampleColor?: string` — the colour the sample layer uses. Default `'color.accent.bg'`.
+- `filter?: string`: optional path glob. With no filter, narrowing comes from the `$type` check plus the 0–1 range, so common layouts (`number.opacity.*`, `opacity.*`) are picked up without configuration.
+- `type?: 'number' | 'opacity'`: default `'number'`.
+- `sampleColor?: string`: the colour the sample layer uses. Default `'color.accent.bg'`.
 
 ### BorderPreview
 
@@ -178,4 +178,4 @@ Border rendered per `strokeStyle` primitive. Supports string forms (`solid`, `da
 <GradientPalette />
 ```
 
-Wide sample per `gradient` token (linear, left → right by default) with a stop list. DTCG gradients are stop arrays — the gradient *function* is a rendering choice the consumer makes.
+Wide sample per `gradient` token (linear, left → right by default) with a stop list. DTCG gradients are stop arrays; the gradient *function* is a rendering choice the consumer makes.

--- a/apps/docs/docs/reference/blocks/samples.mdx
+++ b/apps/docs/docs/reference/blocks/samples.mdx
@@ -6,7 +6,7 @@ sidebar_position: 4
 
 # Sample blocks
 
-Lower-level than the per-type overview blocks — these render the visual for **one** token by path. Useful for custom MDX layouts that don't want the full overview chrome, and for embedding a single sample next to prose.
+Lower-level than the per-type overview blocks: these render the visual for **one** token by path. Useful for custom MDX layouts that don't want the full overview chrome, and for embedding a single sample next to prose.
 
 ## MotionSample
 

--- a/apps/docs/docs/reference/blocks/utility.mdx
+++ b/apps/docs/docs/reference/blocks/utility.mdx
@@ -16,7 +16,7 @@ Blocks that surface project-level state rather than tokens themselves.
 
 Project-load diagnostics (parser errors, resolver warnings, disabled-axis validation) as a collapsible list. Green **OK** badge when clean; auto-expands with a severity summary when warnings or errors are present.
 
-Props: `caption?: string` — overrides the summary heading.
+Props: `caption?: string` overrides the summary heading.
 
 ### The `Diagnostic` shape
 
@@ -29,28 +29,27 @@ interface Diagnostic {
   message: string;
   filename?: string;
   line?: number;
-  column?: number;
 }
 ```
 
 `group` identifies the subsystem that produced the diagnostic:
 
-- `parser` — Terrazzo's token-file parser (malformed JSON, invalid `$value`, wrong `$type`, …).
-- `resolver` — resolver-file issues (missing `$ref`, unknown modifier, context with no files).
-- `swatchbook/presets` — preset validation (unknown axis key, invalid context value).
-- Plugin-originated groups — depends on your setup.
+- `parser`: Terrazzo's token-file parser (malformed JSON, invalid `$value`, wrong `$type`, …).
+- `resolver`: resolver-file issues (missing `$ref`, unknown modifier, context with no files).
+- `swatchbook/presets`: preset validation (unknown axis key, invalid context value).
+- Plugin-originated groups: depends on your setup.
 
 ### Severities
 
-- **`error`** — something is structurally broken. A token may be missing from the graph, an alias may be unresolved. The block shows these with a red badge.
-- **`warn`** — something is unusual or probably-a-mistake but the project loaded. Example: a preset with an unknown axis key is dropped and produces a warn.
-- **`info`** — diagnostic for the curious. Rare.
+- **`error`**: something is structurally broken. A token may be missing from the graph, an alias may be unresolved. The block shows these with a red badge.
+- **`warn`**: something is unusual or probably-a-mistake but the project loaded. Example: a preset with an unknown axis key is dropped and produces a warn.
+- **`info`**: diagnostic for the curious. Rare.
 
 ### Reading common diagnostics
 
-- **`parser: Could not resolve alias "{color.palette.blue.500}"`** — the alias target doesn't exist in the merged graph. Check for a typo in the path, or a missing token file that wasn't included in `tokens` globs.
-- **`parser: Invalid token value for $type "color"`** — the `$value` doesn't parse as the declared `$type`. Usually a string missing a unit or a color in the wrong format.
-- **`swatchbook/presets: Preset "X" has unknown axis key "Y"`** — a preset references an axis that doesn't exist on the project. Either the axis name was renamed or the preset predates the resolver change.
+- **`parser: Could not resolve alias "{color.palette.blue.500}"`**: the alias target doesn't exist in the merged graph. Check for a typo in the path, or a missing token file that wasn't included in `tokens` globs.
+- **`parser: Invalid token value for $type "color"`**: the `$value` doesn't parse as the declared `$type`. Usually a string missing a unit or a color in the wrong format.
+- **`swatchbook/presets: Preset "X" has unknown axis key "Y"`**: a preset references an axis that doesn't exist on the project. Either the axis name was renamed or the preset predates the resolver change.
 
 ### Failing CI on errors
 
@@ -101,9 +100,9 @@ interface FormatColorResult {
 
 - `hex` falls back to space-separated `rgb()` for out-of-gamut colors and marks them `outOfGamut: true`; blocks render a ⚠ glyph beside the value.
 - `oklch` is wide-gamut and never marks `outOfGamut`.
-- `raw` returns a compact JSON of the normalized Terrazzo shape — useful for DTCG authors who want to see exactly what the parser stored.
+- `raw` returns a compact JSON of the normalized Terrazzo shape, useful for DTCG authors who want to see exactly what the parser stored.
 - `fallback` defaults to `'—'`; pass a custom string when integrating with surfaces that need a different placeholder.
 
-`COLOR_FORMATS` is the runtime list used to validate stored user choices — reach for it when you need to enumerate the formats (toolbar pills, validation) without duplicating the union.
+`COLOR_FORMATS` is the runtime list used to validate stored user choices; reach for it when you need to enumerate the formats (toolbar pills, validation) without duplicating the union.
 
-`NormalizedColor` is the shape `formatColor` accepts — a structural copy of Terrazzo's `ColorValueNormalized` (`colorSpace`, `components` / `channels`, `alpha`, optional `hex`). Use it when typing custom block code that produces or consumes the same payload.
+`NormalizedColor` is the shape `formatColor` accepts: a structural copy of Terrazzo's `ColorValueNormalized` (`colorSpace`, `components` / `channels`, `alpha`, optional `hex`). Use it when typing custom block code that produces or consumes the same payload.

--- a/apps/docs/docs/reference/concepts.mdx
+++ b/apps/docs/docs/reference/concepts.mdx
@@ -12,7 +12,7 @@ Reference and guide pages assume this vocabulary; new readers and returning read
 
 ## Preview host, not transformer
 
-Swatchbook is the **preview side** of a DTCG pipeline. It parses tokens, displays them inside Storybook, and reacts to axis flips from a toolbar. It does **not** transform tokens for production platforms — that is what a consumer's `@terrazzo/cli` (or Style Dictionary, or comparable) build is for.
+Swatchbook is the **preview side** of a DTCG pipeline. It parses tokens, displays them inside Storybook, and reacts to axis flips from a toolbar. It does **not** transform tokens for production platforms; that is what a consumer's `@terrazzo/cli` (or Style Dictionary, or comparable) build is for.
 
 The boundary line cuts cleanly:
 
@@ -39,9 +39,9 @@ This is the alternative to a flat string-ID model (`light-brand-a-high`). One di
 
 Axes come from one of three sources, in priority order:
 
-- **Resolver-driven** — `config.resolver` points at a DTCG 2025.10 resolver file. Each modifier in the resolver becomes one axis.
-- **Layered config** — `config.axes` declares them inline.
-- **Synthetic fallback** — neither input supplied. A single axis named `theme` is created so the project still loads.
+- **Resolver-driven**: `config.resolver` points at a DTCG 2025.10 resolver file. Each modifier in the resolver becomes one axis.
+- **Layered config**: `config.axes` declares them inline.
+- **Synthetic fallback**: neither input supplied. A single axis named `theme` is created so the project still loads.
 
 ## Tuples
 
@@ -57,42 +57,42 @@ Tuples are the **only** way the system addresses theming state. Composed names l
 
 ## The token graph
 
-After parse and resolve, Swatchbook builds a **token graph** — the in-memory structure every read goes through.
+After parse and resolve, Swatchbook builds a **token graph**, the in-memory structure every read goes through.
 
 Conceptually:
 
 - **One node per token path** (`color.surface.default`, `space.md`, `typography.heading.font-size`).
 - **A baseline value** at the project's default tuple.
-- **Per-axis writes** — for each non-default `(axis, context)`, what value this token takes when that axis is in that context.
-- **Alias edges** — when a token references another token (`{color.brand.accent}` or DTCG 2025.10 `$ref`), the graph records the edge so the walker can compose values at any tuple.
+- **Per-axis writes**: for each non-default `(axis, context)`, what value this token takes when that axis is in that context.
+- **Alias edges**: when a token references another token (`{color.brand.accent}` or DTCG 2025.10 `$ref`), the graph records the edge so the walker can compose values at any tuple.
 
-The walker is the API surface: `resolveAt(tuple)` for a single token at a tuple, `resolveAllAt(tuple)` for every token at a tuple, `getVariance(path)` for which axes affect a given token. Walker calls are memoized — repeating a query at the same tuple is cheap.
+The walker is the API surface: `resolveAt(tuple)` for a single token at a tuple, `resolveAllAt(tuple)` for every token at a tuple, `getVariance(path)` for which axes affect a given token. Walker calls are memoized, so repeating a query at the same tuple is cheap.
 
-The graph replaced an earlier cartesian-product model where every combination of axes was materialised at load. The graph approach scales linearly in axes × contexts, not exponentially in their combination — so a 12-axis project loads in reasonable time. See the [token pipeline reference](./token-pipeline.mdx) for the load mechanism and [Core reference](./core.mdx) for the walker API.
+The graph replaced an earlier cartesian-product model where every combination of axes was materialised at load. The graph approach scales linearly in axes × contexts, not exponentially in their combination, so a 12-axis project loads in reasonable time. See the [token pipeline reference](./token-pipeline.mdx) for the load mechanism and [Core reference](./core.mdx) for the walker API.
 
 ## Alignment with Terrazzo's pipeline
 
 Swatchbook's preview-time loader reuses Terrazzo's parser end-to-end. The same `parserInput.resolver` that Terrazzo's CLI works against is what Swatchbook reads. Some implications:
 
-- The `$value` shapes, the `$type` semantics, the alias forms (`{token.path}` legacy and `$ref` JSON Pointer), the resolver schema — all of these come from Terrazzo. Swatchbook does not introduce its own DTCG dialect.
+- The `$value` shapes, the `$type` semantics, the alias forms (`{token.path}` legacy and `$ref` JSON Pointer), the resolver schema: all of these come from Terrazzo. Swatchbook does not introduce its own DTCG dialect.
 - A consumer's existing `terrazzo.config.ts` carries fields Swatchbook can re-use directly (`cssOptions`, `listingOptions`, `terrazzoPlugins`). The [Aligning with your token build](../guides/sharing-terrazzo-options.mdx) guide describes which fields cross the boundary and which are preview-only.
-- When Terrazzo's parser or resolver changes behaviour, Swatchbook inherits the change. When something doesn't render correctly in preview but builds correctly through Terrazzo CLI, the issue is usually on Swatchbook's side rather than upstream — Swatchbook reads a subset of the parser's output and the gap is usually how Swatchbook is choosing to read it.
+- When Terrazzo's parser or resolver changes behaviour, Swatchbook inherits the change. When something doesn't render correctly in preview but builds correctly through Terrazzo CLI, the issue is usually on Swatchbook's side rather than upstream. Swatchbook reads a subset of the parser's output and the gap is usually how Swatchbook is choosing to read it.
 
 ## What's loaded, in order
 
-A complete load — `loadProject` → graph + CSS + diagnostics — proceeds roughly:
+A complete load (`loadProject` → graph + CSS + diagnostics) proceeds roughly:
 
 1. **Parse the resolver** (if `config.resolver` is set), or the token globs, or both.
 2. **Build the token graph** from the parsed output: baseline values, per-axis writes, alias edges.
-3. **Validate** — alias targets, alias cycles, color shape, unresolved `$ref`. Each finding emits a diagnostic.
-4. **Run the Token Listing build** — an in-memory `@terrazzo/plugin-token-listing` pass populates per-token `previewValue`, `names.<platform>`, and source location data on `Project.listing`.
-5. **Emit the CSS** — one `:root` block for the default tuple, plus per-axis-context blocks for non-default tuples, plus compound blocks for joint-variance tokens.
+3. **Validate** alias targets, alias cycles, color shape, unresolved `$ref`. Each finding emits a diagnostic.
+4. **Run the Token Listing build**: an in-memory `@terrazzo/plugin-token-listing` pass populates per-token `previewValue`, `names.<platform>`, and source location data on `Project.listing`.
+5. **Emit the CSS**: one `:root` block for the default tuple, plus per-axis-context blocks for non-default tuples, plus compound blocks for joint-variance tokens.
 
-Every step's output lives on the returned `Project` object: `tokenGraph`, `axes`, `defaultTuple`, `listing`, `css`, `diagnostics`. See the [Core reference](./core.mdx) for the full shape and the [Diagnostics reference](./diagnostics.mdx) for what fires when.
+Every step's output lives on the returned `Project` object: `tokenGraph`, `axes`, `defaultTuple`, `listing`, `diagnostics`. CSS is produced separately by `emitAxisProjectedCss(project)` rather than stored on `Project`. See the [Core reference](./core.mdx) for the full shape and the [Diagnostics reference](./diagnostics.mdx) for what fires when.
 
 ## See also
 
-- [Axes reference](./axes.mdx) — full vocabulary and per-story override mechanics.
-- [The token pipeline](./token-pipeline.mdx) — how the virtual module ships graph + CSS to the preview.
-- [Aligning with your token build](../guides/sharing-terrazzo-options.mdx) — the boundary between Swatchbook's preview pipeline and a production Terrazzo build.
-- [Diagnostics](./diagnostics.mdx) — every `swatchbook/<group>` warning and error the loader can emit.
+- [Axes reference](./axes.mdx): full vocabulary and per-story override mechanics.
+- [The token pipeline](./token-pipeline.mdx): how the virtual module ships graph + CSS to the preview.
+- [Aligning with your token build](../guides/sharing-terrazzo-options.mdx): the boundary between Swatchbook's preview pipeline and a production Terrazzo build.
+- [Diagnostics](./diagnostics.mdx): every `swatchbook/<group>` warning and error the loader can emit.

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -54,17 +54,17 @@ export default defineSwatchbookConfig({
 }
 ```
 
-The separate file path (`configPath`) is useful when the same config is consumed by other tooling — a CLI, a CI lint job, a custom build script. For Storybook-only projects, inline is one less file to track. `defineSwatchbookConfig` is an identity helper — it gives you typed autocomplete on the object you pass in and returns it unchanged.
+The separate file path (`configPath`) is useful when the same config is consumed by other tooling: a CLI, a CI lint job, a custom build script. For Storybook-only projects, inline is one less file to track. `defineSwatchbookConfig` is an identity helper; it gives you typed autocomplete on the object you pass in and returns it unchanged.
 
 ## Picking a theming input
 
-`Config` has three valid shapes — `ResolverConfig | LayeredConfig | PlainConfig`. Which load-strategy field is present determines the shape, and invalid combinations (like `{ resolver, axes }` or `{ axes }` without `tokens`) are compile-time errors. The runtime also validates the same constraints for plain-JS callers.
+`Config` has three valid shapes: `ResolverConfig | LayeredConfig | PlainConfig`. Which load-strategy field is present determines the shape, and invalid combinations (like `{ resolver, axes }` or `{ axes }` without `tokens`) are compile-time errors. The runtime also validates the same constraints for plain-JS callers.
 
 Exactly three shapes are legal:
 
-- **Resolver** (`ResolverConfig`) — `resolver: 'path/to/resolver.json'`. The DTCG-spec-native path; the file declares sets, modifiers, and resolutionOrder, and the modifiers become your axes. Recommended.
-- **Layered** (`LayeredConfig`) — `axes: [...]` + `tokens: [...]`. For projects without a resolver document. You declare axes inline; each context names overlay files that layer onto the base `tokens`.
-- **Plain parse** (`PlainConfig`) — `tokens: [...]` alone. Single synthetic `theme` axis; every token loaded as one tuple. Useful for smoke-testing a token set before adopting a resolver.
+- **Resolver** (`ResolverConfig`): `resolver: 'path/to/resolver.json'`. The DTCG-spec-native path; the file declares sets, modifiers, and resolutionOrder, and the modifiers become your axes. Recommended.
+- **Layered** (`LayeredConfig`): `axes: [...]` + `tokens: [...]`. For projects without a resolver document. You declare axes inline; each context names overlay files that layer onto the base `tokens`.
+- **Plain parse** (`PlainConfig`): `tokens: [...]` alone. Single synthetic `theme` axis; every token loaded as one tuple. Useful for smoke-testing a token set before adopting a resolver.
 
 All three variants extend a shared base (`cssVarPrefix`, `presets`, `disabledAxes`, `chrome`, `cssOptions`, `listingOptions`, `terrazzoPlugins`, `maxJointArity`, `default`, `outDir`).
 
@@ -74,9 +74,9 @@ All three variants extend a shared base (`cssVarPrefix`, `presets`, `disabledAxe
 
 Glob patterns (relative to the config's cwd) for base DTCG token files.
 
-- **Resolver projects (`resolver` set)** — optional. The resolver's own `$ref` targets fully determine which files get loaded, and the addon's Vite plugin derives HMR watch paths from the resolved source list. Supplying `tokens` alongside `resolver` is still valid and unions the watch paths — useful when you want HMR to pick up files the resolver doesn't reference directly.
-- **Layered projects (`axes` set)** — required. The layered loader parses `[...base, ...overlayFilesInAxisOrder]` per tuple; without `tokens` there's nothing to layer onto.
-- **Plain-parse (no resolver, no axes)** — required. Every file matched by the globs gets parsed into the single synthetic theme.
+- **Resolver projects (`resolver` set)**: optional. The resolver's own `$ref` targets fully determine which files get loaded, and the addon's Vite plugin derives HMR watch paths from the resolved source list. Supplying `tokens` alongside `resolver` is still valid and unions the watch paths, useful when you want HMR to pick up files the resolver doesn't reference directly.
+- **Layered projects (`axes` set)**: required. The layered loader parses `[...base, ...overlayFilesInAxisOrder]` per tuple; without `tokens` there's nothing to layer onto.
+- **Plain-parse (no resolver, no axes)**: required. Every file matched by the globs gets parsed into the single synthetic theme.
 
 ### `resolver?: string`
 
@@ -97,13 +97,13 @@ interface AxisConfig {
 }
 ```
 
-`contexts` is a map from context name to an ordered list of overlay files (paths or globs, relative to the config's cwd). An empty array is legal — it means "no override," which is the baseline for an axis that introduces nothing by default (`Default: []`).
+`contexts` is a map from context name to an ordered list of overlay files (paths or globs, relative to the config's cwd). An empty array is legal; it means "no override," which is the baseline for an axis that introduces nothing by default (`Default: []`).
 
-The loader materializes one entry per non-default context per axis — never every combination at once. Last write wins on duplicate token paths across base + overlays; overlay files listed later in `axes` win over earlier ones.
+The loader materializes one entry per non-default context per axis, never every combination at once. Last write wins on duplicate token paths across base + overlays; overlay files listed later in `axes` win over earlier ones.
 
 ### `default?: Partial<Record<string, string>>`
 
-Initial active tuple, keyed by axis name. Partial is fine — any axis you omit falls back to that axis's own `default` at load time. Unknown axis keys and invalid context values produce `warn` diagnostics (group `swatchbook/default`) and are sanitized out.
+Initial active tuple, keyed by axis name. Partial is fine; any axis you omit falls back to that axis's own `default` at load time. Unknown axis keys and invalid context values produce `warn` diagnostics (group `swatchbook/default`) and are sanitized out.
 
 ```ts
 // Every axis specified:
@@ -122,7 +122,7 @@ Prefix prepended to every emitted CSS variable. `color.accent.bg` becomes `var(-
 
 ### `outDir?: string`
 
-Project-local directory for codegen artifacts (default `.swatchbook`). The addon preset writes `tokens.d.ts` here — add `"include": [".swatchbook/**/*.d.ts"]` to your tsconfig so `useToken()` autocompletes.
+Project-local directory for codegen artifacts (default `.swatchbook`). The addon preset writes `tokens.d.ts` here; add `"include": [".swatchbook/**/*.d.ts"]` to your tsconfig so `useToken()` autocompletes.
 
 ### `presets?: Preset[]`
 
@@ -136,11 +136,11 @@ interface Preset {
 }
 ```
 
-Partial tuples are legal — omitted axes resolve to the axis's `default` when the preset is applied. `loadProject` validates presets: unknown axis keys and invalid context values surface as `warn` diagnostics (group `swatchbook/presets`) and are sanitized out, but the preset itself stays in `Project.presets` (an empty preset is still a valid tuple — it resolves to all defaults).
+Partial tuples are legal; omitted axes resolve to the axis's `default` when the preset is applied. `loadProject` validates presets: unknown axis keys and invalid context values surface as `warn` diagnostics (group `swatchbook/presets`) and are sanitized out, but the preset itself stays in `Project.presets` (an empty preset is still a valid tuple, resolving to all defaults).
 
 ### `disabledAxes`
 
-Type: `string[]` — optional.
+Type: `string[]`, optional.
 
 Axis names to suppress from this Storybook session. Each listed axis is **pinned to its `default` context**: the toolbar dropdown disappears, the axis drops out of `Project.axes`, non-default tuples fold away, and CSS emission stops including the axis in compound selectors. The Design Tokens panel still shows a small pinned indicator so authors don't forget the modifier is being suppressed.
 
@@ -152,15 +152,15 @@ defineSwatchbookConfig({
 });
 ```
 
-Config-level only — there's no runtime toggle. Disabling an axis is the cleanest way to hide a work-in-progress modifier (or an experimental axis you don't want surfaced yet) without editing the resolver document. Unknown axis names produce `warn` diagnostics (group `swatchbook/disabled-axes`) and are ignored; the filtered list lands on `Project.disabledAxes` for downstream tooling.
+Config-level only; there's no runtime toggle. Disabling an axis is the cleanest way to hide a work-in-progress modifier (or an experimental axis you don't want surfaced yet) without editing the resolver document. Unknown axis names produce `warn` diagnostics (group `swatchbook/disabled-axes`) and are ignored; the filtered list lands on `Project.disabledAxes` for downstream tooling.
 
 ### `chrome`
 
-Type: `Record<string, string>` — optional.
+Type: `Record<string, string>`, optional.
 
-Override one or more of swatchbook's ten block-chrome roles. Block components (`<TokenTable>`, `<ColorPalette>`, etc.) read a fixed `--swatchbook-*` CSS variable namespace for their surfaces, text, and accents — independent of `cssVarPrefix`, so your token namespace never collides with chrome reads. Every role is always declared: by default, to the hard-coded literals in `DEFAULT_CHROME_MAP` (which use `light-dark()` so chrome auto-flips with the active `color-scheme` — Storybook's light/dark preference, the OS, whatever). Any role you set in `chrome` replaces that literal with a `var(--<prefix>-<your-token>)` reference so chrome reflows with your own theme switches instead.
+Override one or more of swatchbook's ten block-chrome roles. Block components (`<TokenTable>`, `<ColorPalette>`, etc.) read a fixed `--swatchbook-*` CSS variable namespace for their surfaces, text, and accents, independent of `cssVarPrefix`, so your token namespace never collides with chrome reads. Every role is always declared: by default, to the hard-coded literals in `DEFAULT_CHROME_MAP` (which use `light-dark()` so chrome auto-flips with the active `color-scheme`: Storybook's light/dark preference, the OS, whatever). Any role you set in `chrome` replaces that literal with a `var(--<prefix>-<your-token>)` reference so chrome reflows with your own theme switches instead.
 
-The ten roles (closed set — also exported as `CHROME_ROLES` and the `ChromeRole` type from `@unpunnyfuns/swatchbook-core`):
+The ten roles (closed set, also exported as `CHROME_ROLES` and the `ChromeRole` type from `@unpunnyfuns/swatchbook-core`):
 
 | Role              | Reads as                               |
 | ----------------- | -------------------------------------- |
@@ -190,7 +190,7 @@ defineSwatchbookConfig({
 });
 ```
 
-Produces a single `:root` chrome block with all ten roles declared — overrides become `var(...)` references that inherit per-theme values automatically, the rest stay on `DEFAULT_CHROME_MAP`'s hard-coded literals:
+Produces a single `:root` chrome block with all ten roles declared: overrides become `var(...)` references that inherit per-theme values automatically, the rest stay on `DEFAULT_CHROME_MAP`'s hard-coded literals:
 
 ```css
 :root {
@@ -210,22 +210,22 @@ Produces a single `:root` chrome block with all ten roles declared — overrides
 
 **Composite sub-field targets are accepted.** `typography.body` is a composite token that emits one sub-variable per field; the chrome map can target those directly (`bodyFontSize: 'typography.body.font-size'`) even though the sub-field isn't a standalone token ID.
 
-Unknown role keys (outside the ten above) and target paths that don't resolve to any token or composite sub-field in any theme produce `warn` diagnostics (group `swatchbook/chrome`) and are dropped — the corresponding chrome slot falls back to its hard-coded literal default. The validated entries land on `Project.chrome` for downstream tooling.
+Unknown role keys (outside the ten above) and target paths that don't resolve to any token or composite sub-field in any theme produce `warn` diagnostics (group `swatchbook/chrome`) and are dropped; the corresponding chrome slot falls back to its hard-coded literal default. The validated entries land on `Project.chrome` for downstream tooling.
 
 ### `cssOptions`
 
-Type: `Omit<CSSPluginOptions, 'variableName' | 'permutations' | 'filename' | 'skipBuild'>` — optional.
+Type: `Omit<CSSPluginOptions, 'variableName' | 'permutations' | 'filename' | 'skipBuild'>`, optional.
 
-Options forwarded to the `@terrazzo/plugin-css` instance swatchbook runs internally — for the stylesheet it emits for the Storybook preview and for the Token Listing's `names.css` derivation. Use this when your production Terrazzo build passes non-default options to `plugin-css` (`legacyHex`, a custom `transform`, `include` / `exclude` globs, etc.) and you want the docs-side output to match.
+Options forwarded to the `@terrazzo/plugin-css` instance swatchbook runs internally: for the stylesheet it emits for the Storybook preview and for the Token Listing's `names.css` derivation. Use this when your production Terrazzo build passes non-default options to `plugin-css` (`legacyHex`, a custom `transform`, `include` / `exclude` globs, etc.) and you want the docs-side output to match.
 
 Four fields are managed internally and stripped from the allowed type:
 
-- `variableName` — swatchbook routes naming through `@terrazzo/token-tools/css.makeCSSVar` with your `cssVarPrefix`; overriding this would desync the listing's `names.css` from the emitted stylesheet.
-- `permutations` — synthesized one-per-theme so CSS emission is axis-aware; overriding breaks the preview's toolbar cascade.
-- `filename` — the internal stylesheet is captured in memory, never written to disk.
-- `skipBuild` — setting `true` would null out the listing's `previewValue` derivation, breaking every block that displays a value.
+- `variableName`: swatchbook routes naming through `@terrazzo/token-tools/css.makeCSSVar` with your `cssVarPrefix`; overriding this would desync the listing's `names.css` from the emitted stylesheet.
+- `permutations`: synthesized one-per-theme so CSS emission is axis-aware; overriding breaks the preview's toolbar cascade.
+- `filename`: the internal stylesheet is captured in memory, never written to disk.
+- `skipBuild`: setting `true` would null out the listing's `previewValue` derivation, breaking every block that displays a value.
 
-Everything else passes through. Three plugin-css selectors (`baseSelector`, `baseScheme`, `modeSelectors`) pass the type check but swatchbook ignores them — `permutations`-based emission supersedes them. Setting any produces a `swatchbook/css-options` warn diagnostic.
+Everything else passes through. Three plugin-css selectors (`baseSelector`, `baseScheme`, `modeSelectors`) pass the type check but swatchbook ignores them; `permutations`-based emission supersedes them. Setting any produces a `swatchbook/css-options` warn diagnostic.
 
 ```ts
 defineSwatchbookConfig({
@@ -239,7 +239,7 @@ See [Aligning with your token build](../guides/sharing-terrazzo-options.mdx) for
 
 ### `listingOptions`
 
-Type: `Omit<TokenListingPluginOptions, 'filename'>` — optional.
+Type: `Omit<TokenListingPluginOptions, 'filename'>`, optional.
 
 Options forwarded to `@terrazzo/plugin-token-listing`. The listing is how swatchbook surfaces authoritative per-token metadata (plugin-css-computed CSS variable names, preview values, alias chains, source file + line references) into `Project.listing` and the block-side `ProjectSnapshot.listing`. Use `listingOptions.platforms` to register additional platforms beyond the built-in `css` entry:
 
@@ -259,15 +259,15 @@ defineSwatchbookConfig({
 });
 ```
 
-Each `platforms` entry names a Terrazzo plugin whose identifier-naming logic derives the token's identifier on that platform. The plugin has to be loaded in the build for the reference to resolve — see `terrazzoPlugins` below.
+Each `platforms` entry names a Terrazzo plugin whose identifier-naming logic derives the token's identifier on that platform. The plugin has to be loaded in the build for the reference to resolve; see `terrazzoPlugins` below.
 
 `filename` is managed internally (the listing is captured in memory, not written to disk) and is stripped from the option type.
 
 ### `terrazzoPlugins`
 
-Type: `readonly Plugin[]` — optional.
+Type: `readonly Plugin[]`, optional.
 
-Additional Terrazzo plugins loaded alongside swatchbook's internal `plugin-css` + `plugin-token-listing`. Required when `listingOptions.platforms` references anything beyond the built-in `css` — the referenced plugin has to actually run in the same build for the listing to resolve its naming. Plugins whose output swatchbook doesn't consume are harmless — they run, their output files land in the in-memory output set, nothing else happens.
+Additional Terrazzo plugins loaded alongside swatchbook's internal `plugin-css` + `plugin-token-listing`. Required when `listingOptions.platforms` references anything beyond the built-in `css`: the referenced plugin has to actually run in the same build for the listing to resolve its naming. Plugins whose output swatchbook doesn't consume are harmless; they run, their output files land in the in-memory output set, nothing else happens.
 
 Common use: load `@terrazzo/plugin-swift` / `-android` / `-js` / `-sass` alongside so their naming logic populates `listing[path].names.<platform>` for block consumption.
 
@@ -275,15 +275,15 @@ See [Sharing Terrazzo options](../guides/sharing-terrazzo-options.mdx) for the p
 
 ### `maxJointArity`
 
-Type: `number` — optional. Default `4`.
+Type: `number`, optional. Default `4`.
 
 Maximum arity of joint-divergence detection per token. A joint divergence is a multi-axis tuple where the cartesian-correct value differs from cascade composition of all lower-arity blocks; each emits a compound CSS selector (`[data-axis-a="…"][data-axis-b="…"]…`) at emission time.
 
 The default of `4` covers the largest joint shapes real-world design systems tend to express: `mode × brand × density × contrast` or similar. Most consumers never need to change this.
 
-**When to bump (5+):** the design system has tokens with genuine 5+-axis joint divergences — concretely, tokens where the value at some 5-axis combination differs from what CSS cascade composes from all the 2-axis, 3-axis, and 4-axis blocks. Without the bump, those tuples will resolve to the cascade-composed value rather than the cartesian-correct one. The visual symptom is a wrong color (or other token value) at that specific 5+-axis combination.
+**When to bump (5+):** the design system has tokens with genuine 5+-axis joint divergences: concretely, tokens where the value at some 5-axis combination differs from what CSS cascade composes from all the 2-axis, 3-axis, and 4-axis blocks. Without the bump, those tuples will resolve to the cascade-composed value rather than the cartesian-correct one. The visual symptom is a wrong color (or other token value) at that specific 5+-axis combination.
 
-**When to lower (≤3):** load-time work is a concern. Per-token probe work scales as `Σ_{k=2..arity} C(|affectedBy|, k) × Π non-default contexts in combo`. Tokens affected by many axes including dense (large-context-count) ones dominate. Setting `maxJointArity: 1` disables joint-block emission entirely — useful when joint divergences aren't relevant for your pipeline, or as a debugging step.
+**When to lower (≤3):** load-time work is a concern. Per-token probe work scales as `Σ_{k=2..arity} C(|affectedBy|, k) × Π non-default contexts in combo`. Tokens affected by many axes including dense (large-context-count) ones dominate. Setting `maxJointArity: 1` disables joint-block emission entirely, useful when joint divergences aren't relevant for your pipeline, or as a debugging step.
 
 ```ts
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
@@ -298,6 +298,6 @@ export default defineSwatchbookConfig({
 
 ## See also
 
-- [Axes reference](./axes.mdx) — the runtime model for selection.
-- [Reference: core](./core.mdx) — the loader APIs this config drives.
-- [Sharing Terrazzo options](../guides/sharing-terrazzo-options.mdx) — keep the swatchbook build aligned with a production Terrazzo CLI.
+- [Axes reference](./axes.mdx): the runtime model for selection.
+- [Reference: core](./core.mdx): the loader APIs this config drives.
+- [Sharing Terrazzo options](../guides/sharing-terrazzo-options.mdx): keep the swatchbook build aligned with a production Terrazzo CLI.

--- a/apps/docs/docs/reference/core.mdx
+++ b/apps/docs/docs/reference/core.mdx
@@ -19,7 +19,7 @@ npm install @unpunnyfuns/swatchbook-core
 
 ### `defineSwatchbookConfig(config)`
 
-Identity helper for a typed `swatchbook.config.ts`. No runtime effect — just TypeScript ergonomics. See the [Config reference](./config.mdx) for every field's semantics.
+Identity helper for a typed `swatchbook.config.ts`. No runtime effect, just TypeScript ergonomics. See the [Config reference](./config.mdx) for every field's semantics.
 
 ```ts
 import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
@@ -33,7 +33,7 @@ export default defineSwatchbookConfig({
 
 ### `loadProject(config, cwd?)`
 
-Parse + resolve a project. Returns a `Project` carrying the token graph and a `resolveAt(tuple)` accessor — no resolver calls happen at consumer-read time.
+Parse + resolve a project. Returns a `Project` carrying the token graph and a `resolveAt(tuple)` accessor; no resolver calls happen at consumer-read time.
 
 ```ts
 import { loadProject } from '@unpunnyfuns/swatchbook-core';
@@ -64,7 +64,7 @@ for (const [path, token] of Object.entries(project.defaultTokens)) {
 
 ### `emitAxisProjectedCss(project, options?)`
 
-Emit the project's resolved CSS as a string — the same output the addon publishes into `virtual:swatchbook/tokens` at preview time. The emitter walks the token graph: each per-axis non-default context gets its own `[data-<prefix>-<axis>="<context>"]` selector block; the default-tuple tokens go to `:root`; tokens whose value differs when more than one axis changes get compound `[data-…][data-…]` selectors. Total block count scales with axes × contexts, not every combination of axes.
+Emit the project's resolved CSS as a string: the same output the addon publishes into `virtual:swatchbook/tokens` at preview time. The emitter walks the token graph: each per-axis non-default context gets its own `[data-<prefix>-<axis>="<context>"]` selector block; the default-tuple tokens go to `:root`; tokens whose value differs when more than one axis changes get compound `[data-…][data-…]` selectors. Total block count scales with axes × contexts, not every combination of axes.
 
 ```ts
 import { loadProject, emitAxisProjectedCss } from '@unpunnyfuns/swatchbook-core';
@@ -75,22 +75,22 @@ const css = emitAxisProjectedCss(project);
 // [data-sb-mode="Dark"] { --sb-color-accent-bg: …; }
 ```
 
-For production builds, prefer Terrazzo's CLI — `emitAxisProjectedCss` exists primarily for tooling that wants the same emission the addon does.
+For production builds, prefer Terrazzo's CLI; `emitAxisProjectedCss` exists primarily for tooling that wants the same emission the addon does.
 
 ## Browser-safe subpaths
 
-Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths. Each is tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports — safe to import from preview-side bundles, the Storybook manager, or any browser consumer.
+Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths. Each is tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports, safe to import from preview-side bundles, the Storybook manager, or any browser consumer.
 
 | Subpath | Export | Purpose |
 | --- | --- | --- |
-| `/graph` | `resolveAt`, `resolveAllAt`, `resolveAliasAt`, `resolveAliasAllAt`, `getVariance`, `getAffectedBy`, `listPaths` + `TokenGraph` / `TokenGraphNode` / `WriteValue` types | Graph query helpers — browser-safe, no Terrazzo dependency at query time. See [Graph queries](#graph-queries) below. |
+| `/graph` | `resolveAt`, `resolveAllAt`, `resolveAliasAt`, `resolveAliasAllAt`, `getVariance`, `getAffectedBy`, `listPaths` + `TokenGraph` / `TokenGraphNode` / `WriteValue` types | Graph query helpers, browser-safe, no Terrazzo dependency at query time. See [Graph queries](#graph-queries) below. |
 | `/snapshot-for-wire` | `snapshotForWire(project, css)` + `SnapshotForWire` type | JSON-friendly subset of `Project` for cross-boundary transport. |
 | `/themes` | `enumerateThemes({axes, presets, defaultTuple})` + `tupleToName(axes, tuple)` + `ThemeEntry` / `ThemeEnumAxis` / `ThemeEnumPreset` types | Enumerate single-axis tuples + presets as a unified theme list; compose stable theme IDs from tuples. |
 | `/match-path` | `matchPath(path, filter)` | Glob-style path matcher (`*` single-segment, `**` multi-segment, bare prefix treated as descendants); shared by blocks' filter prop and the MCP `list_tokens` tool. |
 | `/fuzzy` | `fuzzyFilter` + `fuzzyMatches` | uFuzzy-backed token search; powers the MCP `search_tokens` tool. |
-| `/css-var` | `makeCssVar(path, prefix)` | Compose `var(--prefix-path)` strings — same shape Terrazzo's plugin-css emits. |
-| `/data-attr` | `dataAttr(prefix, key)` | Compose `data-prefix-key` attribute names — namespaced to `cssVarPrefix`. |
-| `/style-element` | `ensureStyleElement(elementId, text)` + `SWATCHBOOK_STYLE_ELEMENT_ID` | Idempotent `<style>` injector — shared between the addon's preview decorator and the blocks-side stylesheet path. |
+| `/css-var` | `makeCssVar(path, prefix)` | Compose `var(--prefix-path)` strings, same shape Terrazzo's plugin-css emits. |
+| `/data-attr` | `dataAttr(prefix, key)` | Compose `data-prefix-key` attribute names, namespaced to `cssVarPrefix`. |
+| `/style-element` | `ensureStyleElement(elementId, text)` + `SWATCHBOOK_STYLE_ELEMENT_ID` | Idempotent `<style>` injector, shared between the addon's preview decorator and the blocks-side stylesheet path. |
 
 ```ts
 import { resolveAt, getVariance } from '@unpunnyfuns/swatchbook-core/graph';
@@ -99,15 +99,15 @@ import { snapshotForWire } from '@unpunnyfuns/swatchbook-core/snapshot-for-wire'
 
 ## Graph queries
 
-`@unpunnyfuns/swatchbook-core/graph` exports the full set of graph query helpers. All are browser-safe — no `@terrazzo/parser`, no `node:*` imports. Import from this subpath whenever resolution or variance queries are needed outside the Node build context (the preview, the Storybook manager, integrations).
+`@unpunnyfuns/swatchbook-core/graph` exports the full set of graph query helpers. All are browser-safe: no `@terrazzo/parser`, no `node:*` imports. Import from this subpath whenever resolution or variance queries are needed outside the Node build context (the preview, the Storybook manager, integrations).
 
 | Export | Signature | Description |
 | --- | --- | --- |
 | `resolveAt` | `(graph, path, tuple) → SwatchbookToken \| undefined` | Resolved leaf value for one token at a given tuple. Memoizable across calls with the same shared `memo` map. |
 | `resolveAllAt` | `(graph, tuple) → TokenMap` | Resolved `TokenMap` for every path in the graph at a given tuple. |
-| `resolveAliasAt` | `(graph, path, tuple) → SwatchbookToken \| undefined` | Alias-preserving view — stops at the first alias/partial-alias write and returns a token with `aliasOf` populated rather than recursing to a leaf. |
+| `resolveAliasAt` | `(graph, path, tuple) → SwatchbookToken \| undefined` | Alias-preserving view; stops at the first alias/partial-alias write and returns a token with `aliasOf` populated rather than recursing to a leaf. |
 | `resolveAliasAllAt` | `(graph, tuple) → TokenMap` | Full `TokenMap` with alias-preserving view for every path. |
-| `getVariance` | `(graph, path) → AxisVarianceResult` | `AxisVarianceResult` (whether the token's value changes across axes, and which axes) for one token path — which axes affect it, and the stringified value per context per axis. |
+| `getVariance` | `(graph, path) → AxisVarianceResult` | `AxisVarianceResult` (whether the token's value changes across axes, and which axes) for one token path: which axes affect it, and the stringified value per context per axis. |
 | `getAffectedBy` | `(graph, path) → readonly string[]` | Set of axis names that can change this token's resolved value at any tuple. |
 | `listPaths` | `(graph) → readonly string[]` | Sorted array of every token path in the graph. |
 
@@ -134,7 +134,7 @@ const paths = listPaths(project.tokenGraph);
 
 ### `CHROME_ROLES`
 
-Frozen list of the ten role names that block chrome reads from. Independent of `config.cssVarPrefix` — these always live under the `--swatchbook-*` namespace so blocks remain stylable regardless of consumer prefix.
+Frozen list of the ten role names that block chrome reads from. Independent of `config.cssVarPrefix`: these always live under the `--swatchbook-*` namespace so blocks remain stylable regardless of consumer prefix.
 
 ```ts
 import { CHROME_ROLES } from '@unpunnyfuns/swatchbook-core';
@@ -187,7 +187,7 @@ interface ResolverConfig extends CommonConfig {
 
 ### `LayeredConfig`
 
-Authored layered axes — per-context overlay globs that layer onto the base `tokens`. The base `tokens` is required.
+Authored layered axes: per-context overlay globs that layer onto the base `tokens`. The base `tokens` is required.
 
 ```ts
 interface LayeredConfig extends CommonConfig {
@@ -293,7 +293,7 @@ interface TokenGraph {
 }
 ```
 
-Walkable graph keyed by token path. JSON-serializable — no Maps or Sets — so the same shape works on Node and in the browser. `axisDefaults` and `axisContexts` carry enough axis metadata for variance queries without needing the original `Axis[]` array.
+Walkable graph keyed by token path. JSON-serializable (no Maps or Sets) so the same shape works on Node and in the browser. `axisDefaults` and `axisContexts` carry enough axis metadata for variance queries without needing the original `Axis[]` array.
 
 ### `TokenGraphNode`
 
@@ -314,7 +314,7 @@ Per-token-path node. `baselineValue` is the resolved leaf at the default tuple. 
 
 ### `TokenListingByPath`
 
-Path-indexed alias over `@terrazzo/plugin-token-listing`'s `ListedToken` shape. Node-side code reads the raw `ListedToken` shape (`listing[path].$extensions['app.terrazzo.listing'].names.css`). Blocks receive the slimmed snapshot form where the access path is `listing[path].names.css` — block authors should call `resolveCssVar(path, project)` rather than indexing the path manually. The full entry carries `originalValue` (pre-resolution, aliases preserved) and `source.loc` (file + line range pointing at the authoring source).
+Path-indexed alias over `@terrazzo/plugin-token-listing`'s `ListedToken` shape. Node-side code reads the raw `ListedToken` shape (`listing[path].$extensions['app.terrazzo.listing'].names.css`). Blocks receive the slimmed snapshot form where the access path is `listing[path].names.css`; block authors should call `resolveCssVar(path, project)` rather than indexing the path manually. The full entry carries `originalValue` (pre-resolution, aliases preserved) and `source.loc` (file + line range pointing at the authoring source).
 
 ```ts
 type TokenListingByPath = Record<string, ListedToken>;
@@ -442,8 +442,8 @@ The shape of `project.resolveAt`.
 
 ## Do / don't
 
-- ✅ Use this package at build time — Node scripts, SSR, Storybook presets. It has no DOM dependency.
-- ✅ Ship `project.tokenGraph` to the browser via [`/snapshot-for-wire`](#browser-safe-subpaths) — `TokenGraph` is JSON-serializable. Query it on the browser side with the [`/graph`](#graph-queries) helpers.
+- ✅ Use this package at build time: Node scripts, SSR, Storybook presets. It has no DOM dependency.
+- ✅ Ship `project.tokenGraph` to the browser via [`/snapshot-for-wire`](#browser-safe-subpaths); `TokenGraph` is JSON-serializable. Query it on the browser side with the [`/graph`](#graph-queries) helpers.
 - ✅ Use `getVariance(graph, path)` from `/graph` for per-token variance classification.
 - ❌ Don't import from `@terrazzo/parser` directly unless you need features core doesn't expose.
-- ❌ Don't ship the full `Project` object to the browser — `resolveAt` is a function and `cwd` is a Node-side absolute path. Use `snapshotForWire(project, css)` to get a JSON-friendly subset.
+- ❌ Don't ship the full `Project` object to the browser: `resolveAt` is a function and `cwd` is a Node-side absolute path. Use `snapshotForWire(project, css)` to get a JSON-friendly subset.

--- a/apps/docs/docs/reference/diagnostics.mdx
+++ b/apps/docs/docs/reference/diagnostics.mdx
@@ -10,7 +10,7 @@ Swatchbook surfaces load-time and runtime problems as `Diagnostic` entries on `P
 
 - **The Design Tokens panel** in Storybook, live, while you author.
 - **`Project.diagnostics`** on the loaded project, for programmatic consumers (build scripts, tests, CI checks).
-- **The terminal** when `loadProject` runs outside Storybook — preset boot, MCP server start, the docs site's build.
+- **The terminal** when `loadProject` runs outside Storybook: preset boot, MCP server start, the docs site's build.
 
 This page catalogs every diagnostic group the core emits, what triggers each known message, and what to check when one fires.
 
@@ -26,9 +26,9 @@ interface Diagnostic {
 }
 ```
 
-`severity` follows the usual gradient. `error` means something downstream cannot be done correctly (e.g. an alias target that doesn't exist — the walker has nothing to resolve to). `warn` means the load completed but a piece of input was dropped, partial, or structurally suspect. `info` is informational and rarely fires.
+`severity` follows the usual gradient. `error` means something downstream cannot be done correctly (e.g. an alias target that doesn't exist, so the walker has nothing to resolve to). `warn` means the load completed but a piece of input was dropped, partial, or structurally suspect. `info` is informational and rarely fires.
 
-`group` is namespaced by feature area (`swatchbook/<area>`). It's stable across releases — consumers can filter on it.
+`group` is namespaced by feature area (`swatchbook/<area>`). It's stable across releases, so consumers can filter on it.
 
 `filename` / `line` are present when the parser knows the authoring source location. Token-tree diagnostics usually carry them; configuration diagnostics generally don't.
 
@@ -39,16 +39,16 @@ Graph construction and walker integrity. Fires during `loadProject` once the par
 | Severity | When it fires | What to check |
 |---|---|---|
 | `error` | A modifier writes a token as an alias to a target path that isn't defined in any baseline or modifier. Walker has no resolution to fall back to. | The alias target spelling. The set of files the resolver actually loads. |
-| `error` | Graph build itself threw. The graph is empty; `resolveAt()` returns baseline-only values. | The cause string in the message — usually a malformed token shape that escaped the parser's own validation. |
-| `warn` | An alias cycle was detected. The walker returns the baseline literal at the cycle entry. | The chain printed in the message — at least one link in it is the unintended loop. |
+| `error` | Graph build itself threw. The graph is empty; `resolveAt()` returns baseline-only values. | The cause string in the message, usually a malformed token shape that escaped the parser's own validation. |
+| `warn` | An alias cycle was detected. The walker returns the baseline literal at the cycle entry. | The chain printed in the message; at least one link in it is the unintended loop. |
 | `warn` | A color token's `$value` has a `components` field that isn't a numeric array (missing, or some other type). CSS emission will fail for any context that resolves to this token. | The token's `$value.components` field in its source. Color tokens in DTCG object form require `components: [number, ...]`. |
-| `warn` | A color token's `components` field carries an unresolved DTCG `$ref` object — a JSON Pointer the upstream parser did not substitute. | That the JSON Pointer resolves against the rest of the token tree. If yes, the parser version handles `$ref` into non-Object targets. |
+| `warn` | A color token's `components` field carries an unresolved DTCG `$ref` object, a JSON Pointer the upstream parser did not substitute. | That the JSON Pointer resolves against the rest of the token tree. If yes, the parser version handles `$ref` into non-Object targets. |
 
 The two warnings about color shape (`structurally invalid` and `Unresolved $ref`) are belt-and-braces for the same emit-time failure: colorjs.io's `coords.map is not a function`. Both fire at load time so the panel surfaces them before any block tries to render the offending token.
 
 ## `swatchbook/listing`
 
-Token Listing build problems. Fires when `loadProject` runs the in-memory `@terrazzo/plugin-token-listing` build to populate `listing[path]`. All severities are `warn` — when the listing build fails, blocks fall back to raw value display rather than aborting.
+Token Listing build problems. Fires when `loadProject` runs the in-memory `@terrazzo/plugin-token-listing` build to populate `listing[path]`. All severities are `warn`: when the listing build fails, blocks fall back to raw value display rather than aborting.
 
 | When it fires | What to check |
 |---|---|
@@ -56,7 +56,7 @@ Token Listing build problems. Fires when `loadProject` runs the in-memory `@terr
 | The listing build wrote no `tokens.listing.json` output file. | The plugin's configuration. The listing plugin needs to be installed and present in the internal plugin set. |
 | The listing JSON had no `data` array. | The plugin version. Format compatibility is `0.1.0-alpha.x`; a major version change in the plugin's output shape can produce this. |
 
-`<TokenTable>` and `<ColorTable>` previews fall back to raw values — they remain readable, but per-platform name columns are blank.
+`<TokenTable>` and `<ColorTable>` previews fall back to raw values; they remain readable, but per-platform name columns are blank.
 
 ## `swatchbook/css-options`
 
@@ -66,7 +66,7 @@ Token Listing build problems. Fires when `loadProject` runs the in-memory `@terr
 |---|---|---|
 | `warn` | Any of `cssOptions.baseSelector`, `cssOptions.baseScheme`, or `cssOptions.modeSelectors` is set. Swatchbook drives emission through its own permutations API and ignores these. | Whether the value is intentional. If the consumer's production CLI build needs these, set them on the production config and leave them off `cssOptions`. The [Aligning with your token build](../guides/sharing-terrazzo-options.mdx) guide describes the split. |
 
-A separate set of `cssOptions` fields (`variableName`, `permutations`, `filename`, `skipBuild`) is fully stripped before being passed to the internal `plugin-css` build — those don't emit a diagnostic.
+A separate set of `cssOptions` fields (`variableName`, `permutations`, `filename`, `skipBuild`) is fully stripped before being passed to the internal `plugin-css` build; those don't emit a diagnostic.
 
 ## `swatchbook/chrome`
 
@@ -96,7 +96,7 @@ A separate set of `cssOptions` fields (`variableName`, `permutations`, `filename
 
 ## `swatchbook/default`
 
-`config.default` validation. Same shape as preset validation — invalid entries are tolerant-dropped to the axis's own default rather than failing the load.
+`config.default` validation. Same shape as preset validation: invalid entries are tolerant-dropped to the axis's own default rather than failing the load.
 
 | Severity | When it fires | What to check |
 |---|---|---|
@@ -124,16 +124,16 @@ swatchbook: failed to transform token "<path>" at permutation <tuple>.
 
 The fields:
 
-- **`<path>`** — the token's path identifier, dot-separated.
-- **`<tuple>`** — the active axis-tuple as a JSON object. Every axis in the project appears with its context value.
-- **`$type`** — the token's DTCG `$type`.
-- **`$value`** — the serialized `$value` at this tuple, as it was when the failure happened.
-- **`cause`** — the original error message. The original error object is attached to `err.cause` for stack-walking.
+- **`<path>`**: the token's path identifier, dot-separated.
+- **`<tuple>`**: the active axis-tuple as a JSON object. Every axis in the project appears with its context value.
+- **`$type`**: the token's DTCG `$type`.
+- **`$value`**: the serialized `$value` at this tuple, as it was when the failure happened.
+- **`cause`**: the original error message. The original error object is attached to `err.cause` for stack-walking.
 
 This wrap turns colorjs.io-style tracebacks (`coords.map is not a function`, four frames deep in a third-party library) into a single actionable line of forensic detail. The `swatchbook/token-graph` load-time validators catch most malformed-shape causes before they reach emit; the wrap catches the rest.
 
 ## See also
 
-- [Project.diagnostics](./core.mdx) — programmatic access to the full diagnostic array.
-- [The token pipeline](./token-pipeline.mdx) — where in the load flow each diagnostic fires.
-- [Aligning with your token build](../guides/sharing-terrazzo-options.mdx) — the `swatchbook/css-options` warning in context.
+- [Project.diagnostics](./core.mdx): programmatic access to the full diagnostic array.
+- [The token pipeline](./token-pipeline.mdx): where in the load flow each diagnostic fires.
+- [Aligning with your token build](../guides/sharing-terrazzo-options.mdx): the `swatchbook/css-options` warning in context.

--- a/apps/docs/docs/reference/mcp.mdx
+++ b/apps/docs/docs/reference/mcp.mdx
@@ -6,11 +6,11 @@ sidebar_position: 4
 
 # MCP server
 
-Published as `@unpunnyfuns/swatchbook-mcp`. [Model Context Protocol](https://modelcontextprotocol.io/) server for swatchbook — exposes a DTCG project's tokens, axes, and diagnostics to AI agents without running Storybook.
+Published as `@unpunnyfuns/swatchbook-mcp`. [Model Context Protocol](https://modelcontextprotocol.io/) server for swatchbook. Exposes a DTCG project's tokens, axes, and diagnostics to AI agents without running Storybook.
 
 ## What it's for
 
-Agents that need to reason about your design tokens — figma-to-token round-trips, alias-chain navigation, CI lint hooks, AI-assisted authoring — without spinning up a Storybook iframe. Point it at a `swatchbook.config.{ts,mts,js,mjs}` or a bare DTCG `resolver.json` and it parses the project on startup, then answers MCP tool calls against the resolved graph.
+Agents that need to reason about your design tokens (figma-to-token round-trips, alias-chain navigation, CI lint hooks, AI-assisted authoring) without spinning up a Storybook iframe. Point it at a `swatchbook.config.{ts,mts,js,mjs}` or a bare DTCG `resolver.json` and it parses the project on startup, then answers MCP tool calls against the resolved graph.
 
 ## Install
 
@@ -18,7 +18,7 @@ Agents that need to reason about your design tokens — figma-to-token round-tri
 npm install -D @unpunnyfuns/swatchbook-mcp
 ```
 
-Or run straight from `npx` — the package ships a `swatchbook-mcp` bin.
+Or run straight from `npx`; the package ships a `swatchbook-mcp` bin.
 
 ## Run
 
@@ -34,7 +34,7 @@ CLI flags:
 
 | Flag               | What                                                                                                                             |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `--config <path>`  | Required. A `swatchbook.config.{ts,mts,js,mjs}` (full config) or a DTCG `resolver.json` (bare — other options at defaults).       |
+| `--config <path>`  | Required. A `swatchbook.config.{ts,mts,js,mjs}` (full config) or a DTCG `resolver.json` (bare, other options at defaults).       |
 | `--cwd <path>`     | Override the working directory for resolving relative `resolver` / `tokens` paths.                                                |
 | `--no-watch`       | Disable live-reload. By default the server watches the config + resolved source files and swaps in fresh data on edits.           |
 | `--help`, `-h`     | Print usage and exit.                                                                                                             |
@@ -59,7 +59,7 @@ Add an entry to the client's MCP server config:
 }
 ```
 
-The `mcpServers` shape is the same across MCP hosts; consult the host's docs for where its config file lives. Restart the client and ask it about your tokens — it'll call `describe_project` first, then drill into whatever you asked about.
+The `mcpServers` shape is the same across MCP hosts; consult the host's docs for where its config file lives. Restart the client and ask it about your tokens; it'll call `describe_project` first, then drill into whatever you asked about.
 
 ## Tools
 
@@ -71,14 +71,14 @@ The `mcpServers` shape is the same across MCP hosts; consult the host's docs for
 | `resolve_theme`       | `tuple`, `filter?`, `type?`                               | Resolved token map for an axis tuple (`{ mode: "Dark", brand: "…" }`). Fills omitted axes from defaults.      |
 | `get_token`           | `path`                                                    | Full detail: per-theme value, alias chain, aliased-by list, CSS var reference.                                |
 | `get_alias_chain`     | `path`                                                    | Forward alias chain per theme (`path → ... → primitive`). Empty when the token is a primitive.                |
-| `get_aliased_by`      | `path`, `maxDepth?`                                       | Backward alias tree — every token that resolves through this path. Shallower aliases first; cycles in the alias graph are caught and broken.       |
+| `get_aliased_by`      | `path`, `maxDepth?`                                       | Backward alias tree: every token that resolves through this path. Shallower aliases first; cycles in the alias graph are caught and broken.       |
 | `get_consumer_output` | `path`, `tuple?`                                          | CSS var, resolved value, compound `[data-…]` selector + HTML attrs needed to pin the tuple on `<html>`.        |
 | `get_color_formats`   | `path`, `theme?`                                          | Color token rendered in `hex` / `rgb` / `hsl` / `oklch` / `raw`, each with an `outOfGamut` flag.                |
-| `get_color_contrast`  | `foreground`, `background`, `theme?`, `algorithm?`        | Pair-wise contrast between two color tokens. Returns the score under `value` — `wcag21` → ratio (1–21) + AA/AAA pass flags (normal + large text); `apca` → signed Lc + body / large-text / non-text pass flags. |
+| `get_color_contrast`  | `foreground`, `background`, `theme?`, `algorithm?`        | Pair-wise contrast between two color tokens. Returns the score under `value`: `wcag21` → ratio (1–21) + AA/AAA pass flags (normal + large text); `apca` → signed Lc + body / large-text / non-text pass flags. |
 | `get_axis_variance`   | `path`                                                    | Classify how the token's resolved value depends on each axis. Returns `kind` (`constant` / `single` / `multi`), varying vs constant axes, and a per-axis breakdown with the value seen in each context. |
 | `list_axes`           | (none)                                                    | Axes + contexts + themes + presets from the project config.                                                   |
 | `get_diagnostics`     | `severity?` `'error' \| 'warn' \| 'info'`                 | Parser / resolver / validation diagnostics.                                                                   |
-| `emit_css`            | (none)                                                    | Full project stylesheet — `:root` default + per-tuple compound-selector blocks.                                |
+| `emit_css`            | (none)                                                    | Full project stylesheet: `:root` default + per-tuple compound-selector blocks.                                |
 
 Path globs accept `*` (one segment), `**` (any number of segments trailing or mid-path), or exact dot-paths.
 
@@ -95,10 +95,10 @@ const server = createServer(project);
 await server.connect(new StdioServerTransport());
 ```
 
-`loadFromConfig` accepts the same `.ts` / `.mts` / `.js` / `.mjs` / `.json` shapes the CLI does. `createServer(project)` returns the server augmented with `setProject(next)` — call it after re-loading the project to swap in fresh data without restarting the MCP transport. The CLI uses this to live-reload on token edits.
+`loadFromConfig` accepts the same `.ts` / `.mts` / `.js` / `.mjs` / `.json` shapes the CLI does. `createServer(project)` returns the server augmented with `setProject(next)`; call it after re-loading the project to swap in fresh data without restarting the MCP transport. The CLI uses this to live-reload on token edits.
 
 ## See also
 
-- [`@unpunnyfuns/swatchbook-core`](./core.mdx) — the loader this server wraps.
-- [Model Context Protocol](https://modelcontextprotocol.io/) — upstream spec.
-- [MCP Inspector](https://github.com/modelcontextprotocol/inspector) — web UI to poke the server interactively.
+- [`@unpunnyfuns/swatchbook-core`](./core.mdx): the loader this server wraps.
+- [Model Context Protocol](https://modelcontextprotocol.io/): upstream spec.
+- [MCP Inspector](https://github.com/modelcontextprotocol/inspector): web UI to poke the server interactively.

--- a/apps/docs/docs/reference/switcher.mdx
+++ b/apps/docs/docs/reference/switcher.mdx
@@ -6,9 +6,9 @@ sidebar_position: 3
 
 # Switcher
 
-Published as `@unpunnyfuns/swatchbook-switcher`. Framework-agnostic React component that draws the theme-switcher menu — preset pills, one row per axis, an optional footer for host-specific controls. The Storybook addon's toolbar mounts it inside a popover; the docs site's navbar mounts the same component. Reach for this package directly when you want the switcher on a non-Storybook surface.
+Published as `@unpunnyfuns/swatchbook-switcher`. Framework-agnostic React component that draws the theme-switcher menu: preset pills, one row per axis, an optional footer for host-specific controls. The Storybook addon's toolbar mounts it inside a popover; the docs site's navbar mounts the same component. Reach for this package directly when you want the switcher on a non-Storybook surface.
 
-Most consumers pick it up transitively via `@unpunnyfuns/swatchbook-addon` — `import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` works without adding a sibling dependency. Install directly when you're outside Storybook (Docusaurus, Next.js, a vanilla React app).
+Most consumers pick it up transitively via `@unpunnyfuns/swatchbook-addon`; `import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` works without adding a sibling dependency. Install directly when you're outside Storybook (Docusaurus, Next.js, a vanilla React app).
 
 ## Install
 
@@ -22,7 +22,7 @@ Peer requirements: React 18+. The package ships its own stylesheet at `dist/styl
 import '@unpunnyfuns/swatchbook-switcher/style.css';
 ```
 
-The component is a *menu*, not a *button*. It draws no trigger of its own — you decide when it's visible (popover, drawer, inline) and how the active tuple gets applied.
+The component is a *menu*, not a *button*. It draws no trigger of its own; you decide when it's visible (popover, drawer, inline) and how the active tuple gets applied.
 
 ## Mount example
 
@@ -68,9 +68,9 @@ export function MySwitcher({ axes, presets, defaults }) {
 }
 ```
 
-The pattern is identical across hosts — only the surrounding chrome changes (Docusaurus navbar plugin, a Next.js layout component, an emotion-themed React app). The component never reaches into the DOM itself, so wherever the `data-<prefix>-<axis>` attributes need to land is up to the caller.
+The pattern is identical across hosts; only the surrounding chrome changes (Docusaurus navbar plugin, a Next.js layout component, an emotion-themed React app). The component never reaches into the DOM itself, so wherever the `data-<prefix>-<axis>` attributes need to land is up to the caller.
 
-For a working example, the docs site you're reading mounts `<ThemeSwitcher>` inside the navbar — see [`apps/docs/src/components/SwatchbookSwitcherButton.tsx`](https://github.com/unpunnyfuns/swatchbook/blob/main/apps/docs/src/components/SwatchbookSwitcherButton.tsx) for the full popover-trigger setup, including `aria-haspopup` / `aria-expanded` wiring on the trigger button.
+For a working example, the docs site you're reading mounts `<ThemeSwitcher>` inside the navbar; see [`apps/docs/src/components/SwatchbookSwitcherButton.tsx`](https://github.com/unpunnyfuns/swatchbook/blob/main/apps/docs/src/components/SwatchbookSwitcherButton.tsx) for the full popover-trigger setup, including `aria-haspopup` / `aria-expanded` wiring on the trigger button.
 
 ## Props
 
@@ -95,9 +95,9 @@ interface ThemeSwitcherProps {
 | `activeTuple` | yes | Active axis selections, keyed by axis name. Drives which pill in each axis row is `--active`. |
 | `defaults` | yes | Fallback values used to fill in axes a preset doesn't explicitly set. |
 | `lastApplied` | yes | Name of the most recently applied preset, or `null`. Drives the "modified since applied" dot. |
-| `onAxisChange` | yes | Receives `(axisName, next)` when the user clicks an axis pill. Caller decides what "applied" means — set `data-*` attributes, route, write to global state. |
+| `onAxisChange` | yes | Receives `(axisName, next)` when the user clicks an axis pill. Caller decides what "applied" means: set `data-*` attributes, route, write to global state. |
 | `onPresetApply` | yes | Receives the full preset object when a preset pill is clicked. Caller fills in omitted axes from `defaults` and applies the resulting tuple. |
-| `onKeyDown` | no | Optional key handler — typically used by hosts to close their popover on `Escape`. |
+| `onKeyDown` | no | Optional key handler, typically used by hosts to close their popover on `Escape`. |
 | `footer` | no | Host-specific node rendered after the axes (e.g. the Storybook addon's color-format picker). The switcher itself ships no color-format UI. |
 
 ## Input shapes
@@ -118,7 +118,7 @@ interface SwitcherPreset {
 }
 ```
 
-`SwitcherAxis` and `SwitcherPreset` are structurally compatible with `Project.axes` / `Project.presets` from `@unpunnyfuns/swatchbook-core` — pass them through unchanged. The shapes are re-declared in the switcher package so it stays framework-agnostic and doesn't pull `core` as a runtime dependency.
+`SwitcherAxis` and `SwitcherPreset` are structurally compatible with `Project.axes` / `Project.presets` from `@unpunnyfuns/swatchbook-core`; pass them through unchanged. The shapes are re-declared in the switcher package so it stays framework-agnostic and doesn't pull `core` as a runtime dependency.
 
 ## `presetTuple(preset, axes, defaults)`
 
@@ -130,7 +130,7 @@ function presetTuple(
 ): Record<string, string>;
 ```
 
-Compose a preset's sanitized partial tuple with the axis defaults — the omitted axes fall back to their defaults, and any context the preset names that isn't listed on its axis is silently dropped. Mirrors the preview decorator's own fallback logic so what a host sends out matches what the preview honors.
+Compose a preset's sanitized partial tuple with the axis defaults: the omitted axes fall back to their defaults, and any context the preset names that isn't listed on its axis is silently dropped. Mirrors the preview decorator's own fallback logic so what a host sends out matches what the preview honors.
 
 The Storybook addon's manager toolbar imports this directly to avoid carrying a byte-identical local copy; other hosts that apply presets through their own pathway are welcome to.
 
@@ -144,13 +144,13 @@ The component is *pure*: it reads its inputs, draws the menu, and calls back whe
 
 That makes it portable but also means the host owns the policy for what "applying a preset" or "switching an axis" actually does. The two common shapes:
 
-- **Attribute on `<html>`** — set `data-<prefix>-<axis>` on `document.documentElement` per change. Pairs with `cssVarPrefix` from `loadProject` so emitted CSS targets the same selectors. The Storybook addon and the docs-site switcher both use this.
-- **Class on `<body>`** — toggle `theme-<value>` on `document.body.classList`. Useful if the project's stylesheet uses class-based scoping instead of attribute selectors.
+- **Attribute on `<html>`**: set `data-<prefix>-<axis>` on `document.documentElement` per change. Pairs with `cssVarPrefix` from `loadProject` so emitted CSS targets the same selectors. The Storybook addon and the docs-site switcher both use this.
+- **Class on `<body>`**: toggle `theme-<value>` on `document.body.classList`. Useful if the project's stylesheet uses class-based scoping instead of attribute selectors.
 
 Persisting across reloads is also up to the host. The Storybook addon piggybacks on Storybook's globals API; the docs-site switcher syncs with Docusaurus's `useColorMode` for `mode` and persists the rest via `localStorage`.
 
 ## Styling hooks
 
-The component renders within a fixed `.sb-switcher` container. Class names follow BEM-style namespacing (`.sb-switcher__pill`, `.sb-switcher__section-label`, `.sb-switcher__divider`, …). Visual polish — surface, border, focus ring — comes from the bundled `style.css`.
+The component renders within a fixed `.sb-switcher` container. Class names follow BEM-style namespacing (`.sb-switcher__pill`, `.sb-switcher__section-label`, `.sb-switcher__divider`, …). Visual polish (surface, border, focus ring) comes from the bundled `style.css`.
 
 For deeper restyling, target the class names from your own stylesheet after the bundled one has loaded. The chrome variables (`--swatchbook-*`) the blocks use are not consumed here; the switcher's surface is intentionally self-contained.

--- a/apps/docs/docs/reference/token-pipeline.mdx
+++ b/apps/docs/docs/reference/token-pipeline.mdx
@@ -39,24 +39,24 @@ Nothing written to disk. Edit your config or a token file, Vite notices, the plu
 
 ## HMR
 
-The Vite plugin watches every file your config loaded (the resolver, every `$ref` target, every token file the globs matched) and triggers a reload on any change. Reload is cheap — one `loadProject` call and one module invalidation, not a full-page reload — so the preview re-renders in place without losing toolbar state, story args, or scroll position.
+The Vite plugin watches every file your config loaded (the resolver, every `$ref` target, every token file the globs matched) and triggers a reload on any change. Reload is cheap (one `loadProject` call and one module invalidation, not a full-page reload), so the preview re-renders in place without losing toolbar state, story args, or scroll position.
 
 A short-form HMR event rides Storybook's channel to push the fresh snapshot into running blocks. Token graph updates in under a second on a typical save; edit a token with the [live Storybook](pathname:///storybook/) open to see it.
 
-See [consuming the active theme](../guides/consuming-the-active-theme.mdx) for how stories react to axis flips — related but distinct plumbing.
+See [consuming the active theme](../guides/consuming-the-active-theme.mdx) for how stories react to axis flips: related but distinct plumbing.
 
 ## Not a production theming API
 
-The virtual module lives inside Vite's module graph — the Storybook preview resolves it, consumer apps (Next.js, a Vite SPA, Remix) don't. For production, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources; its plugin ecosystem (`plugin-css`, `plugin-js`, `plugin-tailwind`, `plugin-swift`, `plugin-sass`, …) covers downstream platforms. When both pipelines run, [align their options](../guides/sharing-terrazzo-options.mdx) so what swatchbook shows matches what your apps ship.
+The virtual module lives inside Vite's module graph: the Storybook preview resolves it, consumer apps (Next.js, a Vite SPA, Remix) don't. For production, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources; its plugin ecosystem (`plugin-css`, `plugin-js`, `plugin-tailwind`, `plugin-swift`, `plugin-sass`, …) covers downstream platforms. When both pipelines run, [align their options](../guides/sharing-terrazzo-options.mdx) so what swatchbook shows matches what your apps ship.
 
 ## Where the same property holds
 
-- **Storybook preview** — the primary case.
-- **Docs site blocks outside Storybook** — the blocks package works outside Storybook given a `ProjectSnapshot` through `SwatchbookProvider`. This docs site does that: a small build step computes the snapshot JSON once and ships it as a regular import.
-- **MCP server** — `@unpunnyfuns/swatchbook-mcp` loads the project directly via `loadProject` at startup, exposes its tools against the in-memory graph, watches the same source files for live reload. No intermediate build step.
+- **Storybook preview**: the primary case.
+- **Docs site blocks outside Storybook**: the blocks package works outside Storybook given a `ProjectSnapshot` through `SwatchbookProvider`. This docs site does that: a small build step computes the snapshot JSON once and ships it as a regular import.
+- **MCP server**: `@unpunnyfuns/swatchbook-mcp` loads the project directly via `loadProject` at startup, exposes its tools against the in-memory graph, watches the same source files for live reload. No intermediate build step.
 
 ## Sharp edges
 
-- The virtual module is **addon-internal plumbing**. Its shape, export set, and event names can change between minor versions without a changeset entry. Consumers shouldn't import from `virtual:swatchbook/tokens` directly — use `SwatchbookProvider` + the exported hooks.
-- **Vite is required.** The addon bundles the plugin for Storybook's Vite integration. Webpack-based Storybook setups don't get the virtual module materialized; they'd fall back to a pre-built snapshot or switch to the Vite builder. Storybook 10's default is Vite, so this only bites older setups.
+- The virtual module is **addon-internal plumbing**. Its shape, export set, and event names can change between minor versions without a changeset entry. Consumers shouldn't import from `virtual:swatchbook/tokens` directly; use `SwatchbookProvider` + the exported hooks.
+- **Vite is required.** The addon bundles the plugin for Storybook's Vite integration. Webpack-based Storybook setups don't get the virtual module materialized; they would fall back to a pre-built snapshot or switch to the Vite builder. Storybook 10's default is Vite, so this only bites older setups.
 - File-system edits flow through a **dir-level `fs.watch`** (not a file-level watcher) so atomic-save editors survive.

--- a/apps/storybook/README.md
+++ b/apps/storybook/README.md
@@ -1,73 +1,18 @@
-# React + TypeScript + Vite
+# swatchbook storybook
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The reference Storybook for swatchbook. It exercises the addon and doc blocks against the repo's own [`@unpunnyfuns/swatchbook-tokens`](../../packages/tokens) dogfood token set, doubling as a manual proving ground and the source for the published reference build.
 
-Currently, two official plugins are available:
+Private workspace package. Not published.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Run
 
-## React Compiler
-
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```sh
+pnpm storybook          # dev server on :6006
+pnpm test:storybook     # story-level interaction tests via Vitest
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+From the repo root, `pnpm dev` runs this through Turborepo.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Documentation
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) hosts the concepts, guides, and full API reference. The published reference build lives at [/storybook](https://unpunnyfuns.github.io/swatchbook/storybook/).

--- a/apps/storybook/src/docs/Borders.mdx
+++ b/apps/storybook/src/docs/Borders.mdx
@@ -5,7 +5,7 @@ import { BorderPreview, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
 # Borders
 
-DTCG `border` tokens compose `width`, `style`, and `color` — emitted as a
+DTCG `border` tokens compose `width`, `style`, and `color`, emitted as a
 CSS `border` shorthand. Color typically aliases into `color.border.*`
 so mode changes repaint the stroke.
 

--- a/apps/storybook/src/docs/Colors.mdx
+++ b/apps/storybook/src/docs/Colors.mdx
@@ -7,14 +7,14 @@ import { ColorPalette, ColorTable, OpacityScale, TokenTable } from '@unpunnyfuns
 
 Color tokens split into two groups under the `color.*` root:
 
-- **`color.palette.*`** — raw hue primitives (`blue.500`, `neutral.0`,
+- **`color.palette.*`**: raw hue primitives (`blue.500`, `neutral.0`,
   `red.100`, …). No aliases, theme-invariant.
-- **`color.<role>.*`** — semantic roles (`surface.default`, `text.muted`,
+- **`color.<role>.*`**: semantic roles (`surface.default`, `text.muted`,
   `accent.bg`, `border.default`, `status.success-bg`). Each role aliases
   into `color.palette.*` and carries mode- and brand-varied values
   through the resolver.
 
-Component styling reads the role paths directly — variation is handled
+Component styling reads the role paths directly. Variation is handled
 by the active `mode × brand × contrast` tuple, flowing through the
 modifier overlays.
 
@@ -52,6 +52,8 @@ under each status name.
     subtle: 'subtle',
     inverse: 'inverse',
     accent: 'accent',
+    danger: 'danger',
+    success: 'success',
   }}
 />
 
@@ -73,20 +75,20 @@ not when styling components directly.
 
 ## Raw table
 
-The same tokens as rows with resolved values, types, and CSS var names —
+The same tokens as rows with resolved values, types, and CSS var names,
 handy when you know the path you're looking for.
 
 <TokenTable filter="color.**" type="color" />
 
 ## Opacity
 
-Opacity tokens live under `number.opacity.*` — `$type: 'number'`, values
-in `[0, 1]`. The bare number (`0.4`) tells you less than the visible
+Opacity tokens live under `number.opacity.*` (`$type: 'number'`, values
+in `[0, 1]`). The bare number (`0.4`) tells you less than the visible
 effect; `<OpacityScale>` renders each token as the sample colour at that
 opacity over a checkerboard so the transparency reads.
 
 <OpacityScale filter="number.opacity.**" />
 
 The swatch colour is `color.accent.bg` by default. Pass `sampleColor` to
-demo the token against whatever surface role matters — scrims against
+demo the token against whatever surface role matters: scrims against
 `color.text.inverse`, muted text against `color.text.default`, etc.

--- a/apps/storybook/src/docs/Dashboard.mdx
+++ b/apps/storybook/src/docs/Dashboard.mdx
@@ -5,8 +5,7 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 
 # Dashboard
 
-A sample composition that allows users to navigate. Flip permutations from the toolbar — every block below
-re-renders against the active tuple.
+A sample composition that wires the diagnostics, token-graph, and full-listing blocks into one browsable view. Flip permutations from the toolbar and every block below re-renders against the active tuple.
 
 ## Diagnostics
 

--- a/apps/storybook/src/docs/Dimensions.mdx
+++ b/apps/storybook/src/docs/Dimensions.mdx
@@ -5,7 +5,7 @@ import { DimensionScale, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 
 # Dimensions
 
-DTCG `dimension` tokens are `{ value, unit }` objects — most of the scale
+DTCG `dimension` tokens are `{ value, unit }` objects; most of the scale
 is in `px` / `rem`. The reference fixture splits dimensions into two
 groups: **`space.*`** (layout spacing) and **`radius.*`** (border
 radii). Size primitives live under `size.*`.

--- a/apps/storybook/src/docs/Fonts.mdx
+++ b/apps/storybook/src/docs/Fonts.mdx
@@ -6,7 +6,7 @@ import { FontFamilyPreview, FontWeightScale, TokenDetail } from '@unpunnyfuns/sw
 # Fonts
 
 Two primitive token types back every `typography.*` composite:
-**`fontFamily`** (a font stack — string or array) and **`fontWeight`**
+**`fontFamily`** (a font stack, string or array) and **`fontWeight`**
 (a numeric weight). This page shows both separately; see
 [Typography](?path=/docs/docs-typography--docs) for the composites that
 combine them.

--- a/apps/storybook/src/docs/Gradients.mdx
+++ b/apps/storybook/src/docs/Gradients.mdx
@@ -6,8 +6,8 @@ import { GradientPalette, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 # Gradients
 
 DTCG `gradient` tokens are arrays of `{ color, position }` stops. The
-rendering function — `linear-gradient` / `radial-gradient` / `conic-gradient`
-— is a choice the consumer makes at use-site; the token carries only the
+rendering function (`linear-gradient` / `radial-gradient` / `conic-gradient`)
+is a choice the consumer makes at use-site; the token carries only the
 stops. This showcase uses `linear-gradient(to right, …)` for previews.
 
 ## All gradients

--- a/apps/storybook/src/docs/Introduction.mdx
+++ b/apps/storybook/src/docs/Introduction.mdx
@@ -5,31 +5,31 @@ import { Meta } from '@storybook/addon-docs/blocks';
 # Swatchbook
 
 A Storybook addon and set of MDX doc blocks for **documenting DTCG
-design tokens**. This storybook is the integration testbed — it loads
-`@unpunnyfuns/swatchbook-tokens` — this repo's own DTCG token set (flat
+design tokens**. This storybook is the integration testbed. It loads
+`@unpunnyfuns/swatchbook-tokens`, this repo's own DTCG token set (flat
 per-`$type` tokens with palette primitives under `color.palette.*` and
 semantic roles at `color.<role>.*`, plus `mode × brand × contrast`
-modifier axes via a DTCG resolver) — through the addon and dogfoods every
+modifier axes via a DTCG resolver), through the addon and dogfoods every
 block in the library.
 
 ## Pages
 
-- **[Dashboard](?path=/docs/docs-dashboard--docs)** — the recommended
+- **[Dashboard](?path=/docs/docs-dashboard--docs)**: the recommended
   composition: `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />`
   on one page. This is the pattern that replaces the old in-manager
   Design Tokens panel.
-- **[Colors](?path=/docs/docs-colors--docs)** — `ColorPalette` grids.
-- **[Typography](?path=/docs/docs-typography--docs)** — `TypographyScale`
+- **[Colors](?path=/docs/docs-colors--docs)**: `ColorPalette` grids.
+- **[Typography](?path=/docs/docs-typography--docs)**: `TypographyScale`
   rendering composites with real sub-values.
-- **[Fonts](?path=/docs/docs-fonts--docs)** — `FontFamilyPreview` and
+- **[Fonts](?path=/docs/docs-fonts--docs)**: `FontFamilyPreview` and
   `FontWeightScale` for the primitives that back typography composites.
-- **[Dimensions](?path=/docs/docs-dimensions--docs)** — `DimensionScale`
+- **[Dimensions](?path=/docs/docs-dimensions--docs)**: `DimensionScale`
   for spacing and radius scales.
 - **[Borders](?path=/docs/docs-borders--docs)**,
   **[Shadows](?path=/docs/docs-shadows--docs)**,
   **[StrokeStyles](?path=/docs/docs-strokestyles--docs)**,
   **[Gradients](?path=/docs/docs-gradients--docs)**,
-  **[Motion](?path=/docs/docs-motion--docs)** — per-type preview blocks.
+  **[Motion](?path=/docs/docs-motion--docs)**: per-type preview blocks.
 
 ## Live theme switching
 
@@ -37,24 +37,24 @@ The toolbar (single icon button in the top bar) opens a popover with
 preset pills, one dropdown per modifier declared in the resolver
 (`mode`, `brand`), and a color-format picker (`hex` / `rgb` / `hsl` /
 `oklch` / `raw`). Every block on every page re-renders against the
-active tuple — and color-display formats flip live too.
+active tuple, and color-display formats flip live too.
 
 ## Blocks
 
 Every block ships from `@unpunnyfuns/swatchbook-blocks`. Highlights:
 
-- **`TokenTable`** / **`TokenNavigator`** — searchable tabular and tree
+- **`TokenTable`** / **`TokenNavigator`**: searchable tabular and tree
   views of the active theme's graph. Both carry `filter` and `sortBy`
   props for scoping and ordering.
-- **`TokenDetail`** — single-token inspector: composite preview, alias
+- **`TokenDetail`**: single-token inspector: composite preview, alias
   chain, aliased-by tree, per-axis variance matrix, CSS-var snippet.
-- **`ColorPalette`** — swatch grid, auto-groups by path depth.
-- **`TypographyScale`** / **`FontFamilyPreview`** / **`FontWeightScale`** —
+- **`ColorPalette`**: swatch grid, auto-groups by path depth.
+- **`TypographyScale`** / **`FontFamilyPreview`** / **`FontWeightScale`**:
   type primitives and composites rendered at their own values.
-- **`Diagnostics`** — collapsible list of parser/resolver warnings. Green
+- **`Diagnostics`**: collapsible list of parser/resolver warnings. Green
   OK when clean; auto-expands on errors.
 - **`DimensionScale`** / **`BorderPreview`** / **`ShadowPreview`** /
-  **`StrokeStylePreview`** / **`GradientPalette`** / **`MotionPreview`** —
+  **`StrokeStylePreview`** / **`GradientPalette`** / **`MotionPreview`**:
   per-type visual previews.
 
 See the [blocks reference](https://unpunnyfuns.github.io/swatchbook/reference/blocks)

--- a/apps/storybook/src/docs/Motion.mdx
+++ b/apps/storybook/src/docs/Motion.mdx
@@ -8,7 +8,7 @@ import { MotionPreview, TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 Three related DTCG types cover motion: **`duration`** (a time value),
 **`cubicBezier`** (a four-number easing array), and **`transition`** (a
 composite of duration + easing + optional delay). The addon respects
-`prefers-reduced-motion` — if the user has it set, the samples fall back
+`prefers-reduced-motion`: if the user has it set, the samples fall back
 to a textual placeholder.
 
 ## System transitions
@@ -24,7 +24,7 @@ speed control is global to this block.
 
 ## Easings
 
-<MotionPreview filter="easing.**" />
+<MotionPreview filter="cubicBezier.**" />
 
 ## Inspect a single token
 

--- a/apps/storybook/src/docs/StrokeStyles.mdx
+++ b/apps/storybook/src/docs/StrokeStyles.mdx
@@ -9,7 +9,7 @@ DTCG `strokeStyle` covers the CSS `border-style` keywords (`solid`,
 `dashed`, `dotted`, `double`, etc.) plus richer object forms carrying
 explicit `dashArray` / `lineCap` for SVG strokes. String-form values
 render as a literal `border-style`; object-form tokens fall back to a
-textual display — there's no pure-CSS equivalent.
+textual display; there's no pure-CSS equivalent.
 
 ## Stroke style primitives
 

--- a/apps/storybook/src/docs/Typography.mdx
+++ b/apps/storybook/src/docs/Typography.mdx
@@ -5,7 +5,7 @@ import { TokenDetail, TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
 
 # Typography
 
-Typography tokens are DTCG composites — each `$value` is an object with
+Typography tokens are DTCG composites: each `$value` is an object with
 `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, and optional
 `letterSpacing`. Every sub-value aliases into the relevant primitive
 (`font.family.sans`, `size.rem-400`, `font.weight.regular`, …).

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -2,9 +2,9 @@
 
 Storybook 10 addon for documenting DTCG design tokens.
 
-Loads your token files, resolves the alias graph, and adds a toolbar that flips the active theme tuple (`mode × brand × contrast × …`). Every story and MDX doc block re-renders against the new tuple without per-story wiring — component stories and the token reference share one source of truth.
+Loads your token files, resolves the alias graph, and adds a toolbar that flips the active theme tuple (`mode × brand × contrast × …`). Every story and MDX doc block re-renders against the new tuple without per-story wiring, so component stories and the token reference share one source of truth.
 
-Bundles MDX doc blocks (`<TokenTable />`, `<ColorPalette />`, `<TokenDetail />`, …), a standalone `<ThemeSwitcher>` for non-Storybook surfaces, and a typed `useToken()` hook for stories that need a resolved value at runtime. Re-exports [`@unpunnyfuns/swatchbook-blocks`](../blocks) and [`@unpunnyfuns/swatchbook-switcher`](../switcher) — a single install covers the whole React surface.
+Bundles MDX doc blocks (`<TokenTable />`, `<ColorPalette />`, `<TokenDetail />`, …), a standalone `<ThemeSwitcher>` for non-Storybook surfaces, and a typed `useToken()` hook for stories that need a resolved value at runtime. Re-exports [`@unpunnyfuns/swatchbook-blocks`](../blocks) and [`@unpunnyfuns/swatchbook-switcher`](../switcher), so a single install covers the whole React surface.
 
 ## Install
 
@@ -56,4 +56,4 @@ Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/
 
 ## Documentation
 
-[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/): concepts, guides, and full API reference.

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -2,9 +2,9 @@
 
 React MDX doc blocks for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-Render your DTCG tokens in `.mdx` stories — swatch grids, type-specific previews, per-token inspectors. The blocks react to the toolbar's axis flips without any wiring in your story code.
+Render your DTCG tokens in `.mdx` stories: swatch grids, type-specific previews, per-token inspectors. The blocks react to the toolbar's axis flips without any wiring in your story code.
 
-Most consumers pick this up transitively via [`@unpunnyfuns/swatchbook-addon`](../addon); `import { TokenTable } from '@unpunnyfuns/swatchbook-addon'` works out of the box. Install this package directly when you want blocks *without* the Storybook addon — unit tests, a standalone React app wrapping tokens in a custom surface.
+Most consumers pick this up transitively via [`@unpunnyfuns/swatchbook-addon`](../addon); `import { TokenTable } from '@unpunnyfuns/swatchbook-addon'` works out of the box. Install this package directly when you want blocks *without* the Storybook addon, such as unit tests or a standalone React app wrapping tokens in a custom surface.
 
 ## Install
 
@@ -39,10 +39,10 @@ Block catalogue, props, and composition patterns live in the [blocks reference](
 
 ## Boundaries
 
-- ✅ Compose multiple blocks per page — each mounts independently.
+- ✅ Compose multiple blocks per page; each mounts independently.
 - ✅ Render outside Storybook with a hand-built or loaded `ProjectSnapshot`.
-- ❌ Don't import from `virtual:swatchbook/tokens` — it's the addon's internal wiring, not a public API. Use `SwatchbookProvider`.
-- ❌ Don't use `useGlobals` / `useArgs` from `storybook/preview-api` inside custom blocks — those hooks throw in docs context.
+- ❌ Don't import from `virtual:swatchbook/tokens`; it's the addon's internal wiring, not a public API. Use `SwatchbookProvider`.
+- ❌ Don't use `useGlobals` / `useArgs` from `storybook/preview-api` inside custom blocks; those hooks throw in docs context.
 
 ## Credits
 
@@ -50,4 +50,4 @@ Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/
 
 ## Documentation
 
-[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/): concepts, guides, and full API reference.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 The framework-free loader at the heart of [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-Parses DTCG token files via [Terrazzo](https://terrazzo.app/), resolves aliases, composes themes through a DTCG 2025.10 resolver or authored layered axes. No DOM, no React — just a `Project` object you can consume from any Node-side tool.
+Parses DTCG token files via [Terrazzo](https://terrazzo.app/), resolves aliases, composes themes through a DTCG 2025.10 resolver or authored layered axes. No DOM, no React, just a `Project` object you can consume from any Node-side tool.
 
 Storybook consumers get this transitively via [`@unpunnyfuns/swatchbook-addon`](../addon). Install directly when you're running `loadProject` outside Storybook: build scripts, CLIs, docs-site generators, custom tooling.
 
@@ -27,32 +27,31 @@ const project = await loadProject(config, process.cwd());
 // Read the default-tuple snapshot directly.
 const defaults = project.defaultTokens;
 
-// Read any tuple via the composer — bounded over per-axis cells +
-// joint overrides, no resolver round-trip.
+// Read any tuple via the composer: bounded over the token graph,
+// no resolver round-trip.
 const darkBrandA = project.resolveAt({ mode: 'Dark', brand: 'Brand A' });
 ```
 
-The [config reference](https://unpunnyfuns.github.io/swatchbook/reference/config) covers every field; the [core reference](https://unpunnyfuns.github.io/swatchbook/reference/core) covers the `Project` shape and exported helpers (`emitAxisProjectedCss`, `jointOverrideKey`, typed `Axis` / `Config` / `Diagnostic` / `Project`).
+The [config reference](https://unpunnyfuns.github.io/swatchbook/reference/config) covers every field; the [core reference](https://unpunnyfuns.github.io/swatchbook/reference/core) covers the `Project` shape and exported helpers (`emitAxisProjectedCss`, typed `Axis` / `Config` / `Diagnostic` / `Project`).
 
 ## Browser-safe subpaths
 
-Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths — each tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports:
+Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths, each tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports:
 
-- `@unpunnyfuns/swatchbook-core/resolve-at` — `buildResolveAt(axes, cells, jointOverrides, defaultTuple)`
-- `@unpunnyfuns/swatchbook-core/snapshot-for-wire` — `snapshotForWire(project, css)` + `SnapshotForWire` type
-- `@unpunnyfuns/swatchbook-core/themes` — `enumerateThemes({axes, presets, defaultTuple})` + `tupleToName(axes, tuple)` + `ThemeEntry` type
-- `@unpunnyfuns/swatchbook-core/match-path` — `matchPath(path, filter)` glob-style matcher (`*` / `**`)
-- `@unpunnyfuns/swatchbook-core/fuzzy` — uFuzzy-backed token search
-- `@unpunnyfuns/swatchbook-core/css-var` — `makeCssVar(path, prefix)`
-- `@unpunnyfuns/swatchbook-core/data-attr` — `dataAttr(prefix, key)`
-- `@unpunnyfuns/swatchbook-core/style-element` — `ensureStyleElement(id, text)` + `SWATCHBOOK_STYLE_ELEMENT_ID`
+- `@unpunnyfuns/swatchbook-core/snapshot-for-wire`: `snapshotForWire(project, css)` + `SnapshotForWire` type
+- `@unpunnyfuns/swatchbook-core/themes`: `enumerateThemes({axes, presets, defaultTuple})` + `tupleToName(axes, tuple)` + `ThemeEntry` type
+- `@unpunnyfuns/swatchbook-core/match-path`: `matchPath(path, filter)` glob-style matcher (`*` / `**`)
+- `@unpunnyfuns/swatchbook-core/fuzzy`: uFuzzy-backed token search
+- `@unpunnyfuns/swatchbook-core/css-var`: `makeCssVar(path, prefix)`
+- `@unpunnyfuns/swatchbook-core/data-attr`: `dataAttr(prefix, key)`
+- `@unpunnyfuns/swatchbook-core/style-element`: `ensureStyleElement(id, text)` + `SWATCHBOOK_STYLE_ELEMENT_ID`
 
 ## Boundaries
 
-- ✅ Build-time use — Node, scripts, SSR, Storybook presets.
+- ✅ Build-time use: Node, scripts, SSR, Storybook presets.
 - ✅ Pair with [Terrazzo](https://terrazzo.app/)'s CLI for production artifact emission (CSS / JS / Tailwind / Swift / Sass / …).
-- ✅ Ship `project.cells` / `project.jointOverrides` / `project.defaultTokens` to the browser via the `snapshot-for-wire` subpath — that's exactly what the addon's preview does.
-- ❌ Don't ship the full `Project` object to the browser. `resolveAt` is a function, `varianceByPath` is a Map, and `cwd` is a Node-side absolute path; use `snapshotForWire(project, css)` to get a JSON-friendly subset.
+- ✅ Ship `project.tokenGraph` / `project.defaultTokens` / `project.defaultTuple` to the browser via the `snapshot-for-wire` subpath. That's exactly what the addon's preview does.
+- ❌ Don't ship the full `Project` object to the browser. `resolveAt` is a function and `cwd` is a Node-side absolute path; use `snapshotForWire(project, css)` to get a JSON-friendly subset.
 - ❌ Don't reach into `@terrazzo/parser` directly. Stay on the core surface so upgrades don't churn your code.
 
 ## Credits
@@ -61,4 +60,4 @@ Token parsing, alias resolution, and DTCG resolver evaluation are provided by [T
 
 ## Documentation
 
-[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/): concepts, guides, and full API reference.

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -2,7 +2,7 @@
 
 Preview-side adapters that let your Storybook stories use [Tailwind v4](./src/tailwind.ts) or a [CSS-in-JS library](./src/css-in-js.ts) against [swatchbook](https://github.com/unpunnyfuns/swatchbook)'s tokens.
 
-Not a replacement for your production build. Integrations are preview-only — they let `bg-sb-surface-default` or `theme.color.accent.bg` resolve correctly inside Storybook; for production artifacts, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources.
+Not a replacement for your production build. Integrations are preview-only: they let `bg-sb-surface-default` or `theme.color.accent.bg` resolve correctly inside Storybook; for production artifacts, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources.
 
 ## Install
 
@@ -35,13 +35,13 @@ export default defineMain({
 });
 ```
 
-Per-integration wiring details live in the [Integrations guide](https://unpunnyfuns.github.io/swatchbook/guides/integrations/) — Tailwind's Vite plugin setup, the CSS-in-JS `virtual:swatchbook/theme` import, role-map overrides, and how to write your own integration against the `SwatchbookIntegration` contract.
+Per-integration wiring details live in the [Integrations guide](https://unpunnyfuns.github.io/swatchbook/guides/integrations/): Tailwind's Vite plugin setup, the CSS-in-JS `virtual:swatchbook/theme` import, role-map overrides, and how to write your own integration against the `SwatchbookIntegration` contract.
 
 ## Boundaries
 
 - ✅ Preview-side use inside Storybook. Stories that style with utility classes or theme accessors pick up the swatchbook toolbar's axis flips via CSS cascade.
-- ❌ No MUI / Vuetify / Bootstrap SCSS factories. Those need resolved values per named theme — run Terrazzo's CLI with `@terrazzo/plugin-js` for that case.
+- ❌ No MUI / Vuetify / Bootstrap SCSS factories. Those need resolved values per named theme; run Terrazzo's CLI with `@terrazzo/plugin-js` for that case.
 
 ## Documentation
 
-[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/): concepts, guides, and full API reference.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -25,7 +25,7 @@ Or wire it into an MCP client by adding an entry to its server config:
 }
 ```
 
-Live-reload is on by default — the server watches the config and resolved source files, swapping in fresh data on edits. Pass `--no-watch` to disable.
+Live-reload is on by default: the server watches the config and resolved source files, swapping in fresh data on edits. Pass `--no-watch` to disable.
 
 ## Programmatic use
 
@@ -50,4 +50,4 @@ Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/
 
 ## Documentation
 
-[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/): concepts, guides, and full API reference.

--- a/packages/switcher/README.md
+++ b/packages/switcher/README.md
@@ -2,7 +2,7 @@
 
 The framework-agnostic theme-switcher UI for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-A React component: axis dropdowns, preset pills, color-format selector. The Storybook addon's toolbar uses it; so does the docs-site navbar. Reach for this package directly when you want the switcher on a non-Storybook site — a docs navbar, a standalone React app consuming swatchbook tokens.
+A React component: axis dropdowns, preset pills, color-format selector. The Storybook addon's toolbar uses it; so does the docs-site navbar. Reach for this package directly when you want the switcher on a non-Storybook site, such as a docs navbar or a standalone React app consuming swatchbook tokens.
 
 Most consumers pick it up transitively via [`@unpunnyfuns/swatchbook-addon`](../addon); `import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` works out of the box.
 
@@ -24,8 +24,8 @@ import '@unpunnyfuns/swatchbook-switcher/style.css';
   activeTuple={{ mode: 'Dark' }}
   defaults={{ mode: 'Light', brand: 'Default', contrast: 'Normal' }}
   lastApplied={null}
-  onAxisChange={(axis, context) => {
-    document.documentElement.setAttribute(`data-sb-${axis}`, context);
+  onAxisChange={(axisName, next) => {
+    document.documentElement.setAttribute(`data-sb-${axisName}`, next);
   }}
   onPresetApply={(preset: SwitcherPreset) => {
     for (const [axis, value] of Object.entries(preset.axes)) {
@@ -35,11 +35,11 @@ import '@unpunnyfuns/swatchbook-switcher/style.css';
 />;
 ```
 
-The component is pure — it doesn't read or write to storage, and it doesn't bake in any particular way of applying the active tuple. The caller decides how to translate `onAxisChange` / `onPresetApply` into DOM updates, routing changes, or global state.
+The component is pure: it doesn't read or write to storage, and it doesn't bake in any particular way of applying the active tuple. The caller decides how to translate `onAxisChange` / `onPresetApply` into DOM updates, routing changes, or global state.
 
-Color-format selection isn't part of the switcher — hosts that need it slot a `<ColorFormatSelector>` (or any other custom node) into the optional `footer` prop.
+Color-format selection isn't part of the switcher; hosts that need it slot a `<ColorFormatSelector>` (or any other custom node) into the optional `footer` prop.
 
-`SwitcherAxis` / `SwitcherPreset` are the accepted shapes and are cross-compatible with `Project.axes` / `Project.presets` from `@unpunnyfuns/swatchbook-core` — pass them through directly.
+`SwitcherAxis` / `SwitcherPreset` are the accepted shapes and are cross-compatible with `Project.axes` / `Project.presets` from `@unpunnyfuns/swatchbook-core`, so pass them through directly.
 
 ## Credits
 
@@ -47,4 +47,4 @@ Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/
 
 ## Documentation
 
-[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/) — concepts, guides, and full API reference.
+[unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/): concepts, guides, and full API reference.

--- a/packages/tokens/README.md
+++ b/packages/tokens/README.md
@@ -2,7 +2,7 @@
 
 The reference DTCG fixture for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-An exhaustive DTCG 2025.10 token project — palette primitives, semantic roles, typography composites, motion, shadow, border, gradient, stroke — used as swatchbook's own internal test bed and as a worked example for projects structuring their own token trees.
+An exhaustive DTCG 2025.10 token project (palette primitives, semantic roles, typography composites, motion, shadow, border, gradient, stroke) used as swatchbook's own internal test bed and as a worked example for projects structuring their own token trees.
 
 Private workspace package. Not published.
 
@@ -16,5 +16,5 @@ Private workspace package. Not published.
 import { tokensDir, resolverPath } from '@unpunnyfuns/swatchbook-tokens';
 ```
 
-- ✅ Use the exported path helpers — `import.meta`-resolved, survives `node_modules` hoisting.
+- ✅ Use the exported path helpers; `import.meta`-resolved, survives `node_modules` hoisting.
 - ❌ Don't hard-code `node_modules/@unpunnyfuns/swatchbook-tokens/tokens/...` paths.


### PR DESCRIPTION
Actions the documentation review (full report kept locally). Docs-only, patch changeset so the release snapshot rebuilds. Docs build is green (link integrity intact).

**Accuracy (docs site)**
- `reference/blocks/utility.mdx`: drop the removed `Diagnostic.column` field.
- `reference/blocks/hooks.mdx`: correct `useSwatchbookData()`'s return shape (it does not return `presets`/`tokens`).
- `reference/blocks/overview.mdx`: remove the false `OpacityScale` `filter` default.
- `reference/concepts.mdx`: `css` is not a field on `Project` (it comes from `emitAxisProjectedCss`).
- `intro.mdx`: import `useToken` from the `/hooks` subpath, not the addon root.
- `guides/sharing-terrazzo-options.mdx`: use the public `useSwatchbookData()`, not internal `useProject()`.

**READMEs**
- `packages/core/README.md`: refreshed for the current `tokenGraph` API (dropped `jointOverrideKey`, the nonexistent `resolve-at` subpath, and `cells`/`jointOverrides`/`varianceByPath`).
- `apps/docs/README.md` and `apps/storybook/README.md`: rewrote the untouched Docusaurus/Vite scaffolds into real, on-convention READMEs.
- `packages/switcher/README.md`: fixed the `onAxisChange(axisName, next)` example signature.

**Storybook dogfood**
- `Motion.mdx`: fix the filter (`easing.**` matched nothing → `cubicBezier.**`).
- `Colors.mdx`: add the missing `color.text` `danger`/`success` variants.
- `Dashboard.mdx`: tighten the opener.

**Prose**
- Removed em-dashes from all documentation prose (0 remain outside code samples). No marketing or instruction-register issues were found to fix; those were already clean.

Milestone: Maintenance

Closes #1100

Plan impact: none.
