### PR TITLE
test(core): backfill pure-logic helpers

### DIFF
--- a/packages/core/test/css-escape.test.ts
+++ b/packages/core/test/css-escape.test.ts
@@ -1,0 +1,21 @@
+import { expect, it } from 'vitest';
+import { cssEscape } from '#/css-escape.ts';
+
+it('leaves a plain string untouched', () => {
+  expect(cssEscape('Dark')).toBe('Dark');
+  expect(cssEscape('')).toBe('');
+});
+
+it('escapes a double-quote so it can sit inside a quoted selector value', () => {
+  expect(cssEscape('a"b')).toBe('a\\"b');
+});
+
+it('escapes a backslash', () => {
+  expect(cssEscape('a\\b')).toBe('a\\\\b');
+});
+
+it('escapes the backslash before the quote so an existing \\" is not mangled', () => {
+  // Order is load-bearing: backslash first, then quote. Otherwise the
+  // quote-escape's own backslash would be doubled by the backslash pass.
+  expect(cssEscape('\\"')).toBe('\\\\\\"');
+});

--- a/packages/core/test/permutations/util.test.ts
+++ b/packages/core/test/permutations/util.test.ts
@@ -1,0 +1,31 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { expect, it } from 'vitest';
+import { collectGlobbedFiles } from '#/permutations/util.ts';
+
+function fixtureDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'swatchbook-glob-'));
+  writeFileSync(join(dir, 'a.json'), '{}');
+  writeFileSync(join(dir, 'b.json'), '{}');
+  mkdirSync(join(dir, 'sub'));
+  writeFileSync(join(dir, 'sub', 'c.json'), '{}');
+  return dir;
+}
+
+it('returns absolute paths in sorted order', () => {
+  const dir = fixtureDir();
+  const result = collectGlobbedFiles(['*.json', 'sub/*.json'], dir);
+  expect(result).toEqual([join(dir, 'a.json'), join(dir, 'b.json'), join(dir, 'sub', 'c.json')]);
+});
+
+it('deduplicates files matched by overlapping patterns', () => {
+  const dir = fixtureDir();
+  const result = collectGlobbedFiles(['*.json', '*.json', 'a.json'], dir);
+  expect(result.filter((p) => p.endsWith('a.json'))).toHaveLength(1);
+});
+
+it('returns an empty array when nothing matches', () => {
+  const dir = fixtureDir();
+  expect(collectGlobbedFiles(['*.css'], dir)).toEqual([]);
+});

--- a/packages/core/test/token-graph/internal-utils.test.ts
+++ b/packages/core/test/token-graph/internal-utils.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from 'vitest';
+import { isPlainObject } from '#/token-graph/internal-utils.ts';
+
+it('accepts object literals', () => {
+  expect(isPlainObject({})).toBe(true);
+  expect(isPlainObject({ a: 1 })).toBe(true);
+});
+
+it('rejects null — the typeof-object trap this guard exists for', () => {
+  expect(isPlainObject(null)).toBe(false);
+});
+
+it('rejects arrays', () => {
+  expect(isPlainObject([])).toBe(false);
+  expect(isPlainObject([1, 2])).toBe(false);
+});
+
+it('rejects primitives and undefined', () => {
+  expect(isPlainObject('x')).toBe(false);
+  expect(isPlainObject(42)).toBe(false);
+  expect(isPlainObject(undefined)).toBe(false);
+});

--- a/packages/core/test/tuple-key.test.ts
+++ b/packages/core/test/tuple-key.test.ts
@@ -1,0 +1,20 @@
+import { expect, it } from 'vitest';
+import { canonicalKey } from '#/tuple-key.ts';
+
+it('joins axis entries as sorted `name:value` pairs', () => {
+  expect(canonicalKey({ mode: 'Dark', brand: 'Acme' })).toBe('brand:Acme|mode:Dark');
+});
+
+it('is independent of key insertion order — the memo-dedup invariant', () => {
+  // load.ts and css-axis-projected both key Maps on this; two tuples with
+  // the same effective selection must produce one key regardless of order.
+  expect(canonicalKey({ a: '1', b: '2' })).toBe(canonicalKey({ b: '2', a: '1' }));
+});
+
+it('produces the empty string for the empty tuple', () => {
+  expect(canonicalKey({})).toBe('');
+});
+
+it('handles a single axis', () => {
+  expect(canonicalKey({ mode: 'Light' })).toBe('mode:Light');
+});


### PR DESCRIPTION
First batch of the #1118 test-backfill tail. Four exported core helpers had no direct unit coverage:

| Helper | What's pinned |
|--------|---------------|
| `cssEscape` | plain passthrough, quote/backslash escaping, and the load-bearing **backslash-before-quote** ordering |
| `canonicalKey` | sorted `name:value` format + **order-independence** (the memo-dedup invariant `load.ts` and `css-axis-projected` rely on) |
| `isPlainObject` | the null / array / primitive rejections it exists for |
| `collectGlobbedFiles` | absolute-path resolution, sort, dedup, empty-match (hermetic tmpdir fixture) |

Characterization tests for existing behavior. Verified they actually bite via a mutation check — removing `canonicalKey`'s sort fails exactly the two order-dependent assertions and nothing else.

Tests-only; no changeset.

Milestone: Maintenance

Closes #1155

Refs #1118