### PR TITLE
test: backfill review-identified coverage gaps (core, blocks, mcp)

### DIFF
--- a/packages/blocks/test/channel-globals.browser.test.tsx
+++ b/packages/blocks/test/channel-globals.browser.test.tsx
@@ -1,0 +1,42 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { addons } from 'storybook/preview-api';
+import { afterEach, describe, expect, it } from 'vitest';
+import { useChannelGlobals } from '#/internal/channel-globals.ts';
+
+// The provider-less (MDX docs) path: blocks read the toolbar's axes/format
+// straight off the Storybook globals channel. Each test emits its own
+// globals so it doesn't depend on the shared module snapshot's prior state.
+const channel = addons.getChannel();
+function emitGlobals(globals: Record<string, unknown>): void {
+  act(() => {
+    channel.emit('setGlobals', { globals });
+  });
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useChannelGlobals', () => {
+  it('captures axes and format from a globals event', () => {
+    const { result } = renderHook(() => useChannelGlobals());
+    emitGlobals({ swatchbookAxes: { mode: 'Dark' }, swatchbookColorFormat: 'rgb' });
+    expect(result.current.axes).toEqual({ mode: 'Dark' });
+    expect(result.current.format).toBe('rgb');
+  });
+
+  it('retains a field when a later event omits it (partial merge)', () => {
+    const { result } = renderHook(() => useChannelGlobals());
+    emitGlobals({ swatchbookAxes: { mode: 'Light' }, swatchbookColorFormat: 'hex' });
+    emitGlobals({ swatchbookAxes: { mode: 'Dark' } });
+    expect(result.current.axes).toEqual({ mode: 'Dark' });
+    expect(result.current.format).toBe('hex');
+  });
+
+  it('ignores an unrecognized color format', () => {
+    const { result } = renderHook(() => useChannelGlobals());
+    emitGlobals({ swatchbookColorFormat: 'oklch' });
+    emitGlobals({ swatchbookColorFormat: 'not-a-real-format' });
+    expect(result.current.format).toBe('oklch');
+  });
+});

--- a/packages/blocks/test/use-project-resolvers.test.ts
+++ b/packages/blocks/test/use-project-resolvers.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { resolveColorValue, resolveCssVar } from '#/internal/use-project.ts';
+
+describe('resolveCssVar', () => {
+  it('prefers the listing name over the derived fallback (distinct names prove the branch)', () => {
+    const project = {
+      cssVarPrefix: 'sb',
+      // A name that could NOT come from the fallback derivation of this path,
+      // so a passing test can only mean the listing-first branch ran.
+      listing: { 'color.brand': { names: { css: '--authoritative-from-plugin-css' } } },
+    } as unknown as Parameters<typeof resolveCssVar>[1];
+    expect(resolveCssVar('color.brand', project)).toBe('var(--authoritative-from-plugin-css)');
+  });
+
+  it('falls back to the derived var when the listing has no entry for the path', () => {
+    const project = { cssVarPrefix: 'sb', listing: {} } as unknown as Parameters<
+      typeof resolveCssVar
+    >[1];
+    // The fallback derivation (makeCssVar) is covered in core; here we only
+    // assert it's used (kebab-cased, prefixed) and not the listing.
+    expect(resolveCssVar('color.brand', project)).toBe('var(--sb-color-brand)');
+  });
+});
+
+describe('resolveColorValue', () => {
+  const project = {
+    listing: { 'color.brand': { previewValue: '#abcdef' } },
+  } as unknown as Parameters<typeof resolveColorValue>[3];
+  const raw = { colorSpace: 'srgb', components: [0, 0, 0] };
+
+  it('uses the listing previewValue for hex format on a keyed path', () => {
+    expect(resolveColorValue('color.brand', raw, 'hex', project)).toEqual({
+      value: '#abcdef',
+      outOfGamut: false,
+    });
+  });
+
+  it('falls back to formatColor for non-hex formats (listing has only the canonical form)', () => {
+    const out = resolveColorValue('color.brand', raw, 'rgb', project);
+    expect(out.value).toMatch(/^rgb\(/);
+  });
+
+  it('falls back to formatColor when the path has no listing previewValue', () => {
+    const out = resolveColorValue('color.unlisted', raw, 'hex', project);
+    expect(out.value).toBe('#000000');
+  });
+
+  it('falls back to formatColor for composite sub-colors (path undefined)', () => {
+    const out = resolveColorValue(undefined, raw, 'hex', project);
+    expect(out.value).toBe('#000000');
+  });
+});

--- a/packages/core/test/snapshot-for-wire.test.ts
+++ b/packages/core/test/snapshot-for-wire.test.ts
@@ -20,4 +20,54 @@ describe('snapshotForWire', () => {
     const roundtripped = JSON.parse(JSON.stringify(wire.tokenGraph));
     expect(roundtripped).toEqual(wire.tokenGraph);
   });
+
+  it('slims each listing entry to names + previewValue + source, dropping other extension fields', () => {
+    const project = {
+      axes: [],
+      disabledAxes: [],
+      presets: [],
+      diagnostics: [],
+      config: {},
+      defaultTuple: {},
+      tokenGraph: { nodes: {}, axes: [], axisDefaults: {}, axisContexts: {} },
+      listing: {
+        'color.a': {
+          $name: 'color.a',
+          $type: 'color',
+          $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+          $extensions: {
+            'app.terrazzo.listing': {
+              names: { css: '--color-a' },
+              previewValue: '#000000',
+              source: { resource: 'color.json' },
+              originalValue: { colorSpace: 'srgb', components: [0, 0, 0] },
+            },
+          },
+        },
+      },
+    } as unknown as Parameters<typeof snapshotForWire>[0];
+
+    const wire = snapshotForWire(project, '');
+    expect(wire.listing['color.a']).toEqual({
+      names: { css: '--color-a' },
+      previewValue: '#000000',
+      source: { resource: 'color.json' },
+    });
+    // originalValue (the heavy field) is dropped by the slimmer.
+    expect('originalValue' in wire.listing['color.a']!).toBe(false);
+  });
+
+  it('returns an empty listing for an empty input (a no-op slimmer would too — but the names are asserted above)', () => {
+    const project = {
+      axes: [],
+      disabledAxes: [],
+      presets: [],
+      diagnostics: [],
+      config: {},
+      defaultTuple: {},
+      tokenGraph: { nodes: {}, axes: [], axisDefaults: {}, axisContexts: {} },
+      listing: {},
+    } as unknown as Parameters<typeof snapshotForWire>[0];
+    expect(snapshotForWire(project, '').listing).toEqual({});
+  });
 });

