### PR TITLE
chore: align mismatched dependency versions across workspaces

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -22,20 +22,20 @@
     "@docusaurus/theme-common": "3.10.0",
     "@mdx-js/react": "^3.0.0",
     "@unpunnyfuns/swatchbook-switcher": "workspace:*",
-    "clsx": "^2.0.0",
+    "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.10.0",
     "@docusaurus/plugin-client-redirects": "3.10.0",
     "@docusaurus/tsconfig": "3.10.0",
     "@docusaurus/types": "3.10.0",
-    "@types/react": "^19.0.0",
+    "@types/react": "^19.2.14",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
     "playwright": "^1.59.1",
-    "typescript": "~6.0.2"
+    "typescript": "^6.0.3"
   },
   "browserslist": {
     "production": [

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -51,7 +51,7 @@
     "playwright": "^1.59.1",
     "storybook": "^10.4.4",
     "tailwindcss": "^4.2.4",
-    "typescript": "^6.0.0",
+    "typescript": "^6.0.3",
     "vite": "^8.0.4",
     "vitest": "^4.1.8"
   }

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -111,7 +111,7 @@
     "react-dom": "^19.2.4",
     "storybook": "^10.4.4",
     "tsdown": "^0.21.9",
-    "typescript": "^6.0.0",
+    "typescript": "^6.0.3",
     "vite": "^8.0.4",
     "vitest": "^4.1.8"
   }

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -74,12 +74,12 @@
     "react-dom": "^19.2.4",
     "storybook": "^10.4.4",
     "tsdown": "^0.21.9",
-    "typescript": "^6.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "dependencies": {
     "@unpunnyfuns/swatchbook-core": "workspace:*",
     "clsx": "^2.1.1",
-    "colorjs.io": "0.6.1"
+    "colorjs.io": "^0.6.1"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,7 +108,7 @@
     "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "@vitest/ui": "^4.1.8",
     "tsdown": "^0.21.9",
-    "typescript": "^6.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/integrations/package.json
+++ b/packages/integrations/package.json
@@ -60,7 +60,7 @@
     "@types/node": "^25.6.0",
     "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "tsdown": "^0.21.9",
-    "typescript": "^6.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
-    "colorjs.io": "0.6.1",
+    "colorjs.io": "^0.6.1",
     "jiti": "^2.4.0",
     "zod": "^3.23.8"
   },
@@ -70,7 +70,7 @@
     "@types/node": "^25.6.0",
     "@unpunnyfuns/swatchbook-tokens": "workspace:*",
     "tsdown": "^0.21.9",
-    "typescript": "^6.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   }
 }

--- a/packages/switcher/package.json
+++ b/packages/switcher/package.json
@@ -68,7 +68,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "tsdown": "^0.21.9",
-    "typescript": "^6.0.0",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.8"
   },
   "dependencies": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -23,6 +23,6 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
-    "typescript": "^6.0.0"
+    "typescript": "^6.0.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,16 +67,16 @@ importers:
         specifier: workspace:*
         version: link:../../packages/switcher
       clsx:
-        specifier: ^2.0.0
+        specifier: ^2.1.1
         version: 2.1.1
       prism-react-renderer:
         specifier: ^2.3.0
         version: 2.4.1(react@19.2.5)
       react:
-        specifier: ^19.0.0
+        specifier: ^19.2.4
         version: 19.2.5
       react-dom:
-        specifier: ^19.0.0
+        specifier: ^19.2.4
         version: 19.2.5(react@19.2.5)
     devDependencies:
       '@docusaurus/module-type-aliases':
@@ -92,7 +92,7 @@ importers:
         specifier: 3.10.0
         version: 3.10.0(@swc/core@1.15.26)(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@types/react':
-        specifier: ^19.0.0
+        specifier: ^19.2.14
         version: 19.2.14
       '@unpunnyfuns/swatchbook-core':
         specifier: workspace:*
@@ -101,7 +101,7 @@ importers:
         specifier: ^1.59.1
         version: 1.59.1
       typescript:
-        specifier: ~6.0.2
+        specifier: ^6.0.3
         version: 6.0.3
 
   apps/storybook:
@@ -189,7 +189,7 @@ importers:
         specifier: ^4.2.4
         version: 4.2.4
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.4
@@ -259,7 +259,7 @@ importers:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(oxc-resolver@11.20.0)(typescript@6.0.3)
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vite:
         specifier: ^8.0.4
@@ -277,7 +277,7 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1
       colorjs.io:
-        specifier: 0.6.1
+        specifier: ^0.6.1
         version: 0.6.1
     devDependencies:
       '@testing-library/react':
@@ -314,7 +314,7 @@ importers:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(oxc-resolver@11.20.0)(typescript@6.0.3)
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
@@ -357,7 +357,7 @@ importers:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(oxc-resolver@11.20.0)(typescript@6.0.3)
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
@@ -379,7 +379,7 @@ importers:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(oxc-resolver@11.20.0)(typescript@6.0.3)
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
@@ -394,7 +394,7 @@ importers:
         specifier: workspace:*
         version: link:../core
       colorjs.io:
-        specifier: 0.6.1
+        specifier: ^0.6.1
         version: 0.6.1
       jiti:
         specifier: ^2.4.0
@@ -416,7 +416,7 @@ importers:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(oxc-resolver@11.20.0)(typescript@6.0.3)
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
@@ -459,7 +459,7 @@ importers:
         specifier: ^0.21.9
         version: 0.21.9(@tsdown/css@0.21.9)(oxc-resolver@11.20.0)(typescript@6.0.3)
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
       vitest:
         specifier: ^4.1.8
@@ -471,7 +471,7 @@ importers:
         specifier: ^25.6.0
         version: 25.6.0
       typescript:
-        specifier: ^6.0.0
+        specifier: ^6.0.3
         version: 6.0.3
 
 packages:


### PR DESCRIPTION
## What
`pnpm dlx sherif` flagged **6 `multiple-dependency-versions` mismatches** — declared ranges differing across workspaces (mostly `apps/docs` lagging). Align each to the highest declared range, carets throughout:

| Dependency | Change |
|---|---|
| react / react-dom | docs `^19.0.0` → `^19.2.4` |
| @types/react | docs `^19.0.0` → `^19.2.14` |
| clsx | docs `^2.0.0` → `^2.1.1` |
| typescript | `^6.0.0` / `~6.0.2` → `^6.0.3` everywhere |
| colorjs.io | `0.6.1` (exact, blocks/mcp) → `^0.6.1` (caret, matching core) |

## Notes
- `dependencies`/`devDependencies` only — intentional broad peer ranges (`react >=18`) left alone.
- **Resolved versions are unchanged** — lockfile-respecting `pnpm install` kept every locked version (they all already satisfied the narrowed ranges), so the lockfile diff is specifier-only. No behavior change.
- `pnpm dlx sherif` now reports **✓ No issues found**; build / format:check / lint / typecheck green.
- Range alignment, no shipped-behavior change → no changeset. (The `colorjs.io` exact→caret is a published-dep range widening at the same resolved version; shout if you'd rather record it with a patch changeset.)

Closes #1230

Plan impact: none