### PR TITLE
docs(storybook): name the Dashboard's TokenNavigator section properly

### DIFF
--- a/apps/storybook/src/docs/Dashboard.mdx
+++ b/apps/storybook/src/docs/Dashboard.mdx
@@ -5,13 +5,13 @@ import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook
 
 # Dashboard
 
-A sample composition that wires the diagnostics, token-graph, and full-listing blocks into one browsable view. Flip permutations from the toolbar and every block below re-renders against the active tuple.
+A sample composition that wires the diagnostics, navigator, and full-listing blocks into one browsable view. Flip permutations from the toolbar and every block below re-renders against the active tuple.
 
 ## Diagnostics
 
 <Diagnostics />
 
-## Token graph
+## Token navigator
 
 <TokenNavigator initiallyExpanded={0} />
 


### PR DESCRIPTION
## Problem
`apps/storybook/src/docs/Dashboard.mdx` headed its `<TokenNavigator/>` section `## Token graph` (and called it 'token-graph' in the intro), colliding with **token graph** the in-memory data-structure concept used correctly across `concepts.mdx`, `core.mdx`, `token-pipeline.mdx`, `architecture.mdx`.

## Fix
Rename the section to **Token navigator** (intro wording: 'navigator'), so the block is referred to by its own name and 'token graph' is reserved for the data structure.

An MDX sweep of `apps/storybook` + `apps/docs` confirmed this was the only block-naming collision; the Blocks reference and other narrative docs already name blocks correctly.

apps/storybook is private — no changeset.

Milestone: Maintenance

Closes #1215

Plan impact: none