### PR TITLE
fix(blocks): respect colorSpace in sortTokens and GradientPalette

### DIFF
--- a/.changeset/fix-colorspace-blocks.md
+++ b/.changeset/fix-colorspace-blocks.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix blocks sortTokens and GradientPalette ignoring colorSpace on wide-gamut tokens; both now route through the shared colorjs construction (new core parseColor) so perceptual sort and gradient swatches respect display-p3 / a98-rgb / prophoto-rgb

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import './GradientPalette.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
+import { parseColor } from '@unpunnyfuns/swatchbook-core/format-color';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
@@ -47,19 +48,14 @@ function asStops(raw: unknown): GradientStop[] {
   return raw as GradientStop[];
 }
 
-const pct = (n: number): string => `${(n * 100).toFixed(3)}%`;
-
 function stopCssColor(stop: GradientStop): string {
-  const color = stop.color;
-  if (!color || !Array.isArray(color.components) || color.components.length < 3) {
-    return 'transparent';
-  }
-  const [r, g, b] = color.components;
-  if (r === undefined || g === undefined || b === undefined) return 'transparent';
-  const alpha = color.alpha ?? 1;
-  return alpha === 1
-    ? `rgb(${pct(r)} ${pct(g)} ${pct(b)})`
-    : `rgb(${pct(r)} ${pct(g)} ${pct(b)} / ${alpha})`;
+  // parseColor respects the stop's colorSpace (via the colorjs space-alias
+  // map) and emits a gamut-correct CSS string — e.g. `color(display-p3 …)`
+  // for a P3 stop — rather than the old code's raw sRGB-percentage rendering
+  // that mislabeled every non-sRGB stop.
+  const color = parseColor(stop.color);
+  if (!color) return 'transparent';
+  return color.toString();
 }
 
 function stopKey(path: string, stop: GradientStop, fallback: number): string {

--- a/packages/blocks/src/internal/sort-tokens.ts
+++ b/packages/blocks/src/internal/sort-tokens.ts
@@ -1,4 +1,4 @@
-import Color from 'colorjs.io';
+import { parseColor } from '@unpunnyfuns/swatchbook-core/format-color';
 import type { VirtualToken } from '#/types.ts';
 
 export type SortBy = 'path' | 'value' | 'none';
@@ -167,29 +167,12 @@ function safeNumber(v: number | null | undefined): number {
 }
 
 function colorKey(v: unknown): { l: number; c: number; h: number } | null {
-  if (!v || typeof v !== 'object') return null;
+  // parseColor applies the colorjs space-alias map, so wide-gamut spaces
+  // (display-p3, a98-rgb, prophoto-rgb) yield a perceptual key instead of
+  // throwing and sinking the token to the end of a value sort.
+  const color = parseColor(v);
+  if (!color) return null;
   try {
-    const c = v as {
-      colorSpace?: unknown;
-      components?: unknown;
-      channels?: unknown;
-      hex?: unknown;
-    };
-    let source: unknown;
-    if (typeof c.hex === 'string') source = c.hex;
-    else if (typeof c.colorSpace === 'string') {
-      const channels = Array.isArray(c.components)
-        ? c.components
-        : Array.isArray(c.channels)
-          ? c.channels
-          : undefined;
-      if (!channels) return null;
-      source = { space: c.colorSpace, coords: channels };
-    } else return null;
-    // Color.js's constructor signature is a string or PlainColorObject —
-    // we've already narrowed `source` to one of those shapes above, but
-    // the union ends up broader than Color.js's typed surface.
-    const color = new Color(source as string);
     const [l, chroma, h] = color.to('oklch').coords;
     return { l: safeNumber(l), c: safeNumber(chroma), h: safeNumber(h) };
   } catch {

--- a/packages/blocks/test/gradient-palette.browser.test.tsx
+++ b/packages/blocks/test/gradient-palette.browser.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { GradientPalette, SwatchbookProvider } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import { makeResolveAt } from './_snapshot-helpers.ts';
+
+// A gradient with a Display-P3 first stop and an sRGB second stop. The old
+// stopCssColor rendered every stop's components as raw sRGB percentages,
+// mislabeling the P3 stop as sRGB; routing through parseColor respects the
+// colorSpace and emits a gamut-correct `color(display-p3 …)` string.
+function makeSnapshot(): ProjectSnapshot {
+  const tokens = {
+    'gradient.brand': {
+      $type: 'gradient',
+      $value: [
+        { color: { colorSpace: 'display-p3', components: [1, 0, 0] }, position: 0 },
+        { color: { colorSpace: 'srgb', components: [0, 0, 0] }, position: 1 },
+      ],
+    },
+  };
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = makeResolveAt(tokens);
+  return snap;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a wide-gamut stop in its own color space, not as raw sRGB percentages', () => {
+  const { container } = render(
+    <SwatchbookProvider value={makeSnapshot()}>
+      <GradientPalette />
+    </SwatchbookProvider>,
+  );
+  const swatches = container.querySelectorAll<HTMLElement>('.sb-gradient-palette__stop-swatch');
+  expect(swatches.length).toBe(2);
+  const p3Background = swatches[0]?.style.background ?? '';
+  // The Display-P3 red stop keeps its gamut via color(display-p3 …); it must
+  // not be flattened to the old `rgb(100% 0% 0%)` sRGB-percentage rendering.
+  expect(p3Background).toContain('display-p3');
+  expect(p3Background).not.toMatch(/%/);
+});

--- a/packages/blocks/test/sort-tokens.test.ts
+++ b/packages/blocks/test/sort-tokens.test.ts
@@ -83,4 +83,17 @@ describe('sortTokens', () => {
     const out = sortTokens(input, { by: 'value' });
     expect(out.map(([p]) => p)).toEqual(['shadow.lg', 'shadow.md', 'shadow.sm']);
   });
+
+  it('sorts wide-gamut colors into perceptual position via the colorjs space-alias map', () => {
+    // a98-rgb needs the space-alias map (a98-rgb -> a98rgb) to construct in
+    // colorjs at all; without it the perceptual key is null and the color
+    // sinks to the end instead of sorting by oklch lightness.
+    const input = [
+      entry('c.white', 'color', { colorSpace: 'srgb', components: [1, 1, 1] }),
+      entry('c.mid', 'color', { colorSpace: 'a98-rgb', components: [0.5, 0.5, 0.5] }),
+      entry('c.black', 'color', { colorSpace: 'srgb', components: [0, 0, 0] }),
+    ];
+    const out = sortTokens(input, { by: 'value' });
+    expect(out.map(([p]) => p)).toEqual(['c.black', 'c.mid', 'c.white']);
+  });
 });

