### PR TITLE
fix(addon): decorator reads the live token store so story blocks refresh on HMR

### DIFF
--- a/.changeset/fix-decorator-hmr-snapshot.md
+++ b/.changeset/fix-decorator-hmr-snapshot.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+fix blocks rendered inside stories staying stale after a dev-time token save: the addon decorator now builds its ProjectSnapshot and resolveAt from the live token store (updated on HMR) instead of the static virtual-module exports (blocks now expose useTokenSnapshot)

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -30,6 +30,7 @@ import {
   registerTokenSource,
   SwatchbookContext,
   ThemeContext,
+  useTokenSnapshot,
 } from '@unpunnyfuns/swatchbook-blocks';
 import type { ColorFormat, ProjectSnapshot } from '@unpunnyfuns/swatchbook-blocks';
 import {
@@ -252,9 +253,6 @@ function resolveColorFormat(raw: SwatchbookGlobals[typeof COLOR_FORMAT_GLOBAL_KE
 // downstream `ProjectSnapshot` consumers can key memos on the snapshot
 // wrapper without worrying about `resolveAt` churning when Storybook
 // recreates `context.globals`.
-const previewResolveAt = (tuple: Record<string, string>): TokenMap =>
-  resolveAllAt(virtualTokenGraph, tuple);
-
 const themedDecorator: Decorator = (Story, context) => {
   const globals = context.globals as SwatchbookGlobals;
   const parameters = context.parameters as StoryParameters;
@@ -303,20 +301,32 @@ const themedDecorator: Decorator = (Story, context) => {
     wrapperAttrs[dataAttr(cssVarPrefix, name)] = value;
   });
 
+  // Read token data from the live snapshot store (seeded from the virtual
+  // module at init, updated in place on each dev-time HMR token save) rather
+  // than the static virtual-module exports — so blocks rendered inside
+  // stories pick up edited values without a full preview reload. The tuple /
+  // theme still come from the toolbar globals + per-story params above.
+  const live = useTokenSnapshot();
+  const resolveAt = useMemo(
+    () =>
+      (t: Record<string, string>): TokenMap =>
+        resolveAllAt(live.tokenGraph, t),
+    [live.tokenGraph],
+  );
   const snapshot = useMemo<ProjectSnapshot>(
     () => ({
-      axes: virtualAxes,
+      axes: live.axes,
       activeTheme: themeName,
       activeAxes: tuple,
-      cssVarPrefix,
-      diagnostics,
-      css,
-      listing: virtualListing,
-      tokenGraph: virtualTokenGraph,
-      defaultTuple: virtualDefaultTuple,
-      resolveAt: previewResolveAt,
+      cssVarPrefix: live.cssVarPrefix,
+      diagnostics: live.diagnostics,
+      css: live.css,
+      listing: live.listing,
+      tokenGraph: live.tokenGraph,
+      defaultTuple: live.defaultTuple,
+      resolveAt,
     }),
-    [themeName, tuple],
+    [themeName, tuple, live, resolveAt],
   );
 
   return (

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -44,7 +44,11 @@ export {
   type SwatchbookProviderProps,
   useSwatchbookData,
 } from '#/provider.tsx';
-export { registerTokenSource, type TokenSnapshot } from '#/internal/channel-tokens.ts';
+export {
+  registerTokenSource,
+  type TokenSnapshot,
+  useTokenSnapshot,
+} from '#/internal/channel-tokens.ts';
 export type {
   ProjectSnapshot,
   VirtualAxis,


### PR DESCRIPTION
## Summary

Blocks rendered *inside stories* stayed stale after a dev-time token save — the HMR channel updated the standalone-blocks path but not the decorator's provided snapshot.

## Full description

`themedDecorator` built its `ProjectSnapshot` and `resolveAt` from the static `virtual:swatchbook/tokens` exports (`virtualTokenGraph`, `css`, `virtualListing`, …), so blocks reading `SwatchbookContext` never saw HMR updates. The decorator now reads `useTokenSnapshot()` — the live store seeded at preview init and updated in place on each HMR token save (the mechanism #1135 introduced) — and builds the snapshot + `resolveAt` from it. The tuple/theme still come from toolbar globals + per-story params. `useTokenSnapshot` is now exported from blocks.

The module-level axis helpers (`setRootAxes`, `composeThemeName`) keep using the virtual axis *structure*, which is stable across value edits; only the value-bearing snapshot fields move to the live store.

### Verification
Live in Storybook: with the `UseTokenUpdates/Light` story open, editing `color.palette.neutral.0` in the token source updated the block's `useToken('color.surface.default')` readout from `[1,1,1]` to the new value **in place** — a sentinel set on the preview-iframe window survived, confirming an HMR update rather than a full reload. (HMR-through-decorator is integration-level; verified live rather than unit-tested.)

Milestone: Maintenance

Closes #1136