### PR TITLE
fix: four low-severity correctness bugs from the review

### DIFF
--- a/.changeset/fix-low-severity-bugs.md
+++ b/.changeset/fix-low-severity-bugs.md
@@ -1,0 +1,7 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+fix four low-severity correctness bugs: core hex fallback dropping the alpha byte of #rrggbbaa/#rgba, css-in-js buildTree misfiling a path that collides with a leaf, tailwind mis-bucketing camelCase font-size tokens into spacing, and MCP describe_project counting each token type once per theme

--- a/packages/core/src/format-color.ts
+++ b/packages/core/src/format-color.ts
@@ -80,7 +80,12 @@ function coerce(value: unknown): NormalizedColor | null {
       : undefined;
   if (!colorSpace || !components) {
     if (typeof v['hex'] === 'string') {
-      return { colorSpace: 'srgb', components: hexToComponents(v['hex']) };
+      const { components: hexComponents, alpha: hexAlpha } = hexToColor(v['hex']);
+      return {
+        colorSpace: 'srgb',
+        components: hexComponents,
+        ...(hexAlpha !== undefined && { alpha: hexAlpha }),
+      };
     }
     return null;
   }
@@ -95,7 +100,7 @@ function coerce(value: unknown): NormalizedColor | null {
   };
 }
 
