### PR TITLE
fix(addon): announce a return to the mount-time theme to assistive tech

### DIFF
--- a/.changeset/addon-live-region-return.md
+++ b/.changeset/addon-live-region-return.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+Announce a return to the mount-time theme in the live region (it previously went silent on the way back)

--- a/packages/addon/src/hooks/use-theme-announcement.ts
+++ b/packages/addon/src/hooks/use-theme-announcement.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Page-level theme-flip announcement for an `aria-live` region. Silent on
+ * initial mount (no spurious announcement per story load), then emits
+ * `Theme: <name>` whenever the active theme changes — including a return to
+ * the mount-time theme. Debounced by `delayMs` so rapid axis flips collapse
+ * into one announcement.
+ *
+ * Tracks the *previous* theme, not the initial one: keying off the mount
+ * theme dropped the announcement when the user flipped back to where they
+ * started, leaving screen-reader users with no signal.
+ */
+export function useThemeAnnouncement(themeName: string, delayMs = 250): string {
+  const [announcement, setAnnouncement] = useState('');
+  const prevThemeRef = useRef(themeName);
+  useEffect(() => {
+    if (themeName === prevThemeRef.current) return;
+    prevThemeRef.current = themeName;
+    const timer = setTimeout(() => {
+      setAnnouncement(themeName ? `Theme: ${themeName}` : '');
+    }, delayMs);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [themeName, delayMs]);
+  return announcement;
+}

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -3,7 +3,7 @@ import { resolveAllAt } from '@unpunnyfuns/swatchbook-core/graph';
 import type { TokenMap } from '@unpunnyfuns/swatchbook-core';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import type { CSSProperties } from 'react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { addons } from 'storybook/preview-api';
 import { dataAttr } from '@unpunnyfuns/swatchbook-core/data-attr';
 import { ensureStyleElement } from '@unpunnyfuns/swatchbook-core/style-element';
@@ -45,6 +45,7 @@ import {
 } from '#/constants.ts';
 import type { InitPayload } from '#/channel-types.ts';
 import type { StoryParameters, SwatchbookGlobals } from '#/globals.ts';
+import { useThemeAnnouncement } from '#/hooks/use-theme-announcement.ts';
 
 // Seed blocks' token store with the build-time snapshot from the addon's
 // virtual module. Blocks no longer import `virtual:swatchbook/tokens`
@@ -294,21 +295,10 @@ const themedDecorator: Decorator = (Story, context) => {
   }, [tuple, axesGlobal]);
 
   // Page-level live region announces theme/axis flips to SR users.
-  // Initial mount stays silent (no spurious announcement on every story
-  // load); subsequent `themeName` changes schedule a debounced update so
-  // rapid axis flips (or per-story tuple overrides while paging through
-  // a Storybook docs index) collapse into one announcement.
-  const [announcement, setAnnouncement] = useState('');
-  const initialThemeRef = useRef(themeName);
-  useEffect(() => {
-    if (themeName === initialThemeRef.current) return;
-    const timer = setTimeout(() => {
-      setAnnouncement(themeName ? `Theme: ${themeName}` : '');
-    }, 250);
-    return () => {
-      clearTimeout(timer);
-    };
-  }, [themeName]);
+  // Silent on mount; debounced so rapid axis flips collapse into one
+  // announcement; fires on every change including a return to the
+  // mount-time theme.
+  const announcement = useThemeAnnouncement(themeName);
 
   const wrapperAttrs: Record<string, string> = {};
   for (const axis of virtualAxes) {

--- a/packages/addon/test/use-theme-announcement.browser.test.tsx
+++ b/packages/addon/test/use-theme-announcement.browser.test.tsx
@@ -1,0 +1,30 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { expect, it } from 'vitest';
+import { useThemeAnnouncement } from '#/hooks/use-theme-announcement.ts';
+
+const render = (theme: string) =>
+  renderHook((p: { theme: string }) => useThemeAnnouncement(p.theme, 5), {
+    initialProps: { theme },
+  });
+
+it('stays silent on initial mount', async () => {
+  const { result } = render('Light · Acme');
+  await new Promise((r) => setTimeout(r, 25));
+  expect(result.current).toBe('');
+});
+
+it('announces when the theme changes', async () => {
+  const { result, rerender } = render('Light · Acme');
+  rerender({ theme: 'Dark · Acme' });
+  await waitFor(() => expect(result.current).toBe('Theme: Dark · Acme'));
+});
+
+it('announces a return to the mount-time theme', async () => {
+  // The bug: keying off the *initial* theme dropped this announcement, so a
+  // screen-reader user flipping back to where they started heard nothing.
+  const { result, rerender } = render('Light · Acme');
+  rerender({ theme: 'Dark · Acme' });
+  await waitFor(() => expect(result.current).toBe('Theme: Dark · Acme'));
+  rerender({ theme: 'Light · Acme' });
+  await waitFor(() => expect(result.current).toBe('Theme: Light · Acme'));
+});


### PR DESCRIPTION
Closes #1178 (from #1118).

The decorator's `aria-live` region compared the active theme against the **mount-time** theme (`initialThemeRef`), so flipping back to where you started fell into the `themeName === initial` early-return — no announcement. A screen-reader user who toggled an axis and toggled it back heard nothing on the return.

Fix: extract a `useThemeAnnouncement` hook that tracks the **previous** theme (updated on each change) rather than the initial one. Still silent on mount, still debounced so rapid flips collapse into one announcement. Replaces the inline `useState`/`useRef`/`useEffect` in the decorator.

Mutation-verified: reintroducing the compare-to-initial behavior fails exactly the new "announces a return to the mount-time theme" test (both browsers), and nothing else.

Patch changeset (user-visible a11y behavior).

Milestone: Maintenance

Closes #1178

Refs #1118