### PR TITLE
chore: low-severity cleanup (dead dep, dedup, stale comment)

### DIFF
--- a/.changeset/chore-low-severity-cleanup.md
+++ b/.changeset/chore-low-severity-cleanup.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+remove the unused @terrazzo/token-tools dependency and export TOKENS_UPDATED_EVENT (the dev-time HMR wire event, now the single source shared with the addon)

--- a/packages/addon/src/constants.ts
+++ b/packages/addon/src/constants.ts
@@ -37,14 +37,10 @@ export const INIT_REQUEST_EVENT = 'swatchbook/init-request';
  * listener on the manager can't see iframe events. */
 export const PREVIEW_MOUSEDOWN_EVENT = 'swatchbook/preview-mousedown';
 
-/** Channel event: preview → blocks, carries the fresh virtual-module
- * payload after a dev-time token refresh so blocks can re-render in
- * place without a full iframe reload. Fired by the preview in response
- * to the `HMR_EVENT` below. */
-export const TOKENS_UPDATED_EVENT = 'swatchbook/tokens-updated';
-
 /** Custom Vite HMR event: plugin → preview. Preview forwards it to the
- * Storybook channel as {@link TOKENS_UPDATED_EVENT} so blocks can
- * update their snapshot. A distinct wire string from the channel event
- * so the plugin doesn't need a Storybook-channel dependency. */
+ * Storybook channel as `TOKENS_UPDATED_EVENT` (exported from
+ * `@unpunnyfuns/swatchbook-blocks`, the single source of truth for that
+ * wire string, which blocks also listen on) so blocks can update their
+ * snapshot. A distinct wire string from the channel event so the plugin
+ * doesn't need a Storybook-channel dependency. */
 export const HMR_EVENT = 'swatchbook/hmr-tokens';

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -30,6 +30,7 @@ import {
   registerTokenSource,
   SwatchbookContext,
   ThemeContext,
+  TOKENS_UPDATED_EVENT,
   useTokenSnapshot,
 } from '@unpunnyfuns/swatchbook-blocks';
 import type { ColorFormat, ProjectSnapshot } from '@unpunnyfuns/swatchbook-blocks';
@@ -41,7 +42,6 @@ import {
   INIT_REQUEST_EVENT,
   PREVIEW_MOUSEDOWN_EVENT,
   STYLE_ELEMENT_ID,
-  TOKENS_UPDATED_EVENT,
 } from '#/constants.ts';
 import type { InitPayload } from '#/channel-types.ts';
 import type { StoryParameters, SwatchbookGlobals } from '#/globals.ts';

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -77,7 +77,6 @@
     "vitest": "^4.1.7"
   },
   "dependencies": {
-    "@terrazzo/token-tools": "^2.3.0",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
     "clsx": "^2.1.1",
     "colorjs.io": "0.6.1"

--- a/packages/blocks/src/index.ts
+++ b/packages/blocks/src/index.ts
@@ -47,6 +47,7 @@ export {
 } from '#/provider.tsx';
 export {
   registerTokenSource,
+  TOKENS_UPDATED_EVENT,
   type TokenSnapshot,
   useTokenSnapshot,
 } from '#/internal/channel-tokens.ts';

--- a/packages/blocks/src/internal/channel-tokens.ts
+++ b/packages/blocks/src/internal/channel-tokens.ts
@@ -19,7 +19,9 @@ import type { VirtualAxis, VirtualDiagnostic } from '#/types.ts';
  * `useSyncExternalStore`, so hooks re-render in place on each token save.
  */
 
-const TOKENS_UPDATED_EVENT = 'swatchbook/tokens-updated';
+// The dev-time HMR wire event. Single source of truth: the addon preview
+// emits it, this module listens — exported so the two can't drift.
+export const TOKENS_UPDATED_EVENT = 'swatchbook/tokens-updated';
 
 export interface TokenSnapshot {
   readonly axes: readonly VirtualAxis[];

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -46,7 +46,7 @@ function isVerbose(): boolean {
 function logPhase(label: string, startedAt: number): void {
   if (!isVerbose()) return;
   const ms = performance.now() - startedAt;
-  // biome-ignore lint/suspicious/noConsole: opt-in debug output, gated behind env var
+  // Opt-in debug output, gated behind the verbose env var.
   console.log(`[swatchbook:load] ${label}: ${ms.toFixed(0)}ms`);
 }
 

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,6 +1,7 @@
 import type { Project, TokenMap } from '@unpunnyfuns/swatchbook-core';
 import { emitAxisProjectedCss } from '@unpunnyfuns/swatchbook-core';
 import { cssVarName } from '@unpunnyfuns/swatchbook-core/css-var';
+import { dataAttr } from '@unpunnyfuns/swatchbook-core/data-attr';
 import { getVariance } from '@unpunnyfuns/swatchbook-core/graph';
 import { fuzzyFilter, fuzzyMatches } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import { enumerateThemes, tupleToName } from '@unpunnyfuns/swatchbook-core/themes';
@@ -544,15 +545,14 @@ export function createServer(initial: Project): McpServer & {
       if (!token) return textResult(`Token not found: ${path}`);
 
       const cssVar = `var(${cssVarName(path, project)})`;
-      const attrName = (axis: string): string =>
-        prefix ? `data-${prefix}-${axis}` : `data-${axis}`;
       const attrs: Record<string, string> = {};
       const selectorParts: string[] = [];
       for (const axis of project.axes) {
         const value = activeTuple[axis.name];
         if (value !== undefined) {
-          attrs[attrName(axis.name)] = value;
-          selectorParts.push(`[${attrName(axis.name)}="${value}"]`);
+          const attr = dataAttr(prefix, axis.name);
+          attrs[attr] = value;
+          selectorParts.push(`[${attr}="${value}"]`);
         }
       }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -262,9 +262,6 @@ importers:
 
   packages/blocks:
     dependencies:
-      '@terrazzo/token-tools':
-        specifier: ^2.3.0
-        version: 2.3.0
       '@unpunnyfuns/swatchbook-core':
         specifier: workspace:*
         version: link:../core


### PR DESCRIPTION
## Summary

First cleanup batch from the #1118 polish tail — behavior-preserving dead-code/dedup. Remaining #1118 items (core-resolution dedup/perf, a11y, docs, test backfill) tracked in #1118.

## Changes
- **blocks** — remove the unused `@terrazzo/token-tools` dependency (declared, never imported).
- **core `load.ts`** — drop the inert `biome-ignore` (this is an oxlint repo with no `no-console` rule, so the directive did nothing); keep the intent as a plain comment.
- **mcp `get_consumer_output`** — use core's `dataAttr` helper instead of a hand-rolled inline `data-${prefix}-${axis}` copy.
- **`TOKENS_UPDATED_EVENT`** — dedupe the dev-time HMR wire string: single source exported from blocks (which listens), imported by the addon (which emits), so they can't silently drift.

Gauntlet 37/37.

Milestone: Maintenance

Closes #1147
Refs #1118