### PR TITLE
ci: run docs media capture in the Playwright container

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,6 +17,16 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    # Run in the pinned Playwright image (Chromium + system deps preinstalled)
+    # so the media-capture step needs no `playwright install` and the browser
+    # launches reliably — same container the test suite uses in ci.yml. The
+    # Pages deploy actions below run fine inside it.
+    container:
+      image: ghcr.io/${{ github.repository }}/playwright:v1.59.1-noble
+      options: --ipc=host
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+      HOME: /root
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
@@ -52,9 +62,7 @@ jobs:
         run: pnpm turbo run build:storybook --filter=@unpunnyfuns/swatchbook-storybook
 
       - name: Capture frontpage media
-        run: |
-          pnpm --filter @unpunnyfuns/swatchbook-docs exec playwright install --with-deps chromium
-          pnpm --filter @unpunnyfuns/swatchbook-docs capture
+        run: pnpm --filter @unpunnyfuns/swatchbook-docs capture
 
       - name: Build Docusaurus
         run: pnpm turbo run build --filter=@unpunnyfuns/swatchbook-docs

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -35,7 +35,6 @@
     "@types/react": "^19.0.0",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
     "playwright": "^1.59.1",
-    "sirv-cli": "^3.0.1",
     "typescript": "~6.0.2"
   },
   "browserslist": {

--- a/apps/docs/scripts/capture-media.mjs
+++ b/apps/docs/scripts/capture-media.mjs
@@ -1,6 +1,7 @@
-import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { mkdirSync, readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, extname, join, normalize, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
 
@@ -23,11 +24,42 @@ const STILLS = [
   { match: 'Blocks/TokenNavigator Default', file: 'navigator.png' },
 ];
 
+const MIME = {
+  '.html': 'text/html',
+  '.js': 'text/javascript',
+  '.mjs': 'text/javascript',
+  '.json': 'application/json',
+  '.css': 'text/css',
+  '.map': 'application/json',
+  '.png': 'image/png',
+  '.svg': 'image/svg+xml',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+  '.ttf': 'font/ttf',
+  '.ico': 'image/x-icon',
+  '.txt': 'text/plain',
+};
+
+// Minimal static server for storybook-static. Dependency-free on purpose: the
+// previous `npx sirv` could block on an install prompt in CI. Manager routes
+// (`/?path=…`) strip the query to `/` → index.html; everything else is a real
+// file (iframe.html, index.json, assets).
 function serve() {
-  return spawn('npx', ['sirv', sbStatic, '--port', String(PORT), '--quiet'], {
-    cwd: docsRoot,
-    stdio: 'inherit',
+  const server = createServer(async (req, res) => {
+    try {
+      let urlPath = decodeURIComponent((req.url ?? '/').split('?')[0]);
+      if (urlPath.endsWith('/')) urlPath += 'index.html';
+      const safe = normalize(urlPath).replace(/^(\.\.[/\\])+/, '');
+      const data = await readFile(join(sbStatic, safe));
+      res.writeHead(200, { 'content-type': MIME[extname(safe)] ?? 'application/octet-stream' });
+      res.end(data);
+    } catch {
+      res.writeHead(404);
+      res.end('not found');
+    }
   });
+  server.listen(PORT, '127.0.0.1');
+  return server;
 }
 
 async function waitForServer() {
@@ -99,7 +131,7 @@ async function main() {
     await mgr.close();
   } finally {
     if (browser) await browser.close();
-    server.kill();
+    server.close();
   }
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,9 +103,6 @@ importers:
       playwright:
         specifier: ^1.59.1
         version: 1.59.1
-      sirv-cli:
-        specifier: ^3.0.1
-        version: 3.0.1
       typescript:
         specifier: ~6.0.2
         version: 6.0.3
@@ -5160,10 +5157,6 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
-  console-clear@1.1.1:
-    resolution: {integrity: sha512-pMD+MVR538ipqkG5JXeOEbKWS5um1H4LUUccUQG68qpeqBYbzYy79Gh55jkd2TtPdRfUaLWdv6LPP//5Zt0aPQ==}
-    engines: {node: '>=4'}
-
   content-disposition@0.5.2:
     resolution: {integrity: sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==}
     engines: {node: '>= 0.6'}
@@ -5939,10 +5932,6 @@ packages:
   get-own-enumerable-property-symbols@3.0.2:
     resolution: {integrity: sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==}
 
-  get-port@5.1.1:
-    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
-    engines: {node: '>=8'}
-
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
@@ -6495,10 +6484,6 @@ packages:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
     engines: {node: '>=6'}
 
-  kleur@4.1.5:
-    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
-    engines: {node: '>=6'}
-
   latest-version@7.0.0:
     resolution: {integrity: sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==}
     engines: {node: '>=14.16'}
@@ -6598,10 +6583,6 @@ packages:
   loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
     engines: {node: '>=8.9.0'}
-
-  local-access@1.1.0:
-    resolution: {integrity: sha512-XfegD5pyTAfb+GY6chk283Ox5z8WexG56OvM06RWLpAc/UHozO8X6xAxEkIitZOtsSMM1Yr3DkHgW5W+onLhCw==}
-    engines: {node: '>=6'}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -8144,10 +8125,6 @@ packages:
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
 
-  sade@1.8.1:
-    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
-    engines: {node: '>=6'}
-
   safe-buffer@5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
 
@@ -8194,10 +8171,6 @@ packages:
   selfsigned@5.5.0:
     resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
     engines: {node: '>=18'}
-
-  semiver@1.1.0:
-    resolution: {integrity: sha512-QNI2ChmuioGC1/xjyYwyZYADILWyW6AmS1UH6gDj/SFUUUS4MBAWs/7mxnkRPc/F4iHezDP+O8t0dO8WHiEOdg==}
-    engines: {node: '>=6'}
 
   semver-diff@4.0.0:
     resolution: {integrity: sha512-0Ju4+6A8iOnpL/Thra7dZsSlOHYAHIeMxfhWQRI1/VLcT3WDBZKKtQt/QkBOsiIN9ZpuvHE6cGZ0x4glCMmfiA==}
@@ -8300,11 +8273,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  sirv-cli@3.0.1:
-    resolution: {integrity: sha512-ICXaF2u6IQhLZ0EXF6nqUF4YODfSQSt+mGykt4qqO5rY+oIiwdg7B8w2PVDBJlQulaS2a3J8666CUoDoAuCGvg==}
-    engines: {node: '>=18'}
-    hasBin: true
 
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
@@ -8564,10 +8532,6 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
-
-  tinydate@1.3.0:
-    resolution: {integrity: sha512-7cR8rLy2QhYHpsBDBVYnnWXm8uRTr38RoZakFSW7Bs7PzfMPNZthuMLkwqZv7MTu8lhQ91cOFYS5a7iFj2oR3w==}
-    engines: {node: '>=4'}
 
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
@@ -14633,8 +14597,6 @@ snapshots:
 
   consola@3.4.2: {}
 
-  console-clear@1.1.1: {}
-
   content-disposition@0.5.2: {}
 
   content-disposition@0.5.4:
@@ -15459,8 +15421,6 @@ snapshots:
 
   get-own-enumerable-property-symbols@3.0.2: {}
 
-  get-port@5.1.1: {}
-
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -16049,8 +16009,6 @@ snapshots:
 
   kleur@3.0.3: {}
 
-  kleur@4.1.5: {}
-
   latest-version@7.0.0:
     dependencies:
       package-json: 8.1.1
@@ -16122,8 +16080,6 @@ snapshots:
       big.js: 5.2.2
       emojis-list: 3.0.0
       json5: 2.2.3
-
-  local-access@1.1.0: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -18155,10 +18111,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  sade@1.8.1:
-    dependencies:
-      mri: 1.2.0
-
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
@@ -18203,8 +18155,6 @@ snapshots:
     dependencies:
       '@peculiar/x509': 1.14.3
       pkijs: 3.4.0
-
-  semiver@1.1.0: {}
 
   semver-diff@4.0.0:
     dependencies:
@@ -18359,17 +18309,6 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
-
-  sirv-cli@3.0.1:
-    dependencies:
-      console-clear: 1.1.1
-      get-port: 5.1.1
-      kleur: 4.1.5
-      local-access: 1.1.0
-      sade: 1.8.1
-      semiver: 1.1.0
-      sirv: 3.0.2
-      tinydate: 1.3.0
 
   sirv@2.0.4:
     dependencies:
@@ -18647,8 +18586,6 @@ snapshots:
   tiny-warning@1.0.3: {}
 
   tinybench@2.9.0: {}
-
-  tinydate@1.3.0: {}
 
   tinyexec@1.2.4: {}
 


### PR DESCRIPTION
## Problem

The `Capture frontpage media` step (added in #1201) hung the docs deploy — run 27510301230 froze at that step and was cancelled, so the new frontpage never deployed.

## Cause

- `capture-media.mjs` started the static server with `npx sirv`, which can block on an interactive "install sirv-cli?" stdin prompt in CI.
- `playwright install --with-deps chromium` on a plain runner adds a slow apt step and a browser-launch dependency.

## Fix

- **Dependency-free static server**: replace `npx sirv` with a tiny Node `http` static server in `capture-media.mjs` (serves `storybook-static` for the iframe stills + the manager). Removes the freeze vector and the unused `sirv-cli` dep. Verified locally — all three stills + the switcher shot still capture.
- **Playwright container**: run the docs deploy job in `ghcr.io/<repo>/playwright:v1.59.1-noble` (the image ci.yml already uses; both `playwright` deps are `^1.59.1`, matching the tag). Chromium + system deps are preinstalled, so the `playwright install` step is dropped. The Pages deploy steps run unchanged inside the container.

## Verification

- Capture script runs clean locally with the new server (block / navigator / switcher PNGs produced).
- Lockfile change is just the `sirv-cli` removal (63 deletions, no re-resolution).

Milestone: Maintenance

Closes #1203

Plan impact: none