### PR TITLE
chore: bump hono and shell-quote overrides to clear advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,12 +10,13 @@ overrides:
   ip-address: ^10.1.1
   serialize-javascript: ^7.0.5
   fast-uri: ^3.1.2
-  hono: ^4.12.18
+  hono: ^4.12.21
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   ws: ^8.20.1
   webpack-dev-server: ^5.2.4
   brace-expansion@>=5: ^5.0.6
   qs: ^6.15.2
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -1967,7 +1968,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4.12.18
+      hono: ^4.12.21
 
   '@humanwhocodes/momoa@3.3.10':
     resolution: {integrity: sha512-KWiFQpSAqEIyrTXko3hFNLeQvSK8zXlJQzhhxsyVn58WFRYXST99b3Nqnu+ttOtjds2Pl2grUHGpe2NzhPynuQ==}
@@ -5940,8 +5941,8 @@ packages:
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hookable@6.1.1:
@@ -8133,8 +8134,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shelljs@0.8.5:
@@ -11463,9 +11464,9 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.25
 
   '@humanwhocodes/momoa@3.3.10': {}
 
@@ -11780,7 +11781,7 @@ snapshots:
       cors: 2.8.6
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       shx: 0.3.4
       spawn-rx: 5.1.2
       ws: 8.20.1
@@ -11800,7 +11801,7 @@ snapshots:
       concurrently: 9.2.1
       node-fetch: 3.3.2
       open: 10.2.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       spawn-rx: 5.1.2
       ts-node: 10.9.2(@swc/core@1.15.26)(@types/node@25.6.0)(typescript@6.0.3)
       zod: 3.25.76
@@ -11818,7 +11819,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -11828,7 +11829,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.3.2(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.25
       jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -14485,7 +14486,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -15552,7 +15553,7 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono@4.12.18: {}
+  hono@4.12.25: {}
 
   hookable@6.1.1: {}
 
@@ -15928,7 +15929,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   leven@3.1.0: {}
 
@@ -18163,7 +18164,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shelljs@0.8.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,9 +16,10 @@ overrides:
   ip-address: ^10.1.1
   serialize-javascript: ^7.0.5
   fast-uri: ^3.1.2
-  hono: ^4.12.18
+  hono: ^4.12.21
   '@babel/plugin-transform-modules-systemjs': ^7.29.4
   ws: ^8.20.1
   webpack-dev-server: ^5.2.4
   'brace-expansion@>=5': ^5.0.6
   qs: ^6.15.2
+  shell-quote: ^1.8.4


### PR DESCRIPTION
## Summary

Clears the 5 advisories pnpm audit / dependabot flag in the workspace lockfile — 4 moderate (hono) + 1 critical (shell-quote) — through the existing pnpm overrides block. pnpm audit now reports no known vulnerabilities.

## Full description

- hono `^4.12.18` -> `^4.12.21` (resolves 4.12.25): the 4 moderate advisories (IPv6 deny-rule bypass, Set-Cookie injection, JWT scheme acceptance, mount-prefix strip). Transitive via @modelcontextprotocol/sdk (mcp) and @docusaurus (docs). The old override range permitted the fix but the lockfile was pinned below it.
- shell-quote `^1.8.4` (new override): the critical quote() newline-escaping advisory. Dev-only, transitive via @docusaurus/core > webpack-dev-server > launch-editor.

Workspace-tree overrides — they fix what dependabot/CI scan in this repo's lockfile, and do not propagate to consumers of the published packages, so there's no published-package change and no changeset. Same mechanism as the existing uuid / qs overrides.

Gauntlet green (37/37).

Milestone: Maintenance

Closes #1130