### PR TITLE
fix(addon): re-arm the token watcher so new files trigger reloads

### DIFF
--- a/.changeset/fix-addon-watch-rearm.md
+++ b/.changeset/fix-addon-watch-rearm.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+fix the dev-server token watcher ignoring newly-added token files: it no longer filters to a basename allow-list frozen at server start, and re-arms after each reload so new directories get watched too

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -4,7 +4,7 @@ import { listPaths } from '@unpunnyfuns/swatchbook-core/graph';
 import { snapshotForWire } from '@unpunnyfuns/swatchbook-core/snapshot-for-wire';
 import { watch as fsWatch } from 'node:fs';
 import type { FSWatcher } from 'node:fs';
-import { basename, dirname, isAbsolute, resolve as resolvePath } from 'node:path';
+import { dirname, extname, isAbsolute, resolve as resolvePath } from 'node:path';
 import picomatch from 'picomatch';
 import type { Plugin, ViteDevServer } from 'vite';
 import {
@@ -33,6 +33,12 @@ export interface SwatchbookTokensPluginOptions {
 function resolvedId(virtualId: string): string {
   return `\0${virtualId}`;
 }
+
+// File extensions the dir watcher treats as token sources. Watching a
+// directory surfaces every change in it; this filter keeps editor temp
+// files, `.DS_Store`, etc. from triggering reloads while still catching
+// newly-added token files (the frozen-basename filter previously missed).
+const TOKEN_FILE_EXTENSIONS = new Set(['.json', '.jsonc', '.json5', '.yaml', '.yml']);
 
 /**
  * Vite plugin that serves the virtual `virtual:swatchbook/tokens` module —
@@ -206,41 +212,46 @@ export function swatchbookTokensPlugin({
         if (pending) clearTimeout(pending);
         pending = setTimeout(() => {
           pending = null;
-          void reload(server);
+          // Re-arm after each reload: a token edit can add a `$ref` to a
+          // file in a directory we weren't watching, and the refreshed
+          // `project.sourceFiles` surfaces it.
+          void reload(server).then(armWatchers);
         }, 100);
       };
 
-      // Watch each source file's *parent directory* rather than the file
-      // itself. File-level `fs.watch` is fragile: atomic-save editors
-      // unlink the old inode and write a new one, so the original
-      // watcher either fires a one-shot 'rename' and goes deaf, or on
-      // some platforms loops on ghost events for the old inode. Watching
-      // the dir sidesteps both — the dir inode is stable across the
-      // rename dance — and filename filtering keeps event volume low.
+      // Watch the token *directories* rather than individual files. File-
+      // level `fs.watch` is fragile: atomic-save editors unlink the old
+      // inode and write a new one, so a file watcher fires a one-shot
+      // 'rename' and goes deaf. Watching the dir (inode stable across the
+      // rename) sidesteps that; an extension filter keeps event volume low.
       //
-      // Vite's `server.watcher` still wouldn't carry these events across
-      // pnpm symlink boundaries, so we keep running our own watchers.
-      const byDir = new Map<string, Set<string>>();
-      for (const file of project?.sourceFiles ?? []) {
-        const dir = dirname(file);
-        const set = byDir.get(dir) ?? new Set<string>();
-        set.add(basename(file));
-        byDir.set(dir, set);
-      }
-
-      const fileWatchers: FSWatcher[] = [];
-      for (const [dir, names] of byDir) {
-        try {
-          const w = fsWatch(dir, { persistent: false }, (eventType, filename) => {
-            if (!filename) return;
-            if (!names.has(filename)) return;
-            if (eventType === 'change' || eventType === 'rename') invalidate();
-          });
-          fileWatchers.push(w);
-        } catch {
-          // unwatchable dir — skip. Next loadProject pass will report it.
+      // Re-derived on every call (not a basename set frozen at server
+      // start) so a newly-added token file in a watched dir triggers a
+      // reload. `fs.watch` recursive mode isn't portable to Linux/CI, so we
+      // re-arm after reloads to pick up new directories instead.
+      //
+      // Vite's `server.watcher` wouldn't carry these events across pnpm
+      // symlink boundaries, so we run our own watchers.
+      let fileWatchers: FSWatcher[] = [];
+      function armWatchers(): void {
+        for (const w of fileWatchers) w.close();
+        fileWatchers = [];
+        const dirs = new Set<string>(collectWatchPaths(config, project, cwd));
+        for (const file of project?.sourceFiles ?? []) dirs.add(dirname(file));
+        for (const dir of dirs) {
+          try {
+            const w = fsWatch(dir, { persistent: false }, (eventType, filename) => {
+              if (!filename) return;
+              if (!TOKEN_FILE_EXTENSIONS.has(extname(filename))) return;
+              if (eventType === 'change' || eventType === 'rename') invalidate();
+            });
+            fileWatchers.push(w);
+          } catch {
+            // unwatchable dir — skip. Next loadProject pass will report it.
+          }
         }
       }
+      armWatchers();
       server.httpServer?.once('close', () => {
         for (const w of fileWatchers) w.close();
       });

--- a/packages/addon/test/virtual-plugin-watch.test.ts
+++ b/packages/addon/test/virtual-plugin-watch.test.ts
@@ -1,0 +1,43 @@
+// The dir watcher must reload when a *new* token file appears in a watched
+// directory — the previous implementation froze a basename allow-list at
+// server start, so files added later were silently ignored. Drives the real
+// fs.watch via configureServer against a temp project.
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ViteDevServer } from 'vite';
+import { expect, it, vi } from 'vitest';
+import { swatchbookTokensPlugin } from '#/virtual/plugin.ts';
+
+function colorDoc(name: string, hex: string): string {
+  return JSON.stringify({ color: { $type: 'color', [name]: { $value: hex } } });
+}
+
+it('reloads when a new token file is added to a watched directory', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'sb-watch-'));
+  mkdirSync(join(cwd, 'tokens'));
+  writeFileSync(join(cwd, 'tokens', 'a.json'), colorDoc('a', '#000000'));
+
+  const plugin = swatchbookTokensPlugin({ config: { tokens: ['tokens/**/*.json'] }, cwd });
+  await (plugin.buildStart as unknown as () => Promise<void>).call(plugin);
+
+  const logger = { info: vi.fn(), error: vi.fn(), warn: vi.fn() };
+  const send = vi.fn();
+  const server = {
+    config: { logger },
+    moduleGraph: { getModuleById: () => undefined },
+    ws: { send },
+  } as unknown as ViteDevServer;
+  await (plugin.configureServer as unknown as (s: ViteDevServer) => Promise<void>).call(
+    plugin,
+    server,
+  );
+
+  // A brand-new file in the watched dir — not present when watchers armed.
+  writeFileSync(join(cwd, 'tokens', 'b.json'), colorDoc('b', '#ffffff'));
+
+  // fs.watch event + 100ms debounce + reload.
+  await vi.waitFor(() => expect(send).toHaveBeenCalled(), { timeout: 2000, interval: 100 });
+  const payload = JSON.stringify(send.mock.calls.at(-1)?.[0]);
+  expect(payload).toContain('color.b');
+});


### PR DESCRIPTION
## Summary

The dev-server token watcher ignored newly-added token files: it froze a per-directory basename allow-list at server start and dropped any event whose filename wasn't in it.

## Full description

`configureServer` built `byDir` from `project.sourceFiles` once and filtered events with `if (!names.has(filename)) return;`. So a new file in a watched dir was ignored, a file in a new dir wasn't watched, and the set never rebuilt after a reload.

Fix: watch the token directories (`collectWatchPaths` base dirs ∪ sourceFile parents), filter by token file extension (`.json`/`.jsonc`/`.json5`/`.yaml`/`.yml`) rather than a frozen basename set, and **re-arm** watchers after each reload to pick up directories a new `$ref` introduced. `fs.watch` recursive mode isn't portable to Linux/CI, so re-arming covers new dirs instead of recursive watching.

New integration test drives the real `fs.watch`: adding a second token file to a watched dir triggers a reload whose broadcast carries the new token (`color.b`). RED on the old code — the basename filter rejects unknown filenames. Gauntlet 37/37.

Milestone: Maintenance

Closes #1137