--- a/packages/core/src/format-color.ts
+++ b/packages/core/src/format-color.ts
@@ -51,6 +51,22 @@ export function formatColor(
   return formatOklch(color, alpha);
 }
 
+/**
+ * Construct a colorjs.io `Color` from a normalized DTCG color payload,
+ * applying the space-alias map so wide-gamut spaces (`display-p3`,
+ * `a98-rgb`, `prophoto-rgb`) resolve. Returns null for unrecognized input.
+ *
+ * The shared primitive for consumers that need the color object itself —
+ * perceptual sorting (oklch coords) or a gamut-correct CSS string — rather
+ * than a pre-rendered display string. Replaces the hand-rolled, alias-map-
+ * less colorjs construction that previously lived in each consumer.
+ */
+export function parseColor(value: unknown): Color | null {
+  const normalized = coerce(value);
+  if (!normalized) return null;
+  return toColor(normalized);
+}
+
 // Structural read of Terrazzo's normalized color shape (or a legacy
 // `channels`/`hex` payload) without a hard dep on @terrazzo/token-tools.
 function coerce(value: unknown): NormalizedColor | null {

--- a/packages/core/test/format-color.test.ts
+++ b/packages/core/test/format-color.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatColor } from '#/format-color.ts';
+import { formatColor, parseColor } from '#/format-color.ts';
 
 describe('formatColor', () => {
   it('renders sRGB hex by default for in-gamut colors', () => {
@@ -97,5 +97,27 @@ describe('formatColor', () => {
 
   it('respects a custom fallback', () => {
     expect(formatColor(null, 'hex', 'N/A').value).toBe('N/A');
+  });
+});
+
+describe('parseColor', () => {
+  it('constructs wide-gamut colors via the space-alias map', () => {
+    for (const colorSpace of ['display-p3', 'a98-rgb', 'prophoto-rgb']) {
+      expect(parseColor({ colorSpace, components: [1, 0, 0] }), colorSpace).not.toBeNull();
+    }
+  });
+
+  it('returns null for unrecognized input', () => {
+    expect(parseColor(null)).toBeNull();
+    expect(parseColor({})).toBeNull();
+    expect(parseColor('nope')).toBeNull();
+    expect(parseColor({ colorSpace: 'not-a-space', components: [0, 0, 0] })).toBeNull();
+  });
+
+  it('yields oklch coords usable for perceptual sorting', () => {
+    const color = parseColor({ colorSpace: 'srgb', components: [1, 1, 1] });
+    if (!color) throw new Error('expected a color');
+    const [l] = color.to('oklch').coords;
+    expect(l ?? 0).toBeGreaterThan(0.9);
   });
 });


### PR DESCRIPTION
## Summary

`sortTokens` and `GradientPalette` constructed colorjs colors without the space-alias map, so wide-gamut tokens (`display-p3`, `a98-rgb`, `prophoto-rgb`) misbehaved. Both now route through a shared core primitive.

## Full description

- **sortTokens** `colorKey` passed the raw DTCG space id to colorjs, which threw on wide-gamut spaces — the perceptual key came back null and the token sank to the end of a value sort instead of sorting by oklch lightness.
- **GradientPalette** `stopCssColor` rendered every stop's components as raw sRGB percentages, mislabeling any non-sRGB stop (a P3 red showed as sRGB red).

Adds **`parseColor`** to core's `format-color` module — the kernel's `Color` construction (with the alias map) made public, the natural completion of the #1116 consolidation — and routes both consumers through it. `GradientPalette` stops now emit gamut-correct CSS (`color(display-p3 …)`); wide-gamut colors sort perceptually.

Tests (all RED first): a wide-gamut color now sorts into perceptual position (`sort-tokens.test.ts`); a Display-P3 gradient stop renders in its own space, not sRGB percentages (new `gradient-palette.browser.test.tsx`, chromium + firefox — GradientPalette's first test); `parseColor` coverage in core. Gauntlet 37/37.

Milestone: Maintenance

Closes #1112