### PR TITLE
fix(switcher): surface 'modified' preset state to assistive tech

### DIFF
--- a/.changeset/switcher-modified-a11y.md
+++ b/.changeset/switcher-modified-a11y.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-switcher': patch
+---
+
+Expose a preset's "modified" state in its accessible name, not just the aria-hidden visual dot

--- a/packages/switcher/README.md
+++ b/packages/switcher/README.md
@@ -2,7 +2,7 @@
 
 The framework-agnostic theme-switcher UI for [swatchbook](https://github.com/unpunnyfuns/swatchbook).
 
-A React component: axis dropdowns, preset pills, color-format selector. The Storybook addon's toolbar uses it; so does the docs-site navbar. Reach for this package directly when you want the switcher on a non-Storybook site, such as a docs navbar or a standalone React app consuming swatchbook tokens.
+A React component: axis dropdowns and preset pills, with an optional `footer` slot for host-supplied controls. The Storybook addon's toolbar uses it; so does the docs-site navbar. Reach for this package directly when you want the switcher on a non-Storybook site, such as a docs navbar or a standalone React app consuming swatchbook tokens.
 
 Most consumers pick it up transitively via [`@unpunnyfuns/swatchbook-addon`](../addon); `import { ThemeSwitcher } from '@unpunnyfuns/swatchbook-addon'` works out of the box.
 
@@ -29,7 +29,7 @@ import '@unpunnyfuns/swatchbook-switcher/style.css';
   }}
   onPresetApply={(preset: SwitcherPreset) => {
     for (const [axis, value] of Object.entries(preset.axes)) {
-      document.documentElement.setAttribute(`data-sb-${axis}`, value);
+      if (value !== undefined) document.documentElement.setAttribute(`data-sb-${axis}`, value);
     }
   }}
 />;

--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -164,6 +164,7 @@ function PresetsSection({
               active={matches}
               title={title}
               onClick={() => onApply(preset)}
+              {...(modified && { ariaLabelSuffix: 'modified' })}
               trailing={
                 modified ? <span aria-hidden className="sb-switcher__pill-modified" /> : null
               }

--- a/packages/switcher/test/theme-switcher.browser.test.tsx
+++ b/packages/switcher/test/theme-switcher.browser.test.tsx
@@ -82,6 +82,22 @@ it('marks a preset active when the tuple matches and shows a modified dot when i
   expect(modifiedBtn.querySelector('.sb-switcher__pill-modified')).not.toBeNull();
 });
 
+it('exposes the modified state in the accessible name, not just the visual dot', () => {
+  const props = baseProps();
+  const preset = { name: 'Brand A Light', axes: { mode: 'Light' } };
+  render(
+    <ThemeSwitcher
+      {...props}
+      presets={[preset]}
+      activeTuple={{ mode: 'Dark' }}
+      lastApplied={preset.name}
+    />,
+  );
+  // The dot itself is aria-hidden; without a textual cue a screen-reader
+  // user has no signal the preset diverged from its saved state.
+  expect(screen.getByRole('button', { name: 'Brand A Light (modified)' })).not.toBeNull();
+});
+
 it('renders an externally-supplied footer (for host-specific UI) when passed', () => {
   const props = baseProps();
   render(<ThemeSwitcher {...props} footer={<div data-testid="extra">host extra</div>} />);


### PR DESCRIPTION
The preset "modified" indicator was a visual dot marked `aria-hidden`, so screen-reader users had no signal that a preset diverged from its saved state. It now appends `(modified)` to the pill's accessible name via the existing `ariaLabelSuffix` path. Added a browser test asserting the accessible name carries the cue.

Two README accuracy fixes ride along: the opener listed a color-format selector the component no longer hosts (it moved to the `footer` slot), and the `onPresetApply` example didn't compile under `exactOptionalPropertyTypes`.

Two other items from the #1118 tail dissolved on inspection and are deliberately left alone: the `style.css` import instruction is **not** redundant (tsdown extracts CSS to `dist/style.css`; the JS bundle doesn't inject it), and `SwatchbookToken`'s "seven fields" doc is accurate.

Milestone: Maintenance

Closes #1149

Refs #1118