--- a/packages/core/test/value-key.test.ts
+++ b/packages/core/test/value-key.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest';
+import { valueKey } from '#/value-key.ts';
+
+it('returns the empty string for a missing token', () => {
+  expect(valueKey(undefined)).toBe('');
+  expect(valueKey({})).toBe(valueKey({ $value: undefined }));
+});
+
+it('is insensitive to object key insertion order (the load-bearing invariant)', () => {
+  // A walker that reconstitutes a partial-alias composite appends the
+  // aliased sub-fields last; the key must still match the original order so
+  // delta detection treats the two as equal.
+  const a = { $value: { color: '#000', width: '1px', style: 'solid' } };
+  const b = { $value: { style: 'solid', color: '#000', width: '1px' } };
+  expect(valueKey(a)).toBe(valueKey(b));
+});
+
+it('sorts keys recursively in nested objects', () => {
+  const a = { $value: { outer: { x: 1, y: 2 }, z: 3 } };
+  const b = { $value: { z: 3, outer: { y: 2, x: 1 } } };
+  expect(valueKey(a)).toBe(valueKey(b));
+});
+
+it('distinguishes genuinely different values', () => {
+  expect(valueKey({ $value: '#000' })).not.toBe(valueKey({ $value: '#fff' }));
+  expect(valueKey({ $value: { a: 1 } })).not.toBe(valueKey({ $value: { a: 2 } }));
+});
+
+it('preserves array element order (arrays are not key-sorted)', () => {
+  // Gradient stops / shadow layers are order-significant.
+  expect(valueKey({ $value: [1, 2, 3] })).not.toBe(valueKey({ $value: [3, 2, 1] }));
+});

--- a/packages/mcp/src/bin.ts
+++ b/packages/mcp/src/bin.ts
@@ -10,30 +10,11 @@ import { watch as fsWatch } from 'node:fs';
 import type { FSWatcher } from 'node:fs';
 import { basename, dirname, isAbsolute, resolve } from 'node:path';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { parseArgs } from '#/cli-args.ts';
 import { loadFromConfig } from '#/load-config.ts';
 import { createServer } from '#/server.ts';
 
