### PR TITLE
fix(mcp): error on unknown theme name instead of silent default fallback

### DIFF
--- a/.changeset/fix-mcp-unknown-theme.md
+++ b/.changeset/fix-mcp-unknown-theme.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+fix MCP tools silently falling back to the default theme for an unknown theme name while labeling the response with the requested name; they now return an error listing the valid theme names

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -54,6 +54,24 @@ export function createServer(initial: Project): McpServer & {
     return project.resolveAt(tuple);
   };
 
+  // Validate a tool's `theme` argument. `undefined` means "use the default
+  // theme"; an unrecognized name returns an error result naming the valid
+  // themes rather than silently resolving the default tuple under the wrong
+  // label (which made responses claim data for a theme that doesn't exist).
+  const resolveThemeName = (
+    theme: string | undefined,
+  ): { themeName: string } | { error: ReturnType<typeof textResult> } => {
+    if (theme === undefined) return { themeName: defaultThemeName };
+    if (!tupleByName.has(theme)) {
+      return {
+        error: textResult(
+          `Unknown theme "${theme}". Valid themes: ${[...tupleByName.keys()].join(', ')}`,
+        ),
+      };
+    }
+    return { themeName: theme };
+  };
+
   // Iterate every `(themeName, tuple)` pair the project surfaces —
   // default + singletons + presets. Order is insertion order of
   // `tupleByName` (default first, then singletons per axis, then presets).
@@ -129,7 +147,9 @@ export function createServer(initial: Project): McpServer & {
       },
     },
     ({ filter, type, theme }) => {
-      const themeName = theme ?? defaultThemeName;
+      const resolved = resolveThemeName(theme);
+      if ('error' in resolved) return resolved.error;
+      const themeName = resolved.themeName;
       const tokens = tokensForTheme(themeName);
       const rows: { path: string; type?: string; value: string }[] = [];
       for (const [path, token] of Object.entries(tokens)) {
@@ -308,7 +328,9 @@ export function createServer(initial: Project): McpServer & {
       },
     },
     ({ path, theme }) => {
-      const themeName = theme ?? defaultThemeName;
+      const resolved = resolveThemeName(theme);
+      if ('error' in resolved) return resolved.error;
+      const themeName = resolved.themeName;
       const token = tokensForTheme(themeName)[path];
       if (!token) return textResult(`Token not found: ${path}`);
       if (token.$type !== 'color') {
@@ -344,7 +366,9 @@ export function createServer(initial: Project): McpServer & {
       },
     },
     ({ foreground, background, theme, algorithm }) => {
-      const themeName = theme ?? defaultThemeName;
+      const resolved = resolveThemeName(theme);
+      if ('error' in resolved) return resolved.error;
+      const themeName = resolved.themeName;
       const tokens = tokensForTheme(themeName);
       const fgTok = tokens[foreground];
       const bgTok = tokens[background];
@@ -406,7 +430,9 @@ export function createServer(initial: Project): McpServer & {
       },
     },
     ({ query, theme, limit }) => {
-      const themeName = theme ?? defaultThemeName;
+      const resolved = resolveThemeName(theme);
+      if ('error' in resolved) return resolved.error;
+      const themeName = resolved.themeName;
       const tokens = tokensForTheme(themeName);
       const max = limit ?? 50;
 

--- a/packages/mcp/test/unknown-theme.test.ts
+++ b/packages/mcp/test/unknown-theme.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, expect, it } from 'vitest';
+import type { Project } from '@unpunnyfuns/swatchbook-core';
+import { loadFixtureProject, startTestServer } from './_helpers.ts';
+import type { McpTestHarness } from './_helpers.ts';
+
+let mcp: McpTestHarness;
+
+// beforeAll perf escape hatch: fixture + server boot is ~1s; tests are read-only.
+beforeAll(async () => {
+  const project: Project = await loadFixtureProject();
+  mcp = await startTestServer(project);
+});
+
+afterAll(async () => {
+  await mcp.close();
+});
+
+const COLOR_TOKEN = 'color.surface.default';
+
+it('list_tokens errors on an unknown theme instead of silently using the default', async () => {
+  const text = await mcp.callText('list_tokens', { theme: 'Nonexistent' });
+  expect(text).toContain('Unknown theme');
+  expect(text).toContain('Nonexistent');
+});
+
+it('get_color_formats errors on an unknown theme', async () => {
+  const text = await mcp.callText('get_color_formats', {
+    path: COLOR_TOKEN,
+    theme: 'Nope',
+  });
+  expect(text).toContain('Unknown theme');
+});
+
+it('a real (non-default) theme name still resolves', async () => {
+  const meta = await mcp.callJson<{ themes: string[]; defaultTheme: string }>(
+    'describe_project',
+    {},
+  );
+  const nonDefault = meta.themes.find((t) => t !== meta.defaultTheme);
+  if (!nonDefault) throw new Error('fixture should surface a non-default theme');
+  const result = await mcp.callJson<{ theme: string }>('list_tokens', { theme: nonDefault });
+  expect(result.theme).toBe(nonDefault);
+});


### PR DESCRIPTION
## Summary

MCP tools that take a `theme` argument silently resolved an unknown name to the project's default tuple while labeling the response with the requested name — so a typo'd or stale theme returned default-theme data presented as the theme the agent asked for.

## Full description

`tokensForTheme` did `tupleByName.get(themeName) ?? project.defaultTuple`, and the handlers set `theme: themeName` in the response from the user's input. The fallback (meant for the no-theme-provided case) also swallowed genuinely wrong names.

Adds `resolveThemeName(theme)`: `undefined` means "default theme"; an unrecognized name returns an error result listing the valid theme names. Wired into the four theme-taking tools — `list_tokens`, `get_color_formats`, `get_color_contrast`, `get_axis_variance`. Aligns with the fail-early-with-diagnostics stance.

Tests (RED first): unknown theme on `list_tokens` and `get_color_formats` returns an "Unknown theme" error naming valid themes; a real non-default theme still resolves. (The pre-existing valid-theme test only passed because of this very bug — it asserted the echoed-back label; it now synthesizes a real theme name.) Gauntlet 37/37.

Milestone: Maintenance

Closes #1115