### PR TITLE
chore(core): fuzzy outOfOrder coverage + fix two stale doc comments

### DIFF
--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -15,15 +15,6 @@ import { resolveAllAt } from '#/token-graph/walk.ts';
 import { permutationID } from '#/types.ts';
 import type { Axis, Config, Diagnostic, Permutation, Project, TokenMap } from '#/types.ts';
 
-/**
- * Load a swatchbook project from a config. Read tokens at any axis
- * tuple via `project.resolveAt(tuple)`; read the default-tuple
- * snapshot directly via `project.defaultTokens`.
- *
- * The `cwd` defaults to `process.cwd()`. All relative paths in
- * `config` (token globs, `resolver`, layered axis overlay globs)
- * resolve against this directory.
- */
 /** Default `cssVarPrefix` applied when the config omits one. Namespaces
  * emitted vars (`--swatch-…`) and data attributes (`data-swatch-…`) so
  * swatchbook output doesn't collide with whatever else the consumer has
@@ -51,6 +42,15 @@ function logPhase(label: string, startedAt: number): void {
   console.log(`[swatchbook:load] ${label}: ${ms.toFixed(0)}ms`);
 }
 
+/**
+ * Load a swatchbook project from a config. Read tokens at any axis
+ * tuple via `project.resolveAt(tuple)`; read the default-tuple
+ * snapshot directly via `project.defaultTokens`.
+ *
+ * The `cwd` defaults to `process.cwd()`. All relative paths in
+ * `config` (token globs, `resolver`, layered axis overlay globs)
+ * resolve against this directory.
+ */
 export async function loadProject(config: Config, cwd: string = process.cwd()): Promise<Project> {
   const loadStart = performance.now();
   const logger = new BufferedLogger({ level: 'warn' });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -90,10 +90,10 @@ export type AxisVarianceResult =
     };
 
 /**
- * Compute the resolved `TokenMap` for any tuple of axis selections
- * without touching the resolver. Pure function over `cells +
- * jointOverrides + axes + defaultTuple`; accepts partial tuples
- * (missing axes fall back to their defaults).
+ * Compose the resolved `TokenMap` for any tuple of axis selections.
+ * Graph-backed: walks `Project.tokenGraph` rather than re-running the
+ * resolver. Accepts partial tuples (missing axes fall back to their
+ * defaults) and memoizes on the canonical tuple key.
  */
 export type ResolveAt = (tuple: Record<string, string>) => TokenMap;
 

--- a/packages/core/test/fuzzy.test.ts
+++ b/packages/core/test/fuzzy.test.ts
@@ -48,6 +48,20 @@ it('respects the limit option', () => {
   expect(hits).toHaveLength(2);
 });
 
+it('requires authored term order when outOfOrder is false', () => {
+  // `surface` precedes `default` in the path: in-order matches, reversed does not.
+  expect(fuzzyFilter(paths, 'surface default', (p) => p, { outOfOrder: false })).toContain(
+    'color.surface.default',
+  );
+  expect(fuzzyFilter(paths, 'default surface', (p) => p, { outOfOrder: false })).not.toContain(
+    'color.surface.default',
+  );
+});
+
+it('returns an empty list when the item set is empty', () => {
+  expect(fuzzyFilter([], 'color', (p) => p)).toEqual([]);
+});
+
 it('fuzzyMatches mirrors fuzzyFilter for single haystacks', () => {
   expect(fuzzyMatches('color.surface.default', 'surf def')).toBe(true);
   expect(fuzzyMatches('color.surface.default', 'zzzz')).toBe(false);


### PR DESCRIPTION
Small core batch from #1118.

- **Test:** cover `fuzzy.ts`'s `outOfOrder: false` path (terms must match in authored order) and the empty-items branch — the existing suite only exercised the default `outOfOrder: true`. The remaining uncovered branches are defensive `order === null` / `item === undefined` guards, not worth contrived inputs.
- **Docs:** relocate the `loadProject` doc comment (it was orphaned above `DEFAULT_CSS_VAR_PREFIX` instead of on the function); correct `ResolveAt`'s doc, which still described the removed `cells + jointOverrides` architecture rather than the graph-backed resolver.

Skipped from the same #1118 cluster (with reasons): `token-listing` missing/malformed branches need heavy mocking of the Terrazzo build for low-value degrade paths; `style-element` is DOM-only (core is node-mode); the resolver-edge-cases "either outcome" test is already correct (it asserts meaningfully in both valid upstream behaviours).

Tests + internal doc comments, no API change — no changeset.

Milestone: Maintenance

Closes #1174

Refs #1118