### PR TITLE
fix: four more low-severity bugs from the review

### DIFF
--- a/.changeset/fix-low-severity-round2.md
+++ b/.changeset/fix-low-severity-round2.md
@@ -1,0 +1,8 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+---
+
+fix four more low-severity bugs: AliasedBy hiding shared descendants in diamond alias graphs, the switcher preset active-match against a sparse tuple, the MCP server version reporting the css-var prefix, and css-in-js emitting duplicate exports when group names collide

--- a/packages/blocks/src/token-detail/AliasedBy.tsx
+++ b/packages/blocks/src/token-detail/AliasedBy.tsx
@@ -59,32 +59,36 @@ function AliasedByRow({ node, depth }: { node: AliasedByNode; depth: number }): 
   );
 }
 
-function buildAliasedByTree(
+export function buildAliasedByTree(
   rootPath: string,
   resolved: Record<string, DetailToken>,
 ): AliasedByNode[] {
   const root = resolved[rootPath];
   const direct = root?.aliasedBy;
   if (!direct || direct.length === 0) return [];
-  const visited = new Set<string>([rootPath]);
-  return sortPaths(direct).map((p) => walk(p, resolved, visited, 1));
+  return sortPaths(direct).map((p) => walk(p, resolved, new Set<string>([rootPath]), 1));
 }
 
+// `ancestors` is the current root-to-here path only (copied per descent),
+// not a tree-wide visited set: that guards genuine cycles without hiding a
+// node that legitimately appears under two sibling branches of a diamond
+// alias graph (a shared set let the first branch claim the node and
+// truncate every later one).
 function walk(
   path: string,
   resolved: Record<string, DetailToken>,
-  visited: Set<string>,
+  ancestors: ReadonlySet<string>,
   depth: number,
 ): AliasedByNode {
-  if (visited.has(path)) return { path, children: [] };
-  visited.add(path);
+  if (ancestors.has(path)) return { path, children: [] };
   const token = resolved[path];
   const parents = token?.aliasedBy;
   if (!parents || parents.length === 0) return { path, children: [] };
   if (depth >= ALIASED_BY_DEPTH_CAP) {
     return { path, children: [], truncated: true };
   }
-  const children = sortPaths(parents).map((p) => walk(p, resolved, visited, depth + 1));
+  const childAncestors = new Set(ancestors).add(path);
+  const children = sortPaths(parents).map((p) => walk(p, resolved, childAncestors, depth + 1));
   return { path, children };
 }
 

--- a/packages/blocks/test/aliased-by-tree.test.ts
+++ b/packages/blocks/test/aliased-by-tree.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from 'vitest';
+import { buildAliasedByTree } from '#/token-detail/AliasedBy.tsx';
+import type { DetailToken } from '#/token-detail/internal.ts';
+
+it('shows a shared descendant under every sibling branch of a diamond alias graph', () => {
+  // root is aliased-by A and B; both A and B are aliased-by C. A shared
+  // `visited` set let the first branch claim C and truncate the second;
+  // a per-path ancestor set shows C's subtree under both.
+  const resolved: Record<string, DetailToken> = {
+    root: { aliasedBy: ['a', 'b'] },
+    a: { aliasedBy: ['c'] },
+    b: { aliasedBy: ['c'] },
+    c: { aliasedBy: ['leaf'] },
+    leaf: { aliasedBy: [] },
+  };
+  const tree = buildAliasedByTree('root', resolved);
+  expect(tree.map((n) => n.path)).toEqual(['a', 'b']);
+  // Both branches reach c -> leaf, not just the first.
+  for (const branch of tree) {
+    expect(branch.children.map((n) => n.path)).toEqual(['c']);
+    expect(branch.children[0]?.children.map((n) => n.path)).toEqual(['leaf']);
+  }
+});
+
+it('still guards genuine cycles (a node in its own ancestry stops)', () => {
+  const resolved: Record<string, DetailToken> = {
+    root: { aliasedBy: ['a'] },
+    a: { aliasedBy: ['b'] },
+    b: { aliasedBy: ['a'] },
+  };
+  const tree = buildAliasedByTree('root', resolved);
+  // a -> b -> a is cut at the repeat rather than recursing forever.
+  const a = tree[0];
+  expect(a?.path).toBe('a');
+  const b = a?.children[0];
+  expect(b?.path).toBe('b');
+  expect(b?.children).toEqual([{ path: 'a', children: [] }]);
+});

--- a/packages/integrations/src/css-in-js.ts
+++ b/packages/integrations/src/css-in-js.ts
@@ -74,10 +74,14 @@ function renderTheme(project: Project): string {
   const tree = buildTree(paths, (path) => `var(${cssVarName(path, project)})`);
 
   const groupNames = Object.keys(tree).toSorted();
+  // Distinct group names can sanitize to the same identifier (e.g. `a-b` and
+  // `a.b` both → `a_b`), which would emit duplicate top-level exports — a
+  // SyntaxError in the virtual module. Suffix collisions to keep each unique.
+  const idents = uniqueIdents(groupNames);
   const groupExports = groupNames.map(
-    (name) => `export const ${safeIdent(name)} = ${renderNode(tree[name]!, 1)};`,
+    (name) => `export const ${idents.get(name)!} = ${renderNode(tree[name]!, 1)};`,
   );
-  const aggregate = `export const theme = { ${groupNames.map(safeIdent).join(', ')} };`;
+  const aggregate = `export const theme = { ${groupNames.map((n) => idents.get(n)!).join(', ')} };`;
 
   return [
     '/* Synthesized by @unpunnyfuns/swatchbook-integrations/css-in-js for preview.',
@@ -162,4 +166,20 @@ function safeKey(key: string): string {
 // Top-level exports must be valid JS identifiers.
 function safeIdent(key: string): string {
   return /^[A-Za-z_$][\w$]*$/.test(key) ? key : `_${key.replaceAll(/[^\w$]/g, '_')}`;
+}
+
+// Map each name to a unique JS identifier, suffixing on collision so two
+// names that sanitize to the same ident don't produce duplicate exports.
+export function uniqueIdents(names: readonly string[]): Map<string, string> {
+  const used = new Set<string>();
+  const out = new Map<string, string>();
+  for (const name of names) {
+    const base = safeIdent(name);
+    let ident = base;
+    let n = 2;
+    while (used.has(ident)) ident = `${base}_${n++}`;
+    used.add(ident);
+    out.set(name, ident);
+  }
+  return out;
 }

--- a/packages/integrations/test/css-in-js.test.ts
+++ b/packages/integrations/test/css-in-js.test.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { loadProject } from '@unpunnyfuns/swatchbook-core';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
 import { beforeAll, expect, it } from 'vitest';
-import cssInJsIntegration, { buildTree } from '#/css-in-js.ts';
+import cssInJsIntegration, { buildTree, uniqueIdents } from '#/css-in-js.ts';
 import type { Project } from '@unpunnyfuns/swatchbook-core';
 
 let project: Project;
@@ -95,4 +95,14 @@ it('buildTree nests normal branch paths', () => {
 it('buildTree does not pollute Object.prototype via a __proto__ path segment', () => {
   buildTree(['__proto__.polluted', 'color.brand'], (p) => `<${p}>`);
   expect(({} as Record<string, unknown>)['polluted']).toBeUndefined();
+});
+
+it('uniqueIdents suffixes names that sanitize to the same identifier', () => {
+  // 'a-b' and 'a.b' both sanitize to '_a_b' — they must not collide into
+  // duplicate top-level exports.
+  const m = uniqueIdents(['a-b', 'a.b', 'plain']);
+  expect(m.get('a-b')).toBe('_a_b');
+  expect(m.get('a.b')).toBe('_a_b_2');
+  expect(m.get('plain')).toBe('plain');
+  expect(new Set(m.values()).size).toBe(3);
 });

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -6,6 +6,7 @@ import { fuzzyFilter, fuzzyMatches } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import { enumerateThemes, tupleToName } from '@unpunnyfuns/swatchbook-core/themes';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
+import pkg from '../package.json';
 import { computeContrast } from '#/contrast.ts';
 import { formatColorEveryWay } from '#/format-color.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
@@ -32,7 +33,7 @@ export function createServer(initial: Project): McpServer & {
   const server = new McpServer(
     {
       name: '@unpunnyfuns/swatchbook-mcp',
-      version: project.config.cssVarPrefix ? `project:${project.config.cssVarPrefix}` : 'project',
+      version: pkg.version,
     },
     {
       instructions:

--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -220,13 +220,17 @@ function displayLabelFor(axis: SwitcherAxis): string {
   return axis.name;
 }
 
-function tuplesEqual(
+export function tuplesEqual(
   a: Readonly<Record<string, string>>,
   b: Readonly<Record<string, string>>,
   axes: readonly SwitcherAxis[],
 ): boolean {
+  // Fall back to the axis default on both sides: `activeTuple` is sparse
+  // (the axis pills apply `?? axis.default` for omitted axes), while a preset
+  // tuple is fully defaulted — without this, an active preset whose omitted
+  // axes sit at default reads as inactive.
   for (const axis of axes) {
-    if (a[axis.name] !== b[axis.name]) return false;
+    if ((a[axis.name] ?? axis.default) !== (b[axis.name] ?? axis.default)) return false;
   }
   return true;
 }

--- a/packages/switcher/test/tuples-equal.browser.test.tsx
+++ b/packages/switcher/test/tuples-equal.browser.test.tsx
@@ -1,0 +1,21 @@
+import { expect, it } from 'vitest';
+import { tuplesEqual } from '#/ThemeSwitcher.tsx';
+import type { SwitcherAxis } from '#/types.ts';
+
+// Browser-mode because ThemeSwitcher.tsx pulls its CSS; tuplesEqual itself
+// is a pure comparison helper.
+const axes: readonly SwitcherAxis[] = [
+  { name: 'mode', contexts: ['Light', 'Dark'], default: 'Light' },
+  { name: 'brand', contexts: ['Default', 'BrandA'], default: 'Default' },
+];
+
+it('treats a sparse active tuple (omitted axis = default) as equal to a fully-defaulted preset tuple', () => {
+  // The axis pills render `activeTuple[axis] ?? default`, so the active tuple
+  // can omit axes sitting at their default; the preset tuple is always full.
+  expect(tuplesEqual({ mode: 'Light', brand: 'Default' }, { mode: 'Light' }, axes)).toBe(true);
+});
+
+it('still reports a genuine difference', () => {
+  expect(tuplesEqual({ mode: 'Dark' }, { mode: 'Light' }, axes)).toBe(false);
+  expect(tuplesEqual({ mode: 'Light', brand: 'BrandA' }, { mode: 'Light' }, axes)).toBe(false);
+});


### PR DESCRIPTION
## Summary

Second batch of genuine defects from the #1118 umbrella. Remaining #1118 items are dedup/docs/test/a11y polish (tracked in #1118).

## Fixes
- **blocks AliasedBy** — walked with one tree-wide `visited` set, so a node aliased-by two sibling branches of a diamond graph was claimed by the first branch and truncated in the rest. Now uses a per-path ancestor set (copied on descent): shared descendants render under every branch, genuine cycles are still cut.
- **switcher `tuplesEqual`** — compared a sparse `activeTuple` (the axis pills render `?? axis.default`, so omitted axes are absent) against a fully-defaulted preset tuple, making an active preset read as inactive. Now falls back to the axis default on both sides.
- **mcp** — the server-info `version` carried the css-var prefix (`project:sb`) instead of the package version. Now reports `pkg.version`; the prefix is available via `describe_project`.
- **integrations css-in-js** — distinct group names that sanitize to the same identifier (`a-b`, `a.b` → `_a_b`) emitted duplicate top-level exports (a SyntaxError in the virtual module). A `uniqueIdents` pass suffixes collisions.

Tests: `buildAliasedByTree` diamond + cycle, `tuplesEqual` sparse-tuple, `uniqueIdents` collision (each helper exported for a direct unit test). Gauntlet 37/37.

Milestone: Maintenance

Closes #1145
Refs #1118