### PR TITLE
refactor(blocks): dedup dimension-px + variance-by-path

### DIFF
--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import './DimensionScale.css';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
 import type { DimensionVisual } from '#/dimension-scale/DimensionBar.tsx';
+import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
@@ -39,29 +40,12 @@ export interface DimensionScaleProps {
   sortDir?: SortDir;
 }
 
-const MAX_RENDER_PX = 480;
-
 interface Row {
   path: string;
   cssVar: string;
   displayValue: string;
   pxValue: number;
   capped: boolean;
-}
-
-function toPixels(raw: unknown): number {
-  if (raw == null || typeof raw !== 'object') return Number.NaN;
-  const v = raw as { value?: unknown; unit?: unknown };
-  if (typeof v.value !== 'number' || typeof v.unit !== 'string') return Number.NaN;
-  switch (v.unit) {
-    case 'px':
-      return v.value;
-    case 'rem':
-    case 'em':
-      return v.value * 16;
-    default:
-      return Number.NaN;
-  }
 }
 
 export function DimensionScale({

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -1,4 +1,5 @@
 import type { CSSProperties, ReactElement } from 'react';
+import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
 import { BORDER_STRONG } from '#/internal/styles.tsx';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 
@@ -15,8 +16,6 @@ export interface DimensionBarProps {
    */
   visual?: DimensionVisual;
 }
-
-const MAX_RENDER_PX = 480;
 
 const styles = {
   bar: {
@@ -38,25 +37,6 @@ const styles = {
     minHeight: 1,
   } satisfies CSSProperties,
 };
-
-// Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
-// purpose of deciding whether to cap the rendered bar. Returns `NaN` for
-// units we can't reasonably approximate (ex / ch / %), which the caller
-// treats as "render at cssVar but don't cap".
-function toPixels(raw: unknown): number {
-  if (raw == null || typeof raw !== 'object') return Number.NaN;
-  const v = raw as { value?: unknown; unit?: unknown };
-  if (typeof v.value !== 'number' || typeof v.unit !== 'string') return Number.NaN;
-  switch (v.unit) {
-    case 'px':
-      return v.value;
-    case 'rem':
-    case 'em':
-      return v.value * 16;
-    default:
-      return Number.NaN;
-  }
-}
 
 export function DimensionBar({ path, visual = 'length' }: DimensionBarProps): ReactElement {
   const project = useProject();

--- a/packages/blocks/src/dimension-scale/dimension-px.ts
+++ b/packages/blocks/src/dimension-scale/dimension-px.ts
@@ -1,0 +1,23 @@
+/** Max rendered pixel size for a dimension bar/sample before it's capped. */
+export const MAX_RENDER_PX = 480;
+
+/**
+ * Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
+ * purpose of deciding whether to cap the rendered size. Returns `NaN` for
+ * units we can't reasonably approximate (ex / ch / %), which the caller
+ * treats as "render at cssVar but don't cap".
+ */
+export function toPixels(raw: unknown): number {
+  if (raw == null || typeof raw !== 'object') return Number.NaN;
+  const v = raw as { value?: unknown; unit?: unknown };
+  if (typeof v.value !== 'number' || typeof v.unit !== 'string') return Number.NaN;
+  switch (v.unit) {
+    case 'px':
+      return v.value;
+    case 'rem':
+    case 'em':
+      return v.value * 16;
+    default:
+      return Number.NaN;
+  }
+}

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -10,6 +10,18 @@ import { useEffect, useMemo } from 'react';
 import type { VirtualTokenGraph, VirtualTokenListingShape } from '#/contexts.ts';
 
 type VirtualVarianceByPathShape = Record<string, AxisVarianceResult>;
+
+// Pre-compute variance for every path in the graph. `getVariance` is cheap
+// (O(paths × axes)); callers wrap this in `useMemo` keyed on the graph so it
+// recomputes only on an HMR refresh. Shared by the provider and fallback paths.
+function computeVarianceByPath(graph: VirtualTokenGraph | undefined): VirtualVarianceByPathShape {
+  if (!graph) return {};
+  const out: VirtualVarianceByPathShape = {};
+  for (const path of listPaths(graph)) {
+    out[path] = getVariance(graph, path);
+  }
+  return out;
+}
 import { useActiveAxes, useActiveTheme, useOptionalSwatchbookData } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import type { ColorFormat, FormatColorResult } from '#/format-color.ts';
@@ -126,17 +138,7 @@ export function useProject(): ProjectData {
     // it returns) referentially stable across renders.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tokenGraph, activeTheme]);
-  // Pre-compute variance for every path in the graph. `getVariance` is
-  // cheap (O(paths × axes)); wrapping in `useMemo` keyed on `tokenGraph`
-  // ensures it only recomputes when the graph itself changes.
-  const derivedVarianceByPath = useMemo<VirtualVarianceByPathShape>(() => {
-    if (!tokenGraph) return {};
-    const out: Record<string, AxisVarianceResult> = {};
-    for (const path of listPaths(tokenGraph)) {
-      out[path] = getVariance(tokenGraph, path);
-    }
-    return out;
-  }, [tokenGraph]);
+  const derivedVarianceByPath = useMemo(() => computeVarianceByPath(tokenGraph), [tokenGraph]);
   // Memoize the returned ProjectData against the same stable inner
   // fields — without this, blocks `useMemo([project, …])` calls
   // invalidate every render (the function returns a fresh object
@@ -207,17 +209,10 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
   // module-level virtual-module export — changes only on HMR refresh.
   const resolveAt = useMemo(() => makeResolveAt(tokens.tokenGraph), [tokens.tokenGraph]);
 
-  // Pre-compute variance for every path in the graph, matching the
-  // provider path's approach for consistent O(1) block lookups.
-  const fallbackVarianceByPath = useMemo<VirtualVarianceByPathShape>(() => {
-    const graph = tokens.tokenGraph;
-    if (!graph) return {};
-    const out: Record<string, AxisVarianceResult> = {};
-    for (const path of listPaths(graph)) {
-      out[path] = getVariance(graph, path);
-    }
-    return out;
-  }, [tokens.tokenGraph]);
+  const fallbackVarianceByPath = useMemo(
+    () => computeVarianceByPath(tokens.tokenGraph),
+    [tokens.tokenGraph],
+  );
 
   // Memoize the returned ProjectData against the stable inner fields
   // for the same reason the provider path does — fresh object identity

--- a/packages/blocks/test/dimension-px.test.ts
+++ b/packages/blocks/test/dimension-px.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest';
+import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
+
+it('converts px / rem / em dimension values to pixels', () => {
+  expect(toPixels({ value: 16, unit: 'px' })).toBe(16);
+  expect(toPixels({ value: 1, unit: 'rem' })).toBe(16);
+  expect(toPixels({ value: 2, unit: 'em' })).toBe(32);
+});
+
+it('returns NaN for units it cannot approximate and for malformed values', () => {
+  expect(toPixels({ value: 5, unit: '%' })).toBeNaN();
+  expect(toPixels({ value: '5', unit: 'px' })).toBeNaN();
+  expect(toPixels(null)).toBeNaN();
+  expect(toPixels('16px')).toBeNaN();
+});
+
+it('exposes the render cap', () => {
+  expect(MAX_RENDER_PX).toBe(480);
+});


### PR DESCRIPTION
Two dedups from #1118, behavior-preserving (gated by the blocks suite, 208 tests):

- **`dimension-px.ts`** — `MAX_RENDER_PX` (480) + `toPixels` were **byte-identical** in `DimensionScale` and `DimensionBar`. Extracted to a shared module both import; added a small unit test now that it's a clean pure module.
- **`computeVarianceByPath`** — the `for (path of listPaths(graph)) out[path] = getVariance(graph, path)` loop was duplicated between use-project's provider and fallback paths. Extracted to one helper used at both `useMemo` sites.

Internal refactor + an additive test, no API/behavior change — no changeset.

The third dedup in the #1118 cluster (ShadowPreview composite shapes across 5 files) is larger and gets its own PR.

Milestone: Maintenance

Closes #1180

Refs #1118