### PR TITLE
fix(core): drop baseline alias metadata when a write replaces token structure

### DIFF
--- a/.changeset/fix-alias-metadata-leak.md
+++ b/.changeset/fix-alias-metadata-leak.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+fix resolveAliasAt leaking baseline alias metadata into literal and partial-alias write results, which emitted var() references to the old alias target

--- a/packages/core/src/token-graph/walk.ts
+++ b/packages/core/src/token-graph/walk.ts
@@ -144,11 +144,17 @@ export function resolveAliasAt(
     };
   }
 
-  if (directWrite.kind === 'literal') return { ...node.baselineValue, ...directWrite.value };
+  // A direct write replaces the token's structure at this tuple, so the
+  // baseline's alias metadata must not survive the spread: Terrazzo's
+  // transforms route on aliasChain/partialAliasOf before $value, and a
+  // leaked field emits var() references to the baseline's old target.
+  const { aliasOf: _a, aliasChain: _c, partialAliasOf: _p, ...baseline } = node.baselineValue;
+
+  if (directWrite.kind === 'literal') return { ...baseline, ...directWrite.value };
   if (directWrite.kind === 'alias') {
     const targetLeaf = resolveAt(graph, directWrite.target, tuple);
     return {
-      ...node.baselineValue,
+      ...baseline,
       aliasOf: directWrite.target,
       aliasChain: [directWrite.target],
       $value: targetLeaf?.$value,
@@ -156,7 +162,7 @@ export function resolveAliasAt(
   }
   const composed = resolveAt(graph, path, tuple);
   return {
-    ...node.baselineValue,
+    ...baseline,
     ...directWrite.baseValue,
     partialAliasOf: directWrite.aliasFields,
     $value: composed?.$value,

--- a/packages/core/test/css-axis-projected-alias-flip.test.ts
+++ b/packages/core/test/css-axis-projected-alias-flip.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Alias-baseline → write flips through the emitter. The alias-literal-flip
+ * fixture's Dark mode replaces alias baselines with literals (and one alias
+ * with a different alias); the Dark cell must emit the written value, not a
+ * var() reference to the baseline's old alias target. Terrazzo's transforms
+ * route on aliasChain before $value, so leaked baseline metadata shows up
+ * here as a wrong var() — this file pins the consequence end to end.
+ */
+import { fileURLToPath } from 'node:url';
+import { beforeAll, expect, it } from 'vitest';
+import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
+import { loadProject } from '#/load.ts';
+import type { Project } from '#/types.ts';
+import { extractBlock, grep } from './_helpers.ts';
+
+const fixtureCwd = fileURLToPath(new URL('./fixtures/alias-literal-flip', import.meta.url));
+
+let css: string;
+let darkCell: string;
+
+// beforeAll: loadProject is the expensive step; every test reads the same emitted CSS.
+beforeAll(async () => {
+  const project: Project = await loadProject(
+    {
+      tokens: ['tokens/**/*.json'],
+      resolver: 'tokens/resolver.json',
+      default: { mode: 'Light' },
+      cssVarPrefix: 't',
+    },
+    fixtureCwd,
+  );
+  css = emitAxisProjectedCss(project);
+  darkCell = extractBlock(css, '[data-t-mode="Dark"]');
+}, 30_000);
+
+it('a literal write over an alias baseline emits the literal, not the old alias target', () => {
+  const line = grep(darkCell, '--t-color-text:');
+  expect(line).toBeDefined();
+  expect(line).not.toContain('var(');
+  // White in whatever serialization the transform picks (hex or rgb()).
+  expect(line).toMatch(/#ffffff|#fff\b|rgb\(100% 100% 100%\)/i);
+});
+
+it('an alias write over an alias baseline emits the new target, not the baseline one', () => {
+  expect(grep(darkCell, '--t-color-border-focus:')).toBe(
+    '--t-color-border-focus: var(--t-color-text);',
+  );
+});
+
+it('a composite literal write over a partial-alias baseline emits no stale sub-field var()', () => {
+  // Pins only the metadata leak (no var() to the baseline's alias target).
+  // The width sub-field currently emits garbage because literal composite
+  // writes carry raw (un-normalized) sub-values into the transform — a
+  // separate pre-existing bug, tracked independently.
+  const line = grep(darkCell, '--t-border-input:');
+  expect(line).toBeDefined();
+  expect(line).not.toContain('var(');
+});
+
+it('the baseline cell still aliases through', () => {
+  const root = extractBlock(css, ':root');
+  expect(grep(root, '--t-color-text:')).toBe('--t-color-text: var(--t-color-a);');
+});

--- a/packages/core/test/fixtures/alias-literal-flip/tokens/resolver.json
+++ b/packages/core/test/fixtures/alias-literal-flip/tokens/resolver.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://www.designtokens.org/TR/2025.10/resolver/",
+  "version": "2025.10",
+  "name": "alias-literal-flip",
+  "description": "Minimal fixture where mode=Dark replaces alias baselines with literals (and one literal with a new alias). Pins the emitter against leaking baseline alias metadata into written cells.",
+  "sets": {
+    "tokens": {
+      "sources": [{ "$ref": "./tokens.json" }]
+    }
+  },
+  "modifiers": {
+    "mode": {
+      "contexts": {
+        "Light": [],
+        "Dark": [{ "$ref": "./themes/dark.json" }]
+      },
+      "default": "Light"
+    }
+  },
+  "resolutionOrder": [{ "$ref": "#/sets/tokens" }, { "$ref": "#/modifiers/mode" }]
+}

--- a/packages/core/test/fixtures/alias-literal-flip/tokens/themes/dark.json
+++ b/packages/core/test/fixtures/alias-literal-flip/tokens/themes/dark.json
@@ -1,0 +1,19 @@
+{
+  "color": {
+    "$type": "color",
+    "text": { "$value": "#ffffff" },
+    "border": {
+      "focus": { "$value": "{color.text}" }
+    }
+  },
+  "border": {
+    "$type": "border",
+    "input": {
+      "$value": {
+        "color": "#ffffff",
+        "width": "1px",
+        "style": "solid"
+      }
+    }
+  }
+}

--- a/packages/core/test/fixtures/alias-literal-flip/tokens/tokens.json
+++ b/packages/core/test/fixtures/alias-literal-flip/tokens/tokens.json
@@ -1,0 +1,20 @@
+{
+  "color": {
+    "$type": "color",
+    "a": { "$value": "#000000" },
+    "text": { "$value": "{color.a}" },
+    "border": {
+      "focus": { "$value": "{color.a}" }
+    }
+  },
+  "border": {
+    "$type": "border",
+    "input": {
+      "$value": {
+        "color": "{color.a}",
+        "width": "1px",
+        "style": "solid"
+      }
+    }
+  }
+}

--- a/packages/core/test/token-graph/walk-resolve-alias.test.ts
+++ b/packages/core/test/token-graph/walk-resolve-alias.test.ts
@@ -1,7 +1,115 @@
 import { describe, expect, it } from 'vitest';
+import type { TokenGraph } from '#/token-graph/types.ts';
 import { buildTokenGraph } from '#/token-graph/build.ts';
 import { resolveAliasAllAt, resolveAliasAt, resolveAllAt, resolveAt } from '#/token-graph/walk.ts';
 import { loadReferenceFixtureParserInput } from '../_helpers.ts';
+
+// Minimal graph exercising writes over metadata-carrying baselines.
+// Alias-kind baselineValues retain aliasOf/aliasChain (SLIM_KEYS keeps them),
+// and Terrazzo's transforms route on that metadata before $value — so a write
+// that changes the token's structure must not let the baseline's metadata
+// survive into the resolved view.
+function graphWithMetadataBaselines(): TokenGraph {
+  return {
+    axes: ['mode'],
+    axisDefaults: { mode: 'Light' },
+    nodes: {
+      'color.a': {
+        baselineValue: { $value: '#00aa00', $type: 'color' },
+        baselineKind: 'literal',
+        writes: {},
+        affectedBy: [],
+        aliases: [],
+        aliasedBy: ['color.text'],
+      },
+      'color.text': {
+        baselineValue: {
+          $value: '#000000',
+          $type: 'color',
+          aliasOf: 'color.a',
+          aliasChain: ['color.a'],
+        },
+        baselineKind: 'alias',
+        baselineAliasTarget: 'color.a',
+        writes: {
+          mode: {
+            Dark: { kind: 'literal', value: { $value: '#ffffff', $type: 'color' } },
+          },
+        },
+        affectedBy: ['mode'],
+        aliases: ['color.a'],
+        aliasedBy: [],
+      },
+      'border.focus': {
+        baselineValue: {
+          $value: { color: '#000000', width: '1px' },
+          $type: 'border',
+          aliasOf: 'border.base',
+          aliasChain: ['border.base'],
+        },
+        baselineKind: 'alias',
+        baselineAliasTarget: 'border.base',
+        writes: {
+          mode: {
+            Dark: {
+              kind: 'partial-alias',
+              baseValue: { $value: { color: '#000000', width: '2px' }, $type: 'border' },
+              aliasFields: { color: 'color.a' },
+            },
+          },
+        },
+        affectedBy: ['mode'],
+        aliases: ['border.base'],
+        aliasedBy: [],
+      },
+      'border.base': {
+        baselineValue: { $value: { color: '#000000', width: '1px' }, $type: 'border' },
+        baselineKind: 'literal',
+        writes: {},
+        affectedBy: [],
+        aliases: [],
+        aliasedBy: ['border.focus'],
+      },
+      'border.input': {
+        baselineValue: {
+          $value: { color: '#000000', width: '1px' },
+          $type: 'border',
+          partialAliasOf: { color: 'color.a' },
+        },
+        baselineKind: 'partial-alias',
+        baselinePartialFields: { color: 'color.a' },
+        writes: {
+          mode: {
+            Dark: {
+              kind: 'literal',
+              value: { $value: { color: '#ffffff', width: '1px' }, $type: 'border' },
+            },
+          },
+        },
+        affectedBy: ['mode'],
+        aliases: [],
+        aliasedBy: [],
+      },
+      'color.ring': {
+        baselineValue: {
+          $value: { color: '#000000', width: '1px' },
+          $type: 'border',
+          partialAliasOf: { color: 'color.a' },
+        },
+        baselineKind: 'partial-alias',
+        baselinePartialFields: { color: 'color.a' },
+        writes: {
+          mode: {
+            Dark: { kind: 'alias', target: 'border.base' },
+          },
+        },
+        affectedBy: ['mode'],
+        aliases: [],
+        aliasedBy: [],
+      },
+    },
+  };
+}
 
 describe('resolveAliasAt / resolveAliasAllAt alias-preserving walker', () => {
   it('resolveAliasAllAt returns alias-preserving tokens for every path in the graph', async () => {
@@ -63,5 +171,35 @@ describe('resolveAliasAt / resolveAliasAllAt alias-preserving walker', () => {
     const leafResult = resolveAt(graph, 'color.accent.bg', defaultTuple);
     const aliasResult = resolveAliasAt(graph, 'color.accent.bg', defaultTuple);
     expect(aliasResult?.$value).toEqual(leafResult?.$value);
+  });
+
+  it('a literal write over an alias baseline drops the baseline alias metadata', () => {
+    const graph = graphWithMetadataBaselines();
+    const result = resolveAliasAt(graph, 'color.text', { mode: 'Dark' });
+    expect(result?.$value).toBe('#ffffff');
+    expect(result?.aliasOf).toBeUndefined();
+    expect(result?.aliasChain).toBeUndefined();
+  });
+
+  it('a partial-alias write over an alias baseline drops the whole-token alias metadata', () => {
+    const graph = graphWithMetadataBaselines();
+    const result = resolveAliasAt(graph, 'border.focus', { mode: 'Dark' });
+    expect(result?.partialAliasOf).toEqual({ color: 'color.a' });
+    expect(result?.aliasOf).toBeUndefined();
+    expect(result?.aliasChain).toBeUndefined();
+  });
+
+  it('a literal write over a partial-alias baseline drops the baseline partialAliasOf', () => {
+    const graph = graphWithMetadataBaselines();
+    const result = resolveAliasAt(graph, 'border.input', { mode: 'Dark' });
+    expect(result?.$value).toEqual({ color: '#ffffff', width: '1px' });
+    expect(result?.partialAliasOf).toBeUndefined();
+  });
+
+  it('an alias write over a partial-alias baseline drops the baseline partialAliasOf', () => {
+    const graph = graphWithMetadataBaselines();
+    const result = resolveAliasAt(graph, 'color.ring', { mode: 'Dark' });
+    expect(result?.aliasOf).toBe('border.base');
+    expect(result?.partialAliasOf).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

resolveAliasAt no longer lets a baseline's aliasOf/aliasChain/partialAliasOf survive into the result when a direct write replaces the token's structure at the active tuple.

## Full description

Alias-kind baselineValues retain their alias metadata by design (SLIM_KEYS keeps them for the emitter's var() referencing). But the write branches of resolveAliasAt spread node.baselineValue first, so that metadata leaked into literal, alias, and partial-alias write results. Terrazzo's transforms route on aliasChain / partialAliasOf before $value, so a token whose baseline aliases color.a but whose dark write pins a literal white emitted `var(--prefix-color-a)` (resolving to the old target) instead of the literal.

The fix destructures the three metadata fields out of the baseline before spreading, in all three write branches. New unit tests cover the four flip combinations over a hand-built graph; a new emission-level fixture (alias-literal-flip) plus test pins the dark-cell CSS end to end. Both were verified failing before the fix.

While writing the emission test, a separate pre-existing bug surfaced: literal composite writes carry raw (un-normalized) sub-values into the transforms. Filed as its own issue; the emission test pins only the no-var() half until that lands. Refs #1119.

Milestone: Maintenance
Plan impact: none

Closes #1105