### PR TITLE
fix(blocks): persist doc-block UI state across docs-mode remounts

### DIFF
--- a/.changeset/block-state-docs-remount.md
+++ b/.changeset/block-state-docs-remount.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-blocks': patch
+---
+
+TokenNavigator, TokenTable, and ColorTable now keep their expand, selection, and search state when you flip a theme axis on an MDX docs page (Storybook remounts docs blocks on a globals change, which previously reset that state).

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,13 +1,14 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { memo, useCallback, useDeferredValue, useMemo, useState } from 'react';
+import { memo, useCallback, useDeferredValue, useMemo } from 'react';
 import './ColorTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import type { ColorFormat, NormalizedColor } from '#/format-color.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
+import { useBlockKey, usePersistedState } from '#/internal/persistent-state.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -66,6 +67,8 @@ export interface ColorTableProps {
    * own row.
    */
   variants?: Record<string, string>;
+  /** Disambiguates persisted UI state for two identical-prop tables on a page. */
+  id?: string;
 }
 
 interface Variant {
@@ -98,14 +101,23 @@ export function ColorTable({
   searchable = true,
   onSelect,
   variants,
+  id,
 }: ColorTableProps): ReactElement {
   const project = useProject();
   const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
   const colorFormat = useColorFormat();
-  const [query, setQuery] = useState('');
+  // Persist search + variant selection + expansion across docs-mode remounts.
+  const blockKey = useBlockKey('ColorTable', [filter, caption, id]);
+  const [query, setQuery] = usePersistedState(`${blockKey}::query`, '');
   const deferredQuery = useDeferredValue(query);
-  const [selectedByBase, setSelectedByBase] = useState<Record<string, string>>({});
-  const [expandedByBase, setExpandedByBase] = useState<ReadonlySet<string>>(() => new Set());
+  const [selectedByBase, setSelectedByBase] = usePersistedState<Record<string, string>>(
+    `${blockKey}::selected`,
+    {},
+  );
+  const [expandedByBase, setExpandedByBase] = usePersistedState<ReadonlySet<string>>(
+    `${blockKey}::expanded`,
+    () => new Set(),
+  );
 
   const defs = useMemo(() => buildVariantDefs(variants), [variants]);
 
@@ -160,18 +172,24 @@ export function ColorTable({
 
   const totalTokens = useMemo(() => groups.reduce((n, g) => n + g.variants.length, 0), [groups]);
 
-  const toggleExpand = useCallback((base: string) => {
-    setExpandedByBase((prev) => {
-      const next = new Set(prev);
-      if (next.has(base)) next.delete(base);
-      else next.add(base);
-      return next;
-    });
-  }, []);
+  const toggleExpand = useCallback(
+    (base: string) => {
+      setExpandedByBase((prev) => {
+        const next = new Set(prev);
+        if (next.has(base)) next.delete(base);
+        else next.add(base);
+        return next;
+      });
+    },
+    [setExpandedByBase],
+  );
 
-  const selectVariant = useCallback((base: string, label: string) => {
-    setSelectedByBase((prev) => ({ ...prev, [base]: label }));
-  }, []);
+  const selectVariant = useCallback(
+    (base: string, label: string) => {
+      setSelectedByBase((prev) => ({ ...prev, [base]: label }));
+    },
+    [setSelectedByBase],
+  );
 
   const matchSuffix =
     searchable && query.trim() !== ''

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -8,6 +8,7 @@ import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { useBlockKey, usePersistedState } from '#/internal/persistent-state.ts';
 import { EmptyState } from '#/internal/styles.tsx';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 import { MotionSample } from '#/motion-preview/MotionSample.tsx';
@@ -46,6 +47,13 @@ export interface TokenNavigatorProps {
    * the follow-up UI.
    */
   onSelect?(path: string): void;
+  /**
+   * Disambiguates persisted UI state (expand/collapse, selection, search)
+   * when two navigators with otherwise-identical props sit on the same docs
+   * page. Only needed in that case; the state key is derived from the other
+   * props otherwise.
+   */
+  id?: string;
 }
 
 interface LeafNode {
@@ -204,8 +212,16 @@ export function TokenNavigator({
   initiallyExpanded = 1,
   searchable = true,
   onSelect,
+  id,
 }: TokenNavigatorProps): ReactElement {
   const { resolved, activeTheme, activeAxes, cssVarPrefix } = useProject();
+
+  // Persist UI state (expand/collapse, selection, search) across docs-mode
+  // remounts. Keyed on the props that distinguish one navigator from another
+  // (plus the optional `id`); excludes `initiallyExpanded`/`searchable`, whose
+  // changes are handled by the re-seed effect below rather than a fresh key.
+  const typeKey = type === undefined ? '' : typeof type === 'string' ? type : type.join(',');
+  const blockKey = useBlockKey('TokenNavigator', [root, typeKey, id]);
 
   const typeFilter = useMemo<ReadonlySet<string> | undefined>(() => {
     if (type === undefined) return undefined;
@@ -220,7 +236,10 @@ export function TokenNavigator({
     return out;
   }, [tree, initiallyExpanded]);
 
-  const [expanded, setExpanded] = useState<Set<string>>(initialExpanded);
+  const [expanded, setExpanded] = usePersistedState<Set<string>>(
+    `${blockKey}::expanded`,
+    initialExpanded,
+  );
   const initiallyExpandedRef = useRef(initiallyExpanded);
   useEffect(() => {
     // Re-seed the expand/collapse state ONLY when the `initiallyExpanded`
@@ -231,10 +250,13 @@ export function TokenNavigator({
     if (initiallyExpandedRef.current === initiallyExpanded) return;
     initiallyExpandedRef.current = initiallyExpanded;
     setExpanded(initialExpanded);
-  }, [initiallyExpanded, initialExpanded]);
+  }, [initiallyExpanded, initialExpanded, setExpanded]);
 
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const [query, setQuery] = useState('');
+  const [selectedPath, setSelectedPath] = usePersistedState<string | null>(
+    `${blockKey}::selected`,
+    null,
+  );
+  const [query, setQuery] = usePersistedState(`${blockKey}::query`, '');
   const deferredQuery = useDeferredValue(query);
 
   const { visibleTree, searchExpanded } = useMemo(() => {
@@ -256,21 +278,24 @@ export function TokenNavigator({
     return merged;
   }, [expanded, searchExpanded]);
 
-  const toggle = useCallback((path: string): void => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(path)) next.delete(path);
-      else next.add(path);
-      return next;
-    });
-  }, []);
+  const toggle = useCallback(
+    (path: string): void => {
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        if (next.has(path)) next.delete(path);
+        else next.add(path);
+        return next;
+      });
+    },
+    [setExpanded],
+  );
 
   const handleLeafClick = useCallback(
     (path: string) => {
       if (onSelect) onSelect(path);
       else setSelectedPath(path);
     },
-    [onSelect],
+    [onSelect, setSelectedPath],
   );
 
   // WAI-ARIA tree pattern's roving tabindex — exactly one treeitem at a

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,13 +1,14 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { useCallback, useDeferredValue, useMemo, useState } from 'react';
+import { useCallback, useDeferredValue, useMemo } from 'react';
 import './TokenTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { DetailOverlay } from '#/internal/DetailOverlay.tsx';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
+import { useBlockKey, usePersistedState } from '#/internal/persistent-state.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
@@ -50,6 +51,8 @@ export interface TokenTableProps {
    * follow-up UI (inline panel, drill-down route, …).
    */
   onSelect?(path: string): void;
+  /** Disambiguates persisted UI state for two identical-prop tables on a page. */
+  id?: string;
 }
 
 export function TokenTable({
@@ -60,12 +63,18 @@ export function TokenTable({
   sortDir = 'asc',
   searchable = true,
   onSelect,
+  id,
 }: TokenTableProps): ReactElement {
   const project = useProject();
   const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
   const colorFormat = useColorFormat();
-  const [selectedPath, setSelectedPath] = useState<string | null>(null);
-  const [query, setQuery] = useState('');
+  // Persist selection + search across docs-mode remounts (see persistent-state).
+  const blockKey = useBlockKey('TokenTable', [filter, type, caption, id]);
+  const [selectedPath, setSelectedPath] = usePersistedState<string | null>(
+    `${blockKey}::selected`,
+    null,
+  );
+  const [query, setQuery] = usePersistedState(`${blockKey}::query`, '');
   const deferredQuery = useDeferredValue(query);
 
   const rows = useMemo(() => {
@@ -102,7 +111,7 @@ export function TokenTable({
       if (onSelect) onSelect(path);
       else setSelectedPath(path);
     },
-    [onSelect],
+    [onSelect, setSelectedPath],
   );
 
   const matchSuffix =

--- a/packages/blocks/src/internal/persistent-state.ts
+++ b/packages/blocks/src/internal/persistent-state.ts
@@ -1,0 +1,80 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+
+/**
+ * Block UI state that survives a docs-mode remount.
+ *
+ * In MDX docs mode Storybook re-renders the docs container on every
+ * `updateGlobals` (axis flip), which unmounts and remounts the embedded
+ * blocks — destroying any plain `useState` (expand/collapse, selection,
+ * search). This is the same problem `channel-globals` solves for the
+ * globals: lift the value out of React into module state so it persists
+ * across the remount, and re-seed component state from it on mount.
+ *
+ * `usePersistedState` is a drop-in `useState` whose value is mirrored to a
+ * module-level store under a caller-supplied key, and read back from it on
+ * (re)mount. `useBlockKey` builds a stable key scoped to the current docs
+ * page + block identity so two pages (or two distinct blocks) don't share
+ * an entry.
+ */
+
+const store = new Map<string, unknown>();
+
+/**
+ * Drop all persisted block state. The store is module-global and intentionally
+ * outlives React's tree (that's the whole point), so tests must clear it
+ * between cases to stay isolated — wired via the browser project's setupFiles.
+ */
+export function clearPersistedState(): void {
+  store.clear();
+}
+
+// The current docs/story id, so persisted state is scoped per page. Docs
+// navigation is an SPA swap inside the preview iframe (no reload), so without
+// this scope a `<TokenNavigator root="color">` on page A would inherit page
+// B's expand/selection state. Falls back to the pathname, then empty (SSR).
+function pageScope(): string {
+  if (typeof window === 'undefined') return '';
+  try {
+    return new URLSearchParams(window.location.search).get('id') ?? window.location.pathname;
+  } catch {
+    return '';
+  }
+}
+
+const SEP = '';
+
+/**
+ * Build a stable persistence key for a block's UI state: docs page + block
+ * type + the props that distinguish one instance from another (and an
+ * optional explicit `id` for identical-prop siblings on the same page).
+ */
+export function useBlockKey(
+  blockType: string,
+  parts: readonly (string | number | boolean | undefined)[],
+): string {
+  const partsKey = parts.map((p) => (p === undefined ? '' : String(p))).join(SEP);
+  // pageScope() is read once per (re)mount via the memo; a docs page swap
+  // remounts the block, so the scope is current for the new page.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  return useMemo(() => `${pageScope()}${SEP}${blockType}${SEP}${partsKey}`, [blockType, partsKey]);
+}
+
+/**
+ * `useState`, but the value persists across remounts under `key`. `initial`
+ * may be a value or a lazy initializer (used only on the first mount when the
+ * store has no entry yet — never an actual `T` that's a function here).
+ */
+export function usePersistedState<T>(
+  key: string,
+  initial: T | (() => T),
+): readonly [T, Dispatch<SetStateAction<T>>] {
+  const [value, setValue] = useState<T>(() => {
+    if (store.has(key)) return store.get(key) as T;
+    return typeof initial === 'function' ? (initial as () => T)() : initial;
+  });
+  useEffect(() => {
+    store.set(key, value);
+  }, [key, value]);
+  return [value, setValue] as const;
+}

--- a/packages/blocks/test/_setup-persistent-state.ts
+++ b/packages/blocks/test/_setup-persistent-state.ts
@@ -1,0 +1,7 @@
+import { afterEach } from 'vitest';
+import { clearPersistedState } from '#/internal/persistent-state.ts';
+
+// Block UI state (expand/selection/search) is held in a module-level store so
+// it survives docs-mode remounts. That store outlives React, so without this
+// reset it would leak between test cases. Cleared after every test.
+afterEach(clearPersistedState);

--- a/packages/blocks/test/table-state-persistence.browser.test.tsx
+++ b/packages/blocks/test/table-state-persistence.browser.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * TokenTable / ColorTable UI state must survive a docs-mode remount, the same
+ * way TokenNavigator's does. MDX docs mode unmounts and remounts embedded
+ * blocks on every globals change, so search/selection held in plain component
+ * state would be lost. Each block routes that state through the module-level
+ * `persistent-state` store; these tests assert the search query survives a
+ * full destroy/recreate.
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, expect, it } from 'vitest';
+import { ColorTable, SwatchbookProvider, TokenTable } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+const TOKENS: Record<string, VirtualTokenShape> = {
+  'color.alpha': { $type: 'color', $value: { hex: '#101010' } },
+  'color.beta': { $type: 'color', $value: { hex: '#202020' } },
+};
+
+function snapshot(): ProjectSnapshot {
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light', 'Dark'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = () => TOKENS;
+  return snap;
+}
+
+afterEach(cleanup);
+
+it('TokenTable keeps its search query across a full remount (docs mode)', async () => {
+  const view = () => (
+    <SwatchbookProvider value={snapshot()}>
+      <TokenTable id="persist" />
+    </SwatchbookProvider>
+  );
+  const { unmount } = render(view());
+
+  await userEvent.type(screen.getByPlaceholderText('Search tokens…'), 'alpha');
+  expect((screen.getByPlaceholderText('Search tokens…') as HTMLInputElement).value).toBe('alpha');
+
+  unmount();
+  render(view());
+
+  expect((screen.getByPlaceholderText('Search tokens…') as HTMLInputElement).value).toBe('alpha');
+});
+
+it('ColorTable keeps its search query across a full remount (docs mode)', async () => {
+  const view = () => (
+    <SwatchbookProvider value={snapshot()}>
+      <ColorTable id="persist" />
+    </SwatchbookProvider>
+  );
+  const { unmount } = render(view());
+
+  await userEvent.type(screen.getByPlaceholderText('Search colors…'), 'beta');
+  expect((screen.getByPlaceholderText('Search colors…') as HTMLInputElement).value).toBe('beta');
+
+  unmount();
+  render(view());
+
+  expect((screen.getByPlaceholderText('Search colors…') as HTMLInputElement).value).toBe('beta');
+});

--- a/packages/blocks/test/token-navigator-state-persistence.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-state-persistence.browser.test.tsx
@@ -38,10 +38,12 @@ function snapshotFor(activeTheme: 'Light' | 'Dark'): ProjectSnapshot {
   return snap;
 }
 
-const view = (theme: 'Light' | 'Dark') => (
+// `id` scopes the navigator's persisted UI state; each test passes its own so
+// the module-level store doesn't leak expand state between tests.
+const view = (theme: 'Light' | 'Dark', id: string) => (
   <SwatchbookProvider value={snapshotFor(theme)}>
     {/* initiallyExpanded=0 — the `color` group starts collapsed. */}
-    <TokenNavigator initiallyExpanded={0} searchable={false} />
+    <TokenNavigator initiallyExpanded={0} searchable={false} id={id} />
   </SwatchbookProvider>
 );
 
@@ -53,7 +55,7 @@ const group = (path: string): HTMLLIElement =>
 afterEach(cleanup);
 
 it('keeps the user-expanded group expanded across a mode switch', async () => {
-  const { rerender } = render(view('Light'));
+  const { rerender } = render(view('Light', 'rerender'));
 
   // Expand the `color` group (it starts collapsed at initiallyExpanded=0).
   const color = group('color');
@@ -65,8 +67,49 @@ it('keeps the user-expanded group expanded across a mode switch', async () => {
   });
 
   // Flip the theme — same paths, different values.
-  rerender(view('Dark'));
+  rerender(view('Dark', 'rerender'));
 
   // The expansion the user built must persist, not snap back to the default.
   expect(group('color').getAttribute('aria-expanded')).toBe('true');
+});
+
+it('keeps the user-expanded group expanded across a full remount (docs mode)', async () => {
+  // MDX docs mode does NOT rerender in place: Storybook re-renders the docs
+  // container on a globals change, which unmounts and remounts the embedded
+  // block entirely. Plain component state dies on that remount, so expand
+  // state must be persisted somewhere that survives it.
+  const { unmount } = render(view('Light', 'remount'));
+
+  const color = group('color');
+  expect(color.getAttribute('aria-expanded')).toBe('false');
+  color.focus();
+  await userEvent.keyboard(' ');
+  await waitFor(() => {
+    expect(group('color').getAttribute('aria-expanded')).toBe('true');
+  });
+
+  // Destroy and recreate the block, as a docs-mode axis flip does.
+  unmount();
+  render(view('Dark', 'remount'));
+
+  expect(group('color').getAttribute('aria-expanded')).toBe('true');
+});
+
+it('keeps the open detail drawer open across a full remount (docs mode)', async () => {
+  const { unmount } = render(view('Light', 'drawer'));
+
+  // Expand the group, then open a leaf's detail drawer.
+  group('color').focus();
+  await userEvent.keyboard(' ');
+  await waitFor(() => {
+    expect(group('color').getAttribute('aria-expanded')).toBe('true');
+  });
+  await userEvent.click(group('color.a'));
+  expect(screen.queryByRole('dialog')).not.toBeNull();
+
+  // Full remount, as a docs-mode axis flip does — the drawer must stay open.
+  unmount();
+  render(view('Dark', 'drawer'));
+
+  expect(screen.queryByRole('dialog')).not.toBeNull();
 });

--- a/packages/blocks/vitest.config.ts
+++ b/packages/blocks/vitest.config.ts
@@ -41,6 +41,9 @@ export default defineConfig({
         test: {
           name: 'browser',
           include: ['test/**/*.browser.test.{ts,tsx}'],
+          // Reset the module-level block-state store between tests (see the
+          // setup file); component UI state intentionally outlives React.
+          setupFiles: ['./test/_setup-persistent-state.ts'],
           browser: {
             enabled: true,
             provider: playwright(),


### PR DESCRIPTION
## Problem

On an MDX docs page, flipping a theme axis from the toolbar resets doc-block UI state — TokenNavigator's expand/collapse, the open TokenDetail drawer, search query, table selection. (Reported recurring; PR #1061 fixed only the canvas path.)

## Root cause

In MDX docs mode Storybook re-renders the docs container on every `updateGlobals`, which **unmounts and remounts** the embedded blocks — the same reason `channel-globals` already lifts globals to module state. Block UI state lived in plain component `useState`, so the remount destroyed it. PR #1061's re-seed guard relied on "the decorator does not remount" (true in canvas, false in docs), so docs mode was never covered.

Confirmed: the existing canvas (rerender) persistence test still passes; a new **remount** test reproduces the loss.

## Fix

A module-level `persistent-state` store (generalizing the `channel-globals` pattern): `usePersistedState` + `useBlockKey`, keyed per docs page + block props, with an optional `id` prop to disambiguate identical-prop siblings. Block UI state reads/writes through it so it survives the remount. Applied to:
- **TokenNavigator** — expand/collapse, selection (the drawer), search
- **TokenTable** — selection, search
- **ColorTable** — search, variant selection, expansion

## Tests

Red/green remount regression tests (watched fail first): navigator expand + drawer, table + colortable search. The store outlives React by design, so it's reset between tests via a browser-project setup file. Full blocks suite green (222), addon green (61), format/lint/typecheck clean.

## Note
This is a structural fix for the class (any block's UI state on a docs remount), not another per-block guard — so it won't resurface on the next block.

Milestone: Maintenance

Closes #1205

Plan impact: none