### PR TITLE
test(blocks,integrations): sort-tokens branches + integration config surface

### DIFF
--- a/packages/blocks/test/sort-tokens.test.ts
+++ b/packages/blocks/test/sort-tokens.test.ts
@@ -96,4 +96,26 @@ describe('sortTokens', () => {
     const out = sortTokens(input, { by: 'value' });
     expect(out.map(([p]) => p)).toEqual(['c.black', 'c.mid', 'c.white']);
   });
+
+  it('sorts durations numerically, converting seconds to milliseconds', () => {
+    const input = [
+      entry('d.slow', 'duration', { value: 1, unit: 's' }),
+      entry('d.fast', 'duration', { value: 150, unit: 'ms' }),
+      entry('d.med', 'duration', { value: 500, unit: 'ms' }),
+    ];
+    const out = sortTokens(input, { by: 'value' });
+    expect(out.map(([p]) => p)).toEqual(['d.fast', 'd.med', 'd.slow']);
+  });
+
+  it('clusters a mixed-$type value sort by type, then within each type', () => {
+    // Cross-$type comparison falls back to type-alpha (color < dimension);
+    // within a type the normal value order applies.
+    const input = [
+      entry('z.dim', 'dimension', { value: 4, unit: 'px' }),
+      entry('a.col', 'color', { hex: '#ffffff' }),
+      entry('y.dim', 'dimension', { value: 2, unit: 'px' }),
+    ];
+    const out = sortTokens(input, { by: 'value' });
+    expect(out.map(([p]) => p)).toEqual(['a.col', 'y.dim', 'z.dim']);
+  });
 });

--- a/packages/integrations/test/css-in-js.test.ts
+++ b/packages/integrations/test/css-in-js.test.ts
@@ -106,3 +106,8 @@ it('uniqueIdents suffixes names that sanitize to the same identifier', () => {
   expect(m.get('plain')).toBe('plain');
   expect(new Set(m.values()).size).toBe(3);
 });
+
+it('honors a custom virtualId', () => {
+  const integration = cssInJsIntegration({ virtualId: 'virtual:custom/theme' });
+  expect(integration.virtualModule?.virtualId).toBe('virtual:custom/theme');
+});

--- a/packages/integrations/test/tailwind.test.ts
+++ b/packages/integrations/test/tailwind.test.ts
@@ -117,3 +117,18 @@ it('skips camelCase font-size dimensions instead of mis-bucketing them as spacin
   expect(css).toContain('--spacing-t-md');
   expect(css).not.toContain('fontSize');
 });
+
+it('honors a custom virtualId', () => {
+  const integration = tailwindIntegration({ virtualId: 'virtual:custom/tw.css' });
+  expect(integration.virtualModule?.virtualId).toBe('virtual:custom/tw.css');
+});
+
+it('marks the @theme stylesheet for auto-injection into the preview', () => {
+  expect(tailwindIntegration().virtualModule?.autoInject).toBe(true);
+});
+
+it('emits a font scale from fontFamily tokens', () => {
+  const css = render(project);
+  expect(css).toContain('/* font */');
+  expect(css).toMatch(/--font-sb-[\w-]+: var\(--sb-/);
+});


### PR DESCRIPTION
Test backfill from #1118 (tests-only, no changeset):

- **sort-tokens** (blocks): the `ms`/`s` duration unit conversion (`s` → ×1000) and cross-`$type` clustering (mixed value sort falls back to type-alpha, then orders within each type). The px/rem path was already covered.
- **integrations**: a **custom `virtualId`** (both tailwind + css-in-js asserted only the default), the tailwind **`autoInject`** flag, and the **font scale** emitted from `fontFamily` tokens (the `@theme` test covered color/spacing/radius/shadow but not `--font-*`).

Blocks 214 tests, integrations 25 — all green.

Milestone: Maintenance

Closes #1184

Refs #1118