-interface CliArgs {
-  config?: string;
-  cwd?: string;
-  watch: boolean;
-}
-
-function parseArgs(argv: readonly string[]): CliArgs {
-  const out: CliArgs = { watch: true };
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i];
-    const next = argv[i + 1];
-    if ((arg === '--config' || arg === '-c') && next) {
-      out.config = next;
-      i++;
-    } else if (arg === '--cwd' && next) {
-      out.cwd = next;
-      i++;
-    } else if (arg === '--no-watch') {
-      out.watch = false;
-    } else if (arg === '--help' || arg === '-h') {
-      console.log(`swatchbook-mcp — Model Context Protocol server for swatchbook projects
+const HELP_TEXT = `swatchbook-mcp — Model Context Protocol server for swatchbook projects
 
 Usage:
   swatchbook-mcp --config <path>              Point at a swatchbook.config.{ts,mts,js,mjs}
@@ -57,12 +38,7 @@ Tools exposed:
   get_axis_variance   Classify token variance (constant / single / multi) per axis.
   list_axes           Axes + contexts + themes + presets.
   get_diagnostics     Project diagnostics (optional severity filter).
-  emit_css            Full project stylesheet.`);
-      process.exit(0);
-    }
-  }
-  return out;
-}
+  emit_css            Full project stylesheet.`;
 
 // Watch the project's source files + config path for edits. Debounces
 // filesystem events (editors fire 2-3 per save) into a single reload per
@@ -121,6 +97,10 @@ function setupReload(
 
 async function main(): Promise<void> {
   const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(HELP_TEXT);
+    process.exit(0);
+  }
   if (!args.config) {
     console.error('swatchbook-mcp: --config <path> is required. Use --help for usage.');
     process.exit(1);

--- a/packages/mcp/src/cli-args.ts
+++ b/packages/mcp/src/cli-args.ts
@@ -1,0 +1,32 @@
+/**
+ * Parsed `swatchbook-mcp` CLI arguments. Pure — kept out of `bin.ts` (which
+ * self-executes on import) so the parsing is unit-testable. `--help` is
+ * surfaced as a flag rather than printed here, leaving stdout side effects
+ * and `process.exit` to the entry point.
+ */
+export interface CliArgs {
+  config?: string;
+  cwd?: string;
+  watch: boolean;
+  help: boolean;
+}
+
+export function parseArgs(argv: readonly string[]): CliArgs {
+  const out: CliArgs = { watch: true, help: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = argv[i + 1];
+    if ((arg === '--config' || arg === '-c') && next) {
+      out.config = next;
+      i++;
+    } else if (arg === '--cwd' && next) {
+      out.cwd = next;
+      i++;
+    } else if (arg === '--no-watch') {
+      out.watch = false;
+    } else if (arg === '--help' || arg === '-h') {
+      out.help = true;
+    }
+  }
+  return out;
+}

--- a/packages/mcp/test/cli-args.test.ts
+++ b/packages/mcp/test/cli-args.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from 'vitest';
+import { parseArgs } from '#/cli-args.ts';
+
+it('defaults to watch on, no help, no config', () => {
+  expect(parseArgs([])).toEqual({ watch: true, help: false });
+});
+
+it('parses --config and its -c alias with the following value', () => {
+  expect(parseArgs(['--config', 'swatchbook.config.ts']).config).toBe('swatchbook.config.ts');
+  expect(parseArgs(['-c', 'resolver.json']).config).toBe('resolver.json');
+});
+
+it('parses --cwd', () => {
+  expect(parseArgs(['--config', 'c.ts', '--cwd', '/proj']).cwd).toBe('/proj');
+});
+
+it('--no-watch disables watching', () => {
+  expect(parseArgs(['--config', 'c.ts', '--no-watch']).watch).toBe(false);
+});
+
+it('--help / -h set the help flag without consuming a value', () => {
+  expect(parseArgs(['--help'])).toEqual({ watch: true, help: true });
+  expect(parseArgs(['-h']).help).toBe(true);
+});
+
+it('ignores a flag that expects a value when none follows', () => {
+  // `--config` at the end with no path: not consumed, config stays undefined.
+  expect(parseArgs(['--config']).config).toBeUndefined();
+});
+
+it('takes the last value when a flag is repeated', () => {
+  expect(parseArgs(['-c', 'a.ts', '-c', 'b.ts']).config).toBe('b.ts');
+});


### PR DESCRIPTION
## Summary

Adds the missing tests #1117 flagged — gaps where a real regression would keep the suite green. Test-only plus a small `parseArgs` extraction; no changeset.

## Coverage added
- **core value-key** — key-order-insensitivity invariant (composite delta detection relies on it) + array-order preservation + genuine-difference cases.
- **core snapshot-for-wire** — asserts `slimListing` keeps `names`/`previewValue`/`source` and drops heavy fields like `originalValue` (a no-op slimmer would have passed before).
- **mcp** — extracted `parseArgs` into a pure `cli-args` module (`bin.ts` self-executes on import, so it couldn't be imported) and covered `--config`/`-c`, `--cwd`, `--no-watch`, `--help`, missing-value, repeated-flag.
- **blocks resolveCssVar** — listing-first vs derived fallback, using a listing name that *can't* come from the fallback derivation so the branch is actually distinguishable (the original fixture made them byte-identical).
- **blocks resolveColorValue** — hex-uses-listing-`previewValue` precedence; non-hex and composite-sub-color (`path === undefined`) fallbacks.
- **blocks channel-globals** — the MDX provider-less path: captures axes/format, partial-merge retention, invalid-format guard.

## Notes
- The `use-token` default-fallback "can't fail" gap was already closed by the channel-reactivity test added in #1138.
- The `preview.tsx` tuple-resolution helpers are deferred to a follow-up — they need extraction from a self-executing module; filed separately.

Gauntlet 37/37.

Milestone: Maintenance

Closes #1117