### PR TITLE
chore: add coverage tooling for the test-backfill grind

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "@terrazzo/cli": "^2.3.0",
+    "@vitest/coverage-v8": "^4.1.7",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.64.0",
     "turbo": "^2.9.14",

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -76,6 +76,7 @@
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/**' --coverage.all",
     "test:watch": "vitest",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
     "format": "oxfmt -c ../../.oxfmtrc.json src test",

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -51,6 +51,7 @@
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/**' --coverage.all",
     "test:watch": "vitest",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
     "format": "oxfmt -c ../../.oxfmtrc.json src test",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -83,6 +83,7 @@
     "build": "tsdown src/index.ts src/fuzzy.ts src/token-graph/index.ts src/css-var.ts src/color-formats.ts src/format-color.ts src/data-attr.ts src/snapshot-for-wire.ts src/match-path.ts src/style-element.ts src/themes.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/**' --coverage.all",
     "test:bench": "vitest bench --run",
     "test:watch": "vitest",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -47,6 +47,7 @@
     "build": "tsdown src/tailwind.ts src/css-in-js.ts --format esm --dts --clean --sourcemap",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/**' --coverage.all",
     "test:watch": "vitest",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
     "format": "oxfmt -c ../../.oxfmtrc.json src test",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -52,6 +52,7 @@
     "inspect": "mcp-inspector node dist/bin.mjs -- --config ../../apps/storybook/swatchbook.config.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/**' --coverage.all",
     "test:watch": "vitest",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
     "format": "oxfmt -c ../../.oxfmtrc.json src test",

--- a/packages/switcher/package.json
+++ b/packages/switcher/package.json
@@ -48,6 +48,7 @@
     "build": "tsdown",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
+    "coverage": "vitest run --coverage --coverage.provider=v8 --coverage.reporter=text --coverage.include='src/**' --coverage.all",
     "test:watch": "vitest",
     "lint": "oxlint --deny-warnings -c ../../.oxlintrc.json src test",
     "format": "oxfmt -c ../../.oxfmtrc.json src test",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@terrazzo/cli':
         specifier: ^2.3.0
         version: 2.3.0(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)
+      '@vitest/coverage-v8':
+        specifier: ^4.1.7
+        version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       oxfmt:
         specifier: ^0.45.0
         version: 0.45.0
@@ -9434,11 +9437,11 @@ snapshots:
   '@babel/helpers@7.29.2':
     dependencies:
       '@babel/template': 7.28.6
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.2':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@babel/parser@7.29.7':
     dependencies:
@@ -10021,8 +10024,8 @@ snapshots:
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@babel/traverse@7.29.0':
     dependencies:
@@ -13461,24 +13464,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -13756,7 +13759,7 @@ snapshots:
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
       magicast: 0.5.3
-      obug: 2.1.1
+      obug: 2.1.2
       std-env: 4.1.0
       tinyrainbow: 3.1.0
       vitest: 4.1.7(@types/node@25.6.0)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(vite@8.0.16(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0))


### PR DESCRIPTION
The #1118 test-backfill was guessing gaps from filenames, which misses modules that *are* imported but barely exercised. Adding the v8 coverage provider already surfaced one the heuristic missed: **`core/themes.ts` reads as "has tests" but is 0% line-covered.**

- `@vitest/coverage-v8` dev dep (matches the `^4.1.7` vitest range).
- A `coverage` script on each of the 6 published packages: `vitest run --coverage` with the v8 provider over `src/**` (`--coverage.all` so untested files show as 0% rather than being omitted).

No production or published-package change; tooling only, so no changeset. `coverage/` is already gitignored.

Milestone: Maintenance

Closes #1159

Refs #1118