### PR TITLE
fix(storybook): emulate reduced motion in story tests to stop the a11y hang

### DIFF
--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -166,21 +166,19 @@ export const BorderPreviewRenders = meta.story({
 export const MotionPreviewRenders = meta.story({
   render: () => <MotionPreview filter="transition.**" />,
   play: async ({ canvasElement }) => {
-    await waitForContent(canvasElement, 'div[aria-hidden="true"]');
-    const balls = [...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]')];
-    // Find the one inside a track (has transition-duration set). Skip empty
-    // cases from reduced-motion mode.
-    const animated = balls.find((el) => {
+    // Wait for the block's token rows, not the animated ball: under reduced
+    // motion (which the test runner emulates) no ball is rendered at all.
+    await waitForContent(canvasElement, '.sb-motion-preview__row');
+    expect(canvasElement.textContent ?? '').toMatch(/motion token/i);
+    // Only assert animation timing when a ball actually animates (full motion).
+    const animated = [
+      ...canvasElement.querySelectorAll<HTMLElement>('div[aria-hidden="true"]'),
+    ].find((el) => {
       const td = getComputedStyle(el).transitionDuration;
-      return td && td !== '0s';
+      return td !== '' && td !== '0s';
     });
-    // Under reduced-motion, no ball animates. That's still valid; assert
-    // the block rendered at all.
-    const captionText = canvasElement.textContent ?? '';
-    expect(captionText).toMatch(/motion token/i);
     if (animated) {
-      const duration = getComputedStyle(animated).transitionDuration;
-      expect(duration).not.toBe('0s');
+      expect(getComputedStyle(animated).transitionDuration).not.toBe('0s');
     }
   },
 });

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -26,7 +26,13 @@ export default defineConfig({
         browser: {
           enabled: true,
           headless: true,
-          provider: playwright({}),
+          // Emulate reduced motion so animated stories (MotionSample /
+          // MotionPreview / CompositePreview transition) render their static
+          // fallback during tests. Without it the setInterval loops keep
+          // mutating the DOM and the a11y (axe) pass never reaches a stable
+          // state — the story test runner hangs. The components already honor
+          // prefers-reduced-motion via usePrefersReducedMotion.
+          provider: playwright({ contextOptions: { reducedMotion: 'reduce' } }),
           instances: [{
             browser: 'chromium'
           }]


### PR DESCRIPTION
## Problem
Running story tests (the a11y/axe pass especially) hangs on continuously-animating stories.

## Root cause
`.storybook/preview.tsx` runs axe on every story (`a11y: { test: 'error' }`). The motion components (`MotionSample` / `MotionPreview` / `CompositePreview` transition) animate via `setInterval` unless `usePrefersReducedMotion()` is true — which only held under Chromatic's UA, not the vitest/playwright runner. axe waits for a stable DOM that never arrives → hang.

Isolated via the Storybook MCP: static story + a11y passes fast; animated story with a11y off passes fast; the hang is specifically axe-on-animation. (The Storybook 10.4.4 bump does not fix this — separate, tracked in #1210.)

## Fix
Set the playwright browser context to `reducedMotion: 'reduce'` in `apps/storybook/vite.config.ts`. The motion components already render a static fallback under reduced motion, so axe settles, a11y coverage is retained (it audits the static frame), and tests are deterministic. Also fixed `MotionPreviewRenders`, whose play function waited on the animated ball (absent under reduced motion) — it now waits on the block's token rows and only asserts animation timing when a ball is present.

## Verification
Full storybook suite: **165 passed, 36 files, ~9s** (was hanging). format/lint/typecheck clean. apps/storybook is private — no changeset.

Milestone: Maintenance

Closes #1208

Plan impact: none