### PR TITLE
test(core): harden alias-literal-flip fixture to canonical DTCG dimensions

### DIFF
--- a/packages/core/test/css-axis-projected-alias-flip.test.ts
+++ b/packages/core/test/css-axis-projected-alias-flip.test.ts
@@ -47,14 +47,17 @@ it('an alias write over an alias baseline emits the new target, not the baseline
   );
 });
 
-it('a composite literal write over a partial-alias baseline emits no stale sub-field var()', () => {
-  // Pins only the metadata leak (no var() to the baseline's alias target).
-  // The width sub-field currently emits garbage because literal composite
-  // writes carry raw (un-normalized) sub-values into the transform — a
-  // separate pre-existing bug, tracked independently.
+it('a composite literal write over a partial-alias baseline emits the written sub-values, no stale alias var()', () => {
+  // Baseline border.input aliases its color sub-field to color.a; the Dark
+  // write replaces the whole composite with literals (width 2px, white). The
+  // result must carry the written width and color, not a var() back to the
+  // baseline's partial-alias target.
   const line = grep(darkCell, '--t-border-input:');
   expect(line).toBeDefined();
   expect(line).not.toContain('var(');
+  expect(line).toContain('2px');
+  expect(line).toContain('solid');
+  expect(line).toMatch(/#ffffff|#fff\b|rgb\(100% 100% 100%\)/i);
 });
 
 it('the baseline cell still aliases through', () => {

--- a/packages/core/test/fixtures/alias-literal-flip/tokens/themes/dark.json
+++ b/packages/core/test/fixtures/alias-literal-flip/tokens/themes/dark.json
@@ -11,7 +11,7 @@
     "input": {
       "$value": {
         "color": "#ffffff",
-        "width": "1px",
+        "width": { "value": 2, "unit": "px" },
         "style": "solid"
       }
     }

--- a/packages/core/test/fixtures/alias-literal-flip/tokens/tokens.json
+++ b/packages/core/test/fixtures/alias-literal-flip/tokens/tokens.json
@@ -12,7 +12,7 @@
     "input": {
       "$value": {
         "color": "{color.a}",
-        "width": "1px",
+        "width": { "value": 1, "unit": "px" },
         "style": "solid"
       }
     }


### PR DESCRIPTION
## Summary

#1119 reported that literal composite writes emit garbage dimensions (`undefinedundefined`). On investigation under terrazzo 2.3.0 this is **not a swatchbook bug** — it was an artifact of a malformed test fixture I added in #1120.

## Full description

The `alias-literal-flip` fixture authored border widths as the bare string `"width": "1px"`. That is a pre-2025.10 DTCG draft shape; the 2025.10 dimension type is the object `{ value, unit }`. Terrazzo's 2.3.0 parser correctly does not coerce the non-spec string, so the border transform received `undefined` value/unit and emitted `undefinedundefined`. The `:root` baseline showed the same garbage, which already contradicted #1119's "writes only" framing.

Verified the write-normalization hypothesis is false: with canonical `{value, unit}` dimensions, **both** the baseline and a Dark literal write emit correctly (`1px solid …` and a changed `2px dashed …`, with the written width/style/color all flowing through).

Changes:
- Fixture widths -> `{value, unit}` (baseline 1px, Dark write 2px).
- Tightened the partial-alias-baseline -> literal-write test (the #1120 alias-leak regression) to assert the real written sub-values (`2px`, `solid`, white) and no stale alias `var()`, instead of merely tolerating the garbage with a `not.toContain('var(')` check and a comment pointing at #1119.

Test-only; no changeset.

### Noted, not actioned
Terrazzo silently emits `undefinedundefined` into CSS for a malformed dimension sub-value rather than a diagnostic. The DTCG validation belongs to terrazzo's parser, but swatchbook could add a defensive emit-time warning per its fail-early stance — raised for discussion, not filed.

Milestone: Maintenance

Closes #1119