### PR TITLE
fix(addon): catch HMR reload failures instead of dying on an unhandled rejection

### DIFF
--- a/.changeset/fix-hmr-unhandled-rejection.md
+++ b/.changeset/fix-hmr-unhandled-rejection.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+fix a transient bad token save crashing the Storybook dev server via an unhandled rejection in the HMR reload; failures now log and the previous tokens keep serving

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -6,7 +6,7 @@ import { watch as fsWatch } from 'node:fs';
 import type { FSWatcher } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve as resolvePath } from 'node:path';
 import picomatch from 'picomatch';
-import type { Plugin } from 'vite';
+import type { Plugin, ViteDevServer } from 'vite';
 import {
   HMR_EVENT,
   INTEGRATION_SIDE_EFFECTS_VIRTUAL_ID,
@@ -54,6 +54,48 @@ export function swatchbookTokensPlugin({
     css = emitAxisProjectedCss(project);
   }
 
+  // One reload pass: refresh the project, invalidate the virtual modules,
+  // broadcast the fresh snapshot. Never rejects — a rejection escaping the
+  // watcher's fire-and-forget call is an unhandled rejection that kills
+  // the dev-server process on a transient bad save. Failures log and the
+  // previous project keeps serving (`refresh` only reassigns on success).
+  async function reload(server: ViteDevServer): Promise<void> {
+    try {
+      await refresh();
+    } catch (error) {
+      server.config.logger.error(
+        `\x1b[36m[swatchbook]\x1b[0m token reload failed — keeping previous tokens: ${error instanceof Error ? error.message : String(error)}`,
+        { clear: false, timestamp: true },
+      );
+      return;
+    }
+    if (!project) return;
+    const tokenCount = [...listPaths(project.tokenGraph)].length;
+    const diagCount = project.diagnostics.length;
+    server.config.logger.info(
+      `\x1b[36m[swatchbook]\x1b[0m tokens reloaded — ${tokenCount} tokens, ${diagCount} diagnostic${diagCount === 1 ? '' : 's'}`,
+      { clear: false, timestamp: true },
+    );
+    const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
+    if (mod) server.moduleGraph.invalidateModule(mod);
+    // Invalidate every integration-contributed virtual module so its body
+    // re-renders against the fresh project on the next request.
+    for (const resolvedIntegrationId of integrationById.keys()) {
+      const m = server.moduleGraph.getModuleById(resolvedIntegrationId);
+      if (m) server.moduleGraph.invalidateModule(m);
+    }
+    // Send the fresh snapshot as a custom HMR event instead of a
+    // full-reload. The preview subscribes and re-broadcasts to blocks via
+    // the Storybook channel so the React tree re-renders in place without
+    // losing toolbar / args / scroll state. Field shape matches the
+    // INIT_EVENT payload so the preview can hand it straight through.
+    server.ws.send({
+      type: 'custom',
+      event: HMR_EVENT,
+      data: snapshotForWire(project, css),
+    });
+  }
+
   // Map of resolvedId → integration, indexed once.
   const integrationById = new Map<string, SwatchbookIntegration>();
   // Virtual IDs the preview auto-imports as side effects (global CSS).
@@ -68,6 +110,11 @@ export function swatchbookTokensPlugin({
   return {
     name: 'swatchbook:virtual-tokens',
     enforce: 'pre',
+
+    // Vite's plugin-to-plugin/testing escape hatch. `reload` is the same
+    // pass the debounced fs watcher fires; exposed so tests can exercise
+    // the failure contract without real watcher events.
+    api: { reload },
 
     // Vite uses esbuild for `optimizeDeps` pre-bundling (development
     // mode), and esbuild doesn't see Rollup-style `resolveId` hooks.
@@ -159,36 +206,7 @@ export function swatchbookTokensPlugin({
         if (pending) clearTimeout(pending);
         pending = setTimeout(() => {
           pending = null;
-          void (async () => {
-            await refresh();
-            if (!project) return;
-            const tokenCount = [...listPaths(project.tokenGraph)].length;
-            const diagCount = project.diagnostics.length;
-            server.config.logger.info(
-              `\x1b[36m[swatchbook]\x1b[0m tokens reloaded — ${tokenCount} tokens, ${diagCount} diagnostic${diagCount === 1 ? '' : 's'}`,
-              { clear: false, timestamp: true },
-            );
-            const mod = server.moduleGraph.getModuleById(RESOLVED_VIRTUAL_MODULE_ID);
-            if (mod) server.moduleGraph.invalidateModule(mod);
-            // Invalidate every integration-contributed virtual module so
-            // its body re-renders against the fresh project on the next
-            // request.
-            for (const resolvedIntegrationId of integrationById.keys()) {
-              const m = server.moduleGraph.getModuleById(resolvedIntegrationId);
-              if (m) server.moduleGraph.invalidateModule(m);
-            }
-            // Send the fresh snapshot as a custom HMR event instead of a
-            // full-reload. The preview subscribes and re-broadcasts to
-            // blocks via the Storybook channel so the React tree
-            // re-renders in place without losing toolbar / args / scroll
-            // state. Field shape matches the INIT_EVENT payload so the
-            // preview can hand it straight through.
-            server.ws.send({
-              type: 'custom',
-              event: HMR_EVENT,
-              data: snapshotForWire(project, css),
-            });
-          })();
+          void reload(server);
         }, 100);
       };
 

--- a/packages/addon/test/virtual-plugin-reload.test.ts
+++ b/packages/addon/test/virtual-plugin-reload.test.ts
@@ -1,0 +1,64 @@
+// Tests the plugin's reload pass through `plugin.api.reload` — the same
+// routine the debounced fs watcher fires. A rejection escaping that
+// routine is an unhandled rejection that kills the dev-server process,
+// so the contract under test is: reload never rejects, failures log,
+// and the previous project keeps serving.
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ViteDevServer } from 'vite';
+import { expect, it, vi } from 'vitest';
+import { RESOLVED_VIRTUAL_MODULE_ID } from '#/constants.ts';
+import { swatchbookTokensPlugin } from '#/virtual/plugin.ts';
+
+function tokensJson(hex: string): string {
+  return JSON.stringify({ color: { $type: 'color', a: { $value: hex } } });
+}
+
+async function setup() {
+  const cwd = mkdtempSync(join(tmpdir(), 'sb-reload-'));
+  mkdirSync(join(cwd, 'tokens'));
+  const tokenFile = join(cwd, 'tokens', 't.json');
+  writeFileSync(tokenFile, tokensJson('#000000'));
+
+  const plugin = swatchbookTokensPlugin({ config: { tokens: ['tokens/**/*.json'] }, cwd });
+  await (plugin.buildStart as unknown as () => Promise<void>).call(plugin);
+
+  const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+  const server = {
+    config: { logger },
+    moduleGraph: { getModuleById: () => undefined },
+    ws: { send: vi.fn() },
+  } as unknown as ViteDevServer;
+
+  const reload = (plugin.api as { reload: (s: ViteDevServer) => Promise<void> }).reload;
+  const loadVirtual = (): string =>
+    (plugin.load as unknown as (id: string) => string).call(plugin, RESOLVED_VIRTUAL_MODULE_ID);
+
+  return { tokenFile, server, logger, reload, loadVirtual };
+}
+
+it('a reload hitting a transient bad save logs the failure and keeps serving the previous tokens', async () => {
+  const { tokenFile, server, logger, reload, loadVirtual } = await setup();
+  const before = loadVirtual();
+
+  writeFileSync(tokenFile, '{broken');
+  await expect(reload(server)).resolves.toBeUndefined();
+
+  expect(logger.error).toHaveBeenCalledTimes(1);
+  expect(loadVirtual()).toBe(before);
+  expect(server.ws.send).not.toHaveBeenCalled();
+});
+
+it('a good save after a failed reload recovers and broadcasts the fresh snapshot', async () => {
+  const { tokenFile, server, reload, loadVirtual } = await setup();
+
+  writeFileSync(tokenFile, '{broken');
+  await reload(server);
+
+  writeFileSync(tokenFile, tokensJson('#ffffff'));
+  await reload(server);
+
+  expect(server.ws.send).toHaveBeenCalledTimes(1);
+  expect(loadVirtual()).toContain('ffffff');
+});


### PR DESCRIPTION
## Summary

A transient bad token save (e.g. mid-write invalid JSON) rejected inside the watcher's fire-and-forget reload, and the unhandled rejection killed the Storybook dev server.

## Full description

The debounced invalidate path wrapped the reload in `void (async () => ...)()` with no rejection handling. The reload pass is now an extracted routine with a never-rejects contract: a failed loadProject logs "token reload failed — keeping previous tokens" through the server logger and returns, leaving the previous project serving (refresh only reassigns on success, so state preservation is inherent). The routine is exposed via `plugin.api.reload`, following the file's existing stance that real fs.watch events are impractical to test; tests drive the same routine the watcher fires.

Two tests, both verified failing first: a bad save resolves without rejecting, logs once, and keeps serving the old snapshot; a subsequent good save recovers and broadcasts the fresh snapshot.

Milestone: Maintenance
Plan impact: none

Closes #1107