### PR TITLE
chore(addon): guard + document the storybook/internal surface for major bumps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,7 @@ Three navbar pills: Guides / Reference / Developers. Reference sidebar groups th
 - **Preview ↔ manager comms**: Storybook's channel (`addons.getChannel()` + `emit`/`on`). Manager can't import preview-side Vite virtual modules.
 - **CSF Next addons**: default-export a factory that returns `definePreviewAddon(previewExports)` (from `storybook/internal/csf`). Consumers opt in via `definePreview({ addons: [swatchbookAddon()] })`.
 - **MDX doc blocks can't use story hooks**: `useGlobals` / `useArgs` / `useChannel` / `useParameter` from `storybook/preview-api` require the preview HooksContext, which only exists while a story is rendering. From an MDX doc block they throw. Subscribe to `addons.getChannel()` directly and manage state with plain React hooks.
+- **Major-bump checklist** (per the policy in `docs/decisions.md` — one swatchbook major per Storybook major): the version-fragile surface is small and pinned. `storybook/internal/*` imports (unstable across majors) are exactly two — `internal/components` in `manager.tsx` and `internal/csf` in `index.ts` — guarded by `addon/test/storybook-internal-surface.test.ts` (adding one fails the test). The public-but-still-checkable surface is `storybook/manager-api` (manager) and `storybook/preview-api` (preview + blocks). On a Storybook major: update the peer ranges to `^<new-major>`, add the new major to the `storybook-compat` matrix in `ci.yml`, and re-verify those import sites. The floor of the supported range is exercised by the `storybook-compat` CI job.
 
 ## Storybook MCP
 

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -1,3 +1,6 @@
+// Storybook-internal surface (fragile across Storybook MAJORS). See the
+// major-bump checklist in CLAUDE.md; the import set is pinned by
+// storybook-internal-surface.test.ts.
 import { definePreviewAddon } from 'storybook/internal/csf';
 import * as previewExports from '#/preview.tsx';
 

--- a/packages/addon/src/manager.tsx
+++ b/packages/addon/src/manager.tsx
@@ -3,6 +3,9 @@ import { COLOR_FORMATS, ColorFormatSelector } from '#/ColorFormatSelector.tsx';
 import type { ColorFormat } from '#/ColorFormatSelector.tsx';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
+// Storybook-internal surface (fragile across Storybook MAJORS). See the
+// major-bump checklist in CLAUDE.md; the import set is pinned by
+// storybook-internal-surface.test.ts.
 import { Button, ToggleButton, WithTooltip } from 'storybook/internal/components';
 import { addons, types, useGlobals, useStorybookApi } from 'storybook/manager-api';
 import type {

--- a/packages/addon/test/storybook-internal-surface.test.ts
+++ b/packages/addon/test/storybook-internal-surface.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, it } from 'vitest';
+
+/**
+ * `storybook/internal/*` paths are unstable across Storybook MAJOR versions —
+ * each one is a migration point at the next major bump. This pins the set we
+ * knowingly depend on; adding a new one fails here, forcing a conscious edit
+ * (and a glance at CLAUDE.md's Storybook major-bump checklist) rather than the
+ * surface creeping silently.
+ */
+const ALLOWED = new Set(['storybook/internal/components', 'storybook/internal/csf']);
+
+const SRC = join(process.cwd(), 'src');
+
+function tsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...tsFiles(path));
+    else if (/\.tsx?$/.test(entry.name)) out.push(path);
+  }
+  return out;
+}
+
+it('keeps the storybook/internal/* import surface within the known set', () => {
+  const found = new Set<string>();
+  for (const file of tsFiles(SRC)) {
+    for (const match of readFileSync(file, 'utf8').matchAll(
+      /from '(storybook\/internal\/[\w-]+)'/g,
+    )) {
+      found.add(match[1] as string);
+    }
+  }
+  // Every dependency we have is one we've consciously accepted as a major-bump point.
+  for (const spec of found) {
+    expect(ALLOWED.has(spec), `unexpected storybook/internal import: ${spec}`).toBe(true);
+  }
+  // And the set isn't empty for a silly reason (regex drift / moved files).
+  expect(found.size).toBeGreaterThan(0);
+});


### PR DESCRIPTION
The actionable part of #1167 — keep the Storybook-major-fragile surface small, pinned, and documented.

The surface turned out to be tiny and already well-localized (one import per natural home), so rather than risk cross-bundle contamination by forcing a barrel, this **pins and documents** it:

- **Two `storybook/internal/*` imports** (`internal/components` in `manager.tsx`, `internal/csf` in `index.ts`) are marked at their sites and guarded by a new `storybook-internal-surface.test.ts` — adding a third fails the test, so the surface can't creep silently.
- **CLAUDE.md major-bump checklist** under Storybook gotchas: bump peer ranges to `^<new-major>`, add the major to the `storybook-compat` matrix, re-verify the `internal/*` + `manager-api`/`preview-api` import sites.

The only remaining #1167 item — adding the SB 11 prerelease to the matrix — is genuinely blocked on SB 11 existing, and is now captured in that checklist (its proper home), so this closes the issue.

Tests + docs/comments, no changeset.

Milestone: Maintenance

Closes #1167