### PR TITLE
feat(blocks): add row indicators to the token navigator

### DIFF
--- a/.changeset/token-navigator-row-indicators.md
+++ b/.changeset/token-navigator-row-indicators.md
@@ -1,0 +1,6 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+---
+
+TokenNavigator rows show alias chain, reverse-reference count, axis-variance, out-of-gamut, and deprecation indicators, with click-to-navigate on alias references

--- a/apps/docs/docs/reference/blocks/inspector.mdx
+++ b/apps/docs/docs/reference/blocks/inspector.mdx
@@ -14,7 +14,7 @@ Single-token deep-dive. `<TokenDetail>` is the composition; each subcomponent be
 <TokenDetail path="color.accent.bg" />
 ```
 
-Full deep-dive: header + composite preview + composite breakdown + alias chain + aliased-by tree + per-axis variance + consumer output + usage snippet.
+Full deep-dive: header + composite preview + composite breakdown + alias chain + aliased-by tree + per-axis variance + consumer output + usage snippet. A token carrying DTCG `$deprecated` shows a deprecation notice below the header, with the message when `$deprecated` is a string.
 
 Props: `path: string`, `heading?: string` (defaults to `path`).
 

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -25,6 +25,8 @@ Most blocks in this group take:
 
 Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A fuzzy-search input at the top filters leaves by path: case-insensitive, out-of-order terms, single-character typo tolerance. Matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
+Between the type pill and the preview, a leaf carries an indicator strip when there is something to show: a forward alias chain (`→ target`, capped past two hops with the full chain on the accessible label), a reverse `← N` count of tokens that reference this one, an axis-variance badge when the resolved value flips across mode / brand / contrast, an out-of-gamut marker on colors outside sRGB for the active format, and a deprecation badge with a struck-through name for tokens carrying DTCG `$deprecated`. Alias references are navigable: clicking a chain node, or a single reverse referrer, moves the tree to that token; several referrers open a chooser. The chain reflects the active theme, so a token that aliases different palette entries per mode shows the path true in the current context.
+
 Props:
 
 - `root?: string`: mount at this subtree (e.g. `"color"`, `"typography"`). Omit to show everything.

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -1,4 +1,5 @@
-import { TokenNavigator } from '@unpunnyfuns/swatchbook-blocks';
+import { SwatchbookProvider, TokenNavigator } from '@unpunnyfuns/swatchbook-blocks';
+import type { ProjectSnapshot, VirtualTokenShape } from '@unpunnyfuns/swatchbook-blocks';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
 import preview from '../../.storybook/preview.tsx';
@@ -243,5 +244,210 @@ export const FocusVisibleRow = meta.story({
       Number.parseFloat(computed.outlineWidth),
       'focus-visible row outline-width must be > 0',
     ).toBeGreaterThan(0);
+  },
+});
+
+// Deterministic token map used by the Indicators story. Covers every
+// indicator variant: multi-hop forward chain (3 hops → first … last cap),
+// reverse count ≥ 2 (opens a popover menu), out-of-gamut color (display-P3
+// red outside sRGB), string-form deprecation, and boolean-form deprecation.
+const INDICATOR_TOKENS: Record<string, VirtualTokenShape> = {
+  // Semantic alias — three-hop chain: text.primary → brand.fg → palette.blue.600 → palette.blue.500
+  'color.text.primary': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.11, 0.44, 0.95], alpha: 1 },
+    aliasOf: 'color.brand.fg',
+    aliasChain: ['color.brand.fg', 'color.palette.blue.600', 'color.palette.blue.500'],
+  },
+  // Intermediate alias node
+  'color.brand.fg': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.11, 0.44, 0.95], alpha: 1 },
+    aliasOf: 'color.palette.blue.600',
+    aliasChain: ['color.palette.blue.600', 'color.palette.blue.500'],
+  },
+  // Another intermediate
+  'color.palette.blue.600': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.11, 0.44, 0.95], alpha: 1 },
+    aliasOf: 'color.palette.blue.500',
+    aliasChain: ['color.palette.blue.500'],
+  },
+  // Primitive — referenced by two tokens, so the reverse button opens a menu.
+  'color.palette.blue.500': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.23, 0.51, 0.97], alpha: 1 },
+    aliasedBy: ['color.text.primary', 'color.border.focus'],
+  },
+  // Second reverse referent so the blue.500 count shows ← 2.
+  'color.border.focus': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.23, 0.51, 0.97], alpha: 1 },
+    aliasOf: 'color.palette.blue.500',
+    aliasChain: ['color.palette.blue.500'],
+  },
+  // Out-of-gamut: display-P3 primary red lies outside sRGB, triggering ⚠.
+  'color.accent.vivid': {
+    $type: 'color',
+    $value: { colorSpace: 'display-p3', components: [1, 0, 0], alpha: 1 },
+  },
+  // Deprecated with a guidance message (string form).
+  'color.legacy.brand': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.8, 0.2, 0.1], alpha: 1 },
+    $deprecated: 'use color.text.primary instead',
+  },
+  // Deprecated without a message (boolean form).
+  'color.legacy.neutral': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.5, 0.5, 0.5], alpha: 1 },
+    $deprecated: true,
+  },
+};
+
+// Module-level snapshot so its identity is stable across re-renders.
+// A new object per render would invalidate the `resolved` memo inside
+// `useProject`, causing `tree` → `initialExpanded` to churn identity,
+// which trips the re-seed effect and loops: setExpanded → re-render → …
+const INDICATORS_SNAPSHOT: ProjectSnapshot = (() => {
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = () => INDICATOR_TOKENS;
+  return snap;
+})();
+
+/**
+ * Row indicator strip smoke test. Wraps the navigator in a local
+ * `SwatchbookProvider` so the token set is deterministic, independent of
+ * the reference project loaded by the global decorator.
+ *
+ * Covers: multi-hop forward alias chain (capped to first → … → last),
+ * reverse-reference count that opens a popover menu (≥ 2 referents),
+ * out-of-gamut glyph (display-P3 red), string-form deprecation badge, and
+ * boolean-form deprecation badge.
+ *
+ * The variance badge is absent here: `varianceByPath` only populates from
+ * a real loaded project, not a hand-built snapshot. Variance already
+ * renders on `Default` and `ColorSubtree` with the real project data.
+ */
+export const Indicators = meta.story({
+  render: () => (
+    <SwatchbookProvider value={INDICATORS_SNAPSHOT}>
+      {/*
+        Give the navigator a unique `id` so its `usePersistedState` block key
+        doesn't collide with sibling stories that share the same `root`/`type`
+        defaults. Without an `id`, every un-rooted navigator story persists
+        its expand/collapse state under the same key and the state from
+        FullyCollapsed (or any prior run) bleeds in here, leaving groups
+        collapsed so leaf rows never appear.
+      */}
+      <TokenNavigator id="indicators" initiallyExpanded={6} />
+    </SwatchbookProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Wait for the tree to settle. Because `usePersistedState` reads from a
+    // module-level store that persists between story runs, even with the
+    // unique `id` above a warm run may restore a collapsed state from a
+    // previous iteration of this story. Expand all top-level groups
+    // explicitly so the leaf rows are guaranteed visible regardless.
+    await waitFor(() => {
+      if (!canvasElement.querySelector('[data-testid="token-navigator-group"]')) {
+        throw new Error('token navigator did not render any group rows');
+      }
+    });
+
+    // Expand all collapsed groups, one at a time, until none remain.
+    // Recursive so the lint rule (`no-await-in-loop`) is avoided: we pick the
+    // first collapsed group, expand it, wait for the state change, then recurse.
+    const expandOne = async (): Promise<void> => {
+      const collapsed = canvasElement.querySelector<HTMLElement>(
+        '[data-testid="token-navigator-group"][aria-expanded="false"]',
+      );
+      if (!collapsed) return;
+      const row = collapsed.querySelector<HTMLElement>('[data-testid="token-navigator-group-row"]');
+      if (!row) return;
+      await userEvent.click(row);
+      await waitFor(() => {
+        if (collapsed.getAttribute('aria-expanded') !== 'true') {
+          throw new Error('group did not expand');
+        }
+      });
+      await expandOne();
+    };
+    await expandOne();
+
+    await waitFor(() => {
+      if (!canvasElement.querySelector('[data-testid="token-navigator-leaf"]')) {
+        throw new Error('tree did not render any leaf rows after expanding all groups');
+      }
+    });
+
+    // 1. The three-hop forward chain renders on color.text.primary. Find it by
+    // the leaf row's data-path attribute so there's no ambiguity across the
+    // multiple alias-forward indicators in the tree.
+    const textPrimaryLeaf = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="token-navigator-leaf"][data-path="color.text.primary"]',
+    );
+    expect(textPrimaryLeaf, 'color.text.primary leaf must be in the DOM').not.toBeNull();
+    if (!textPrimaryLeaf) throw new Error('color.text.primary leaf not found');
+
+    const forwardStrip = textPrimaryLeaf.querySelector<HTMLElement>(
+      '[data-testid="row-indicator-alias-forward"]',
+    );
+    expect(
+      forwardStrip,
+      'forward alias chain must be present on color.text.primary',
+    ).not.toBeNull();
+    if (!forwardStrip)
+      throw new Error('row-indicator-alias-forward not found on color.text.primary');
+
+    // 2. The three-hop chain is capped to first → … → last. Both nodes should
+    // be navigable buttons (color.brand.fg and color.palette.blue.500).
+    const aliasNodes = forwardStrip.querySelectorAll<HTMLElement>('[data-testid="alias-node"]');
+    expect(aliasNodes.length, 'capped chain shows two alias nodes (first + last)').toBe(2);
+
+    // Click the first node — navigates to color.brand.fg (already in the tree).
+    const firstNode = aliasNodes[0];
+    if (!firstNode) throw new Error('no alias-node found inside forward chain');
+    await userEvent.click(firstNode);
+    // After navigation, color.brand.fg is selected (overlay opens or row gains
+    // selected state). The leaf row is already in the DOM; just assert it exists.
+    await waitFor(() => {
+      const target = canvasElement.querySelector(
+        '[data-testid="token-navigator-leaf"][data-path="color.brand.fg"]',
+      );
+      if (!target) throw new Error('color.brand.fg leaf row missing after alias navigation');
+    });
+
+    // 3. The reverse count for color.palette.blue.500 shows ← 2 and opens a menu.
+    const blue500Leaf = canvasElement.querySelector<HTMLElement>(
+      '[data-testid="token-navigator-leaf"][data-path="color.palette.blue.500"]',
+    );
+    expect(blue500Leaf, 'color.palette.blue.500 leaf must be in the DOM').not.toBeNull();
+    if (!blue500Leaf) throw new Error('color.palette.blue.500 leaf not found');
+
+    const reverseBtn = blue500Leaf.querySelector<HTMLElement>(
+      '[data-testid="row-indicator-alias-reverse"]',
+    );
+    expect(reverseBtn, 'reverse count button must be on the blue.500 leaf row').not.toBeNull();
+    if (!reverseBtn) throw new Error('row-indicator-alias-reverse not found on blue.500');
+    expect(reverseBtn.getAttribute('aria-label')).toBe('referenced by 2 tokens');
+    await userEvent.click(reverseBtn);
+
+    // Menu should now contain one item per referent.
+    const menuItems = await canvas.findAllByRole('menuitem');
+    expect(menuItems.length).toBeGreaterThanOrEqual(2);
+    const itemPaths = menuItems.map((el) => el.textContent?.trim());
+    expect(itemPaths).toContain('color.text.primary');
+    expect(itemPaths).toContain('color.border.focus');
   },
 });

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -44,10 +44,22 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
   const gamut = isColor ? formatColor(token.$value, colorFormat) : null;
   const value = formatTokenValue(token.$value, token.$type, colorFormat, listing[path]);
   const outOfGamut = gamut?.outOfGamut ?? false;
+  const dep = token.$deprecated;
+  const isDeprecated = dep === true || (typeof dep === 'string' && dep.length > 0);
 
   return (
     <div {...wrapperAttrs} className={cx(wrapperAttrs['className'], 'sb-token-detail')}>
       <TokenHeader path={path} {...(heading !== undefined && { heading })} />
+      {isDeprecated && (
+        <div
+          className="sb-token-detail__deprecated"
+          data-testid="token-detail-deprecated"
+          role="note"
+        >
+          <span aria-hidden>⚠ </span>
+          Deprecated{typeof dep === 'string' ? `: ${dep}` : ''}
+        </div>
+      )}
 
       <div className="sb-token-detail__section-header">Resolved value · {activeTheme}</div>
       <CompositePreview path={path} />

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -194,7 +194,7 @@
   border-radius: 3px;
   background: none;
   font: inherit;
-  color: var(--swatchbook-accent-default, #3b82f6);
+  color: var(--swatchbook-accent-default, light-dark(#1d4ed8, #93c5fd));
   cursor: pointer;
 }
 
@@ -269,7 +269,7 @@
   font: inherit;
   text-align: left;
   white-space: nowrap;
-  color: var(--swatchbook-accent-default, #3b82f6);
+  color: var(--swatchbook-accent-default, light-dark(#1d4ed8, #93c5fd));
   cursor: pointer;
 }
 

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -161,3 +161,123 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* Row indicators: alias references (forward chain + reverse count),
+   axis-variance badge, out-of-gamut glyph, deprecation badge. */
+.sb-token-navigator__indicators {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 8px;
+  min-width: 0;
+  font-size: 11px;
+  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.9));
+}
+
+.sb-token-navigator__alias-forward,
+.sb-token-navigator__alias-reverse {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.sb-token-navigator__alias-arrow {
+  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.6));
+}
+
+.sb-token-navigator__alias-node {
+  padding: 0 2px;
+  border: none;
+  border-radius: 3px;
+  background: none;
+  font: inherit;
+  color: var(--swatchbook-accent-default, #3b82f6);
+  cursor: pointer;
+}
+
+.sb-token-navigator__alias-node:hover {
+  text-decoration: underline;
+}
+
+.sb-token-navigator__alias-node--offview {
+  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.6));
+  text-decoration: none;
+  cursor: default;
+}
+
+.sb-token-navigator__variance,
+.sb-token-navigator__deprecated {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.sb-token-navigator__variance-glyph {
+  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.7));
+}
+
+.sb-token-navigator__gamut {
+  margin-left: 2px;
+}
+
+.sb-token-navigator__deprecated {
+  font-size: 9px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: light-dark(#92400e, #fbbf24);
+  background: light-dark(rgba(245, 158, 11, 0.15), rgba(245, 158, 11, 0.18));
+}
+
+.sb-token-navigator__leaf-row[data-deprecated='true'] .sb-token-navigator__tail {
+  text-decoration: line-through;
+  text-decoration-color: light-dark(#92400e, #fbbf24);
+  opacity: 0.75;
+}
+
+.sb-token-navigator__reverse-wrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.sb-token-navigator__reverse-menu {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 10;
+  margin: 2px 0 0;
+  padding: 4px;
+  list-style: none;
+  background: var(--swatchbook-surface-raised, light-dark(#fff, #1a1a1a));
+  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.sb-token-navigator__reverse-item {
+  display: block;
+  width: 100%;
+  padding: 4px 8px;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  font: inherit;
+  text-align: left;
+  white-space: nowrap;
+  color: var(--swatchbook-accent-default, #3b82f6);
+  cursor: pointer;
+}
+
+.sb-token-navigator__reverse-item:hover:not(:disabled) {
+  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.12));
+}
+
+.sb-token-navigator__reverse-item:disabled {
+  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.6));
+  cursor: default;
+}

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -168,7 +168,6 @@
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  margin-left: 8px;
   min-width: 0;
   font-size: 11px;
   color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.9));

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -764,7 +764,6 @@ const LeafRow = memo(function LeafRow({
         </span>
         <span className="sb-token-navigator__tail">{node.segment}</span>
         {type && <span className="sb-token-navigator__type-pill">{type}</span>}
-        <LeafPreview path={node.path} token={node.token} />
         <RowIndicators
           path={node.path}
           token={node.token}
@@ -774,6 +773,7 @@ const LeafRow = memo(function LeafRow({
           resolveInView={resolveInView}
           onNavigate={onNavigate}
         />
+        <LeafPreview path={node.path} token={node.token} />
       </div>
     </li>
   );

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -13,6 +13,8 @@ import { EmptyState } from '#/internal/styles.tsx';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 import { MotionSample } from '#/motion-preview/MotionSample.tsx';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
+import { ancestorGroupPaths, isInView } from '#/token-navigator/navigate.ts';
+import { RowIndicators } from '#/token-navigator/RowIndicators.tsx';
 import type { VirtualToken } from '#/types.ts';
 
 export interface TokenNavigatorProps {
@@ -306,6 +308,31 @@ export function TokenNavigator({
   // points at a now-hidden row (e.g. after a search narrows the tree).
   const [storedFocus, setStoredFocus] = useState<string | null>(null);
   const treeItemRefs = useRef<Map<string, HTMLLIElement>>(new Map());
+
+  const resolveInView = useCallback(
+    (path: string): boolean => isInView(path, { resolved, root, typeFilter }),
+    [resolved, root, typeFilter],
+  );
+
+  const navigateTo = useCallback(
+    (target: string): void => {
+      setQuery('');
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        for (const p of ancestorGroupPaths(target, root)) next.add(p);
+        return next;
+      });
+      if (onSelect) onSelect(target);
+      else setSelectedPath(target);
+      setStoredFocus(target);
+      requestAnimationFrame(() => {
+        const el = treeItemRefs.current.get(target);
+        el?.scrollIntoView({ block: 'nearest' });
+        el?.focus();
+      });
+    },
+    [root, onSelect, setQuery, setExpanded, setSelectedPath],
+  );
   const registerTreeItem = useCallback(
     (path: string) =>
       (el: HTMLLIElement | null): void => {
@@ -538,6 +565,9 @@ export function TokenNavigator({
               onToggle={toggle}
               onFocusPath={setStoredFocus}
               onLeafClick={handleLeafClick}
+              root={root}
+              resolveInView={resolveInView}
+              onNavigate={navigateTo}
               level={1}
               setsize={visibleTree.length}
               posinset={i + 1}
@@ -565,6 +595,9 @@ interface TreeNodeRowProps {
   onToggle(path: string): void;
   onFocusPath(path: string): void;
   onLeafClick(path: string): void;
+  root: string | undefined;
+  resolveInView(path: string): boolean;
+  onNavigate(path: string): void;
   // 1-indexed depth in the tree (top-level = 1).
   level: number;
   // Number of siblings at this level (including self).
@@ -581,6 +614,9 @@ function TreeNodeRow({
   onToggle,
   onFocusPath,
   onLeafClick,
+  root,
+  resolveInView,
+  onNavigate,
   level,
   setsize,
   posinset,
@@ -593,6 +629,9 @@ function TreeNodeRow({
         registerTreeItem={registerTreeItem}
         onFocusPath={onFocusPath}
         onLeafClick={onLeafClick}
+        root={root}
+        resolveInView={resolveInView}
+        onNavigate={onNavigate}
         level={level}
         setsize={setsize}
         posinset={posinset}
@@ -647,6 +686,9 @@ function TreeNodeRow({
               onToggle={onToggle}
               onFocusPath={onFocusPath}
               onLeafClick={onLeafClick}
+              root={root}
+              resolveInView={resolveInView}
+              onNavigate={onNavigate}
               level={level + 1}
               setsize={node.children.length}
               posinset={i + 1}
@@ -664,6 +706,9 @@ interface LeafRowProps {
   registerTreeItem(path: string): (el: HTMLLIElement | null) => void;
   onFocusPath(path: string): void;
   onLeafClick(path: string): void;
+  root: string | undefined;
+  resolveInView(path: string): boolean;
+  onNavigate(path: string): void;
   // 1-indexed depth in the tree (top-level = 1).
   level: number;
   // Number of siblings at this level (including self).
@@ -678,11 +723,19 @@ const LeafRow = memo(function LeafRow({
   registerTreeItem,
   onFocusPath,
   onLeafClick,
+  root,
+  resolveInView,
+  onNavigate,
   level,
   setsize,
   posinset,
 }: LeafRowProps): ReactElement {
   const type = node.token.$type ?? '';
+  const project = useProject();
+  const colorFormat = useColorFormat();
+  const variance = project.varianceByPath[node.path];
+  const dep = node.token.$deprecated;
+  const isDeprecated = dep === true || (typeof dep === 'string' && dep.length > 0);
   return (
     <li
       ref={registerTreeItem(node.path)}
@@ -700,6 +753,7 @@ const LeafRow = memo(function LeafRow({
       <div
         className="sb-token-navigator__leaf-row"
         data-testid="token-navigator-leaf-row"
+        data-deprecated={isDeprecated ? 'true' : undefined}
         onClick={() => {
           onFocusPath(node.path);
           onLeafClick(node.path);
@@ -711,6 +765,15 @@ const LeafRow = memo(function LeafRow({
         <span className="sb-token-navigator__tail">{node.segment}</span>
         {type && <span className="sb-token-navigator__type-pill">{type}</span>}
         <LeafPreview path={node.path} token={node.token} />
+        <RowIndicators
+          path={node.path}
+          token={node.token}
+          root={root}
+          variance={variance}
+          colorFormat={colorFormat}
+          resolveInView={resolveInView}
+          onNavigate={onNavigate}
+        />
       </div>
     </li>
   );

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -29,6 +29,12 @@ export interface VirtualTokenShape {
   $type?: string | undefined;
   $value?: unknown;
   $description?: string | undefined;
+  /**
+   * DTCG `$deprecated` — `true` or a message string. Mirrors core's
+   * `SwatchbookToken.$deprecated`; reaches blocks via the resolved token
+   * map reconstructed from the wire `tokenGraph`.
+   */
+  $deprecated?: string | boolean | undefined;
   aliasOf?: string | undefined;
   aliasChain?: readonly string[] | undefined;
   aliasedBy?: readonly string[] | undefined;

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -1,4 +1,8 @@
-import { resolveAllAt, getVariance, listPaths } from '@unpunnyfuns/swatchbook-core/graph';
+import {
+  resolveAllWithProvenanceAt,
+  getVariance,
+  listPaths,
+} from '@unpunnyfuns/swatchbook-core/graph';
 import { makeCssVar } from '@unpunnyfuns/swatchbook-core/css-var';
 import {
   ensureStyleElement,
@@ -53,7 +57,7 @@ export interface ProjectData {
   varianceByPath: VirtualVarianceByPathShape;
   /**
    * Compose the resolved `TokenMap` for any tuple of axis selections.
-   * Backed browser-side by `resolveAllAt` over the `tokenGraph`.
+   * Backed browser-side by `resolveAllWithProvenanceAt` over the `tokenGraph`.
    */
   resolveAt: (tuple: Record<string, string>) => ResolvedTokens;
 }
@@ -77,7 +81,7 @@ function makeResolveAt(
   graph: VirtualTokenGraph | undefined,
 ): (tuple: Record<string, string>) => ResolvedTokens {
   if (!graph) return () => ({});
-  return (tuple) => resolveAllAt(graph, tuple) as unknown as ResolvedTokens;
+  return (tuple) => resolveAllWithProvenanceAt(graph, tuple) as unknown as ResolvedTokens;
 }
 
 // Build the `resolveAt` accessor for a snapshot. Prefers the
@@ -203,7 +207,7 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
 
   const activeTheme = contextThemeName || tupleToName(tokens.axes, activeAxes);
 
-  // `resolveAllAt` is a pure function over the graph; the only memo
+  // `resolveAllWithProvenanceAt` is a pure function over the graph; the only memo
   // we need is for the outer closure so React's reference equality
   // stays stable between renders. `tokens.tokenGraph` is the stable
   // module-level virtual-module export — changes only on HMR refresh.

--- a/packages/blocks/src/token-detail/internal.ts
+++ b/packages/blocks/src/token-detail/internal.ts
@@ -7,6 +7,7 @@ export interface DetailToken {
   $type?: string;
   $value?: unknown;
   $description?: string;
+  $deprecated?: string | boolean;
   aliasOf?: string;
   aliasChain?: readonly string[];
   aliasedBy?: readonly string[];

--- a/packages/blocks/src/token-detail/styles.css
+++ b/packages/blocks/src/token-detail/styles.css
@@ -343,3 +343,12 @@
   cursor: pointer;
   flex-shrink: 0;
 }
+
+.sb-token-detail__deprecated {
+  margin: 6px 0;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 12px;
+  color: light-dark(#92400e, #fbbf24);
+  background: light-dark(rgba(245, 158, 11, 0.15), rgba(245, 158, 11, 0.18));
+}

--- a/packages/blocks/src/token-navigator/RowIndicators.tsx
+++ b/packages/blocks/src/token-navigator/RowIndicators.tsx
@@ -97,6 +97,28 @@ function ForwardChain({ chain, root, resolveInView, onNavigate }: ForwardChainPr
   );
 }
 
+interface VarianceBadgeProps {
+  variance: AxisVarianceResult;
+}
+
+function VarianceBadge({ variance }: VarianceBadgeProps): ReactElement | null {
+  if (variance.kind === 'constant') return null;
+  const axes = variance.varyingAxes;
+  const label = variance.kind === 'single' ? variance.axis : `${axes.length} axes`;
+  return (
+    <span
+      className="sb-token-navigator__variance"
+      data-testid="row-indicator-variance"
+      aria-label={`varies by ${axes.join(', ')}`}
+    >
+      <span className="sb-token-navigator__variance-glyph" aria-hidden>
+        ⊹
+      </span>
+      {label}
+    </span>
+  );
+}
+
 interface ReverseCountProps {
   count: number;
 }
@@ -118,13 +140,14 @@ function ReverseCount({ count }: ReverseCountProps): ReactElement {
 
 /** Per-row indicator strip: alias references, variance, gamut, deprecation. */
 export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
-  const { token, root, resolveInView, onNavigate } = props;
+  const { token, root, variance, resolveInView, onNavigate } = props;
   const aliasChain =
     Array.isArray(token.aliasChain) && token.aliasChain.length > 0 ? token.aliasChain : undefined;
   const reverseCount =
     Array.isArray(token.aliasedBy) && token.aliasedBy.length > 0 ? token.aliasedBy.length : 0;
+  const isVarying = variance !== undefined && variance.kind !== 'constant';
 
-  if (!aliasChain && reverseCount === 0) return null;
+  if (!aliasChain && reverseCount === 0 && !isVarying) return null;
 
   return (
     <span className="sb-token-navigator__indicators">
@@ -137,6 +160,7 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
         />
       )}
       {reverseCount > 0 && <ReverseCount count={reverseCount} />}
+      {variance && <VarianceBadge variance={variance} />}
     </span>
   );
 }

--- a/packages/blocks/src/token-navigator/RowIndicators.tsx
+++ b/packages/blocks/src/token-navigator/RowIndicators.tsx
@@ -1,5 +1,5 @@
 import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 import type { ColorFormat } from '#/format-color.ts';
 import { formatColor } from '#/format-color.ts';
@@ -147,11 +147,37 @@ interface ReverseCountProps {
 
 function ReverseCount({ referents, resolveInView, onNavigate }: ReverseCountProps): ReactElement {
   const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLSpanElement>(null);
   const count = referents.length;
   const single = count === 1;
 
+  // Move focus to the first enabled menu item on open; close on outside pointerdown.
+  useEffect(() => {
+    if (single || !open) return;
+    const first = wrapRef.current?.querySelector<HTMLElement>(
+      'button[role="menuitem"]:not(:disabled)',
+    );
+    first?.focus();
+
+    const handlePointerDown = (e: PointerEvent) => {
+      if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('pointerdown', handlePointerDown);
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown);
+    };
+  }, [open, single]);
+
   return (
-    <span className="sb-token-navigator__reverse-wrap">
+    <span
+      ref={wrapRef}
+      className="sb-token-navigator__reverse-wrap"
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') setOpen(false);
+      }}
+    >
       <button
         type="button"
         className="sb-token-navigator__alias-reverse"
@@ -163,9 +189,6 @@ function ReverseCount({ referents, resolveInView, onNavigate }: ReverseCountProp
           e.stopPropagation();
           if (single) onNavigate(referents[0] as string);
           else setOpen((v) => !v);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Escape') setOpen(false);
         }}
       >
         <span className="sb-token-navigator__alias-arrow" aria-hidden>

--- a/packages/blocks/src/token-navigator/RowIndicators.tsx
+++ b/packages/blocks/src/token-navigator/RowIndicators.tsx
@@ -97,22 +97,46 @@ function ForwardChain({ chain, root, resolveInView, onNavigate }: ForwardChainPr
   );
 }
 
+interface ReverseCountProps {
+  count: number;
+}
+
+function ReverseCount({ count }: ReverseCountProps): ReactElement {
+  return (
+    <span
+      className="sb-token-navigator__alias-reverse"
+      data-testid="row-indicator-alias-reverse"
+      aria-label={`referenced by ${count} ${count === 1 ? 'token' : 'tokens'}`}
+    >
+      <span className="sb-token-navigator__alias-arrow" aria-hidden>
+        ←
+      </span>
+      {count}
+    </span>
+  );
+}
+
 /** Per-row indicator strip: alias references, variance, gamut, deprecation. */
 export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
   const { token, root, resolveInView, onNavigate } = props;
   const aliasChain =
     Array.isArray(token.aliasChain) && token.aliasChain.length > 0 ? token.aliasChain : undefined;
+  const reverseCount =
+    Array.isArray(token.aliasedBy) && token.aliasedBy.length > 0 ? token.aliasedBy.length : 0;
 
-  if (!aliasChain) return null;
+  if (!aliasChain && reverseCount === 0) return null;
 
   return (
     <span className="sb-token-navigator__indicators">
-      <ForwardChain
-        chain={aliasChain}
-        root={root}
-        resolveInView={resolveInView}
-        onNavigate={onNavigate}
-      />
+      {aliasChain && (
+        <ForwardChain
+          chain={aliasChain}
+          root={root}
+          resolveInView={resolveInView}
+          onNavigate={onNavigate}
+        />
+      )}
+      {reverseCount > 0 && <ReverseCount count={reverseCount} />}
     </span>
   );
 }

--- a/packages/blocks/src/token-navigator/RowIndicators.tsx
+++ b/packages/blocks/src/token-navigator/RowIndicators.tsx
@@ -1,0 +1,118 @@
+import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
+import type { ReactElement } from 'react';
+import type { ColorFormat } from '#/format-color.ts';
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+export interface RowIndicatorsProps {
+  path: string;
+  token: VirtualTokenShape;
+  /** Active navigator root prefix, for relative chain-node labels. */
+  root: string | undefined;
+  /** Per-path variance result for the variance badge. */
+  variance: AxisVarianceResult | undefined;
+  /** Active color format, for the gamut check (color rows only). */
+  colorFormat: ColorFormat;
+  /** True when a path can be selected in the current tree (structural filters). */
+  resolveInView: (path: string) => boolean;
+  /** Navigate the tree to a path (expand ancestors, select, scroll). */
+  onNavigate: (path: string) => void;
+}
+
+// Strip the navigator's `root` prefix from a path for a compact chain label.
+function relativeLabel(path: string, root: string | undefined): string {
+  if (root && path.startsWith(`${root}.`)) return path.slice(root.length + 1);
+  return path;
+}
+
+interface ForwardChainProps {
+  chain: readonly string[];
+  root: string | undefined;
+  resolveInView: (path: string) => boolean;
+  onNavigate: (path: string) => void;
+}
+
+/**
+ * The forward alias chain for one row. Full chain in `aria-label`; visually
+ * capped to first … last beyond two hops (no width measurement). Each shown
+ * node navigates when in view, else renders as plain text.
+ */
+function ForwardChain({ chain, root, resolveInView, onNavigate }: ForwardChainProps): ReactElement {
+  const full = chain.map((p) => relativeLabel(p, root)).join(' → ');
+  const capped = chain.length > 2;
+  const shown = capped ? [chain[0] as string, chain[chain.length - 1] as string] : [...chain];
+
+  return (
+    <span
+      className="sb-token-navigator__alias-forward"
+      data-testid="row-indicator-alias-forward"
+      aria-label={`aliases ${full}`}
+    >
+      <span className="sb-token-navigator__alias-arrow" aria-hidden>
+        →
+      </span>
+      {shown.map((target, i) => {
+        const label = relativeLabel(target, root);
+        const node = resolveInView(target) ? (
+          <button
+            type="button"
+            className="sb-token-navigator__alias-node"
+            data-testid="alias-node"
+            aria-label={target}
+            onClick={(e) => {
+              e.stopPropagation();
+              onNavigate(target);
+            }}
+          >
+            {label}
+          </button>
+        ) : (
+          <span
+            className="sb-token-navigator__alias-node sb-token-navigator__alias-node--offview"
+            data-testid="alias-node"
+            title="outside current view"
+          >
+            {label}
+          </span>
+        );
+        const sep =
+          capped && i === 0 ? (
+            <span className="sb-token-navigator__alias-arrow" aria-hidden>
+              {' '}
+              → … →{' '}
+            </span>
+          ) : i < shown.length - 1 ? (
+            <span className="sb-token-navigator__alias-arrow" aria-hidden>
+              {' '}
+              →{' '}
+            </span>
+          ) : null;
+        return (
+          <span key={target}>
+            {node}
+            {sep}
+          </span>
+        );
+      })}
+    </span>
+  );
+}
+
+/** Per-row indicator strip: alias references, variance, gamut, deprecation. */
+export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
+  const { token, root, resolveInView, onNavigate } = props;
+  const aliasChain =
+    Array.isArray(token.aliasChain) && token.aliasChain.length > 0 ? token.aliasChain : undefined;
+
+  if (!aliasChain) return null;
+
+  return (
+    <span className="sb-token-navigator__indicators">
+      <ForwardChain
+        chain={aliasChain}
+        root={root}
+        resolveInView={resolveInView}
+        onNavigate={onNavigate}
+      />
+    </span>
+  );
+}

--- a/packages/blocks/src/token-navigator/RowIndicators.tsx
+++ b/packages/blocks/src/token-navigator/RowIndicators.tsx
@@ -1,4 +1,5 @@
 import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
+import { useState } from 'react';
 import type { ReactElement } from 'react';
 import type { ColorFormat } from '#/format-color.ts';
 import { formatColor } from '#/format-color.ts';
@@ -139,20 +140,61 @@ function VarianceBadge({ variance }: VarianceBadgeProps): ReactElement | null {
 }
 
 interface ReverseCountProps {
-  count: number;
+  referents: readonly string[];
+  resolveInView: (path: string) => boolean;
+  onNavigate: (path: string) => void;
 }
 
-function ReverseCount({ count }: ReverseCountProps): ReactElement {
+function ReverseCount({ referents, resolveInView, onNavigate }: ReverseCountProps): ReactElement {
+  const [open, setOpen] = useState(false);
+  const count = referents.length;
+  const single = count === 1;
+
   return (
-    <span
-      className="sb-token-navigator__alias-reverse"
-      data-testid="row-indicator-alias-reverse"
-      aria-label={`referenced by ${count} ${count === 1 ? 'token' : 'tokens'}`}
-    >
-      <span className="sb-token-navigator__alias-arrow" aria-hidden>
-        ←
-      </span>
-      {count}
+    <span className="sb-token-navigator__reverse-wrap">
+      <button
+        type="button"
+        className="sb-token-navigator__alias-reverse"
+        data-testid="row-indicator-alias-reverse"
+        aria-label={`referenced by ${count} ${count === 1 ? 'token' : 'tokens'}`}
+        aria-haspopup={single ? undefined : 'menu'}
+        aria-expanded={single ? undefined : open}
+        onClick={(e) => {
+          e.stopPropagation();
+          if (single) onNavigate(referents[0] as string);
+          else setOpen((v) => !v);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Escape') setOpen(false);
+        }}
+      >
+        <span className="sb-token-navigator__alias-arrow" aria-hidden>
+          ←
+        </span>
+        {count}
+      </button>
+      {!single && open && (
+        <ul className="sb-token-navigator__reverse-menu" role="menu">
+          {referents.map((ref) => (
+            <li key={ref} role="none">
+              <button
+                type="button"
+                role="menuitem"
+                className="sb-token-navigator__reverse-item"
+                disabled={!resolveInView(ref)}
+                title={resolveInView(ref) ? undefined : 'outside current view'}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setOpen(false);
+                  onNavigate(ref);
+                }}
+              >
+                {ref}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
     </span>
   );
 }
@@ -184,7 +226,13 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
           onNavigate={onNavigate}
         />
       )}
-      {reverseCount > 0 && <ReverseCount count={reverseCount} />}
+      {reverseCount > 0 && token.aliasedBy && (
+        <ReverseCount
+          referents={token.aliasedBy}
+          resolveInView={resolveInView}
+          onNavigate={onNavigate}
+        />
+      )}
       {variance && <VarianceBadge variance={variance} />}
       {outOfGamut && (
         <span

--- a/packages/blocks/src/token-navigator/RowIndicators.tsx
+++ b/packages/blocks/src/token-navigator/RowIndicators.tsx
@@ -98,6 +98,24 @@ function ForwardChain({ chain, root, resolveInView, onNavigate }: ForwardChainPr
   );
 }
 
+interface DeprecatedBadgeProps {
+  deprecated: string | boolean;
+}
+
+function DeprecatedBadge({ deprecated }: DeprecatedBadgeProps): ReactElement {
+  const label = typeof deprecated === 'string' ? `deprecated: ${deprecated}` : 'deprecated';
+  return (
+    <span
+      className="sb-token-navigator__deprecated"
+      data-testid="row-indicator-deprecated"
+      title={label}
+      aria-label={label}
+    >
+      deprecated
+    </span>
+  );
+}
+
 interface VarianceBadgeProps {
   variance: AxisVarianceResult;
 }
@@ -149,11 +167,15 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
   const isVarying = variance !== undefined && variance.kind !== 'constant';
   const outOfGamut =
     token.$type === 'color' && (formatColor(token.$value, colorFormat)?.outOfGamut ?? false);
+  const deprecated = token.$deprecated;
+  const isDeprecated =
+    deprecated === true || (typeof deprecated === 'string' && deprecated.length > 0);
 
-  if (!aliasChain && reverseCount === 0 && !isVarying && !outOfGamut) return null;
+  if (!aliasChain && reverseCount === 0 && !isVarying && !outOfGamut && !isDeprecated) return null;
 
   return (
     <span className="sb-token-navigator__indicators">
+      {isDeprecated && deprecated !== undefined && <DeprecatedBadge deprecated={deprecated} />}
       {aliasChain && (
         <ForwardChain
           chain={aliasChain}

--- a/packages/blocks/src/token-navigator/RowIndicators.tsx
+++ b/packages/blocks/src/token-navigator/RowIndicators.tsx
@@ -1,6 +1,7 @@
 import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
 import type { ReactElement } from 'react';
 import type { ColorFormat } from '#/format-color.ts';
+import { formatColor } from '#/format-color.ts';
 import type { VirtualTokenShape } from '#/contexts.ts';
 
 export interface RowIndicatorsProps {
@@ -140,14 +141,16 @@ function ReverseCount({ count }: ReverseCountProps): ReactElement {
 
 /** Per-row indicator strip: alias references, variance, gamut, deprecation. */
 export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
-  const { token, root, variance, resolveInView, onNavigate } = props;
+  const { token, root, variance, colorFormat, resolveInView, onNavigate } = props;
   const aliasChain =
     Array.isArray(token.aliasChain) && token.aliasChain.length > 0 ? token.aliasChain : undefined;
   const reverseCount =
     Array.isArray(token.aliasedBy) && token.aliasedBy.length > 0 ? token.aliasedBy.length : 0;
   const isVarying = variance !== undefined && variance.kind !== 'constant';
+  const outOfGamut =
+    token.$type === 'color' && (formatColor(token.$value, colorFormat)?.outOfGamut ?? false);
 
-  if (!aliasChain && reverseCount === 0 && !isVarying) return null;
+  if (!aliasChain && reverseCount === 0 && !isVarying && !outOfGamut) return null;
 
   return (
     <span className="sb-token-navigator__indicators">
@@ -161,6 +164,15 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
       )}
       {reverseCount > 0 && <ReverseCount count={reverseCount} />}
       {variance && <VarianceBadge variance={variance} />}
+      {outOfGamut && (
+        <span
+          className="sb-token-navigator__gamut"
+          title="Out of sRGB gamut for this format"
+          aria-label="out of gamut"
+        >
+          ⚠
+        </span>
+      )}
     </span>
   );
 }

--- a/packages/blocks/src/token-navigator/navigate.ts
+++ b/packages/blocks/src/token-navigator/navigate.ts
@@ -1,0 +1,42 @@
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+/**
+ * The group paths to expand so `path` becomes visible in the tree — the
+ * cumulative dotted prefixes of `path`, excluding `path` itself and any
+ * prefix at or above `root` (the navigator's implicit root container is not
+ * a group node). Matches `buildTree`'s full-dotted group-path scheme.
+ */
+export function ancestorGroupPaths(path: string, root: string | undefined): string[] {
+  const segments = path.split('.');
+  const out: string[] = [];
+  for (let i = 1; i < segments.length; i += 1) {
+    const prefix = segments.slice(0, i).join('.');
+    if (root && !prefix.startsWith(`${root}.`)) continue;
+    out.push(prefix);
+  }
+  return out;
+}
+
+/** Context a navigation target is tested against — the active structural filters. */
+export interface InViewContext {
+  resolved: Record<string, VirtualTokenShape>;
+  root?: string | undefined;
+  typeFilter?: ReadonlySet<string> | undefined;
+}
+
+/**
+ * Whether `path` survives the navigator's structural (`root` / `type`)
+ * filters and exists in the resolved map — i.e. it can be selected in the
+ * current tree. Transient search is NOT considered here: a target hidden
+ * only by an active query is still "in view" once the query is cleared,
+ * which the caller handles.
+ */
+export function isInView(path: string, ctx: InViewContext): boolean {
+  const token = ctx.resolved[path];
+  if (!token) return false;
+  if (ctx.root && !(path === ctx.root || path.startsWith(`${ctx.root}.`))) return false;
+  if (ctx.typeFilter && !(token.$type !== undefined && ctx.typeFilter.has(token.$type))) {
+    return false;
+  }
+  return true;
+}

--- a/packages/blocks/test/token-detail.browser.test.tsx
+++ b/packages/blocks/test/token-detail.browser.test.tsx
@@ -4,9 +4,15 @@ import { SwatchbookProvider, TokenDetail } from '#/index.ts';
 import type { ProjectSnapshot } from '#/index.ts';
 import { makeResolveAt } from './_snapshot-helpers.ts';
 
-function makeSnapshot(): ProjectSnapshot {
+function makeSnapshot(
+  extraTokens: Record<
+    string,
+    { $type: string; $value: unknown; $deprecated?: string | boolean }
+  > = {},
+): ProjectSnapshot {
   const tokens = {
     'color.brand.primary': { $type: 'color', $value: { hex: '#3b82f6' } },
+    ...extraTokens,
   };
   const snap: ProjectSnapshot = {
     axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
@@ -62,5 +68,23 @@ describe('TokenDetail', () => {
       ),
     ).not.toThrow();
     expect(screen.getByText(/not found in theme/)).toBeDefined();
+  });
+
+  it('renders a deprecation notice with the message', async () => {
+    render(
+      <SwatchbookProvider
+        value={makeSnapshot({
+          'color.old': {
+            $type: 'color',
+            $value: { hex: '#f00' },
+            $deprecated: 'use color.new instead',
+          },
+        })}
+      >
+        <TokenDetail path="color.old" />
+      </SwatchbookProvider>,
+    );
+    const notice = await screen.findByTestId('token-detail-deprecated');
+    expect(notice.textContent).toContain('use color.new instead');
   });
 });

--- a/packages/blocks/test/token-navigator-navigate.test.ts
+++ b/packages/blocks/test/token-navigator-navigate.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from 'vitest';
+import type { VirtualTokenShape } from '#/contexts.ts';
+import { ancestorGroupPaths, isInView } from '#/token-navigator/navigate.ts';
+
+const resolved: Record<string, VirtualTokenShape> = {
+  'color.palette.blue.500': { $type: 'color', $value: { hex: '#00f' } },
+  'space.md': { $type: 'dimension', $value: '8px' },
+};
+
+it('ancestorGroupPaths returns cumulative prefixes excluding the leaf, no root', () => {
+  expect(ancestorGroupPaths('color.palette.blue.500', undefined)).toEqual([
+    'color',
+    'color.palette',
+    'color.palette.blue',
+  ]);
+});
+
+it('ancestorGroupPaths drops prefixes at or above a set root', () => {
+  expect(ancestorGroupPaths('color.palette.blue.500', 'color')).toEqual([
+    'color.palette',
+    'color.palette.blue',
+  ]);
+});
+
+it('isInView honors root prefix', () => {
+  expect(isInView('color.palette.blue.500', { root: 'color', resolved })).toBe(true);
+  expect(isInView('space.md', { root: 'color', resolved })).toBe(false);
+});
+
+it('isInView honors the type filter', () => {
+  const typeFilter = new Set(['color']);
+  expect(isInView('color.palette.blue.500', { resolved, typeFilter })).toBe(true);
+  expect(isInView('space.md', { resolved, typeFilter })).toBe(false);
+});
+
+it('isInView is false for a path absent from resolved', () => {
+  expect(isInView('ghost.token', { resolved })).toBe(false);
+});

--- a/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@vitest/browser/context';
 import { afterEach, expect, it, vi } from 'vitest';
 import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
@@ -253,4 +253,87 @@ it('reverse count > 1 opens a popover whose items navigate', async () => {
   const item = await screen.findByRole('menuitem', { name: 'color.text.primary' });
   await userEvent.click(item);
   expect(onNavigate).toHaveBeenCalledWith('color.text.primary');
+});
+
+it('renders an off-view forward node as plain non-clickable text', async () => {
+  const onNavigate = vi.fn();
+  render(
+    <RowIndicators
+      path="t"
+      token={{ $type: 'color', $value: { hex: '#00f' }, aliasChain: ['color.hidden'] }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={() => false}
+      onNavigate={onNavigate}
+    />,
+  );
+  const node = screen.getByTestId('alias-node');
+  expect(node.tagName.toLowerCase()).not.toBe('button');
+  expect(node).toHaveAttribute('title', 'outside current view');
+  await userEvent.click(node);
+  expect(onNavigate).not.toHaveBeenCalled();
+});
+
+it('closes the reverse popover on Escape from within the menu', async () => {
+  render(
+    <RowIndicators
+      path="t"
+      token={{ $type: 'color', $value: { hex: '#00f' }, aliasedBy: ['color.a', 'color.b'] }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={() => true}
+      onNavigate={() => {}}
+    />,
+  );
+  await userEvent.click(screen.getByTestId('row-indicator-alias-reverse'));
+  const menuItem = await screen.findByRole('menuitem', { name: 'color.a' });
+  expect(menuItem).toBeTruthy();
+  await userEvent.keyboard('{Escape}');
+  await waitFor(() => {
+    expect(screen.queryByRole('menuitem', { name: 'color.a' })).toBeNull();
+  });
+});
+
+it('moves focus into the menu on open (first enabled item)', async () => {
+  render(
+    <RowIndicators
+      path="t"
+      token={{ $type: 'color', $value: { hex: '#00f' }, aliasedBy: ['color.a', 'color.b'] }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={() => true}
+      onNavigate={() => {}}
+    />,
+  );
+  await userEvent.click(screen.getByTestId('row-indicator-alias-reverse'));
+  const menuItem = await screen.findByRole('menuitem', { name: 'color.a' });
+  await waitFor(() => expect(document.activeElement).toBe(menuItem));
+});
+
+it('closes the reverse popover on outside pointerdown', async () => {
+  render(
+    <div>
+      <button type="button" data-testid="outside">
+        outside
+      </button>
+      <RowIndicators
+        path="t"
+        token={{ $type: 'color', $value: { hex: '#00f' }, aliasedBy: ['color.a', 'color.b'] }}
+        root={undefined}
+        variance={undefined}
+        colorFormat="hex"
+        resolveInView={() => true}
+        onNavigate={() => {}}
+      />
+    </div>,
+  );
+  await userEvent.click(screen.getByTestId('row-indicator-alias-reverse'));
+  await screen.findByRole('menuitem', { name: 'color.a' });
+  await userEvent.click(screen.getByTestId('outside'));
+  await waitFor(() => {
+    expect(screen.queryByRole('menuitem', { name: 'color.a' })).toBeNull();
+  });
 });

--- a/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen, within } from '@testing-library/react';
-import { afterEach, expect, it } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, expect, it, vi } from 'vitest';
 import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
 import type { VirtualTokenShape } from '#/contexts.ts';
 import { RowIndicators } from '#/token-navigator/RowIndicators.tsx';
@@ -212,4 +213,44 @@ it('shows no deprecation badge when not deprecated', () => {
     />,
   );
   expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
+});
+
+it('reverse count of 1 navigates directly on click', async () => {
+  const onNavigate = vi.fn();
+  render(
+    <RowIndicators
+      path="t"
+      token={{ $type: 'color', $value: { hex: '#00f' }, aliasedBy: ['color.brand'] }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={onNavigate}
+    />,
+  );
+  await userEvent.click(screen.getByTestId('row-indicator-alias-reverse'));
+  expect(onNavigate).toHaveBeenCalledWith('color.brand');
+});
+
+it('reverse count > 1 opens a popover whose items navigate', async () => {
+  const onNavigate = vi.fn();
+  render(
+    <RowIndicators
+      path="t"
+      token={{
+        $type: 'color',
+        $value: { hex: '#00f' },
+        aliasedBy: ['color.brand', 'color.text.primary'],
+      }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={onNavigate}
+    />,
+  );
+  await userEvent.click(screen.getByTestId('row-indicator-alias-reverse'));
+  const item = await screen.findByRole('menuitem', { name: 'color.text.primary' });
+  await userEvent.click(item);
+  expect(onNavigate).toHaveBeenCalledWith('color.text.primary');
 });

--- a/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
@@ -1,0 +1,53 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import type { VirtualTokenShape } from '#/contexts.ts';
+import { RowIndicators } from '#/token-navigator/RowIndicators.tsx';
+
+afterEach(cleanup);
+
+const noop = () => {};
+const inView = () => true;
+
+function renderRow(path: string, token: VirtualTokenShape, root?: string) {
+  return render(
+    <RowIndicators
+      path={path}
+      token={token}
+      root={root}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={noop}
+    />,
+  );
+}
+
+it('renders the full forward chain with relative labels and arrows', () => {
+  renderRow(
+    'color.text.primary',
+    {
+      $type: 'color',
+      $value: { hex: '#00f' },
+      aliasChain: ['color.brand', 'color.palette.blue.500'],
+    },
+    'color',
+  );
+  const chain = screen.getByTestId('row-indicator-alias-forward');
+  const nodes = within(chain).getAllByTestId('alias-node');
+  expect(nodes.map((n) => n.textContent)).toEqual(['brand', 'palette.blue.500']);
+  expect(chain.textContent).toContain('→');
+});
+
+it('caps chains longer than two hops to first … last with full chain in aria-label', () => {
+  renderRow('a', { $type: 'color', $value: { hex: '#00f' }, aliasChain: ['b', 'c', 'd'] });
+  const chain = screen.getByTestId('row-indicator-alias-forward');
+  const nodes = within(chain).getAllByTestId('alias-node');
+  expect(nodes.map((n) => n.textContent)).toEqual(['b', 'd']);
+  expect(chain.textContent).toContain('…');
+  expect(chain).toHaveAttribute('aria-label', expect.stringContaining('b → c → d'));
+});
+
+it('renders nothing forward for a primitive', () => {
+  renderRow('color.blue', { $type: 'color', $value: { hex: '#00f' } });
+  expect(screen.queryByTestId('row-indicator-alias-forward')).toBeNull();
+});

--- a/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
@@ -131,3 +131,36 @@ it('constant variance shows no badge', () => {
   });
   expect(screen.queryByTestId('row-indicator-variance')).toBeNull();
 });
+
+it('flags an out-of-gamut color for the active format', () => {
+  render(
+    <RowIndicators
+      path="c"
+      token={{
+        $type: 'color',
+        $value: { colorSpace: 'display-p3', components: [1, 0, 0], alpha: 1 },
+      }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={noop}
+    />,
+  );
+  expect(screen.getByLabelText('out of gamut')).toBeTruthy();
+});
+
+it('shows no gamut warning for an in-gamut color', () => {
+  render(
+    <RowIndicators
+      path="c"
+      token={{ $type: 'color', $value: { hex: '#00ff00' } }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={noop}
+    />,
+  );
+  expect(screen.queryByLabelText('out of gamut')).toBeNull();
+});

--- a/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
@@ -164,3 +164,52 @@ it('shows no gamut warning for an in-gamut color', () => {
   );
   expect(screen.queryByLabelText('out of gamut')).toBeNull();
 });
+
+it('shows a deprecation badge with the message in aria-label', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' }, $deprecated: 'use color.new' }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={noop}
+    />,
+  );
+  const badge = screen.getByTestId('row-indicator-deprecated');
+  expect(badge).toHaveAttribute('aria-label', expect.stringContaining('use color.new'));
+});
+
+it('shows a deprecation badge for the boolean flag form', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' }, $deprecated: true }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={noop}
+    />,
+  );
+  expect(screen.getByTestId('row-indicator-deprecated')).toHaveAttribute(
+    'aria-label',
+    'deprecated',
+  );
+});
+
+it('shows no deprecation badge when not deprecated', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' } }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={noop}
+    />,
+  );
+  expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
+});

--- a/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, render, screen, within } from '@testing-library/react';
 import { afterEach, expect, it } from 'vitest';
+import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
 import type { VirtualTokenShape } from '#/contexts.ts';
 import { RowIndicators } from '#/token-navigator/RowIndicators.tsx';
 
@@ -77,4 +78,56 @@ it('renders both indicators for a mid-chain token', () => {
 it('renders no reverse count when nothing references the token', () => {
   renderRow('color.blue', { $type: 'color', $value: { hex: '#00f' } });
   expect(screen.queryByTestId('row-indicator-alias-reverse')).toBeNull();
+});
+
+function renderVariance(variance: AxisVarianceResult) {
+  return render(
+    <RowIndicators
+      path="t"
+      token={{ $type: 'color', $value: { hex: '#00f' } }}
+      root={undefined}
+      variance={variance}
+      colorFormat="hex"
+      resolveInView={inView}
+      onNavigate={noop}
+    />,
+  );
+}
+
+it('single-axis variance shows the axis name', () => {
+  renderVariance({
+    path: 't',
+    kind: 'single',
+    axis: 'mode',
+    varyingAxes: ['mode'],
+    constantAcrossAxes: [],
+    perAxis: {},
+  });
+  const badge = screen.getByTestId('row-indicator-variance');
+  expect(badge.textContent).toContain('mode');
+});
+
+it('multi-axis variance shows the count with axes in aria-label', () => {
+  renderVariance({
+    path: 't',
+    kind: 'multi',
+    varyingAxes: ['mode', 'contrast'],
+    constantAcrossAxes: [],
+    perAxis: {},
+  });
+  const badge = screen.getByTestId('row-indicator-variance');
+  expect(badge.textContent).toContain('2');
+  expect(badge).toHaveAttribute('aria-label', expect.stringContaining('mode'));
+  expect(badge).toHaveAttribute('aria-label', expect.stringContaining('contrast'));
+});
+
+it('constant variance shows no badge', () => {
+  renderVariance({
+    path: 't',
+    kind: 'constant',
+    varyingAxes: [],
+    constantAcrossAxes: ['mode'],
+    perAxis: {},
+  });
+  expect(screen.queryByTestId('row-indicator-variance')).toBeNull();
 });

--- a/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-indicators.browser.test.tsx
@@ -51,3 +51,30 @@ it('renders nothing forward for a primitive', () => {
   renderRow('color.blue', { $type: 'color', $value: { hex: '#00f' } });
   expect(screen.queryByTestId('row-indicator-alias-forward')).toBeNull();
 });
+
+it('renders a reverse count from aliasedBy length', () => {
+  renderRow('color.blue.500', {
+    $type: 'color',
+    $value: { hex: '#00f' },
+    aliasedBy: ['color.brand', 'color.text.primary'],
+  });
+  const rev = screen.getByTestId('row-indicator-alias-reverse');
+  expect(rev.textContent).toContain('2');
+  expect(rev).toHaveAttribute('aria-label', expect.stringContaining('referenced by 2'));
+});
+
+it('renders both indicators for a mid-chain token', () => {
+  renderRow('color.brand', {
+    $type: 'color',
+    $value: { hex: '#00f' },
+    aliasChain: ['color.blue.500'],
+    aliasedBy: ['color.text.primary'],
+  });
+  expect(screen.getByTestId('row-indicator-alias-forward')).toBeTruthy();
+  expect(screen.getByTestId('row-indicator-alias-reverse')).toBeTruthy();
+});
+
+it('renders no reverse count when nothing references the token', () => {
+  renderRow('color.blue', { $type: 'color', $value: { hex: '#00f' } });
+  expect(screen.queryByTestId('row-indicator-alias-reverse')).toBeNull();
+});

--- a/packages/blocks/test/token-navigator-row-navigation.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-row-navigation.browser.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Integration tests for RowIndicators mounted inside LeafRow.
+ *
+ * Covers two concerns:
+ * 1. Clicking a forward chain node navigates the tree — expands ancestor
+ *    groups and reveals the target leaf. The fixture nests the target two
+ *    levels deep under a prefix the alias chain points to, so it starts
+ *    collapsed and the navigation genuinely has work to do.
+ * 2. A deprecated token's leaf-row div carries `data-deprecated="true"`.
+ */
+import { cleanup, render, screen, waitFor, within } from '@testing-library/react';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, expect, it } from 'vitest';
+import { SwatchbookProvider, TokenNavigator } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+// `color.text.primary` aliases `color.palette.blue.500`. With no `root` set,
+// both live in the tree; `color.palette.blue.500` sits a level below the
+// initial expanded depth, so it starts collapsed and the forward-chain click
+// has genuine expand work to do.
+const TOKENS: Record<string, VirtualTokenShape> = {
+  'color.text.primary': {
+    $type: 'color',
+    $value: { hex: '#0000ff' },
+    aliasChain: ['color.palette.blue.500'],
+  },
+  'color.palette.blue.500': {
+    $type: 'color',
+    $value: { hex: '#0000ff' },
+    aliasedBy: ['color.text.primary'],
+  },
+};
+
+function snapshot(): ProjectSnapshot {
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = () => TOKENS;
+  return snap;
+}
+
+afterEach(cleanup);
+
+it('clicking a forward chain node navigates the tree to that token', async () => {
+  // No `root` restriction so both tokens appear. `initiallyExpanded={2}`
+  // expands `color` and its child groups (`text`, `palette`) but NOT the
+  // level-3 `color.palette.blue` group — so `color.palette.blue.500` starts
+  // hidden while `color.text.primary` (and its forward-chain indicator) is
+  // visible. Clicking the forward node must expand the ancestors and reveal it.
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <TokenNavigator searchable={false} initiallyExpanded={2} />
+    </SwatchbookProvider>,
+  );
+
+  // Wait for the forward-chain indicator on color.text.primary to appear.
+  const forward = await screen.findByTestId('row-indicator-alias-forward');
+  const node = within(forward).getAllByTestId('alias-node')[0] as HTMLElement;
+
+  // The alias-node should be a clickable button (resolveInView returns true
+  // because color.palette.blue.500 is present in resolved with no type filter).
+  expect(node.tagName.toLowerCase()).toBe('button');
+
+  // Target starts hidden — its `color.palette.blue` ancestor is collapsed.
+  // This is what makes the click below a genuine expand-and-reveal, not a no-op.
+  expect(
+    screen
+      .queryAllByTestId('token-navigator-leaf')
+      .find((el) => el.getAttribute('data-path') === 'color.palette.blue.500'),
+  ).toBeUndefined();
+
+  await userEvent.click(node);
+
+  // After navigation the target leaf must be present in the tree.
+  await waitFor(() => {
+    const leaves = screen.getAllByTestId('token-navigator-leaf');
+    const target = leaves.find((el) => el.getAttribute('data-path') === 'color.palette.blue.500');
+    expect(target).toBeTruthy();
+  });
+});
+
+it('applies a strikethrough flag to a deprecated row', async () => {
+  const deprecated: Record<string, VirtualTokenShape> = {
+    'color.old': { $type: 'color', $value: { hex: '#f00' }, $deprecated: 'use color.new' },
+  };
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = () => deprecated;
+  render(
+    <SwatchbookProvider value={snap}>
+      <TokenNavigator searchable={false} />
+    </SwatchbookProvider>,
+  );
+  const row = await screen.findByTestId('token-navigator-leaf-row');
+  expect(row.getAttribute('data-deprecated')).toBe('true');
+});

--- a/packages/blocks/test/token-navigator-varying-alias.browser.test.tsx
+++ b/packages/blocks/test/token-navigator-varying-alias.browser.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Regression: a varying alias must show its per-tuple forward chain.
+ *
+ * `surface` aliases `palette.light` in Light and `palette.dark` in Dark.
+ * In the Dark theme, `surface`'s row indicator must name `palette.dark`,
+ * not `palette.light`. This test is graph-backed (no `resolveAt` on the
+ * snapshot) so it exercises the `resolveAllWithProvenanceAt` path in
+ * `use-project`.
+ */
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { SwatchbookProvider, TokenNavigator } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import type { VirtualTokenGraph } from '#/contexts.ts';
+
+function graph(): VirtualTokenGraph {
+  return {
+    axes: ['mode'],
+    axisDefaults: { mode: 'Light' },
+    axisContexts: { mode: ['Light', 'Dark'] },
+    nodes: {
+      'palette.light': {
+        baselineValue: { $value: { hex: '#ffffff' }, $type: 'color' },
+        baselineKind: 'literal',
+        writes: {},
+        affectedBy: [],
+        aliases: [],
+        aliasedBy: ['surface'],
+      },
+      'palette.dark': {
+        baselineValue: { $value: { hex: '#000000' }, $type: 'color' },
+        baselineKind: 'literal',
+        writes: {},
+        affectedBy: [],
+        aliases: [],
+        aliasedBy: ['surface'],
+      },
+      surface: {
+        baselineValue: { $value: { hex: '#ffffff' }, $type: 'color' },
+        baselineKind: 'alias',
+        baselineAliasTarget: 'palette.light',
+        writes: { mode: { Dark: { kind: 'alias', target: 'palette.dark' } } },
+        affectedBy: ['mode'],
+        aliases: ['palette.light'],
+        aliasedBy: [],
+      },
+    },
+  };
+}
+
+function darkSnapshot(): ProjectSnapshot {
+  return {
+    axes: [{ name: 'mode', contexts: ['Light', 'Dark'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { mode: 'Light' },
+    activeTheme: 'Dark',
+    activeAxes: { mode: 'Dark' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+    tokenGraph: graph(),
+  };
+}
+
+afterEach(cleanup);
+
+it('a varying alias shows its per-tuple forward chain in the dark theme', async () => {
+  render(
+    <SwatchbookProvider value={darkSnapshot()}>
+      <TokenNavigator searchable={false} />
+    </SwatchbookProvider>,
+  );
+  const leaves = await screen.findAllByTestId('token-navigator-leaf');
+  const surfaceLeaf = leaves.find((el) => el.getAttribute('data-path') === 'surface')!;
+  const forward = within(surfaceLeaf).getByTestId('row-indicator-alias-forward');
+  expect(forward).toHaveAttribute('aria-label', expect.stringContaining('palette.dark'));
+});

--- a/packages/blocks/test/virtual-token-deprecated.test.ts
+++ b/packages/blocks/test/virtual-token-deprecated.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest';
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+// Type-level contract: VirtualTokenShape must accept $deprecated so blocks
+// can read it off resolved tokens. A runtime assertion keeps the test real.
+it('VirtualTokenShape accepts $deprecated as string | boolean', () => {
+  const withMessage: VirtualTokenShape = {
+    $type: 'color',
+    $value: { hex: '#000' },
+    $deprecated: 'use color.new',
+  };
+  const withFlag: VirtualTokenShape = {
+    $type: 'color',
+    $value: { hex: '#000' },
+    $deprecated: true,
+  };
+  expect(withMessage.$deprecated).toBe('use color.new');
+  expect(withFlag.$deprecated).toBe(true);
+});

--- a/packages/core/src/token-graph/build.ts
+++ b/packages/core/src/token-graph/build.ts
@@ -16,6 +16,7 @@ const SLIM_KEYS = [
   '$value',
   '$type',
   '$description',
+  '$deprecated',
   'aliasOf',
   'aliasChain',
   'partialAliasOf',

--- a/packages/core/src/token-graph/index.ts
+++ b/packages/core/src/token-graph/index.ts
@@ -1,5 +1,11 @@
 export type { TokenGraph, TokenGraphNode, WriteValue } from '#/token-graph/types.ts';
 
-export { resolveAt, resolveAllAt, resolveAliasAt, resolveAliasAllAt } from '#/token-graph/walk.ts';
+export {
+  resolveAt,
+  resolveAllAt,
+  resolveAliasAt,
+  resolveAliasAllAt,
+  aliasChainAt,
+} from '#/token-graph/walk.ts';
 
 export { getAffectedBy, getVariance, listPaths } from '#/token-graph/queries.ts';

--- a/packages/core/src/token-graph/index.ts
+++ b/packages/core/src/token-graph/index.ts
@@ -6,6 +6,7 @@ export {
   resolveAliasAt,
   resolveAliasAllAt,
   aliasChainAt,
+  resolveAllWithProvenanceAt,
 } from '#/token-graph/walk.ts';
 
 export { getAffectedBy, getVariance, listPaths } from '#/token-graph/queries.ts';

--- a/packages/core/src/token-graph/walk.ts
+++ b/packages/core/src/token-graph/walk.ts
@@ -214,6 +214,36 @@ export function resolveAliasAllAt(graph: TokenGraph, tuple: Record<string, strin
   return result;
 }
 
+/**
+ * Browser display resolver: every token's resolved leaf `$value` (same as
+ * `resolveAllAt`) plus correct, tuple-aware alias provenance — the full
+ * forward `aliasChain` / immediate `aliasOf` (from `aliasChainAt`) and the
+ * graph node's structural-union `aliasedBy` (project-scoped reverse edges,
+ * stable across tuples). This is the source of truth for alias indicators;
+ * `resolveAllAt` stays the pure-leaf resolver the CSS emitter and `load.ts`
+ * use. Aliases keep their OWN provenance even when their target varies by
+ * axis (the defect this fixes: `resolveAllAt` substitutes the target's).
+ */
+export function resolveAllWithProvenanceAt(
+  graph: TokenGraph,
+  tuple: Record<string, string>,
+): TokenMap {
+  const result: TokenMap = {};
+  for (const path of Object.keys(graph.nodes)) {
+    const view = resolveAliasAt(graph, path, tuple);
+    if (view === undefined) continue;
+    const chain = aliasChainAt(graph, path, tuple);
+    const aliasedBy = graph.nodes[path]?.aliasedBy ?? [];
+    const { aliasOf: _aliasOf, aliasChain: _aliasChain, ...rest } = view;
+    result[path] = {
+      ...rest,
+      ...(chain.length > 0 ? { aliasOf: chain[0], aliasChain: chain } : {}),
+      aliasedBy,
+    };
+  }
+  return result;
+}
+
 function composePartial(
   graph: TokenGraph,
   base: SwatchbookToken,

--- a/packages/core/src/token-graph/walk.ts
+++ b/packages/core/src/token-graph/walk.ts
@@ -179,6 +179,32 @@ export function resolveAliasAt(
   };
 }
 
+/**
+ * The full forward alias chain for `path` at `tuple` — the target paths it
+ * resolves through, hop by hop, to the final literal, e.g.
+ * `['color.brand', 'color.palette.blue.500']`. Each hop's immediate target is
+ * whatever `resolveAliasAt` resolves at this tuple (per-tuple alias write,
+ * else baseline alias), so the chain is correct in every axis context, not
+ * just the default. Empty for a literal. Visited-set bounds cycles.
+ */
+export function aliasChainAt(
+  graph: TokenGraph,
+  path: string,
+  tuple: Record<string, string>,
+): string[] {
+  const chain: string[] = [];
+  const visited = new Set<string>([path]);
+  let current = path;
+  for (;;) {
+    const target = resolveAliasAt(graph, current, tuple)?.aliasOf;
+    if (target === undefined || visited.has(target)) break;
+    chain.push(target);
+    visited.add(target);
+    current = target;
+  }
+  return chain;
+}
+
 export function resolveAliasAllAt(graph: TokenGraph, tuple: Record<string, string>): TokenMap {
   const result: TokenMap = {};
   for (const path of Object.keys(graph.nodes)) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,10 +9,10 @@ import type { TokenGraph } from '#/token-graph/types.ts';
 /**
  * Swatchbook's public token shape — the contract surfaced on
  * `Project.defaultTokens` and `Project.resolveAt()` output. A strict
- * subset of `@terrazzo/parser`'s `TokenNormalized`: the seven fields
+ * subset of `@terrazzo/parser`'s `TokenNormalized`: the fields
  * downstream blocks actually read, no internals (`id`, `source`,
- * `originalValue`, `group`, `dependencies`, `$extensions`, `$extends`,
- * `$deprecated`) leaked through.
+ * `originalValue`, `group`, `dependencies`, `$extensions`, `$extends`)
+ * leaked through.
  *
  * Insulates swatchbook consumers from Terrazzo type churn: a future
  * `TokenNormalized` field rename or restructure won't ripple into the
@@ -24,6 +24,14 @@ export interface SwatchbookToken {
   $type?: string | undefined;
   $value?: unknown;
   $description?: string | undefined;
+  /**
+   * DTCG `$deprecated`, already group-inheritance-normalized per token by
+   * the parser. `true` (deprecated, no message) or a string (deprecated,
+   * with a message that typically points at the replacement). Surfaced as
+   * a row indicator + strikethrough in TokenNavigator and a notice in
+   * TokenDetail.
+   */
+  $deprecated?: string | boolean | undefined;
   aliasOf?: string | undefined;
   aliasChain?: readonly string[] | undefined;
   aliasedBy?: readonly string[] | undefined;

--- a/packages/core/test/__snapshots__/css-axis-projected.css
+++ b/packages/core/test/__snapshots__/css-axis-projected.css
@@ -56,6 +56,7 @@
   --sb-color-text-danger: var(--sb-color-palette-red-700);
   --sb-color-text-default: var(--sb-color-palette-neutral-900);
   --sb-color-text-inverse: var(--sb-color-palette-neutral-0);
+  --sb-color-text-link: var(--sb-color-palette-blue-700);
   --sb-color-text-muted: var(--sb-color-palette-neutral-600);
   --sb-color-text-subtle: var(--sb-color-palette-neutral-500);
   --sb-color-text-success: var(--sb-color-palette-green-700);

--- a/packages/core/test/token-graph-deprecated.test.ts
+++ b/packages/core/test/token-graph-deprecated.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from 'vitest';
+import { buildTokenGraphFromLayered } from '#/token-graph/build.ts';
+import { resolveAllAt } from '#/token-graph/walk.ts';
+import type { TokenMap } from '#/types.ts';
+
+// A constant (axis-free) token carrying $deprecated must keep the field on
+// its graph baseline AND on the browser-side resolved value. $deprecated is
+// gated by SLIM_KEYS in the graph builder — without the allowlist entry it
+// is stripped at build time and never reaches blocks.
+function fixture(): TokenMap {
+  return {
+    'color.old': {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [1, 0, 0], alpha: 1 },
+      $deprecated: 'use color.new instead',
+    },
+    'color.live': {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0, 1, 0], alpha: 1 },
+    },
+    'flag.gone': {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0, 0, 1], alpha: 1 },
+      $deprecated: true,
+    },
+  };
+}
+
+it('keeps $deprecated on the graph baseline and resolved output', () => {
+  const { graph } = buildTokenGraphFromLayered([], fixture(), {}, {});
+
+  expect(graph.nodes['color.old']?.baselineValue.$deprecated).toBe('use color.new instead');
+  expect(graph.nodes['flag.gone']?.baselineValue.$deprecated).toBe(true);
+  expect(graph.nodes['color.live']?.baselineValue.$deprecated).toBeUndefined();
+
+  const resolved = resolveAllAt(graph, {});
+  expect(resolved['color.old']?.$deprecated).toBe('use color.new instead');
+  expect(resolved['flag.gone']?.$deprecated).toBe(true);
+  expect(resolved['color.live']?.$deprecated).toBeUndefined();
+});

--- a/packages/core/test/token-graph/alias-chain-at.test.ts
+++ b/packages/core/test/token-graph/alias-chain-at.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from 'vitest';
+import type { TokenGraph } from '#/token-graph/types.ts';
+import { aliasChainAt } from '#/token-graph/walk.ts';
+
+function graph(): TokenGraph {
+  return {
+    axes: ['mode'],
+    axisDefaults: { mode: 'Light' },
+    axisContexts: { mode: ['Light', 'Dark'] },
+    nodes: {
+      'palette.0': { baselineValue: { $value: '#fff', $type: 'color' }, baselineKind: 'literal', writes: {}, affectedBy: [], aliases: [], aliasedBy: ['surface'] },
+      'palette.9': { baselineValue: { $value: '#000', $type: 'color' }, baselineKind: 'literal', writes: {}, affectedBy: [], aliases: [], aliasedBy: ['surface'] },
+      'blue.5': { baselineValue: { $value: '#00f', $type: 'color' }, baselineKind: 'literal', writes: {}, affectedBy: [], aliases: [], aliasedBy: ['brand'] },
+      surface: {
+        baselineValue: { $value: '#fff', $type: 'color', aliasOf: 'palette.0', aliasChain: ['palette.0'] },
+        baselineKind: 'alias',
+        baselineAliasTarget: 'palette.0',
+        writes: { mode: { Dark: { kind: 'alias', target: 'palette.9' } } },
+        affectedBy: ['mode'],
+        aliases: ['palette.0'],
+        aliasedBy: [],
+      },
+      brand: {
+        baselineValue: { $value: '#00f', $type: 'color', aliasOf: 'blue.5', aliasChain: ['blue.5'] },
+        baselineKind: 'alias',
+        baselineAliasTarget: 'blue.5',
+        writes: {},
+        affectedBy: [],
+        aliases: ['blue.5'],
+        aliasedBy: ['text'],
+      },
+      text: {
+        baselineValue: { $value: '#00f', $type: 'color', aliasOf: 'brand', aliasChain: ['brand', 'blue.5'] },
+        baselineKind: 'alias',
+        baselineAliasTarget: 'brand',
+        writes: {},
+        affectedBy: [],
+        aliases: ['brand'],
+        aliasedBy: [],
+      },
+    },
+  };
+}
+
+it('varying alias: chain points at the per-tuple target', () => {
+  expect(aliasChainAt(graph(), 'surface', { mode: 'Light' })).toEqual(['palette.0']);
+  expect(aliasChainAt(graph(), 'surface', { mode: 'Dark' })).toEqual(['palette.9']);
+});
+
+it('constant alias: full multi-hop chain to the leaf', () => {
+  expect(aliasChainAt(graph(), 'text', { mode: 'Light' })).toEqual(['brand', 'blue.5']);
+});
+
+it('literal: empty chain', () => {
+  expect(aliasChainAt(graph(), 'palette.0', { mode: 'Light' })).toEqual([]);
+});
+
+it('cycle-safe: stops on a repeated target', () => {
+  const g = graph();
+  g.nodes['blue.5'] = { ...g.nodes['blue.5']!, baselineKind: 'alias', baselineAliasTarget: 'brand', aliases: ['brand'] };
+  const chain = aliasChainAt(g, 'brand', { mode: 'Light' });
+  expect(chain.length).toBeLessThan(10);
+  expect(new Set(chain).size).toBe(chain.length);
+});

--- a/packages/core/test/token-graph/resolve-provenance.test.ts
+++ b/packages/core/test/token-graph/resolve-provenance.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import type { TokenGraph } from '#/token-graph/types.ts';
+import { resolveAllAt, resolveAllWithProvenanceAt } from '#/token-graph/walk.ts';
+
+function graph(): TokenGraph {
+  return {
+    axes: ['mode'],
+    axisDefaults: { mode: 'Light' },
+    axisContexts: { mode: ['Light', 'Dark'] },
+    nodes: {
+      'palette.0': { baselineValue: { $value: '#fff', $type: 'color' }, baselineKind: 'literal', writes: {}, affectedBy: [], aliases: [], aliasedBy: ['surface'] },
+      'palette.9': { baselineValue: { $value: '#000', $type: 'color' }, baselineKind: 'literal', writes: {}, affectedBy: [], aliases: [], aliasedBy: ['surface'] },
+      surface: {
+        baselineValue: { $value: '#fff', $type: 'color', aliasOf: 'palette.0', aliasChain: ['palette.0'], aliasedBy: ['legacy.global'] },
+        baselineKind: 'alias',
+        baselineAliasTarget: 'palette.0',
+        writes: { mode: { Dark: { kind: 'alias', target: 'palette.9' } } },
+        affectedBy: ['mode'],
+        aliases: ['palette.0'],
+        aliasedBy: ['button.bg'],
+      },
+    },
+  };
+}
+
+describe('resolveAllWithProvenanceAt', () => {
+  it("varying alias in the non-default tuple keeps its own forward chain (not the target's)", () => {
+    const dark = resolveAllWithProvenanceAt(graph(), { mode: 'Dark' });
+    expect(dark['surface']?.aliasChain).toEqual(['palette.9']);
+    expect(dark['surface']?.aliasOf).toBe('palette.9');
+  });
+
+  it('$value matches resolveAllAt (the leaf), unchanged', () => {
+    const dark = resolveAllWithProvenanceAt(graph(), { mode: 'Dark' });
+    const leaf = resolveAllAt(graph(), { mode: 'Dark' });
+    expect(dark['surface']?.$value).toEqual(leaf['surface']?.$value);
+  });
+
+  it('aliasedBy is the graph node structural union, not the parser-global baseline field', () => {
+    const dark = resolveAllWithProvenanceAt(graph(), { mode: 'Dark' });
+    expect(dark['surface']?.aliasedBy).toEqual(['button.bg']);
+    expect(dark['palette.9']?.aliasedBy).toEqual(['surface']);
+  });
+
+  it('literal has no forward chain', () => {
+    const dark = resolveAllWithProvenanceAt(graph(), { mode: 'Dark' });
+    expect(dark['palette.9']?.aliasChain ?? []).toEqual([]);
+    expect(dark['palette.9']?.aliasOf).toBeUndefined();
+  });
+});

--- a/packages/tokens/tokens/color.json
+++ b/packages/tokens/tokens/color.json
@@ -349,7 +349,8 @@
       "inverse":   { "$value": "{color.palette.neutral.0}" },
       "accent":    { "$value": "{color.palette.blue.700}" },
       "danger":    { "$value": "{color.palette.red.700}" },
-      "success":   { "$value": "{color.palette.green.700}" }
+      "success":   { "$value": "{color.palette.green.700}" },
+      "link":      { "$value": "{color.palette.blue.700}", "$deprecated": "Use color.text.accent instead." }
     },
     "border": {
       "default":   { "$value": "{color.palette.neutral.200}" },


### PR DESCRIPTION
## Summary

Adds a per-row indicator strip to the TokenNavigator block: alias references (forward chain + reverse count, both click-to-navigate), an axis-variance badge, an out-of-gamut glyph, and a deprecation badge with row strikethrough. Sits between the type pill and the value preview. Surfaced in TokenDetail too, and includes a core correctness fix so alias provenance survives axis-varying resolution.

## Full description

**Indicators** (`packages/blocks/src/token-navigator/RowIndicators.tsx`), each rendered only when its data is present:
- **Alias forward chain** `→ a → b` with relative-to-root labels, a >2-hop cap (`→ first → … → last`, full chain in `aria-label`), and off-view targets as plain text.
- **Reverse count** `← N`: navigates directly for one referrer, opens a keyboard-operable `role=menu` popover (Escape / outside-click dismiss, focus into the menu) for several.
- **Axis variance** badge (single axis named, multi shown as a count with axes in the label).
- **Out-of-gamut** glyph, reusing the existing convention, color rows only.
- **Deprecation** badge + row strikethrough, driven by DTCG `$deprecated` plumbed core → token graph (`SLIM_KEYS`) → blocks; also surfaced as a notice in TokenDetail.

**Correctness fix** (core): a theme-varying alias previously lost its forward chain and showed a misattributed reverse count in non-default contexts, because the resolved map read alias structure off a leaf-resolved value. New `aliasChainAt` + `resolveAllWithProvenanceAt` make the browser resolved map carry tuple-correct `aliasChain`/`aliasOf` and structural-union `aliasedBy`. `resolveAllAt` is untouched, so the CSS emit path is unchanged.

Navigation is built on the navigator's existing expand/select/scroll state. No public component API changes.

Tested: core unit tests for the new resolvers; browser-mode (real Chromium + Firefox) tests for every indicator, navigation, the popover, and a graph-backed regression for the varying-alias case; a Storybook `Indicators` story with an interaction test. Full monorepo gauntlet green.

Milestone: Block value display + chrome consistency

Plan impact: none (design/plan are local-only).

Closes #1235