### PR TITLE
fix(mcp): map DTCG wide-gamut color-space ids to colorjs.io identifiers

### DIFF
--- a/.changeset/fix-mcp-dtcg-color-spaces.md
+++ b/.changeset/fix-mcp-dtcg-color-spaces.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+fix get_color_formats and get_color_contrast rejecting DTCG wide-gamut color-space ids (display-p3, a98-rgb, prophoto-rgb)

--- a/packages/mcp/src/format-color.ts
+++ b/packages/mcp/src/format-color.ts
@@ -23,6 +23,15 @@ interface NormalizedColor {
   alpha?: number;
 }
 
+// Map DTCG / CSS Color 4 space identifiers to the shorter identifiers
+// colorjs.io registers. Only the ones that differ need an entry. Same
+// table as blocks' format-color (consolidation tracked in issue 1116).
+const COLORJS_SPACE_ALIASES: Record<string, string> = {
+  'display-p3': 'p3',
+  'a98-rgb': 'a98rgb',
+  'prophoto-rgb': 'prophoto',
+};
+
 export function formatColor(raw: unknown, format: ColorFormat): FormatColorResult | null {
   if (!raw || typeof raw !== 'object') return null;
   const normalized = raw as NormalizedColor;
@@ -38,7 +47,8 @@ export function formatColor(raw: unknown, format: ColorFormat): FormatColorResul
   try {
     const coords = components.map((c) => (c == null ? 0 : c));
     const [r = 0, g = 0, b = 0] = coords;
-    color = new Color(normalized.colorSpace, [r, g, b], normalized.alpha ?? 1);
+    const space = COLORJS_SPACE_ALIASES[normalized.colorSpace] ?? normalized.colorSpace;
+    color = new Color(space, [r, g, b], normalized.alpha ?? 1);
   } catch {
     return null;
   }

--- a/packages/mcp/test/format-color.test.ts
+++ b/packages/mcp/test/format-color.test.ts
@@ -72,6 +72,16 @@ describe('formatColor', () => {
     expect(result?.value).toMatch(/\/ 0\.5/);
   });
 
+  it('accepts the DTCG wide-gamut space ids colorjs.io names differently', () => {
+    // DTCG tokens carry the CSS Color 4 ids; colorjs.io registers the
+    // short forms (p3, a98rgb, prophoto). All three must format.
+    for (const colorSpace of ['display-p3', 'a98-rgb', 'prophoto-rgb']) {
+      const result = formatColor({ colorSpace, components: [1, 0, 0] }, 'oklch');
+      expect(result, colorSpace).not.toBeNull();
+      expect(formatColor({ colorSpace, components: [1, 0, 0] }, 'hex'), colorSpace).not.toBeNull();
+    }
+  });
+
   it('returns null when colorjs.io rejects the color space', () => {
     const bogus = { colorSpace: 'not-a-real-space', components: [0, 0, 0] };
     expect(formatColor(bogus, 'hex')).toBeNull();


### PR DESCRIPTION
## Summary

display-p3, a98-rgb, and prophoto-rgb tokens failed in get_color_formats and get_color_contrast because formatColor passed the DTCG space id straight to colorjs.io, which registers the short forms (p3, a98rgb, prophoto).

## Full description

Applies the same three-entry alias table blocks' format-color already carries, just before constructing the Color. New test pins all three DTCG ids formatting in hex and oklch; verified failing first (display-p3 returned null). Full consolidation of the three format-color copies into core is tracked separately. Refs #1116.

Milestone: Maintenance
Plan impact: none

Closes #1108