### PR TITLE
refactor(core): serve defaultTokens through resolveAt for the slim shape

### DIFF
--- a/.changeset/core-default-tokens-slim.md
+++ b/.changeset/core-default-tokens-slim.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+`Project.defaultTokens` now carries the documented slim `SwatchbookToken` shape (served through `resolveAt`), no longer leaking the resolver's internal Terrazzo fields

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -83,16 +83,6 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
     config.default,
     filteredAxes,
   );
-  // `project.defaultTokens` is the resolved TokenMap at the
-  // user-specified default tuple. Singleton enumeration always
-  // materializes the axes-defaults tuple; if `config.default` points
-  // somewhere else, resolve it on the side.
-  const computedDefault = permutationID(defaultTuple);
-  const defaultTokens: TokenMap =
-    filteredResolved[computedDefault] ??
-    (normalized.parserInput?.resolver
-      ? normalized.parserInput.resolver.apply(defaultTuple)
-      : (filteredResolved[filteredPermutations[0]?.name ?? ''] ?? {}));
 
   const { presets, diagnostics: presetDiagnostics } = validatePresets(config.presets, filteredAxes);
 
@@ -167,6 +157,12 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
       return result;
     };
   })();
+
+  // `project.defaultTokens` is the resolved snapshot at the user's default
+  // tuple, served through the same graph-backed `resolveAt` as every other
+  // tuple — so it carries the slim `SwatchbookToken` shape the type promises
+  // rather than the raw `TokenNormalized` the resolver emits.
+  const defaultTokens = resolveAt(defaultTuple);
 
   // `validateChrome` checks targets against the project's path universe.
   // `listPaths` returns every path present in the graph.

--- a/packages/core/test/load.test.ts
+++ b/packages/core/test/load.test.ts
@@ -37,6 +37,17 @@ describe('loadProject — resolver mode', () => {
     expect(Object.keys(project.defaultTokens).length).toBeGreaterThan(100);
   });
 
+  it('serves defaultTokens in the slim SwatchbookToken shape, not raw TokenNormalized', () => {
+    // defaultTokens flows through the graph-backed resolveAt, so it must not
+    // leak the resolver's internal fields the SwatchbookToken contract omits.
+    const leaked = ['id', 'source', 'originalValue', 'mode', 'group', '$extensions'];
+    for (const [path, token] of Object.entries(project.defaultTokens)) {
+      for (const field of leaked) {
+        expect(token, `${path} leaked ${field}`).not.toHaveProperty(field);
+      }
+    }
+  });
+
   it('surfaces resolver modifiers as independent axes', () => {
     expect(project.axes).toEqual([
       {


### PR DESCRIPTION
Closes #1188 (from #1118).

`Project.defaultTokens` was the **raw resolver output** — full `TokenNormalized` carrying `id` / `source` / `originalValue` / `mode` / `$extensions` — even though its type is `TokenMap` (`SwatchbookToken`), which omits exactly those fields. `resolveAt` (graph-backed) already yields the slim shape, so `defaultTokens` now flows through it: one resolution path, output matching the contract.

- **Values unchanged** — the full core suite (297 tests) stays green; only the undocumented leaked fields are dropped.
- Added a guard test asserting `defaultTokens` entries don't carry the leaked internals.

Patch changeset (runtime shape aligns to the documented type; no type change).

Milestone: Maintenance

Closes #1188

Refs #1118