### PR TITLE
fix(core): apply cssOptions in the axis-projected emitter, not just the listing

### DIFF
--- a/.changeset/fix-cssoptions-to-emitter.md
+++ b/.changeset/fix-cssoptions-to-emitter.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+fix cssOptions (legacyHex, transform) only reaching the listing build and not the axis-projected emitter, so preview CSS now matches the listing previewValue instead of diverging

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -25,6 +25,16 @@ function withSyntheticIds(map: TokenMap): RawTokenMap {
   return out;
 }
 
+// Produces a token's emitted CSS value, applying the same cssOptions the
+// listing build (plugin-css) applies — `legacyHex` color output and a user
+// `transform` hook — so preview CSS and the listing previewValue come from
+// one option set and never diverge.
+type TransformValue = (
+  token: TokenNormalized,
+  tokensSet: RawTokenMap,
+  permutation: Record<string, string>,
+) => ReturnType<typeof transformCSSValue>;
+
 // Distinguishes a token's variance shape so the emitter can route it.
 type VarianceInfo =
   | {
@@ -278,6 +288,18 @@ export function emitAxisProjectedCss(
   const transformAlias = (token: TokenNormalized): string =>
     makeCSSVar(token.id, { ...varOpts, wrapVar: true });
 
+  // Mirror plugin-css's value pipeline (see token-listing's build) so the
+  // emitted CSS matches the listing previewValue: same legacyHex color
+  // output, same user `transform` fallback before transformCSSValue.
+  const cssOptions = project.config.cssOptions;
+  const customTransform = cssOptions?.transform;
+  const color =
+    cssOptions?.legacyHex !== undefined ? { legacyHex: cssOptions.legacyHex } : undefined;
+  const transformValue: TransformValue = (token, tokensSet, permutation) => {
+    const opts = { tokensSet, permutation, transformAlias, ...(color && { color }) };
+    return customTransform?.(token, opts) ?? transformCSSValue(token, opts);
+  };
+
   const { axes, tokenGraph } = project;
   const variance = options.variance ?? analyzeProjectVariance(project);
 
@@ -301,7 +323,7 @@ export function emitAxisProjectedCss(
       () => true,
       defaultTuple,
       varOpts,
-      transformAlias,
+      transformValue,
     );
     if (lines.length > 0) blocks.push(`:root {\n${lines.join('\n')}\n}`);
   }
@@ -345,7 +367,7 @@ export function emitAxisProjectedCss(
         (path) => deltaPaths.has(path) && axisTouchesToken(axis.name, variance.get(path)),
         cellTuple,
         varOpts,
-        transformAlias,
+        transformValue,
       );
       if (lines.length === 0) continue;
       const selector = `[${dataAttr(prefix, axis.name)}="${cssEscape(ctx)}"]`;
@@ -359,7 +381,7 @@ export function emitAxisProjectedCss(
   //    truth for that specific token; group those cases by tuple to emit
   //    one compound block per unique joint tuple containing every token
   //    that diverges there.
-  for (const block of collectJointBlocks(project, variance, prefix, varOpts, transformAlias)) {
+  for (const block of collectJointBlocks(project, variance, prefix, varOpts, transformValue)) {
     blocks.push(block);
   }
 
@@ -426,7 +448,7 @@ function collectJointBlocks(
   variance: Map<string, VarianceInfo>,
   prefix: string,
   varOpts: VarOpts,
-  transformAlias: (token: TokenNormalized) => string,
+  transformValue: TransformValue,
 ): string[] {
   const { axes, tokenGraph, defaultTuple } = project;
   if (axes.length < 2) return [];
@@ -508,7 +530,7 @@ function collectJointBlocks(
         fullTokens,
         fullTuple,
         varOpts,
-        transformAlias,
+        transformValue,
       )) {
         lines.push(`  ${decl.varName}: ${decl.value};`);
       }
@@ -544,7 +566,7 @@ function collectLines(
   accept: (path: string) => boolean,
   permutation: Record<string, string>,
   varOpts: VarOpts,
-  transformAlias: (token: TokenNormalized) => string,
+  transformValue: TransformValue,
 ): string[] {
   const lines: string[] = [];
   for (const [path, token] of Object.entries(tokens)) {
@@ -555,7 +577,7 @@ function collectLines(
       tokensForAliasResolution,
       permutation,
       varOpts,
-      transformAlias,
+      transformValue,
     )) {
       lines.push(`  ${decl.varName}: ${decl.value};`);
     }
@@ -574,12 +596,12 @@ export function* collectTokenDeclarations(
   tokensSet: RawTokenMap,
   permutation: Record<string, string>,
   varOpts: VarOpts,
-  transformAlias: (token: TokenNormalized) => string,
+  transformValue: TransformValue,
 ): Generator<{ varName: string; value: string }> {
   const varName = makeCSSVar(path, varOpts);
   let value: ReturnType<typeof transformCSSValue>;
   try {
-    value = transformCSSValue(token, { tokensSet, permutation, transformAlias });
+    value = transformValue(token, tokensSet, permutation);
   } catch (error) {
     const permutationStr = JSON.stringify(permutation);
     const valueStr = safeStringify(token.$value);

--- a/packages/core/test/css-axis-projected-css-options.test.ts
+++ b/packages/core/test/css-axis-projected-css-options.test.ts
@@ -1,0 +1,38 @@
+/**
+ * cssOptions must shape the emitter's value output, not just the listing's.
+ * plugin-css (which builds Project.listing) applies cssOptions like
+ * `legacyHex` and a user `transform`; the axis-projected emitter calls the
+ * same transformCSSValue and so must apply them too, or the preview CSS the
+ * blocks render diverges from the listing previewValue they display.
+ */
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
+import { loadProject } from '#/load.ts';
+import type { Config } from '#/types.ts';
+import { extractBlock, grep } from './_helpers.ts';
+
+const cwd = fileURLToPath(new URL('./fixtures/css-options-legacyhex', import.meta.url));
+
+async function load(cssOptions: Config['cssOptions']) {
+  return loadProject({ tokens: ['tokens/**/*.json'], cssVarPrefix: 't', cssOptions }, cwd);
+}
+
+function previewValue(project: Awaited<ReturnType<typeof load>>, path: string): string | undefined {
+  return project.listing[path]?.$extensions['app.terrazzo.listing'].previewValue;
+}
+
+it('legacyHex makes the emitter output hex, matching the listing previewValue', async () => {
+  const project = await load({ legacyHex: true });
+  const css = emitAxisProjectedCss(project);
+  const emitted = grep(extractBlock(css, ':root'), '--t-color-brand:');
+  expect(emitted).toBe('--t-color-brand: #3b82f6;');
+  // The block-side previewValue and the emitted CSS come from one option set.
+  expect(emitted).toBe(`--t-color-brand: ${previewValue(project, 'color.brand')};`);
+});
+
+it('a user cssOptions.transform reaches the emitter', async () => {
+  const project = await load({ transform: (token) => (token.$type === 'color' ? 'tomato' : undefined) });
+  const css = emitAxisProjectedCss(project);
+  expect(grep(extractBlock(css, ':root'), '--t-color-brand:')).toBe('--t-color-brand: tomato;');
+});

--- a/packages/core/test/css-axis-projected-error-context.test.ts
+++ b/packages/core/test/css-axis-projected-error-context.test.ts
@@ -6,8 +6,17 @@
  * triggered it.
  */
 import type { TokenNormalized } from '@terrazzo/parser';
+import { transformCSSValue } from '@terrazzo/token-tools/css';
 import { expect, it } from 'vitest';
 import { collectTokenDeclarations } from '#/css-axis-projected.ts';
+
+// The real value transform — collectTokenDeclarations wraps whatever this
+// throws with token context, so the malformed token must reach transformCSSValue.
+const transformValue = (
+  token: TokenNormalized,
+  tokensSet: Record<string, TokenNormalized>,
+  permutation: Record<string, string>,
+) => transformCSSValue(token, { tokensSet, permutation });
 
 it('rethrows with token path, permutation, and $value when transformCSSValue fails', () => {
   // A color token whose `components` field is missing — exactly the
@@ -31,7 +40,7 @@ it('rethrows with token path, permutation, and $value when transformCSSValue fai
       { 'color.broken': malformed },
       { mode: 'Dark', brand: 'Brand A' },
       { prefix: 'sb' },
-      () => '',
+      transformValue,
     )) {
       // exhaust the generator
     }
@@ -63,7 +72,7 @@ it('preserves the underlying error as cause', () => {
       { 'color.broken': malformed },
       {},
       { prefix: 'sb' },
-      () => '',
+      transformValue,
     )) {
       // exhaust the generator
     }

--- a/packages/core/test/fixtures/css-options-legacyhex/tokens/tokens.json
+++ b/packages/core/test/fixtures/css-options-legacyhex/tokens/tokens.json
@@ -1,0 +1,6 @@
+{
+  "color": {
+    "$type": "color",
+    "brand": { "$value": "#3b82f6" }
+  }
+}


### PR DESCRIPTION
## Summary

`cssOptions` reached the listing build (`plugin-css`) but not the axis-projected emitter, so preview CSS could diverge from the `previewValue` blocks display.

## Full description

`computeTokenListing` forwards `cssOptions` into `plugin-css`, which applies them when it calls `transformCSSValue` — `color: { legacyHex }` and a user `transform` fallback. `emitAxisProjectedCss` called `transformCSSValue` with only `{ tokensSet, permutation, transformAlias }`, so the same token rendered differently in the emitted CSS versus the listing previewValue (e.g. `legacyHex: true` → `#3b82f6` in the listing but `rgb(23.137% 50.98% 96.471%)` in preview CSS).

Fix: build one `transformValue` closure in `emitAxisProjectedCss` that mirrors plugin-css's pipeline (`color.legacyHex`, then the `cssOptions.transform` hook as a fallback before `transformCSSValue`) and thread it through `collectLines` / `collectJointBlocks` / `collectTokenDeclarations` in place of the bare `transformAlias` (which was only ever used to feed that one call). Default behavior with no `cssOptions` is unchanged — the golden snapshot is untouched.

New test (`css-axis-projected-css-options.test.ts`): `legacyHex` makes the emitter emit hex equal to the listing previewValue; a user `transform` reaches the emitter. Both verified failing first (emitter ignored the options, output `rgb(...)`). The error-context test now passes a real `transformValue` closure so its malformed-token path still throws through the wrapper.

Milestone: Maintenance

Closes #1114