### PR TITLE
fix(blocks): hoist useProject above TokenDetail's missing-token early return

### DIFF
--- a/.changeset/fix-token-detail-conditional-hook.md
+++ b/.changeset/fix-token-detail-conditional-hook.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix TokenDetail crashing when a token appears or disappears between renders (useProject was called after a conditional early return)

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -27,6 +27,7 @@ export interface TokenDetailProps {
 export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
   const { token, cssVar, activeTheme, activeAxes, cssVarPrefix } = useTokenDetailData(path);
   const colorFormat = useColorFormat();
+  const { listing } = useProject();
   const wrapperAttrs = blockWrapperAttrs(cssVarPrefix, activeAxes);
 
   if (!token) {
@@ -39,7 +40,6 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
     );
   }
 
-  const { listing } = useProject();
   const isColor = token.$type === 'color';
   const gamut = isColor ? formatColor(token.$value, colorFormat) : null;
   const value = formatTokenValue(token.$value, token.$type, colorFormat, listing[path]);

--- a/packages/blocks/test/token-detail.browser.test.tsx
+++ b/packages/blocks/test/token-detail.browser.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SwatchbookProvider, TokenDetail } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import { makeResolveAt } from './_snapshot-helpers.ts';
+
+function makeSnapshot(): ProjectSnapshot {
+  const tokens = {
+    'color.brand.primary': { $type: 'color', $value: { hex: '#3b82f6' } },
+  };
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = makeResolveAt(tokens);
+  return snap;
+}
+
+describe('TokenDetail', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the token value for a known path', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenDetail path="color.brand.primary" />
+      </SwatchbookProvider>,
+    );
+    expect(screen.getByRole('heading', { name: 'color.brand.primary' })).toBeDefined();
+  });
+
+  it('shows the not-found message for an unknown path', () => {
+    render(
+      <SwatchbookProvider value={makeSnapshot()}>
+        <TokenDetail path="color.missing" />
+      </SwatchbookProvider>,
+    );
+    expect(screen.getByText(/not found in theme/)).toBeDefined();
+  });
+
+  it('survives the token disappearing between renders', () => {
+    // Regression guard: useProject() used to be called after the
+    // missing-token early return, so flipping a present token to a
+    // missing one changed the hook order and crashed React.
+    const snapshot = makeSnapshot();
+    const { rerender } = render(
+      <SwatchbookProvider value={snapshot}>
+        <TokenDetail path="color.brand.primary" />
+      </SwatchbookProvider>,
+    );
+    expect(() =>
+      rerender(
+        <SwatchbookProvider value={snapshot}>
+          <TokenDetail path="color.gone" />
+        </SwatchbookProvider>,
+      ),
+    ).not.toThrow();
+    expect(screen.getByText(/not found in theme/)).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

TokenDetail called useProject() after its missing-token early return, so a token appearing or disappearing between renders changed the hook order and crashed React.

## Full description

The fix hoists the useProject() call above the early return alongside the other hooks. Adds TokenDetail's first render tests (browser mode, chromium + firefox): known path renders, unknown path shows the not-found message, and the regression case where the rendered token disappears between renders — verified failing with 'Rendered fewer hooks than expected' before the fix.

Milestone: Maintenance
Plan impact: none

Closes #1106