### PR TITLE
fix(blocks): size the motion preview loop to the token duration

### DIFF
--- a/.changeset/blocks-motion-loop-duration.md
+++ b/.changeset/blocks-motion-loop-duration.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+Size the composite motion preview's loop to the token's real duration instead of a fixed 1200ms

--- a/packages/blocks/src/token-detail/CompositePreview.tsx
+++ b/packages/blocks/src/token-detail/CompositePreview.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { cssVarAsNumber } from '#/internal/css-var-style.ts';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
+import { transitionDurationMs } from '#/token-detail/transition-duration.ts';
 
 export interface CompositePreviewProps {
   /** Full dot-path of the token to preview. */
@@ -65,7 +66,9 @@ export function CompositePreviewContent({
     );
   }
   if (type === 'transition') {
-    return <TransitionSample transition={cssVar} />;
+    return (
+      <TransitionSample transition={cssVar} durationMs={transitionDurationMs(type, rawValue)} />
+    );
   }
   if (type === 'dimension') {
     return (
@@ -75,7 +78,12 @@ export function CompositePreviewContent({
     );
   }
   if (type === 'duration') {
-    return <TransitionSample transition={`left ${cssVar} ease`} />;
+    return (
+      <TransitionSample
+        transition={`left ${cssVar} ease`}
+        durationMs={transitionDurationMs(type, rawValue)}
+      />
+    );
   }
   if (type === 'fontFamily') {
     return (
@@ -95,7 +103,12 @@ export function CompositePreviewContent({
     );
   }
   if (type === 'cubicBezier') {
-    return <TransitionSample transition={`left 800ms ${cssVar}`} />;
+    return (
+      <TransitionSample
+        transition={`left 800ms ${cssVar}`}
+        durationMs={transitionDurationMs(type, rawValue)}
+      />
+    );
   }
   if (type === 'gradient') {
     return (
@@ -187,21 +200,36 @@ function asDashLengths(raw: unknown): number[] {
   return out;
 }
 
-function TransitionSample({ transition }: { transition: string }): ReactElement {
+// Toggle cadence when the token carries no readable duration.
+const DEFAULT_LOOP_MS = 1200;
+// Rest at each end so the eye registers the position before the ball returns;
+// added on top of the move duration so each leg fully completes first.
+const MOTION_HOLD_MS = 400;
+
+function TransitionSample({
+  transition,
+  durationMs,
+}: {
+  transition: string;
+  durationMs?: number | undefined;
+}): ReactElement {
   const reduced = usePrefersReducedMotion();
   const [phase, setPhase] = useState<0 | 1>(0);
 
   useEffect(() => {
     if (reduced) return;
+    // Match the loop to the token's real duration; a long token otherwise
+    // reversed mid-move under the old fixed 1200ms interval.
+    const loopMs = durationMs === undefined ? DEFAULT_LOOP_MS : durationMs + MOTION_HOLD_MS;
     const id = requestAnimationFrame(() => setPhase(1));
     const loop = window.setInterval(() => {
       setPhase((p) => (p === 0 ? 1 : 0));
-    }, 1200);
+    }, loopMs);
     return () => {
       cancelAnimationFrame(id);
       window.clearInterval(loop);
     };
-  }, [reduced]);
+  }, [reduced, durationMs]);
 
   if (reduced) {
     return (

--- a/packages/blocks/src/token-detail/transition-duration.ts
+++ b/packages/blocks/src/token-detail/transition-duration.ts
@@ -1,0 +1,38 @@
+/**
+ * Numeric duration (ms) the motion preview should animate over for a given
+ * token type, read from its resolved `$value`. Lets the sample's toggle loop
+ * match the token's real duration instead of a fixed cadence — a long token
+ * (say 2s) otherwise reverses mid-move under the old hardcoded interval.
+ * Returns `undefined` for types that carry no duration, so the caller can
+ * fall back to its default.
+ */
+export function transitionDurationMs(
+  type: string | undefined,
+  rawValue: unknown,
+): number | undefined {
+  // The cubicBezier sample animates `left 800ms <bezier>`, so its loop is fixed.
+  if (type === 'cubicBezier') return 800;
+  if (type === 'duration') return parseDurationMs(rawValue);
+  if (type === 'transition' && rawValue !== null && typeof rawValue === 'object') {
+    return parseDurationMs((rawValue as { duration?: unknown }).duration);
+  }
+  return undefined;
+}
+
+// Parse a DTCG duration (`{ value, unit }`), a CSS string (`300ms` / `1.5s`),
+// or a bare number (treated as ms) into milliseconds.
+function parseDurationMs(v: unknown): number | undefined {
+  if (typeof v === 'number') return v;
+  if (typeof v === 'string') {
+    const m = /^([\d.]+)(ms|s)?$/.exec(v.trim());
+    if (!m?.[1]) return undefined;
+    const n = Number(m[1]);
+    if (Number.isNaN(n)) return undefined;
+    return m[2] === 's' ? n * 1000 : n;
+  }
+  if (v !== null && typeof v === 'object') {
+    const d = v as { value?: unknown; unit?: unknown };
+    if (typeof d.value === 'number') return d.unit === 's' ? d.value * 1000 : d.value;
+  }
+  return undefined;
+}

--- a/packages/blocks/test/transition-duration.test.ts
+++ b/packages/blocks/test/transition-duration.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from 'vitest';
+import { transitionDurationMs } from '#/token-detail/transition-duration.ts';
+
+it('reads a millisecond duration object directly', () => {
+  expect(transitionDurationMs('duration', { value: 300, unit: 'ms' })).toBe(300);
+});
+
+it('converts a seconds duration object to ms', () => {
+  expect(transitionDurationMs('duration', { value: 2, unit: 's' })).toBe(2000);
+});
+
+it('parses string durations in ms and s', () => {
+  expect(transitionDurationMs('duration', '450ms')).toBe(450);
+  expect(transitionDurationMs('duration', '1.5s')).toBe(1500);
+});
+
+it('treats a bare number as milliseconds', () => {
+  expect(transitionDurationMs('duration', 250)).toBe(250);
+});
+
+it('reads the duration sub-field of a transition composite', () => {
+  expect(
+    transitionDurationMs('transition', {
+      duration: { value: 200, unit: 'ms' },
+      delay: { value: 0, unit: 'ms' },
+      timingFunction: [0.4, 0, 0.2, 1],
+    }),
+  ).toBe(200);
+});
+
+it('returns the fixed 800ms the cubicBezier sample animates over', () => {
+  expect(transitionDurationMs('cubicBezier', [0.4, 0, 0.2, 1])).toBe(800);
+});
+
+it('returns undefined for types without a duration or an unparseable value', () => {
+  expect(transitionDurationMs('color', '#fff')).toBeUndefined();
+  expect(transitionDurationMs('duration', { value: 'x' })).toBeUndefined();
+  expect(transitionDurationMs('duration', 'not-a-duration')).toBeUndefined();
+});


### PR DESCRIPTION
Closes #1176 (from #1118).

`TransitionSample` (the composite motion preview) toggled the ball on a hardcoded **1200ms `setInterval`**, regardless of the token's actual duration — so a longer token (e.g. 2s) reversed direction mid-move and never completed a leg.

Fix: a pure `transitionDurationMs(type, rawValue)` helper extracts the duration (ms) from the resolved `$value` (`duration` tokens, the `duration` sub-field of `transition` composites, the fixed 800ms the cubicBezier sample animates over), and `TransitionSample` drives its loop at `duration + a short hold`. Falls back to 1200ms when the type carries no readable duration.

The helper is extracted to its own module and unit-tested (node mode, 7 cases: ms/s objects, string + bare-number parsing, the transition sub-field, cubicBezier, and the undefined cases).

Patch changeset (user-visible preview behavior).

Milestone: Maintenance

Closes #1176

Refs #1118