### PR TITLE
ci: pin the GitHub Latest release badge to addon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,9 +309,18 @@ jobs:
             if [ -z "$notes" ]; then
               notes="Published to npm. See packages/${pkg}/CHANGELOG.md."
             fi
+            # Pin "Latest" to addon deterministically. The six are one fixed
+            # version released together, but only one release can hold the
+            # badge; our tags don't parse as semver (`…-addon@1.2.3`, not
+            # `v1.2.3`), so GitHub falls back to most-recently-created and the
+            # badge would otherwise land on whichever package this loop emits
+            # last. addon is the package consumers install, so it gets the badge.
+            latest="--latest=false"
+            [ "$pkg" = "addon" ] && latest="--latest"
             gh release create "$tag" \
               --target "$GITHUB_SHA" \
               --title "$tag" \
-              --notes "$notes"
+              --notes "$notes" \
+              "$latest"
             echo "  ✓ released $tag"
           done


### PR DESCRIPTION
## Summary

The publish job (#1192) creates the six fixed-group releases per run in loop order `core → … → mcp`. Only one release can hold GitHub's "Latest" badge, and our tags don't parse as semver (`@unpunnyfuns/swatchbook-addon@1.2.3`, not `v1.2.3`), so GitHub falls back to most-recently-created — landing the badge on `mcp` every release.

addon is the package consumers install, so it should hold the badge.

## Change

In the release loop, pass `--latest` for addon and `--latest=false` for the rest, so the badge lands on addon deterministically regardless of loop order.

The current badge (0.62.1) was already corrected manually during the tag backfill; this keeps future releases correct.

Milestone: Maintenance

Closes #1195

Plan impact: none