### PR TITLE
fix: preserve alias provenance in the addon and core resolver consumers

### DIFF
--- a/.changeset/addon-resolver-provenance.md
+++ b/.changeset/addon-resolver-provenance.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-addon": patch
+---
+
+The addon's preview decorator and useToken resolver now preserve alias provenance, so an axis-varying alias keeps its own chain, reverse references, description, and deprecation in the real Storybook; previously the addon's raw resolver shadowed use-project's provenance resolver, silently undoing that fix outside of tests

--- a/.changeset/core-resolveat-provenance.md
+++ b/.changeset/core-resolveat-provenance.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+`project.resolveAt` now preserves alias provenance, so an axis-varying alias keeps its own chain, target, and description at non-default tuples; the MCP's per-theme token introspection was returning the resolved leaf target's metadata instead of the alias's own

--- a/packages/addon/src/hooks/use-token.ts
+++ b/packages/addon/src/hooks/use-token.ts
@@ -3,7 +3,7 @@ import {
   defaultTuple as virtualDefaultTuple,
   tokenGraph as virtualTokenGraph,
 } from 'virtual:swatchbook/tokens';
-import { resolveAllAt } from '@unpunnyfuns/swatchbook-core/graph';
+import { resolveAllWithProvenanceAt } from '@unpunnyfuns/swatchbook-core/graph';
 import { makeCssVar } from '@unpunnyfuns/swatchbook-core/css-var';
 import {
   useActiveAxes,
@@ -16,7 +16,8 @@ import {
 // preview decorator does for its `previewResolveAt` but lives in this
 // file so the hook can be called outside the addon's preview wrapper
 // (autodocs / MDX renders).
-const fallbackResolveAt = (tuple: Record<string, string>) => resolveAllAt(virtualTokenGraph, tuple);
+const fallbackResolveAt = (tuple: Record<string, string>) =>
+  resolveAllWithProvenanceAt(virtualTokenGraph, tuple);
 
 /**
  * Consumers augment this interface (via the addon's generated
@@ -55,7 +56,7 @@ export interface TokenInfo {
  * Storybook's preview-only hooks. Reads from the addon-provided
  * `SwatchbookContext` when present (preferred — uses the lifted
  * `resolveAt` accessor and the live active tuple); falls back to the
- * module-scope `fallbackResolveAt` (`resolveAllAt(virtualTokenGraph,
+ * module-scope `fallbackResolveAt` (`resolveAllWithProvenanceAt(virtualTokenGraph,
  * tuple)`) over the virtual module's default tuple when no provider is
  * mounted.
  */

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -1,5 +1,5 @@
 /// <reference types="vite/client" />
-import { resolveAllAt } from '@unpunnyfuns/swatchbook-core/graph';
+import { resolveAllWithProvenanceAt } from '@unpunnyfuns/swatchbook-core/graph';
 import type { TokenMap } from '@unpunnyfuns/swatchbook-core';
 import type { Decorator, Preview } from '@storybook/react-vite';
 import type { CSSProperties } from 'react';
@@ -256,7 +256,7 @@ const themedDecorator: Decorator = (Story, context) => {
   const resolveAt = useMemo(
     () =>
       (t: Record<string, string>): TokenMap =>
-        resolveAllAt(live.tokenGraph, t),
+        resolveAllWithProvenanceAt(live.tokenGraph, t),
     [live.tokenGraph],
   );
   const snapshot = useMemo<ProjectSnapshot>(

--- a/packages/addon/test/use-token.browser.test.tsx
+++ b/packages/addon/test/use-token.browser.test.tsx
@@ -78,6 +78,19 @@ describe('useToken', () => {
     expect(result.current.description).toBeUndefined();
   });
 
+  it("returns an axis-varying alias's own $description, not the resolved target's", () => {
+    // In Dark, `color.surface` aliases `color.palette.ink` ('Palette ink'),
+    // but its own description is 'Semantic surface'. The raw leaf resolver
+    // returned the target's; the provenance resolver keeps the source's. This
+    // is the regression guard for the addon bypassing the provenance resolver.
+    const { result } = renderHook(() => useToken('color.surface'), {
+      wrapper: withPermutation('Dark', { mode: 'Dark' }),
+    });
+    expect(result.current.description).toBe('Semantic surface');
+    // Value is still the resolved leaf (palette.ink in Dark).
+    expect(result.current.value).toEqual({ colorSpace: 'srgb', components: [0, 0, 0] });
+  });
+
   it('tracks the live toolbar axis tuple over the channel in provider-less (MDX) renders', () => {
     // No provider/decorator context — the MDX / autodocs case. The active
     // tuple then comes only from the toolbar globals over the channel; the

--- a/packages/addon/test/virtual-stub.ts
+++ b/packages/addon/test/virtual-stub.ts
@@ -60,6 +60,53 @@ export const tokenGraph: TokenGraph = {
       aliasedBy: [],
       affectedBy: [],
     },
+    'color.palette.blue': {
+      baselineValue: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 1] },
+        $description: 'Palette blue',
+      },
+      baselineKind: 'literal',
+      writes: {},
+      aliases: [],
+      aliasedBy: ['color.surface'],
+      affectedBy: [],
+    },
+    'color.palette.ink': {
+      baselineValue: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 0] },
+        $description: 'Palette ink',
+      },
+      baselineKind: 'literal',
+      writes: {},
+      aliases: [],
+      aliasedBy: ['color.surface'],
+      affectedBy: [],
+    },
+    // Axis-varying alias: aliases palette.blue at baseline (Light), re-points
+    // to palette.ink in Dark. Carries its OWN $description; the raw leaf
+    // resolver would substitute the target's, the provenance resolver keeps
+    // the source's. Regression fixture for the addon provenance bypass.
+    'color.surface': {
+      baselineValue: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0, 1] },
+        $description: 'Semantic surface',
+        aliasOf: 'color.palette.blue',
+        aliasChain: ['color.palette.blue'],
+      },
+      baselineKind: 'alias',
+      baselineAliasTarget: 'color.palette.blue',
+      writes: {
+        mode: {
+          Dark: { kind: 'alias', target: 'color.palette.ink' },
+        },
+      },
+      aliases: ['color.palette.blue'],
+      aliasedBy: [],
+      affectedBy: ['mode'],
+    },
   },
   axes: ['mode'],
   axisDefaults: { mode: 'Light' },

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -103,11 +103,14 @@ export interface ProjectSnapshot {
   /** The default tuple — `{ axis: axis.default }` for every axis. */
   defaultTuple: Record<string, string>;
   /**
-   * Pre-built `resolveAt(tuple)` accessor. The addon's preview
-   * decorator instantiates this once per iframe lifetime, backed by
-   * `resolveAllAt` over the stable `tokenGraph` export. Hand-built
-   * snapshots (tests, MDX) can omit this; blocks fall back to
-   * building a graph-backed resolver from `tokenGraph`.
+   * Pre-built `resolveAt(tuple)` accessor. The addon's preview decorator
+   * instantiates this once per iframe lifetime. When present, use-project
+   * prefers it over building its own from `tokenGraph`, so it MUST preserve
+   * alias provenance — back it with `resolveAllWithProvenanceAt`, not the raw
+   * leaf `resolveAllAt`, or axis-varying aliases silently lose their chain /
+   * reverse refs / description at non-default tuples. Hand-built snapshots
+   * (tests, MDX) can omit this; blocks then fall back to a provenance-aware
+   * graph-backed resolver built from `tokenGraph`.
    */
   resolveAt?: (tuple: Record<string, string>) => Record<string, VirtualTokenShape>;
 }