-function hexToComponents(hex: string): number[] {
+function hexToColor(hex: string): { components: number[]; alpha?: number } {
   const h = hex.replace('#', '');
   const expanded =
     h.length === 3 || h.length === 4
@@ -107,7 +112,12 @@ function hexToComponents(hex: string): number[] {
   const r = parseInt(expanded.slice(0, 2), 16) / 255;
   const g = parseInt(expanded.slice(2, 4), 16) / 255;
   const b = parseInt(expanded.slice(4, 6), 16) / 255;
-  return [r, g, b];
+  // Preserve the alpha byte of #rgba / #rrggbbaa values instead of dropping it.
+  if (expanded.length >= 8) {
+    const a = parseInt(expanded.slice(6, 8), 16) / 255;
+    if (!Number.isNaN(a)) return { components: [r, g, b], alpha: a };
+  }
+  return { components: [r, g, b] };
 }
 
 // Map Terrazzo's canonical CSS Color 4 space identifiers to the shorter

--- a/packages/core/test/format-color.test.ts
+++ b/packages/core/test/format-color.test.ts
@@ -84,6 +84,13 @@ describe('formatColor', () => {
     expect(out.value).toBe('rgb(59 130 246)');
   });
 
+  it('preserves the alpha byte of #rrggbbaa / #rgba hex payloads', () => {
+    // 0x80 / 255 ≈ 0.502 — previously dropped, rendering fully opaque.
+    expect(formatColor({ hex: '#ff000080' }, 'rgb').value).toBe('rgb(255 0 0 / 0.502)');
+    // 4-digit shorthand expands the alpha nibble too (#f008 → alpha 0x88).
+    expect(formatColor({ hex: '#f008' }, 'rgb').value).toContain('/');
+  });
+
   it('returns the fallback "—" for non-color input', () => {
     expect(formatColor(null, 'hex').value).toBe('—');
     expect(formatColor(undefined, 'hex').value).toBe('—');

--- a/packages/integrations/src/css-in-js.ts
+++ b/packages/integrations/src/css-in-js.ts
@@ -107,7 +107,10 @@ export function buildTree(
   sortedPaths: readonly string[],
   leafFor: (path: string) => string,
 ): TreeNode {
-  const root: TreeNode = {};
+  // Null-prototype nodes: token path segments become object keys, so a
+  // `__proto__` segment from untrusted token input would otherwise mutate
+  // Object.prototype. With no prototype, such a key is just an own property.
+  const root: TreeNode = Object.create(null);
   for (const path of sortedPaths) {
     const segments = path.split('.');
     let node = root;
@@ -124,7 +127,7 @@ export function buildTree(
         break;
       }
       if (existing === undefined) {
-        const next: TreeNode = {};
+        const next: TreeNode = Object.create(null);
         node[seg] = next;
         node = next;
       } else {

--- a/packages/integrations/src/css-in-js.ts
+++ b/packages/integrations/src/css-in-js.ts
@@ -95,7 +95,7 @@ function collectPaths(project: Project): string[] {
   return [...listPaths(project.tokenGraph)];
 }
 
-interface TreeNode {
+export interface TreeNode {
   [key: string]: TreeNode | string;
 }
 
@@ -103,15 +103,26 @@ interface TreeNode {
 // On a leaf/branch collision (a short path's leaf shares a key a longer path
 // wants to nest under) the leaf wins — real DTCG trees don't hit this, but
 // explicit beats silent UB.
-function buildTree(sortedPaths: readonly string[], leafFor: (path: string) => string): TreeNode {
+export function buildTree(
+  sortedPaths: readonly string[],
+  leafFor: (path: string) => string,
+): TreeNode {
   const root: TreeNode = {};
   for (const path of sortedPaths) {
     const segments = path.split('.');
     let node = root;
+    let collided = false;
     for (let i = 0; i < segments.length - 1; i++) {
       const seg = segments[i]!;
       const existing = node[seg];
-      if (typeof existing === 'string') break;
+      // A token already occupies this segment as a leaf, so the deeper path
+      // can't nest under it (a key can't be both a string and an object).
+      // Drop the deeper path rather than misfiling it under the truncated
+      // key the loop happened to stop on.
+      if (typeof existing === 'string') {
+        collided = true;
+        break;
+      }
       if (existing === undefined) {
         const next: TreeNode = {};
         node[seg] = next;
@@ -120,6 +131,7 @@ function buildTree(sortedPaths: readonly string[], leafFor: (path: string) => st
         node = existing;
       }
     }
+    if (collided) continue;
     const leafKey = segments.at(-1)!;
     if (node[leafKey] === undefined) node[leafKey] = leafFor(path);
   }

--- a/packages/integrations/src/tailwind.ts
+++ b/packages/integrations/src/tailwind.ts
@@ -142,6 +142,9 @@ function deriveRoles(project: Project): RoleMap {
 
 const SPACING_ROOTS = ['space', 'spacing'] as const;
 const RADIUS_ROOTS = ['radius', 'borderRadius', 'border-radius'] as const;
+// Single-segment font-size roots — camelCase/dashed forms the dotted
+// `font.size.*` check below misses, which otherwise bucket into spacing.
+const FONT_SIZE_ROOTS = ['fontSize', 'font-size', 'textSize', 'text-size'] as const;
 const FONT_PREFIXES = ['font.family.', 'fontFamily.', 'font.'] as const;
 
 // Map one token's $type + path to its Tailwind { scale, role }, or null to skip.
@@ -169,6 +172,7 @@ function classify(path: string, type: string | undefined): { scale: string; role
       }
       // Font-size-ish dimensions are skipped — Tailwind's `--text-*` entries
       // expect a size+line-height pair that this integration doesn't build.
+      if ((FONT_SIZE_ROOTS as readonly string[]).includes(head)) return null;
       if (head === 'font' && /size|text/i.test(path)) return null;
       if (head === 'text') return null;
       // Default-bucket any other dimension under spacing — safer than guessing.

--- a/packages/integrations/test/css-in-js.test.ts
+++ b/packages/integrations/test/css-in-js.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { loadProject } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
 import { beforeAll, expect, it } from 'vitest';
-import cssInJsIntegration from '#/css-in-js.ts';
+import cssInJsIntegration, { buildTree } from '#/css-in-js.ts';
 import type { Project } from '@unpunnyfuns/swatchbook-core';
 
 let project: Project;
@@ -76,4 +76,18 @@ it('derives accessor var() names with Terrazzo naming for camelCase paths', asyn
   // the var that actually gets emitted, not a dot-to-dash respelling.
   expect(js).toContain('"var(--t-color-brand-primary)"');
   expect(js).not.toContain('var(--t-color-brandPrimary)');
+});
+
+it('buildTree drops a deeper path colliding with a leaf instead of misfiling it', () => {
+  // 'color' is a token (leaf) and 'color.brand' a deeper token — a key can't
+  // be both string and object, so the deeper path is dropped, not misfiled
+  // under root.brand (the truncated key the loop used to stop on).
+  expect(buildTree(['color', 'color.brand'], (p) => `<${p}>`)).toEqual({ color: '<color>' });
+});
+
+it('buildTree nests normal branch paths', () => {
+  expect(buildTree(['color.brand.primary', 'space.md'], (p) => `<${p}>`)).toEqual({
+    color: { brand: { primary: '<color.brand.primary>' } },
+    space: { md: '<space.md>' },
+  });
 });

--- a/packages/integrations/test/css-in-js.test.ts
+++ b/packages/integrations/test/css-in-js.test.ts
@@ -91,3 +91,8 @@ it('buildTree nests normal branch paths', () => {
     space: { md: '<space.md>' },
   });
 });
+
+it('buildTree does not pollute Object.prototype via a __proto__ path segment', () => {
+  buildTree(['__proto__.polluted', 'color.brand'], (p) => `<${p}>`);
+  expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+});

--- a/packages/integrations/test/tailwind.test.ts
+++ b/packages/integrations/test/tailwind.test.ts
@@ -98,3 +98,22 @@ it('derives source vars with Terrazzo naming for camelCase paths', async () => {
   expect(css).toContain('var(--t-color-brand-primary)');
   expect(css).not.toContain('var(--t-color-brandPrimary)');
 });
+
+it('skips camelCase font-size dimensions instead of mis-bucketing them as spacing', async () => {
+  const cwd = mkdtempSync(join(tmpdir(), 'sb-tw-fontsize-'));
+  mkdirSync(join(cwd, 'tokens'));
+  writeFileSync(
+    join(cwd, 'tokens', 't.json'),
+    JSON.stringify({
+      fontSize: { $type: 'dimension', md: { $value: { value: 16, unit: 'px' } } },
+      space: { $type: 'dimension', md: { $value: { value: 8, unit: 'px' } } },
+    }),
+  );
+  const p = await loadProject({ tokens: ['tokens/**/*.json'], cssVarPrefix: 't' }, cwd);
+  const css = render(p);
+  // space.md buckets into the spacing scale; fontSize.md is skipped (Tailwind
+  // --text-* wants a size+line-height pair we don't build) rather than landing
+  // in spacing under a camelCase role.
+  expect(css).toContain('--spacing-t-md');
+  expect(css).not.toContain('fontSize');
+});

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -87,14 +87,15 @@ export function createServer(initial: Project): McpServer & {
       inputSchema: {},
     },
     () => {
-      const typeCounts: Record<string, number> = {};
       const tokensPerTheme: Record<string, number> = {};
       for (const { name, tuple } of eachTheme()) {
-        const tokens = project.resolveAt(tuple);
-        tokensPerTheme[name] = Object.keys(tokens).length;
-        for (const token of Object.values(tokens)) {
-          if (token.$type) typeCounts[token.$type] = (typeCounts[token.$type] ?? 0) + 1;
-        }
+        tokensPerTheme[name] = Object.keys(project.resolveAt(tuple)).length;
+      }
+      // `$type` is theme-invariant, so count each token once from the default
+      // theme — counting per theme inflated every type by the theme count.
+      const typeCounts: Record<string, number> = {};
+      for (const token of Object.values(project.resolveAt(project.defaultTuple))) {
+        if (token.$type) typeCounts[token.$type] = (typeCounts[token.$type] ?? 0) + 1;
       }
       const diagBySeverity = { error: 0, warn: 0, info: 0 } as Record<string, number>;
       for (const d of project.diagnostics) {

--- a/packages/mcp/test/project-metadata.test.ts
+++ b/packages/mcp/test/project-metadata.test.ts
@@ -44,14 +44,17 @@ it('describe_project: returns axis summary, theme list, token counts, and diagno
   expect(result.diagnostics.total).toBeGreaterThanOrEqual(0);
 });
 
-it('describe_project: types histogram covers every DTCG type present', async () => {
+it('describe_project: types histogram counts each token once, not once per theme', async () => {
   const result = await mcp.callJson<DescribeProjectResult>('describe_project');
-  // Sum across types should equal the total token count across themes —
-  // sanity that the histogram came from the same walk as tokensPerTheme.
   const totalFromTypes = Object.values(result.types).reduce((a, b) => a + b, 0);
-  const totalFromThemes = Object.values(result.tokensPerTheme).reduce((a, b) => a + b, 0);
+  const defaultThemeTokens = result.tokensPerTheme[result.defaultTheme!];
+  const totalAcrossThemes = Object.values(result.tokensPerTheme).reduce((a, b) => a + b, 0);
   expect(totalFromTypes).toBeGreaterThan(0);
-  expect(totalFromThemes).toBeGreaterThan(0);
+  // `$type` is theme-invariant: the histogram counts each token once (from the
+  // default theme), so it matches a single theme's token count — not the sum
+  // across every theme, which the per-theme loop previously inflated it to.
+  expect(totalFromTypes).toBe(defaultThemeTokens);
+  expect(totalAcrossThemes).toBeGreaterThan(totalFromTypes);
 });
 
 interface ListAxesResult {


### PR DESCRIPTION
## Summary

The genuine defects within the #1118 low-severity umbrella, fixed with regression tests. The remaining #1118 items are quality/docs/test nits (tracked in #1118).

## Fixes
- **core format-color** — the hex fallback read only 6 digits, dropping the alpha byte of `#rrggbbaa` / `#rgba` payloads (rendered fully opaque). Now extracts it.
- **integrations css-in-js `buildTree`** — when a deeper path collides with a leaf (a key can't be both a string and an object), it was misfiled under the truncated key the loop stopped on. Now dropped.
- **integrations tailwind `classify`** — camelCase font-size roots (`fontSize.*`) missed the dotted `font.size` check and were bucketed into the spacing scale. Added camelCase/dashed font-size roots to the skip.
- **mcp `describe_project`** — the type histogram counted each token once *per theme*, inflating every type by the theme count. `$type` is theme-invariant, so it now counts once from the default theme.

Each has a regression test (`buildTree` exported for a direct unit test; the existing histogram test's buggy "equals sum across themes" assumption was corrected). Gauntlet 37/37.

Milestone: Maintenance

Closes #1143
Refs #1118