### PR TITLE
refactor(core): remove dead fillPresetTuple

### DIFF
--- a/packages/core/src/presets.ts
+++ b/packages/core/src/presets.ts
@@ -48,20 +48,3 @@ export function validatePresets(raw: Preset[] | undefined, axes: Axis[]): Preset
 
   return { presets, diagnostics };
 }
-
-/**
- * Fill a preset's sanitized partial tuple with each axis's `default`,
- * yielding a complete tuple that names every axis. Matches what the
- * toolbar's "apply preset" button sends out — keeps emitted output and
- * runtime activation in lockstep.
- */
-export function fillPresetTuple(
-  presetAxes: Partial<Record<string, string>>,
-  axes: readonly Axis[],
-): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const axis of axes) {
-    out[axis.name] = presetAxes[axis.name] ?? axis.default;
-  }
-  return out;
-}


### PR DESCRIPTION
The coverage pass (#1160) flagged `fillPresetTuple` as the lone uncovered function in `presets.ts`. It's dead: its only caller was the preset-materialization loop removed in #1152, and it isn't re-exported from any index or `/subpath`. Removed; `Axis` stays (still used by `validatePresets`).

Internal-only; no changeset.

Milestone: Maintenance

Closes #1163

Refs #1118