### PR TITLE
test(core): cover themes, color-formats, makeCssVar + glob branch

### DIFF
--- a/packages/core/test/color-formats.test.ts
+++ b/packages/core/test/color-formats.test.ts
@@ -1,0 +1,6 @@
+import { expect, it } from 'vitest';
+import { COLOR_FORMATS } from '#/color-formats.ts';
+
+it('lists the supported color display formats in toolbar order', () => {
+  expect(COLOR_FORMATS).toEqual(['hex', 'rgb', 'hsl', 'oklch', 'raw']);
+});

--- a/packages/core/test/make-css-var.test.ts
+++ b/packages/core/test/make-css-var.test.ts
@@ -1,0 +1,14 @@
+import { expect, it } from 'vitest';
+import { makeCssVar } from '#/css-var.ts';
+
+it('wraps the property in var() with the prefix segment', () => {
+  expect(makeCssVar('color.brand.primary', 'sb')).toBe('var(--sb-color-brand-primary)');
+});
+
+it('omits the prefix segment when the prefix is empty', () => {
+  expect(makeCssVar('color.brand.primary', '')).toBe('var(--color-brand-primary)');
+});
+
+it('kebab-cases camelCase path segments', () => {
+  expect(makeCssVar('color.brandPrimary', 'sb')).toBe('var(--sb-color-brand-primary)');
+});

--- a/packages/core/test/permutations/util.test.ts
+++ b/packages/core/test/permutations/util.test.ts
@@ -29,3 +29,11 @@ it('returns an empty array when nothing matches', () => {
   const dir = fixtureDir();
   expect(collectGlobbedFiles(['*.css'], dir)).toEqual([]);
 });
+
+it('keeps already-absolute matches without re-resolving against cwd', () => {
+  const dir = fixtureDir();
+  // An absolute glob makes globSync yield absolute matches, exercising the
+  // isAbsolute branch that skips the resolve(cwd, match) step.
+  const result = collectGlobbedFiles([join(dir, '*.json')], dir);
+  expect(result).toEqual([join(dir, 'a.json'), join(dir, 'b.json')]);
+});

--- a/packages/core/test/themes.test.ts
+++ b/packages/core/test/themes.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from 'vitest';
+import { enumerateThemes, tupleToName } from '#/themes.ts';
+import type { ThemeEnumAxis } from '#/themes.ts';
+
+const AXES: readonly ThemeEnumAxis[] = [
+  { name: 'mode', default: 'Light', contexts: ['Light', 'Dark'] },
+  { name: 'brand', default: 'Acme', contexts: ['Acme', 'Globex'] },
+];
+const DEFAULTS = { mode: 'Light', brand: 'Acme' };
+
+it('joins axis values by " · " in axis declaration order', () => {
+  expect(tupleToName(AXES, { mode: 'Dark', brand: 'Globex' })).toBe('Dark · Globex');
+});
+
+it('fills axes the tuple omits with their defaults when naming', () => {
+  expect(tupleToName(AXES, { brand: 'Globex' })).toBe('Light · Globex');
+});
+
+it('lists the default tuple first, then one singleton per non-default context', () => {
+  const themes = enumerateThemes({ axes: AXES, presets: [], defaultTuple: DEFAULTS });
+  expect(themes.map((t) => t.name)).toEqual(['Light · Acme', 'Dark · Acme', 'Light · Globex']);
+  expect(themes[0]).toEqual({ name: 'Light · Acme', tuple: { mode: 'Light', brand: 'Acme' } });
+});
+
+it('appends presets with omitted axes filled from defaults', () => {
+  const themes = enumerateThemes({
+    axes: AXES,
+    presets: [{ name: 'Globex Dark', axes: { mode: 'Dark', brand: 'Globex' } }],
+    defaultTuple: DEFAULTS,
+  });
+  expect(themes.at(-1)).toEqual({
+    name: 'Dark · Globex',
+    tuple: { mode: 'Dark', brand: 'Globex' },
+  });
+});
+
+it('collapses a preset that resolves to an already-enumerated singleton', () => {
+  // { mode: Dark } fills to { mode: Dark, brand: Acme } — the mode singleton.
+  const themes = enumerateThemes({
+    axes: AXES,
+    presets: [{ name: 'dupe', axes: { mode: 'Dark' } }],
+    defaultTuple: DEFAULTS,
+  });
+  expect(themes.filter((t) => t.name === 'Dark · Acme')).toHaveLength(1);
+});
+
+it('ignores an undefined preset axis value, leaving that axis at its default', () => {
+  const themes = enumerateThemes({
+    axes: AXES,
+    presets: [{ name: 'sparse', axes: { mode: undefined, brand: 'Globex' } }],
+    defaultTuple: DEFAULTS,
+  });
+  // Collapses into the brand singleton (Light · Globex) rather than erroring.
+  expect(themes.filter((t) => t.name === 'Light · Globex')).toHaveLength(1);
+});


### PR DESCRIPTION
Coverage-guided backfill (provider added in #1160). The v8 pass immediately found a gap the filename survey missed:

| Module | Before | What's now pinned |
|--------|--------|-------------------|
| `themes.ts` | **0%** | `enumerateThemes` default-first ordering, per-axis non-default singletons, preset fill-from-defaults, name dedup; `tupleToName` join + default fallback |
| `css-var.ts` `makeCssVar` | untested fn | `var()` wrapper, prefix on/off, camelCase→kebab |
| `color-formats.ts` | 0% | `COLOR_FORMATS` list + order |
| `permutations/util.ts` | 50% branch | the already-absolute match branch |

Core coverage: 92.0% → 93.8% stmts, 93.3% → 96.1% funcs.

Coverage also surfaced that `presets.ts`'s `fillPresetTuple` is **dead** — its only caller was removed in #1152, and it's not re-exported. I'll send that as a small separate removal rather than test dead code.

Tests-only; no changeset.

Milestone: Maintenance

Closes #1161

Refs #1118