### PR TITLE
chore: tautological dedup test, COLOR_FORMATS parity, switcher doc fix

### DIFF
--- a/packages/addon/src/ColorFormatSelector.tsx
+++ b/packages/addon/src/ColorFormatSelector.tsx
@@ -24,7 +24,9 @@ export type { ColorFormat };
 // from blocks: the manager bundle can't pull `@unpunnyfuns/swatchbook-blocks`
 // (its barrel has a top-level `import 'virtual:swatchbook/tokens'` the
 // manager has no resolver for), and core's leaf carries no colorjs weight.
-const COLOR_FORMAT_OPTIONS: readonly { id: ColorFormat; label: string }[] = [
+// Exported for the parity test that guards this hand-listed label set
+// against drifting from core's canonical `COLOR_FORMATS`.
+export const COLOR_FORMAT_OPTIONS: readonly { id: ColorFormat; label: string }[] = [
   { id: 'hex', label: 'Hex' },
   { id: 'rgb', label: 'RGB' },
   { id: 'hsl', label: 'HSL' },

--- a/packages/addon/test/color-format-parity.test.ts
+++ b/packages/addon/test/color-format-parity.test.ts
@@ -1,0 +1,9 @@
+import { COLOR_FORMATS } from '@unpunnyfuns/swatchbook-core/color-formats';
+import { expect, it } from 'vitest';
+import { COLOR_FORMAT_OPTIONS } from '#/ColorFormatSelector.tsx';
+
+it('the toolbar label set covers exactly core COLOR_FORMATS, in order', () => {
+  // The manager bundle can't import blocks, so it hand-lists labels for each
+  // format. This guards that list against drifting from the canonical set.
+  expect(COLOR_FORMAT_OPTIONS.map((o) => o.id)).toEqual([...COLOR_FORMATS]);
+});

--- a/packages/addon/test/virtual-plugin.test.ts
+++ b/packages/addon/test/virtual-plugin.test.ts
@@ -52,12 +52,12 @@ it('adds the resolver path when set', () => {
 
 it('deduplicates overlapping paths', () => {
   const config: Config = {
-    tokens: ['tokens/**/*.json'],
-    resolver: 'tokens/resolver.json',
+    // Two globs that scan to the same base dir (`tokens/`); without dedup
+    // collectWatchPaths would list `/project/tokens` twice.
+    tokens: ['tokens/**/*.json', 'tokens/**/*.dtcg.json'],
   };
   const paths = collectWatchPaths(config, undefined, CWD);
-  const unique = new Set(paths);
-  expect(paths.length).toBe(unique.size);
+  expect(paths).toEqual(['/project/tokens']);
 });
 
 it('handles absolute paths untouched', () => {

--- a/packages/switcher/src/ThemeSwitcher.tsx
+++ b/packages/switcher/src/ThemeSwitcher.tsx
@@ -102,9 +102,9 @@ interface OptionPillProps {
   title?: string;
   onClick(): void;
   trailing?: ReactElement | null;
-  // Optional accessible-label prefix — disambiguates pills that share a
+  // Optional accessible-label suffix — disambiguates pills that share a
   // label across sections (e.g. `Default` appears on both `mode` and
-  // `brand`). The full accessible name becomes `"<label> <ariaLabelSuffix>"`.
+  // `brand`). The full accessible name becomes `"<label> (<ariaLabelSuffix>)"`.
   ariaLabelSuffix?: string;
 }
 


### PR DESCRIPTION
Three small #1118-tail items (tests + a doc comment, no changeset):

- **Tautological test:** the addon `collectWatchPaths` dedup test passed inputs with no overlapping paths, so it'd stay green even if dedup broke. Now uses two globs that scan to the same base dir (`tokens/`), so the result genuinely collapses to one path.
- **COLOR_FORMATS parity:** ColorFormatSelector hand-lists `COLOR_FORMAT_OPTIONS` (labels) because the manager bundle can't import blocks. Exported it + a parity test asserting its ids equal core's canonical `COLOR_FORMATS`, in order — guards against drift.
- **switcher doc:** `ariaLabelSuffix`'s comment said "prefix" and `"<label> <ariaLabelSuffix>"`; it's actually a suffix rendered as `"<label> (<ariaLabelSuffix>)"`.

addon 60 tests, switcher 24 — green.

Milestone: Maintenance

Closes #1186

Refs #1118