--- a/packages/core/src/load.ts
+++ b/packages/core/src/load.ts
@@ -11,7 +11,7 @@ import { buildTokenGraph, buildTokenGraphFromLayered } from '#/token-graph/build
 import type { BuildTokenGraphResult } from '#/token-graph/build.ts';
 import { buildFailedDiagnostic } from '#/token-graph/diagnostics.ts';
 import { listPaths } from '#/token-graph/queries.ts';
-import { resolveAllAt } from '#/token-graph/walk.ts';
+import { resolveAllWithProvenanceAt } from '#/token-graph/walk.ts';
 import { permutationID } from '#/types.ts';
 import type { Axis, Config, Diagnostic, Permutation, Project, TokenMap } from '#/types.ts';
 
@@ -152,7 +152,7 @@ export async function loadProject(config: Config, cwd: string = process.cwd()): 
       const key = canonicalKey(full);
       const cached = memo.get(key);
       if (cached) return cached;
-      const result = resolveAllAt(tokenGraphResult.graph, full);
+      const result = resolveAllWithProvenanceAt(tokenGraphResult.graph, full);
       memo.set(key, result);
       return result;
     };

--- a/packages/mcp/test/token-introspection.test.ts
+++ b/packages/mcp/test/token-introspection.test.ts
@@ -55,13 +55,14 @@ it('get_token: returns the alias chain and resolved value per theme', async () =
   // cssVar uses the project prefix and dot→dash substitution.
   expect(result.cssVar).toBe(`var(--sb-${ALIAS_TOKEN.replaceAll('.', '-')})`);
   expect(Object.keys(result.perTheme).length).toBe(singletonCount(project));
-  // Every theme entry carries a non-empty value string + (when aliased)
-  // a target that points into the color subtree.
-  for (const entry of Object.values(result.perTheme)) {
+  // `color.surface.default` aliases the palette in EVERY theme (the target
+  // varies per mode: neutral.0 in Light, neutral.900 in Dark). The raw leaf
+  // resolver dropped alias provenance in non-default tuples, leaving aliasOf
+  // undefined for Dark; assert every theme keeps its palette target so a
+  // regression off the provenance resolver is caught.
+  for (const [name, entry] of Object.entries(result.perTheme)) {
     expect(entry.value.length).toBeGreaterThan(0);
-    if (entry.aliasOf) {
-      expect(entry.aliasOf).toMatch(/^color\./);
-    }
+    expect(entry.aliasOf, `${name} should keep its alias target`).toMatch(/^color\.palette\./);
   }
   // The alias target's value varies per mode (Light vs Dark): a
   // resolver bug that emitted the same string across modes would slip
@@ -76,6 +77,11 @@ it('get_token: returns the alias chain and resolved value per theme', async () =
   // the fixture's `color.accent.fg` alias chain flips under mode=Dark.
   const overlap = [...lightValues].filter((v) => darkValues.has(v));
   expect(overlap.length).toBeLessThan(lightValues.size + darkValues.size);
+  // Provenance is tuple-correct: the alias TARGET differs between Light and
+  // Dark, not just the resolved value (a leaf resolver loses this entirely).
+  const lightAlias = new Set(lightThemes.map(([, v]) => v.aliasOf));
+  const darkAlias = new Set(darkThemes.map(([, v]) => v.aliasOf));
+  expect([...lightAlias].some((a) => a !== undefined && !darkAlias.has(a))).toBe(true);
 });
 
 it('get_token: returns the cssVar without a prefix segment when cssVarPrefix is empty', async () => {


### PR DESCRIPTION
## Summary

An audit (the bug-class follow-up to the v0.63 alias-provenance work) found that fix never took effect in two shipped surfaces: the addon's own resolver was shadowing it in the real Storybook, and `project.resolveAt` (consumed by the MCP) never got it. Both are fixed here, each with a regression guard.

## Full description

The v0.63 fix routed blocks' `use-project` through `resolveAllWithProvenanceAt` so axis-varying aliases keep their own chain / reverse refs / description at non-default tuples. But:

- **Addon** (`preview.tsx`, `hooks/use-token.ts`): the preview decorator built `resolveAt` with raw `resolveAllAt` and set it on the snapshot. `use-project` prefers a provided `snapshot.resolveAt`, so blocks rendered in the real Storybook used the raw resolver — the provenance fix only ever ran in graph-backed tests. `useToken`'s `$description` (and its raw MDX fallback) had the same issue. Now both use `resolveAllWithProvenanceAt`.
- **Core** (`load.ts`): `project.resolveAt` was built with raw `resolveAllAt`. The MCP reads `aliasOf`/`aliasChain`/`$description` straight off `project.resolveAt(tuple)[path]`, so per-theme `get_token`/`get_alias_chain` returned the resolved leaf target's metadata for a varying alias in a non-default theme. Now provenance-aware (the default-tuple `defaultTokens` was already safe via the fast path; the emitter keeps the raw `resolveAllAt` it needs).

Only the resolution path changed — `$value` is identical; the alias metadata is now the source token's own.

**Regression guards:**
- `addon/test/use-token`: a varying alias whose target has a different `$description` — asserts `useToken` returns the source's, not the target's (fails on the raw resolver).
- `mcp/test/token-introspection`: strengthened the existing `get_token` test so every theme keeps its palette `aliasOf` and the target differs Light vs Dark (the lenient `if (aliasOf)` check had tolerated the bug).
- `ProjectSnapshot.resolveAt` now documents that a provided accessor must preserve provenance.

Full monorepo gauntlet green.

Milestone: Maintenance

Plan impact: none.

Closes #1241