### PR TITLE
fix: derive CSS var names from the listing instead of dot-to-dash respelling

### DIFF
--- a/.changeset/fix-css-var-names-from-listing.md
+++ b/.changeset/fix-css-var-names-from-listing.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+fix tailwind/css-in-js integrations and MCP get_token/get_consumer_output reporting CSS var names that diverge from plugin-css output on camelCase paths; names now come from the listing via the new core cssVarName helper

--- a/packages/core/src/css-var.ts
+++ b/packages/core/src/css-var.ts
@@ -12,7 +12,24 @@
  * ergonomic minimum.
  */
 import { makeCSSVar } from '@terrazzo/token-tools/css';
+import type { Project } from '#/types.ts';
 
 export function makeCssVar(path: string, prefix: string): string {
   return prefix ? makeCSSVar(path, { prefix, wrapVar: true }) : makeCSSVar(path, { wrapVar: true });
+}
+
+/**
+ * Authoritative custom-property name (bare `--…`, no `var()` wrapper) for a
+ * token path. Listing-first: a resolver-backed project's listing carries the
+ * exact names plugin-css emitted, so reading it can never drift from the
+ * consumer's real output. Falls back to Terrazzo's own derivation for
+ * listing-less projects — never a hand-rolled dot-to-dash, which diverges on
+ * camelCase segments (`color.brandPrimary` is `--color-brand-primary` in
+ * plugin-css output, not `--color-brandPrimary`).
+ */
+export function cssVarName(path: string, project: Pick<Project, 'listing' | 'config'>): string {
+  const listed = project.listing[path]?.$extensions['app.terrazzo.listing'].names['css'];
+  if (listed) return listed;
+  const prefix = project.config.cssVarPrefix;
+  return prefix ? makeCSSVar(path, { prefix }) : makeCSSVar(path);
 }

--- a/packages/core/test/css-var-name.test.ts
+++ b/packages/core/test/css-var-name.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from 'vitest';
+import { cssVarName } from '#/css-var.ts';
+import type { Project } from '#/types.ts';
+
+function fakeProject(
+  listing: Record<string, unknown>,
+  prefix?: string,
+): Pick<Project, 'listing' | 'config'> {
+  return {
+    listing,
+    config: prefix === undefined ? {} : { cssVarPrefix: prefix },
+  } as unknown as Pick<Project, 'listing' | 'config'>;
+}
+
+it('prefers the listing name when the project carries one', () => {
+  const project = fakeProject(
+    {
+      'color.brand.primary': {
+        $extensions: { 'app.terrazzo.listing': { names: { css: '--from-the-listing' } } },
+      },
+    },
+    'sb',
+  );
+  expect(cssVarName('color.brand.primary', project)).toBe('--from-the-listing');
+});
+
+it('falls back to Terrazzo derivation, kebab-casing camelCase segments', () => {
+  expect(cssVarName('color.brandPrimary', fakeProject({}, 'sb'))).toBe('--sb-color-brand-primary');
+});
+
+it('omits the prefix segment when cssVarPrefix is unset', () => {
+  expect(cssVarName('color.brandPrimary', fakeProject({}))).toBe('--color-brand-primary');
+});

--- a/packages/integrations/src/css-in-js.ts
+++ b/packages/integrations/src/css-in-js.ts
@@ -1,4 +1,5 @@
 import type { Project, SwatchbookIntegration } from '@unpunnyfuns/swatchbook-core';
