### PR TITLE
test(addon): cover tuple-resolution helpers via a pure module

### DIFF
--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -45,6 +45,7 @@ import {
 } from '#/constants.ts';
 import type { InitPayload } from '#/channel-types.ts';
 import type { StoryParameters, SwatchbookGlobals } from '#/globals.ts';
+import { resolveTuple } from '#/tuple-resolve.ts';
 
 // Seed blocks' token store with the build-time snapshot from the addon's
 // virtual module. Blocks no longer import `virtual:swatchbook/tokens`
@@ -189,69 +190,6 @@ function broadcastInit(): void {
   );
 }
 
-// Axis-default tuple, used as the baseline before overrides.
-function defaultTuple(): Record<string, string> {
-  const out: Record<string, string> = {};
-  for (const axis of virtualAxes) out[axis.name] = axis.default;
-  return out;
-}
-
-// Reverse-engineer a tuple from a `Light · Brand A · Normal`-shape
-// theme name. Splits on ` · ` and zips with `virtualAxes` in declared
-// order — matches `composeThemeName`'s production direction so a
-// round-trip is lossless. Returns `undefined` when the segment count
-// doesn't match the axis count.
-function tupleForName(name: string): Record<string, string> | undefined {
-  if (!name) return undefined;
-  const parts = name.split(' · ');
-  if (parts.length !== virtualAxes.length) return undefined;
-  const out: Record<string, string> = {};
-  for (let i = 0; i < virtualAxes.length; i++) {
-    const axis = virtualAxes[i] as (typeof virtualAxes)[number];
-    const value = parts[i];
-    if (value === undefined) return undefined;
-    out[axis.name] = value;
-  }
-  return out;
-}
-
-// Merge a partial tuple onto the axis defaults, dropping keys for axes that
-// don't exist and silently falling back to the default for contexts that
-// aren't listed on the axis.
-function normalizeTuple(partial: Readonly<Record<string, string>>): Record<string, string> {
-  const out = defaultTuple();
-  for (const axis of virtualAxes) {
-    const candidate = partial[axis.name];
-    if (candidate !== undefined && axis.contexts.includes(candidate)) {
-      out[axis.name] = candidate;
-    }
-  }
-  return out;
-}
-
-// Resolve the active tuple from all input channels, in priority order:
-//   1. `parameters.swatchbook.axes` — per-story tuple.
-//   2. `parameters.swatchbook.themeName` — per-story composed theme name.
-//   3. `globals.swatchbookAxes` — toolbar-set tuple.
-//   4. virtual module default.
-function resolveTuple(
-  axesGlobal: SwatchbookGlobals[typeof AXES_GLOBAL_KEY],
-  paramSwatchbook: StoryParameters['swatchbook'],
-): Record<string, string> {
-  const paramAxes = paramSwatchbook?.axes;
-  if (paramAxes) {
-    return normalizeTuple(paramAxes);
-  }
-  if (paramSwatchbook?.themeName) {
-    const hit = tupleForName(paramSwatchbook.themeName);
-    if (hit) return normalizeTuple(hit);
-  }
-  if (axesGlobal && typeof axesGlobal === 'object') {
-    return normalizeTuple(axesGlobal as Record<string, string>);
-  }
-  return defaultTuple();
-}
-
 function resolveColorFormat(raw: SwatchbookGlobals[typeof COLOR_FORMAT_GLOBAL_KEY]): ColorFormat {
   if (typeof raw === 'string' && (COLOR_FORMATS as readonly string[]).includes(raw)) {
     return raw as ColorFormat;
@@ -272,7 +210,7 @@ const themedDecorator: Decorator = (Story, context) => {
   const colorFormatGlobal = globals[COLOR_FORMAT_GLOBAL_KEY];
   const paramSwatchbook = parameters.swatchbook;
   const tuple = useMemo(
-    () => resolveTuple(axesGlobal, paramSwatchbook),
+    () => resolveTuple(axesGlobal, paramSwatchbook, virtualAxes),
     [axesGlobal, paramSwatchbook],
   );
   const colorFormat = useMemo(() => resolveColorFormat(colorFormatGlobal), [colorFormatGlobal]);
@@ -289,7 +227,7 @@ const themedDecorator: Decorator = (Story, context) => {
       // On unmount — navigating away from this story, e.g. to an MDX docs
       // page that renders no decorator — revert <html> to the toolbar tuple
       // so a per-story axis override doesn't persist onto the next page.
-      setRootAxes(resolveTuple(axesGlobal, undefined));
+      setRootAxes(resolveTuple(axesGlobal, undefined, virtualAxes));
     };
   }, [tuple, axesGlobal]);
 
@@ -425,7 +363,7 @@ function installGlobalAxisApplier(): void {
   channel.on(INIT_REQUEST_EVENT, broadcastInit);
   const apply = (globals: SwatchbookGlobals): void => {
     ensureStylesheet(css, cssVarPrefix);
-    const tuple = resolveTuple(globals[AXES_GLOBAL_KEY], undefined);
+    const tuple = resolveTuple(globals[AXES_GLOBAL_KEY], undefined, virtualAxes);
     setRootAxes(tuple);
   };
   // Storybook fires `globalsUpdated`, `setGlobals`, and `updateGlobals`

--- a/packages/addon/src/tuple-resolve.ts
+++ b/packages/addon/src/tuple-resolve.ts
@@ -1,0 +1,89 @@
+import type { SwatchbookParameters } from '#/globals.ts';
+
+/**
+ * Axis-tuple resolution shared by the preview decorator and the global
+ * axis-applier. Pure over an explicit `axes` list (the addon passes its
+ * `virtual:swatchbook/tokens` `axes` export) so the resolution rules can be
+ * tested without the virtual module or a running preview.
+ */
+
+/** Minimal axis shape the resolvers read. Structurally satisfied by the addon's virtual `axes` export. */
+export interface ResolveAxis {
+  readonly name: string;
+  readonly default: string;
+  readonly contexts: readonly string[];
+}
+
+/** Axis-default tuple — `{ axis.name: axis.default }` for every axis. The baseline before overrides. */
+export function axisDefaultTuple(axes: readonly ResolveAxis[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const axis of axes) out[axis.name] = axis.default;
+  return out;
+}
+
+/**
+ * Reverse-engineer a tuple from a `Light · Brand A · Normal`-shape theme
+ * name. Splits on ` · ` and zips with `axes` in declared order — the inverse
+ * of `tupleToName`, so a round-trip is lossless. Returns `undefined` when the
+ * segment count doesn't match the axis count.
+ */
+export function tupleForName(
+  name: string,
+  axes: readonly ResolveAxis[],
+): Record<string, string> | undefined {
+  if (!name) return undefined;
+  const parts = name.split(' · ');
+  if (parts.length !== axes.length) return undefined;
+  const out: Record<string, string> = {};
+  for (let i = 0; i < axes.length; i++) {
+    const axis = axes[i] as ResolveAxis;
+    const value = parts[i];
+    if (value === undefined) return undefined;
+    out[axis.name] = value;
+  }
+  return out;
+}
+
+/**
+ * Merge a partial tuple onto the axis defaults: drop keys for axes that don't
+ * exist, and fall back to the default for contexts not listed on the axis.
+ */
+export function normalizeTuple(
+  partial: Readonly<Record<string, string>>,
+  axes: readonly ResolveAxis[],
+): Record<string, string> {
+  const out = axisDefaultTuple(axes);
+  for (const axis of axes) {
+    const candidate = partial[axis.name];
+    if (candidate !== undefined && axis.contexts.includes(candidate)) {
+      out[axis.name] = candidate;
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the active tuple from all input channels, in priority order:
+ *   1. `parameters.swatchbook.axes` — per-story tuple.
+ *   2. `parameters.swatchbook.themeName` — per-story composed theme name.
+ *   3. `globals.swatchbookAxes` — toolbar-set tuple.
+ *   4. axis defaults.
+ */
+export function resolveTuple(
+  axesGlobal: Record<string, string> | undefined,
+  paramSwatchbook: SwatchbookParameters | undefined,
+  axes: readonly ResolveAxis[],
+): Record<string, string> {
+  const paramAxes = paramSwatchbook?.axes;
+  if (paramAxes) {
+    return normalizeTuple(paramAxes, axes);
+  }
+  if (paramSwatchbook?.themeName) {
+    const hit = tupleForName(paramSwatchbook.themeName, axes);
+    if (hit) return normalizeTuple(hit, axes);
+  }
+  if (axesGlobal && typeof axesGlobal === 'object') {
+    return normalizeTuple(axesGlobal, axes);
+  }
+  return axisDefaultTuple(axes);
+}

--- a/packages/addon/test/tuple-resolve.test.ts
+++ b/packages/addon/test/tuple-resolve.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from 'vitest';
+import { axisDefaultTuple, normalizeTuple, resolveTuple, tupleForName } from '#/tuple-resolve.ts';
+import type { ResolveAxis } from '#/tuple-resolve.ts';
+
+const AXES: readonly ResolveAxis[] = [
+  { name: 'mode', default: 'Light', contexts: ['Light', 'Dark'] },
+  { name: 'brand', default: 'Acme', contexts: ['Acme', 'Globex'] },
+];
+
+it('axisDefaultTuple yields every axis at its default', () => {
+  expect(axisDefaultTuple(AXES)).toEqual({ mode: 'Light', brand: 'Acme' });
+});
+
+it('tupleForName reverses a " · "-joined theme name in axis order', () => {
+  expect(tupleForName('Dark · Globex', AXES)).toEqual({ mode: 'Dark', brand: 'Globex' });
+});
+
+it('tupleForName returns undefined when the segment count does not match the axes', () => {
+  expect(tupleForName('Dark', AXES)).toBeUndefined();
+  expect(tupleForName('', AXES)).toBeUndefined();
+});
+
+it('normalizeTuple fills omitted axes from defaults and keeps valid contexts', () => {
+  expect(normalizeTuple({ mode: 'Dark' }, AXES)).toEqual({ mode: 'Dark', brand: 'Acme' });
+});
+
+it('normalizeTuple drops an out-of-context value back to the default', () => {
+  expect(normalizeTuple({ mode: 'Sepia' }, AXES)).toEqual({ mode: 'Light', brand: 'Acme' });
+});
+
+it('normalizeTuple drops keys for axes the project does not have', () => {
+  expect(normalizeTuple({ density: 'Compact' }, AXES)).toEqual({ mode: 'Light', brand: 'Acme' });
+});
+
+it('resolveTuple prefers a per-story axes override over globals', () => {
+  // param axes win; the globals tuple ({ mode: Dark }) is ignored.
+  expect(resolveTuple({ mode: 'Dark' }, { axes: { brand: 'Globex' } }, AXES)).toEqual({
+    mode: 'Light',
+    brand: 'Globex',
+  });
+});
+
+it('resolveTuple falls to a per-story themeName when there is no axes override', () => {
+  expect(resolveTuple({ mode: 'Dark' }, { themeName: 'Dark · Globex' }, AXES)).toEqual({
+    mode: 'Dark',
+    brand: 'Globex',
+  });
+});
+
+it('resolveTuple ignores an unparseable themeName and falls through to globals', () => {
+  expect(resolveTuple({ brand: 'Globex' }, { themeName: 'nope' }, AXES)).toEqual({
+    mode: 'Light',
+    brand: 'Globex',
+  });
+});
+
+it('resolveTuple uses the toolbar globals tuple when no per-story override', () => {
+  expect(resolveTuple({ mode: 'Dark' }, undefined, AXES)).toEqual({ mode: 'Dark', brand: 'Acme' });
+});
+
+it('resolveTuple falls back to axis defaults when nothing is set', () => {
+  expect(resolveTuple(undefined, undefined, AXES)).toEqual({ mode: 'Light', brand: 'Acme' });
+});


### PR DESCRIPTION
Closes #1141 — the decorator's tuple resolvers had no direct tests.

`resolveTuple` / `tupleForName` / `normalizeTuple` / the axis-default helper closed over the module-level `virtualAxes`, so they couldn't be exercised without the virtual module or a running preview (the "hard to test → extract pure logic" smell). Extracted them to **`tuple-resolve.ts`**, parameterized over an explicit `axes` list; `preview.tsx` imports them and threads `virtualAxes` at the three call sites. Behavior is identical — the existing addon suite (incl. the browser-mode decorator/channel tests) stays green.

11 new node-mode tests pin:
- resolution priority: per-story `axes` > `themeName` > toolbar globals > axis defaults
- the `tupleForName` ↔ `tupleToName` round-trip + segment-count guard
- `normalizeTuple` sanitization: out-of-context values fall back to default, unknown axes are dropped

Internal refactor + tests, no API change, so no changeset.

Milestone: Maintenance

Closes #1141