### PR TITLE
ci: pin actions/checkout to exact v6.0.3 tag

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           # Chromatic doesn't upload artifacts, so the immediate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         node: [24]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Don't write the GITHUB_TOKEN into .git/config of the checked-out
           # tree. Downstream steps include actions/upload-artifact, which

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           # Don't write the GITHUB_TOKEN into .git/config of the checked-out
           # tree. The deploy-pages step uses actions/upload-pages-artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           # Don't write a token into .git/config. changesets/action below
@@ -189,7 +189,7 @@ jobs:
       # publish token — no NPM_TOKEN secret. Also covers provenance.
       id-token: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
       # reference resolution (e.g., confirming pinned-SHA tags exist).
       security-events: write
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
       - uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
Clears all six open code-scanning alerts — the same zizmor `ref-version-mismatch` on every workflow's `actions/checkout` step.

The pins were SHA-locked to `de0fac2…` (tag **v6.0.2**) but commented `# v6`. The moving `v6` tag has since advanced to **v6.0.3** (`df4cb1c…`), so the immutable SHA and its comment named different commits — exactly what the lint flags. Bumping all six to the v6.0.3 SHA with an exact `# v6.0.3` comment satisfies both zizmor and the latest-deps policy.

No code or published-package change; CI-only, so no changeset.

Milestone: Maintenance

Closes #1153