### PR TITLE
refactor(core): drop dead preset materialization + dedup tuple-key construction

### DIFF
--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -5,6 +5,7 @@ import { cssEscape } from '#/css-escape.ts';
 import { dataAttr } from '#/data-attr.ts';
 import { listPaths } from '#/token-graph/queries.ts';
 import { resolveAliasAllAt, resolveAllAt } from '#/token-graph/walk.ts';
+import { canonicalKey } from '#/tuple-key.ts';
 import type { Project, TokenMap } from '#/types.ts';
 import { valueKey } from '#/value-key.ts';
 
@@ -466,7 +467,7 @@ function collectJointBlocks(
   for (const [path, info] of variance) {
     if (info.kind !== 'joint-variant') continue;
     for (const jc of info.jointCases) {
-      const key = canonicalPartialKey(jc.tuple);
+      const key = canonicalKey(jc.tuple);
       let entry = grouped.get(key);
       if (!entry) {
         entry = { tuple: jc.tuple, paths: [] };
@@ -539,15 +540,6 @@ function collectJointBlocks(
   }
 
   return blocks;
-}
-
-// Build a stable lookup key for a partial tuple — axis entries joined
-// in sorted key order so `{A: a, B: b}` and `{B: b, A: a}` match.
-function canonicalPartialKey(partial: Record<string, string>): string {
-  return Object.entries(partial)
-    .toSorted(([a], [b]) => a.localeCompare(b))
-    .map(([k, v]) => `${k}=${v}`)
-    .join('|');
 }
 
 // Collect emitted declaration lines for a token map, filtering tokens

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -1,8 +1,9 @@
 import { validateChrome } from '#/chrome.ts';
 import { BufferedLogger, toDiagnostics } from '#/diagnostics.ts';
 import { validateDisabledAxes } from '#/disabled-axes.ts';
-import { fillPresetTuple, validatePresets } from '#/presets.ts';
+import { validatePresets } from '#/presets.ts';
 import { validateCssOptions } from '#/terrazzo-options.ts';
+import { canonicalKey } from '#/tuple-key.ts';
 import { resolveDefaultTuple } from '#/permutations/default.ts';
 import { normalizePermutations } from '#/permutations/normalize.ts';
 import { computeTokenListing } from '#/token-listing.ts';
@@ -95,24 +96,6 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
 
   const { presets, diagnostics: presetDiagnostics } = validatePresets(config.presets, filteredAxes);
 
-  // Materialize any preset tuples the singleton enumeration didn't
-  // cover. Singletons only vary one axis at a time, so any preset
-  // pointing at a multi-non-default tuple needs an extra
-  // `resolver.apply` call to ship the toolbar pill's resolved data.
-  // Resolver-backed projects only — layered presets without a
-  // resolver can't apply() on demand.
-  if (normalized.parserInput?.resolver && presets.length > 0) {
-    const tPresets = performance.now();
-    for (const preset of presets) {
-      const tuple = fillPresetTuple(preset.axes, filteredAxes);
-      const id = permutationID(tuple);
-      if (filteredResolved[id]) continue;
-      filteredResolved[id] = normalized.parserInput.resolver.apply(tuple);
-      filteredPermutations.push({ name: id, input: tuple });
-    }
-    logPhase(`apply ${presets.length} preset tuple(s)`, tPresets);
-  }
-
   const { diagnostics: cssOptionsDiagnostics } = validateCssOptions(config.cssOptions);
 
   const tListing = performance.now();
@@ -176,7 +159,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
         const val = tuple[axis.name];
         if (val !== undefined) full[axis.name] = val;
       }
-      const key = filteredAxes.map((a) => `${a.name}=${full[a.name]}`).join('|');
+      const key = canonicalKey(full);
       const cached = memo.get(key);
       if (cached) return cached;
       const result = resolveAllAt(tokenGraphResult.graph, full);


### PR DESCRIPTION
Two safe cleanups from the #1118 review tail, both gated by the full core suite (268 tests, no behavior change):

- **Dead code:** `loadProject` materialized preset tuples into local `filteredResolved` / `filteredPermutations`. Since `resolveAt` became graph-backed (PR #990) those locals are read only in the mutually-exclusive *layered* branch and never reach the returned `Project` — so in the resolver branch where the loop ran, the work was dead. Removed it (and the now-unused `fillPresetTuple` import). Preset-tuple resolution is served on demand by the graph-backed `resolveAt`; `load-presets.test.ts` still passes, confirming the path.
- **Dedup:** the `resolveAt` memo key and `css-axis-projected`'s joint-block grouping key each hand-rolled the same sorted-tuple-key logic. Both now call the shared `canonicalKey` helper. The grouping key is internal-only (never emitted), so CSS output is byte-identical.

Two other #1118 tail items were checked and deliberately left alone: `forEachPinnedAxis` is live (used in `preview.tsx`), and `SwatchbookToken`'s "seven fields" doc is accurate.

Milestone: Maintenance

Closes #1151

Refs #1118