+import { cssVarName } from '@unpunnyfuns/swatchbook-core/css-var';
 import { listPaths } from '@unpunnyfuns/swatchbook-core/graph';
 
 export interface CssInJsIntegrationOptions {
@@ -69,10 +70,8 @@ export default function cssInJsIntegration(
 // Render the virtual module source: one accessor export per top-level group,
 // plus the aggregate `theme`.
 function renderTheme(project: Project): string {
-  const prefix = project.config.cssVarPrefix ?? '';
-  const varPrefix = prefix ? `${prefix}-` : '';
   const paths = collectPaths(project);
-  const tree = buildTree(paths, (path) => `var(--${varPrefix}${path.replaceAll('.', '-')})`);
+  const tree = buildTree(paths, (path) => `var(${cssVarName(path, project)})`);
 
   const groupNames = Object.keys(tree).toSorted();
   const groupExports = groupNames.map(

--- a/packages/integrations/src/tailwind.ts
+++ b/packages/integrations/src/tailwind.ts
@@ -1,4 +1,5 @@
 import type { Project, SwatchbookIntegration } from '@unpunnyfuns/swatchbook-core';
+import { cssVarName } from '@unpunnyfuns/swatchbook-core/css-var';
 
 export interface TailwindIntegrationOptions {
   /**
@@ -90,7 +91,7 @@ function renderTailwindTheme(project: Project, roles: RoleMap): string {
     if (names.length === 0) continue;
     entries.push(`  /* ${scale} */`);
     for (const [themeKey, sourcePath] of names) {
-      const sourceVar = `--${varPrefix}${sourcePath.replaceAll('.', '-')}`;
+      const sourceVar = cssVarName(sourcePath, project);
       const themeVar = `--${scale}-${varPrefix}${themeKey}`;
       entries.push(`  ${themeVar}: var(${sourceVar});`);
     }

--- a/packages/integrations/test/css-in-js.test.ts
+++ b/packages/integrations/test/css-in-js.test.ts
@@ -1,4 +1,6 @@
-import { dirname } from 'node:path';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { loadProject } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
 import { beforeAll, expect, it } from 'vitest';
@@ -59,4 +61,19 @@ it('output opens with a preview-framed banner pointing at the package', () => {
   expect(js).toMatch(
     /^\/\* Synthesized by @unpunnyfuns\/swatchbook-integrations\/css-in-js for preview\./,
   );
+});
+
+it('derives accessor var() names with Terrazzo naming for camelCase paths', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'sb-cssinjs-camel-'));
+  mkdirSync(join(cwd, 'tokens'));
+  writeFileSync(
+    join(cwd, 'tokens', 't.json'),
+    JSON.stringify({ color: { $type: 'color', brandPrimary: { $value: '#3b82f6' } } }),
+  );
+  const p = await loadProject({ tokens: ['tokens/**/*.json'], cssVarPrefix: 't' }, cwd);
+  const js = render(p);
+  // plugin-css kebab-cases camelCase segments; the accessor must reference
+  // the var that actually gets emitted, not a dot-to-dash respelling.
+  expect(js).toContain('"var(--t-color-brand-primary)"');
+  expect(js).not.toContain('var(--t-color-brandPrimary)');
 });

--- a/packages/integrations/test/tailwind.test.ts
+++ b/packages/integrations/test/tailwind.test.ts
@@ -1,4 +1,6 @@
-import { dirname } from 'node:path';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { loadProject } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
 import { beforeAll, expect, it } from 'vitest';
@@ -80,4 +82,19 @@ it('derived scales are sorted deterministically', () => {
   const spacingMatches = [...css.matchAll(/--spacing-sb-([\w-]+): /g)].map((m) => m[1]!);
   const sorted = spacingMatches.toSorted((a, b) => a.localeCompare(b, 'en'));
   expect(spacingMatches).toEqual(sorted);
+});
+
+it('derives source vars with Terrazzo naming for camelCase paths', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'sb-tw-camel-'));
+  mkdirSync(join(cwd, 'tokens'));
+  writeFileSync(
+    join(cwd, 'tokens', 't.json'),
+    JSON.stringify({ color: { $type: 'color', brandPrimary: { $value: '#3b82f6' } } }),
+  );
+  const p = await loadProject({ tokens: ['tokens/**/*.json'], cssVarPrefix: 't' }, cwd);
+  const css = render(p);
+  // plugin-css kebab-cases camelCase segments; the @theme alias must point
+  // at the var that actually gets emitted, not a dot-to-dash respelling.
+  expect(css).toContain('var(--t-color-brand-primary)');
+  expect(css).not.toContain('var(--t-color-brandPrimary)');
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,5 +1,6 @@
 import type { Project, TokenMap } from '@unpunnyfuns/swatchbook-core';
 import { emitAxisProjectedCss } from '@unpunnyfuns/swatchbook-core';
+import { cssVarName } from '@unpunnyfuns/swatchbook-core/css-var';
 import { getVariance } from '@unpunnyfuns/swatchbook-core/graph';
 import { fuzzyFilter, fuzzyMatches } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import { enumerateThemes, tupleToName } from '@unpunnyfuns/swatchbook-core/themes';
@@ -180,8 +181,7 @@ export function createServer(initial: Project): McpServer & {
 
       if (!found) return textResult(`Token not found: ${path}`);
 
-      const prefix = project.config.cssVarPrefix ?? '';
-      const cssVar = `var(--${prefix ? `${prefix}-` : ''}${path.replaceAll('.', '-')})`;
+      const cssVar = `var(${cssVarName(path, project)})`;
 
       return jsonResult({
         path,
@@ -515,7 +515,7 @@ export function createServer(initial: Project): McpServer & {
       const token = project.resolveAt(activeTuple)[path];
       if (!token) return textResult(`Token not found: ${path}`);
 
-      const cssVar = `var(--${prefix ? `${prefix}-` : ''}${path.replaceAll('.', '-')})`;
+      const cssVar = `var(${cssVarName(path, project)})`;
       const attrName = (axis: string): string =>
         prefix ? `data-${prefix}-${axis}` : `data-${axis}`;
       const attrs: Record<string, string> = {};

--- a/packages/mcp/test/css-var-naming.test.ts
+++ b/packages/mcp/test/css-var-naming.test.ts
@@ -1,0 +1,44 @@
+// get_token / get_consumer_output must report the CSS var name plugin-css
+// actually emits. plugin-css kebab-cases camelCase path segments, so a
+// dot-to-dash respelling diverges on any camelCase path.
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { loadProject } from '@unpunnyfuns/swatchbook-core';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { expect, it } from 'vitest';
+import { startTestServer } from './_helpers.ts';
+
+async function camelCaseProject(): Promise<Project> {
+  const cwd = mkdtempSync(join(tmpdir(), 'sb-mcp-camel-'));
+  mkdirSync(join(cwd, 'tokens'));
+  writeFileSync(
+    join(cwd, 'tokens', 't.json'),
+    JSON.stringify({ color: { $type: 'color', brandPrimary: { $value: '#3b82f6' } } }),
+  );
+  return loadProject({ tokens: ['tokens/**/*.json'], cssVarPrefix: 't' }, cwd);
+}
+
+it('get_token reports the Terrazzo-derived var name for camelCase paths', async () => {
+  const mcp = await startTestServer(await camelCaseProject());
+  try {
+    const result = await mcp.callJson<{ cssVar: string }>('get_token', {
+      path: 'color.brandPrimary',
+    });
+    expect(result.cssVar).toBe('var(--t-color-brand-primary)');
+  } finally {
+    await mcp.close();
+  }
+});
+
+it('get_consumer_output reports the Terrazzo-derived var name for camelCase paths', async () => {
+  const mcp = await startTestServer(await camelCaseProject());
+  try {
+    const result = await mcp.callJson<{ cssVar: string }>('get_consumer_output', {
+      path: 'color.brandPrimary',
+    });
+    expect(result.cssVar).toBe('var(--t-color-brand-primary)');
+  } finally {
+    await mcp.close();
+  }
+});

--- a/packages/mcp/test/token-introspection.test.ts
+++ b/packages/mcp/test/token-introspection.test.ts
@@ -79,7 +79,14 @@ it('get_token: returns the alias chain and resolved value per theme', async () =
 });
 
 it('get_token: returns the cssVar without a prefix segment when cssVarPrefix is empty', async () => {
-  const unprefixed: Project = { ...project, config: { ...project.config, cssVarPrefix: '' } };
+  // Listing cleared along with the prefix: a real load rebuilds the listing
+  // under the new prefix, so keeping the sb-prefixed one would be a state
+  // loadProject can't produce. This pins the listing-less fallback derivation.
+  const unprefixed: Project = {
+    ...project,
+    config: { ...project.config, cssVarPrefix: '' },
+    listing: {},
+  };
   mcp.setProject(unprefixed);
   try {
     const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });


### PR DESCRIPTION
## Summary

The tailwind integration, css-in-js integration, and MCP's get_token / get_consumer_output all derived CSS var names with a naive dot-to-dash replace, which diverges from what plugin-css actually emits for any camelCase path segment (color.brandPrimary emits as --color-brand-primary, not --color-brandPrimary). The integrations referenced vars that never exist; MCP reported names that don't match the consumer's output.

## Full description

Adds cssVarName(path, project) to core's css-var subpath: listing-first (a resolver-backed project's listing carries the exact names plugin-css emitted), falling back to Terrazzo's own makeCSSVar derivation for listing-less projects. The same single-source-of-truth rule blocks already follows via resolveCssVar. All four call sites now route through it.

Tests: core unit tests for listing-first, camelCase fallback, and unprefixed derivation; camelCase regression tests in both integrations and both MCP tools, all verified failing first with the exact divergence (var(--t-color-brandPrimary) vs var(--t-color-brand-primary)). One existing MCP test built a project with an empty prefix but the sb-prefixed listing still attached, a state loadProject cannot produce; it now clears the listing to pin the fallback derivation it was written for.

Milestone: Maintenance
Plan impact: none

Closes #1109