### PR TITLE
fix(core): clear the cycle marker on failed token resolution

### DIFF
--- a/.changeset/fix-cycle-sentinel-failed-resolution.md
+++ b/.changeset/fix-cycle-sentinel-failed-resolution.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+fix a failed token resolution (dangling alias) leaving a cycle marker in the shared memo, which made resolveAllAt return iteration-order-dependent values that disagreed with resolveAt

--- a/packages/core/src/token-graph/walk.ts
+++ b/packages/core/src/token-graph/walk.ts
@@ -4,8 +4,14 @@ import { canonicalKey } from '#/tuple-key.ts';
 import { isPlainObject } from '#/token-graph/internal-utils.ts';
 
 const CYCLE_SENTINEL: unique symbol = Symbol('cycle');
+// Distinct from CYCLE_SENTINEL: marks a path that resolved to undefined
+// (dangling alias, missing node). Without it, a failed resolution would leave
+// the in-progress CYCLE_SENTINEL in the shared memo, and a later lookup would
+// misread that as a cycle and return the failed node's baseline — making
+// resolveAllAt order-dependent and inconsistent with resolveAt.
+const FAILED: unique symbol = Symbol('failed');
 
-type CycleMemo = Map<string, SwatchbookToken | typeof CYCLE_SENTINEL>;
+type CycleMemo = Map<string, SwatchbookToken | typeof CYCLE_SENTINEL | typeof FAILED>;
 
 function resolveAtInternal(
   graph: TokenGraph,
@@ -34,6 +40,7 @@ function resolveAtInternal(
   const cached = memo.get(cacheKey);
   if (cached !== undefined) {
     if (cached === CYCLE_SENTINEL) return node.baselineValue;
+    if (cached === FAILED) return undefined;
     return cached;
   }
 
@@ -72,7 +79,10 @@ function resolveAtInternal(
     }
   }
 
-  if (result !== undefined) memo.set(cacheKey, result);
+  // Always overwrite the CYCLE_SENTINEL placed above — with the resolved value,
+  // or FAILED when resolution came back undefined — so the sentinel never
+  // outlives this call in the shared memo.
+  memo.set(cacheKey, result ?? FAILED);
   return result;
 }
 

--- a/packages/core/test/token-graph/walk-failed-resolution.test.ts
+++ b/packages/core/test/token-graph/walk-failed-resolution.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { TokenGraph } from '#/token-graph/types.ts';
+import { resolveAllAt, resolveAt } from '#/token-graph/walk.ts';
+
+// A dangling alias (write target absent from the graph) resolves to undefined.
+// resolveAllAt shares one memo across every node, so a failed resolution must
+// not poison that memo: it used to leave CYCLE_SENTINEL behind, which a later
+// node's lookup misread as a cycle and "resolved" to the dangling node's
+// baseline — making output depend on Object.keys() iteration order and
+// disagree with resolveAt on a fresh memo.
+//
+// `x` has a Dark alias write to a missing path; `y` aliases `x`. At mode=Dark
+// both fail to resolve. `nodeOrder` controls insertion order so the two
+// orderings exercise both memo-seeding sequences.
+function danglingGraph(nodeOrder: 'x-first' | 'y-first'): TokenGraph {
+  const x = {
+    baselineValue: { $value: '#x', $type: 'color' },
+    baselineKind: 'literal' as const,
+    writes: { mode: { Dark: { kind: 'alias' as const, target: 'missing.path' } } },
+    affectedBy: ['mode'],
+    aliases: ['missing.path'],
+    aliasedBy: ['y'],
+  };
+  const y = {
+    baselineValue: { $value: '#y', $type: 'color' },
+    baselineKind: 'alias' as const,
+    baselineAliasTarget: 'x',
+    writes: {},
+    affectedBy: ['mode'],
+    aliases: ['x'],
+    aliasedBy: [],
+  };
+  const nodes = nodeOrder === 'x-first' ? { x, y } : { y, x };
+  return { axes: ['mode'], axisDefaults: { mode: 'Light' }, nodes };
+}
+
+describe('failed resolution does not poison the shared memo', () => {
+  it('resolveAt returns undefined for a dangling alias and the node aliasing it', () => {
+    const graph = danglingGraph('x-first');
+    expect(resolveAt(graph, 'x', { mode: 'Dark' })).toBeUndefined();
+    expect(resolveAt(graph, 'y', { mode: 'Dark' })).toBeUndefined();
+  });
+
+  it('resolveAllAt omits the failed paths instead of resurrecting their baselines', () => {
+    const result = resolveAllAt(danglingGraph('x-first'), { mode: 'Dark' });
+    expect(result.x).toBeUndefined();
+    expect(result.y).toBeUndefined();
+  });
+
+  it('resolveAllAt output is independent of node iteration order', () => {
+    const xFirst = resolveAllAt(danglingGraph('x-first'), { mode: 'Dark' });
+    const yFirst = resolveAllAt(danglingGraph('y-first'), { mode: 'Dark' });
+    expect(xFirst).toEqual(yFirst);
+  });
+
+  it('resolveAllAt agrees with resolveAt for every node', () => {
+    const graph = danglingGraph('x-first');
+    const all = resolveAllAt(graph, { mode: 'Dark' });
+    for (const path of ['x', 'y']) {
+      expect(all[path]).toEqual(resolveAt(graph, path, { mode: 'Dark' }));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

A failed token resolution (dangling alias / missing node) left the in-progress `CYCLE_SENTINEL` in `resolveAllAt`'s shared memo, where a later node misread it as a cycle and resolved to the failed node's baseline. Output became dependent on `Object.keys()` iteration order and disagreed with `resolveAt`.

## Full description

`resolveAtInternal` sets `CYCLE_SENTINEL` for the current path before recursing, then at the end did `if (result !== undefined) memo.set(cacheKey, result)`. When `result` was `undefined` the sentinel stayed behind. Within a single `resolveAllAt` pass (one shared memo across all nodes), a subsequent node that aliases the failed path hit the `cached === CYCLE_SENTINEL` branch and returned the failed node's `baselineValue` instead of `undefined`.

Fix: add a distinct `FAILED` marker. The end of `resolveAtInternal` now always overwrites the sentinel — with the resolved value, or `FAILED` when resolution returned `undefined` — and the cache-hit check returns `undefined` for `FAILED`. Cycles are unaffected: a cyclic re-entry returns a defined baseline (via the sentinel branch), so the path memoizes a value, never `FAILED`.

New test (`walk-failed-resolution.test.ts`): a dangling alias and the node aliasing it both resolve to `undefined` via `resolveAt`; `resolveAllAt` omits them, is independent of node insertion order, and agrees with `resolveAt`. Verified failing first (3/4 red — `resolveAllAt` resurrected the dangling node's `#x` baseline). Existing cycle tests still pass.

Milestone: Maintenance

Closes #1113