### PR TITLE
chore: add pnpm trustPolicy: no-downgrade (supply-chain hardening)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,7 @@ packages:
 
 minimumReleaseAge: 1440
 blockExoticSubdeps: true
+trustPolicy: 'no-downgrade'
 
 allowBuilds:
   '@swc/core': true


### PR DESCRIPTION
## What
Adds the third pnpm supply-chain setting to `pnpm-workspace.yaml`, completing the trio:

| Setting | Defends against |
|---|---|
| `minimumReleaseAge: 1440` (have) | fast-burn: malicious release yanked within 24h |
| `blockExoticSubdeps: true` (have) | transitive git/tarball-URL deps |
| **`trustPolicy: 'no-downgrade'`** (this PR) | a package whose **trust evidence weakened** vs an earlier release (was publisher-signed / provenance-attested, now isn't) |

`trustPolicy` was introduced in pnpm v10.21.0 (we're on 11.1.2) and accepts `no-downgrade` / `off`. It catches an account-takeover / malicious-republish axis the other two don't.

## Audit + verification
- **Exotic deps:** audited — zero in the tree (lockfile has no tarball/git resolutions; the only `git+https`/`https` strings are metadata fields like `repository.url` / `homepage`, not dependency specifiers). `blockExoticSubdeps` confirmed working.
- **trustPolicy recognized:** `pnpm config get trustPolicy` → `no-downgrade` (not an unknown-setting error), and `pnpm install` runs clean — nothing in the current tree trips the policy.
- Lockfile unchanged (the setting governs future fetches, not resolution). Config-only — no changeset.

Closes #1232

Plan impact: none