### PR TITLE
refactor(blocks): share composite sample formatters + central shapes

### DIFF
--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 import './BorderPreview.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
-import { formatColor } from '#/format-color.ts';
-import type { ColorFormat } from '#/format-color.ts';
+import { formatDimension, formatSubColor } from '#/internal/composite-sample-format.ts';
+import type { BorderValue } from '#/internal/composite-types.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
@@ -29,34 +29,10 @@ export interface BorderPreviewProps {
   sortDir?: SortDir;
 }
 
-interface BorderValue {
-  color?: unknown;
-  width?: unknown;
-  style?: unknown;
-}
-
 interface Row {
   path: string;
   cssVar: string;
   value: BorderValue;
-}
-
-function formatDimension(raw: unknown): string {
-  if (raw == null) return '—';
-  if (typeof raw === 'number') return String(raw);
-  if (typeof raw === 'string') return raw;
-  if (typeof raw === 'object') {
-    const v = raw as { value?: unknown; unit?: unknown };
-    if (typeof v.value === 'number' && typeof v.unit === 'string') {
-      return `${v.value}${v.unit}`;
-    }
-  }
-  return JSON.stringify(raw);
-}
-
-function formatSubColor(raw: unknown, format: ColorFormat): string {
-  if (raw == null) return '—';
-  return formatColor(raw, format).value;
 }
 
 export function BorderPreview({

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -3,8 +3,9 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './ShadowPreview.css';
 import { useColorFormat } from '#/contexts.ts';
-import { formatColor } from '#/format-color.ts';
 import type { ColorFormat } from '#/format-color.ts';
+import { formatDimension, formatSubColor } from '#/internal/composite-sample-format.ts';
+import type { ShadowLayer } from '#/internal/composite-types.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
@@ -30,37 +31,10 @@ export interface ShadowPreviewProps {
   sortDir?: SortDir;
 }
 
-interface ShadowLayer {
-  color?: unknown;
-  offsetX?: unknown;
-  offsetY?: unknown;
-  blur?: unknown;
-  spread?: unknown;
-  inset?: unknown;
-}
-
 interface Row {
   path: string;
   cssVar: string;
   layers: ShadowLayer[];
-}
-
-function formatDimension(raw: unknown): string {
-  if (raw == null) return '—';
-  if (typeof raw === 'number') return String(raw);
-  if (typeof raw === 'string') return raw;
-  if (typeof raw === 'object') {
-    const v = raw as { value?: unknown; unit?: unknown };
-    if (typeof v.value === 'number' && typeof v.unit === 'string') {
-      return `${v.value}${v.unit}`;
-    }
-  }
-  return JSON.stringify(raw);
-}
-
-function formatSubColor(raw: unknown, format: ColorFormat): string {
-  if (raw == null) return '—';
-  return formatColor(raw, format).value;
 }
 
 function asLayers(raw: unknown): ShadowLayer[] {

--- a/packages/blocks/src/internal/composite-sample-format.ts
+++ b/packages/blocks/src/internal/composite-sample-format.ts
@@ -1,0 +1,30 @@
+import { formatColor } from '#/format-color.ts';
+import type { ColorFormat } from '#/format-color.ts';
+
+/**
+ * Display a composite sub-field dimension (shadow offset / blur / spread,
+ * border width, …) in the preview tables. Renders `—` for a missing
+ * sub-field and falls back to JSON for shapes it doesn't recognize.
+ *
+ * Distinct from `format-token-value`'s internal `formatDimension`, which
+ * formats a token's top-level value and has no `—` placeholder — these are
+ * the per-layer sample formatters shared by `ShadowPreview` + `BorderPreview`.
+ */
+export function formatDimension(raw: unknown): string {
+  if (raw == null) return '—';
+  if (typeof raw === 'number') return String(raw);
+  if (typeof raw === 'string') return raw;
+  if (typeof raw === 'object') {
+    const v = raw as { value?: unknown; unit?: unknown };
+    if (typeof v.value === 'number' && typeof v.unit === 'string') {
+      return `${v.value}${v.unit}`;
+    }
+  }
+  return JSON.stringify(raw);
+}
+
+/** Display a composite sub-field color via the active format; `—` when absent. */
+export function formatSubColor(raw: unknown, format: ColorFormat): string {
+  if (raw == null) return '—';
+  return formatColor(raw, format).value;
+}

--- a/packages/blocks/test/composite-sample-format.test.ts
+++ b/packages/blocks/test/composite-sample-format.test.ts
@@ -1,0 +1,21 @@
+import { expect, it } from 'vitest';
+import { formatDimension, formatSubColor } from '#/internal/composite-sample-format.ts';
+
+it('renders an em-dash for a missing sub-field', () => {
+  expect(formatDimension(null)).toBe('—');
+  expect(formatDimension(undefined)).toBe('—');
+});
+
+it('formats dimension objects, numbers, and strings', () => {
+  expect(formatDimension({ value: 4, unit: 'px' })).toBe('4px');
+  expect(formatDimension(2)).toBe('2');
+  expect(formatDimension('1rem')).toBe('1rem');
+});
+
+it('falls back to JSON for shapes it does not recognize', () => {
+  expect(formatDimension({ foo: 1 })).toBe('{"foo":1}');
+});
+
+it('renders an em-dash for a missing sub-field color', () => {
+  expect(formatSubColor(null, 'hex')).toBe('—');
+});


### PR DESCRIPTION
The "five files diverging" item from #1118. ShadowPreview + BorderPreview each re-declared **byte-identical** `formatDimension` / `formatSubColor` sample formatters, plus local `ShadowLayer` / `BorderValue` interfaces that already live in `internal/composite-types.ts`.

- Extracted the two formatters to **`internal/composite-sample-format.ts`** (unit-tested, node mode), imported by both previews.
- Imported `ShadowLayer` / `BorderValue` from `composite-types.ts`; dropped the now-unused `formatColor` imports.

**Deliberately left alone** (verified, not blind consolidation):
- `GradientStop` — the local type is *narrower* (`color: { colorSpace, components, alpha }`) than the central `unknown` one; swapping would lose type info GradientPalette relies on.
- `format-token-value` / `CompositeBreakdown` `formatDimension*` — genuinely different return types / fallbacks (`formatUnknown` vs `JSON.stringify`, `string | null`), so they're not the same function.

Behavior-preserving (gated by the blocks suite, 209 tests); internal + additive test, no changeset.

> Pairs with #1181 (dimension-px + variance dedup) — independent files, either order merges clean.

Milestone: Maintenance

Closes #1182

Refs #1118