### PR TITLE
fix(addon): track live toolbar globals in useToken; revert per-story html override on nav

### DIFF
--- a/.changeset/fix-addon-staleness.md
+++ b/.changeset/fix-addon-staleness.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix addon live-update staleness: useToken now tracks the live toolbar axis tuple over the channel in provider-less (MDX/autodocs) renders, and a per-story axis override no longer sticks to the <html> attributes after navigating to an MDX docs page (blocks now expose useChannelGlobals)

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -5,7 +5,11 @@ import {
 } from 'virtual:swatchbook/tokens';
 import { resolveAllAt } from '@unpunnyfuns/swatchbook-core/graph';
 import { makeCssVar } from '@unpunnyfuns/swatchbook-core/css-var';
-import { useActiveAxes, useOptionalSwatchbookData } from '@unpunnyfuns/swatchbook-blocks';
+import {
+  useActiveAxes,
+  useChannelGlobals,
+  useOptionalSwatchbookData,
+} from '@unpunnyfuns/swatchbook-blocks';
 
 // Module-scope `resolveAt` for the no-provider fallback path. Built
 // once from the stable virtual-module exports — mirrors what the
@@ -58,13 +62,20 @@ export interface TokenInfo {
 export function useToken(path: TokenPath): TokenInfo {
   const snapshot = useOptionalSwatchbookData();
   const contextAxes = useActiveAxes();
+  const channelGlobals = useChannelGlobals();
   const hasContextAxes = Object.keys(contextAxes).length > 0;
 
   const prefix = snapshot?.cssVarPrefix ?? virtualCssVarPrefix;
   const resolver = snapshot?.resolveAt ?? fallbackResolveAt;
+  // Match the active-tuple resolution blocks use (see use-project's
+  // virtual-module fallback): decorator context first, then the live
+  // toolbar globals over the channel (the only signal in MDX / autodocs
+  // where no decorator runs), then the static default tuple. Without the
+  // channel-globals step, useToken stayed pinned to the default in MDX and
+  // disagreed with the rendered CSS after a toolbar axis flip.
   const tuple = hasContextAxes
     ? (contextAxes as Record<string, string>)
-    : (snapshot?.defaultTuple ?? virtualDefaultTuple);
+    : (channelGlobals.axes ?? snapshot?.defaultTuple ?? virtualDefaultTuple);
   const token = resolver(tuple)[path] as
     | { $value?: unknown; $type?: string; $description?: string }
     | undefined;

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -126,8 +126,20 @@ function composeThemeName(tuple: Readonly<Record<string, string>>): string {
 // joint compounds across multiple) — that's the actual scoping
 // surface the cascade resolves through. Prefix follows `cssVarPrefix`
 // so attr namespace and emitted selectors stay in lockstep.
+//
+// Dedupes against the *actual* last-applied root state (module-level, not
+// per-caller): both the decorator (per-story tuple) and the global axis
+// applier (toolbar tuple) write `<html>` through here. Keying the guard on
+// the real last write lets the global applier — or the decorator's unmount
+// cleanup — correct `<html>` back to the toolbar tuple after a per-story
+// override. Previously the global applier's private guard skipped that,
+// leaving MDX docs pages stuck on the prior story's override.
+let lastRootKey: string | null = null;
 function setRootAxes(tuple: Readonly<Record<string, string>>): void {
   if (typeof document === 'undefined') return;
+  const key = composeThemeName(tuple);
+  if (key === lastRootKey) return;
+  lastRootKey = key;
   const root = document.documentElement;
   for (const axis of virtualAxes) {
     const attr = dataAttr(cssVarPrefix, axis.name);
@@ -275,7 +287,13 @@ const themedDecorator: Decorator = (Story, context) => {
 
   useEffect(() => {
     setRootAxes(tuple);
-  }, [tuple]);
+    return () => {
+      // On unmount — navigating away from this story, e.g. to an MDX docs
+      // page that renders no decorator — revert <html> to the toolbar tuple
+      // so a per-story axis override doesn't persist onto the next page.
+      setRootAxes(resolveTuple(axesGlobal, undefined));
+    };
+  }, [tuple, axesGlobal]);
 
   // Page-level live region announces theme/axis flips to SR users.
   // Initial mount stays silent (no spurious announcement on every story
@@ -409,13 +427,12 @@ function installGlobalAxisApplier(): void {
   // downstream `setRootAxes` + `useSyncExternalStore` consumers
   // re-render at most once per real change instead of three times per
   // tick.
-  let lastApplied = '';
+  // No per-caller dedupe here: setRootAxes self-dedupes against the real
+  // last-applied root state, so the global applier always re-applies the
+  // toolbar tuple and can correct <html> after a story's per-story override
+  // (the three events per tick collapse to one DOM write via that guard).
   const onGlobals = (payload: { globals?: SwatchbookGlobals }): void => {
     if (!payload.globals) return;
-    const tuple = resolveTuple(payload.globals[AXES_GLOBAL_KEY], undefined);
-    const themeKey = composeThemeName(tuple);
-    if (themeKey === lastApplied) return;
-    lastApplied = themeKey;
     apply(payload.globals);
   };
   channel.on('globalsUpdated', onGlobals);

--- a/packages/addon/test/use-token.browser.test.tsx
+++ b/packages/addon/test/use-token.browser.test.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react';
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
+import { addons } from 'storybook/preview-api';
 import { describe, expect, it } from 'vitest';
 import { AxesContext, ThemeContext } from '@unpunnyfuns/swatchbook-blocks';
 import { useToken } from '#/hooks/use-token.ts';
@@ -75,5 +76,24 @@ describe('useToken', () => {
       wrapper: withPermutation('Light', { mode: 'Light' }),
     });
     expect(result.current.description).toBeUndefined();
+  });
+
+  it('tracks the live toolbar axis tuple over the channel in provider-less (MDX) renders', () => {
+    // No provider/decorator context — the MDX / autodocs case. The active
+    // tuple then comes only from the toolbar globals over the channel; the
+    // hook used to ignore those and stay pinned to the default tuple.
+    const channel = addons.getChannel();
+    const { result } = renderHook(() => useToken('color.accent.bg'));
+    expect(result.current.value).toEqual({ colorSpace: 'srgb', components: [0, 0.4, 1] });
+
+    act(() => {
+      channel.emit('setGlobals', { globals: { swatchbookAxes: { mode: 'Dark' } } });
+    });
+    expect(result.current.value).toEqual({ colorSpace: 'srgb', components: [0, 0.2, 0.8] });
+
+    // Restore the shared channel-globals store so other tests aren't affected.
+    act(() => {
+      channel.emit('setGlobals', { globals: { swatchbookAxes: { mode: 'Light' } } });
+    });
   });
 });

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -39,6 +39,7 @@ export {
   type VirtualTokenListingShape,
   type VirtualTokenShape,
 } from '#/contexts.ts';
+export { type ChannelGlobals, useChannelGlobals } from '#/internal/channel-globals.ts';
 export {
   SwatchbookProvider,
   type SwatchbookProviderProps,


### PR DESCRIPTION
## Summary

Two of #1111's four live-update staleness findings. The other two are split into focused issues — **#1136** (decorator HMR snapshot is static; pervasive preview.tsx refactor) and **#1137** (frozen fs watch set; fs-watch portability work).

## Full description

**useToken ignored live toolbar globals in MDX (#1111 finding 4).** In provider-less renders (MDX / autodocs, where no decorator supplies `AxesContext`), `useToken` fell straight to the static default tuple, disagreeing with the rendered CSS after a toolbar axis flip. It now resolves `context → live channel globals → default`, mirroring blocks' `use-project` fallback. `useChannelGlobals` is now exported from blocks for this.

**Per-story `<html>` override stuck on MDX (#1111 finding 3).** The decorator wrote per-story axis overrides to `<html>` via `setRootAxes`, but nothing reverted them; the global axis applier's private dedupe guard then skipped re-applying the toolbar tuple, so navigating to an MDX docs page left `<html>` on the prior story's override. Fix: `setRootAxes` self-dedupes against the real last-applied root state, the decorator reverts to the toolbar tuple on unmount, and the global applier drops its stale guard.

### Verification
- **Live in Storybook:** navigating the `tests-themeswitch--dark` per-story override → `docs-colors--docs` (MDX) reverts `<html>` from `data-sb-mode="Dark"` back to `"Light"`. Confirmed via the running preview iframe.
- **Browser test:** new case in `use-token.browser.test.tsx` — provider-less `useToken` tracks a `swatchbookAxes` channel flip (Light→Dark value), with a reset to keep the shared store clean.
- Gauntlet 37/37.

Milestone: Maintenance

Closes #1111