### PR TITLE
feat(blocks): configurable row indicators + $description indicator

### DIFF
--- a/.changeset/configurable-indicators.md
+++ b/.changeset/configurable-indicators.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": minor
+---
+
+TokenNavigator and TokenTable accept an `indicators` prop to configure the per-row indicator strip: turn it off, drop individual indicators, or opt into a new `ⓘ` `$description` glyph

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -25,7 +25,7 @@ Most blocks in this group take:
 
 Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A fuzzy-search input at the top filters leaves by path: case-insensitive, out-of-order terms, single-character typo tolerance. Matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
-Between the type pill and the preview, a leaf carries an indicator strip when there is something to show: a forward alias chain (`→ target`, capped past two hops with the full chain on the accessible label), a reverse `← N` count of tokens that reference this one, an axis-variance badge when the resolved value flips across mode / brand / contrast, an out-of-gamut marker on colors outside sRGB for the active format, and a deprecation badge with a struck-through name for tokens carrying DTCG `$deprecated`. Alias references are navigable: clicking a chain node, or a single reverse referrer, moves the tree to that token; several referrers open a chooser. The chain reflects the active theme, so a token that aliases different palette entries per mode shows the path true in the current context.
+Between the type pill and the preview, a leaf carries an indicator strip when there is something to show: a forward alias chain (`→ target`, capped past two hops with the full chain on the accessible label), a reverse `← N` count of tokens that reference this one, an axis-variance badge when the resolved value flips across mode / brand / contrast, an out-of-gamut marker on colors outside sRGB for the active format, a deprecation badge with a struck-through name for tokens carrying DTCG `$deprecated`, and an opt-in `ⓘ` glyph carrying the token's `$description`. Alias references are navigable: clicking a chain node, or a single reverse referrer, moves the tree to that token; several referrers open a chooser. The chain reflects the active theme, so a token that aliases different palette entries per mode shows the path true in the current context.
 
 Props:
 
@@ -34,6 +34,7 @@ Props:
 - `initiallyExpanded?: number`: depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
 - `searchable?: boolean`: render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
 - `onSelect?(path: string): void`: receives a leaf's full dot-path on click; suppresses the built-in overlay.
+- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present.
 
 ### TokenTable
 
@@ -43,7 +44,7 @@ Props:
 
 Compact table: **Path**, an indicators column, and **Value** (with inline type pill + color swatch). A fuzzy-search input at the top narrows rows by path, type, or value: case-insensitive, out-of-order terms, single-character typo tolerance. Each value cell has a hover-revealed copy-to-clipboard button. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
 
-The middle column carries the same indicator strip as the navigator: the forward alias chain, a reverse `← N` count of tokens that reference the row, an axis-variance badge, an out-of-gamut marker, and a deprecation badge. A deprecated row's path is struck through. Alias references are navigable here too, but the table has no tree to expand: clicking a chain node or a reverse referent opens that token's detail overlay (a chooser when several tokens reference it). The column does not participate in sorting.
+The middle column carries the same indicator strip as the navigator: the forward alias chain, a reverse `← N` count of tokens that reference the row, an axis-variance badge, an out-of-gamut marker, a deprecation badge, and an opt-in `ⓘ` description glyph. A deprecated row's path is struck through. Alias references are navigable here too, but the table has no tree to expand: clicking a chain node or a reverse referent opens that token's detail overlay (a chooser when several tokens reference it). The column does not participate in sorting.
 
 Props:
 
@@ -54,6 +55,7 @@ Props:
 - `sortDir?: 'asc' | 'desc'`: default `'asc'`.
 - `searchable?: boolean`: render a runtime search input above the table. Defaults to `true`.
 - `onSelect?(path: string): void`: suppress the built-in drawer.
+- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present.
 
 ## Per-type
 

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -15,6 +15,8 @@ import { MotionSample } from '#/motion-preview/MotionSample.tsx';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 import { ancestorGroupPaths, isInView } from '#/token-navigator/navigate.ts';
 import { RowIndicators } from '#/indicators/RowIndicators.tsx';
+import { resolveIndicators } from '#/indicators/resolve.ts';
+import type { IndicatorName, IndicatorsProp } from '#/indicators/resolve.ts';
 import type { VirtualToken } from '#/types.ts';
 
 export interface TokenNavigatorProps {
@@ -56,6 +58,8 @@ export interface TokenNavigatorProps {
    * props otherwise.
    */
   id?: string;
+  /** Configure the per-row indicator strip. See `IndicatorsProp`. */
+  indicators?: IndicatorsProp;
 }
 
 interface LeafNode {
@@ -215,6 +219,7 @@ export function TokenNavigator({
   searchable = true,
   onSelect,
   id,
+  indicators,
 }: TokenNavigatorProps): ReactElement {
   const { resolved, activeTheme, activeAxes, cssVarPrefix } = useProject();
 
@@ -229,6 +234,8 @@ export function TokenNavigator({
     if (type === undefined) return undefined;
     return new Set(Array.isArray(type) ? type : [type]);
   }, [type]);
+
+  const enabledIndicators = useMemo(() => resolveIndicators(indicators), [indicators]);
 
   const tree = useMemo(() => buildTree(resolved, root, typeFilter), [resolved, root, typeFilter]);
 
@@ -568,6 +575,7 @@ export function TokenNavigator({
               root={root}
               resolveInView={resolveInView}
               onNavigate={navigateTo}
+              enabled={enabledIndicators}
               level={1}
               setsize={visibleTree.length}
               posinset={i + 1}
@@ -598,6 +606,7 @@ interface TreeNodeRowProps {
   root: string | undefined;
   resolveInView(path: string): boolean;
   onNavigate(path: string): void;
+  enabled: Record<IndicatorName, boolean>;
   // 1-indexed depth in the tree (top-level = 1).
   level: number;
   // Number of siblings at this level (including self).
@@ -617,6 +626,7 @@ function TreeNodeRow({
   root,
   resolveInView,
   onNavigate,
+  enabled,
   level,
   setsize,
   posinset,
@@ -632,6 +642,7 @@ function TreeNodeRow({
         root={root}
         resolveInView={resolveInView}
         onNavigate={onNavigate}
+        enabled={enabled}
         level={level}
         setsize={setsize}
         posinset={posinset}
@@ -689,6 +700,7 @@ function TreeNodeRow({
               root={root}
               resolveInView={resolveInView}
               onNavigate={onNavigate}
+              enabled={enabled}
               level={level + 1}
               setsize={node.children.length}
               posinset={i + 1}
@@ -709,6 +721,7 @@ interface LeafRowProps {
   root: string | undefined;
   resolveInView(path: string): boolean;
   onNavigate(path: string): void;
+  enabled: Record<IndicatorName, boolean>;
   // 1-indexed depth in the tree (top-level = 1).
   level: number;
   // Number of siblings at this level (including self).
@@ -726,6 +739,7 @@ const LeafRow = memo(function LeafRow({
   root,
   resolveInView,
   onNavigate,
+  enabled,
   level,
   setsize,
   posinset,
@@ -753,7 +767,7 @@ const LeafRow = memo(function LeafRow({
       <div
         className="sb-token-navigator__leaf-row"
         data-testid="token-navigator-leaf-row"
-        data-deprecated={isDeprecated ? 'true' : undefined}
+        data-deprecated={enabled.deprecation && isDeprecated ? 'true' : undefined}
         onClick={() => {
           onFocusPath(node.path);
           onLeafClick(node.path);
@@ -772,6 +786,7 @@ const LeafRow = memo(function LeafRow({
           colorFormat={colorFormat}
           canReference={resolveInView}
           onReferenceClick={onNavigate}
+          enabled={enabled}
         />
         <LeafPreview path={node.path} token={node.token} />
       </div>

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -13,6 +13,8 @@ import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
 import { RowIndicators } from '#/indicators/RowIndicators.tsx';
+import { resolveIndicators } from '#/indicators/resolve.ts';
+import type { IndicatorsProp } from '#/indicators/resolve.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface TokenTableProps {
@@ -54,6 +56,8 @@ export interface TokenTableProps {
   onSelect?(path: string): void;
   /** Disambiguates persisted UI state for two identical-prop tables on a page. */
   id?: string;
+  /** Configure the per-row indicator strip. See `IndicatorsProp`. */
+  indicators?: IndicatorsProp;
 }
 
 export function TokenTable({
@@ -65,12 +69,14 @@ export function TokenTable({
   searchable = true,
   onSelect,
   id,
+  indicators,
 }: TokenTableProps): ReactElement {
   const project = useProject();
   const { resolved, activeTheme, activeAxes, cssVarPrefix, listing, varianceByPath } = project;
   const colorFormat = useColorFormat();
   // Persist selection + search across docs-mode remounts (see persistent-state).
   const blockKey = useBlockKey('TokenTable', [filter, type, caption, id]);
+  const enabledIndicators = useMemo(() => resolveIndicators(indicators), [indicators]);
   const [selectedPath, setSelectedPath] = usePersistedState<string | null>(
     `${blockKey}::selected`,
     null,
@@ -195,7 +201,9 @@ export function TokenTable({
               >
                 <td
                   className={cx('sb-token-table__td', 'sb-token-table__path')}
-                  data-deprecated={isDeprecated ? 'true' : undefined}
+                  data-deprecated={
+                    enabledIndicators.deprecation && isDeprecated ? 'true' : undefined
+                  }
                 >
                   {row.path}
                 </td>
@@ -249,6 +257,7 @@ export function TokenTable({
                       colorFormat={colorFormat}
                       canReference={(p) => p in resolved}
                       onReferenceClick={(p) => setSelectedPath(p)}
+                      enabled={enabledIndicators}
                     />
                   )}
                 </td>

--- a/packages/blocks/src/indicators/RowIndicators.tsx
+++ b/packages/blocks/src/indicators/RowIndicators.tsx
@@ -4,6 +4,8 @@ import type { ReactElement } from 'react';
 import type { ColorFormat } from '#/format-color.ts';
 import { formatColor } from '#/format-color.ts';
 import type { VirtualTokenShape } from '#/contexts.ts';
+import { resolveIndicators } from '#/indicators/resolve.ts';
+import type { IndicatorName } from '#/indicators/resolve.ts';
 import './indicators.css';
 
 export interface RowIndicatorsProps {
@@ -19,6 +21,8 @@ export interface RowIndicatorsProps {
   canReference: (path: string) => boolean;
   /** Act on a referenced path — the host decides what that means: the navigator moves the tree, the table opens detail. */
   onReferenceClick: (path: string) => void;
+  /** Resolved enabled-map (from `resolveIndicators`). Defaults to the established four-on set. */
+  enabled?: Record<IndicatorName, boolean>;
 }
 
 // Strip the navigator's `root` prefix from a path for a compact chain label.
@@ -235,6 +239,8 @@ function ReverseCount({
 /** Per-row indicator strip: alias references, variance, gamut, deprecation. */
 export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
   const { token, root, variance, colorFormat, canReference, onReferenceClick } = props;
+  const en = props.enabled ?? resolveIndicators(undefined);
+
   const aliasChain =
     Array.isArray(token.aliasChain) && token.aliasChain.length > 0 ? token.aliasChain : undefined;
   const reverseCount =
@@ -245,13 +251,33 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
   const deprecated = token.$deprecated;
   const isDeprecated =
     deprecated === true || (typeof deprecated === 'string' && deprecated.length > 0);
+  const description =
+    typeof token.$description === 'string' && token.$description.length > 0
+      ? token.$description
+      : undefined;
 
-  if (!aliasChain && reverseCount === 0 && !isVarying && !outOfGamut && !isDeprecated) return null;
+  const showDeprecated = en.deprecation && isDeprecated;
+  const showForward = en.alias && aliasChain !== undefined;
+  const showReverse = en.alias && reverseCount > 0;
+  const showVariance = en.variance && isVarying;
+  const showGamut = en.gamut && outOfGamut;
+  const showDescription = en.description && description !== undefined;
+
+  if (
+    !showDeprecated &&
+    !showForward &&
+    !showReverse &&
+    !showVariance &&
+    !showGamut &&
+    !showDescription
+  ) {
+    return null;
+  }
 
   return (
     <span className="sb-indicator__indicators">
-      {isDeprecated && deprecated !== undefined && <DeprecatedBadge deprecated={deprecated} />}
-      {aliasChain && (
+      {showDeprecated && deprecated !== undefined && <DeprecatedBadge deprecated={deprecated} />}
+      {showForward && aliasChain && (
         <ForwardChain
           chain={aliasChain}
           root={root}
@@ -259,21 +285,31 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
           onReferenceClick={onReferenceClick}
         />
       )}
-      {reverseCount > 0 && token.aliasedBy && (
+      {showReverse && token.aliasedBy && (
         <ReverseCount
           referents={token.aliasedBy}
           canReference={canReference}
           onReferenceClick={onReferenceClick}
         />
       )}
-      {variance && <VarianceBadge variance={variance} />}
-      {outOfGamut && (
+      {showVariance && variance && <VarianceBadge variance={variance} />}
+      {showGamut && (
         <span
           className="sb-indicator__gamut"
           title="Out of sRGB gamut for this format"
           aria-label="out of gamut"
         >
           ⚠
+        </span>
+      )}
+      {showDescription && description !== undefined && (
+        <span
+          className="sb-indicator__description"
+          data-testid="row-indicator-description"
+          title={description}
+          aria-label={`description: ${description}`}
+        >
+          ⓘ
         </span>
       )}
     </span>

--- a/packages/blocks/src/indicators/indicators.css
+++ b/packages/blocks/src/indicators/indicators.css
@@ -111,3 +111,8 @@
   color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.6));
   cursor: default;
 }
+
+.sb-indicator__description {
+  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.8));
+  cursor: help;
+}

--- a/packages/blocks/src/indicators/resolve.ts
+++ b/packages/blocks/src/indicators/resolve.ts
@@ -1,0 +1,32 @@
+/** The individually-toggleable indicators in the row strip. `alias` covers the whole alias unit (forward chain + reverse count). */
+export type IndicatorName = 'alias' | 'variance' | 'gamut' | 'deprecation' | 'description';
+
+/**
+ * Consumer-facing indicator config for the strip-hosting blocks:
+ * - `true` — every indicator on (including the opt-in `description`)
+ * - `false` — every indicator off
+ * - object — per-key override layered over the defaults
+ * - omitted — the defaults
+ */
+export type IndicatorsProp = boolean | Partial<Record<IndicatorName, boolean>>;
+
+/** Established-on set; `description` is opt-in. */
+const DEFAULT_INDICATORS: Record<IndicatorName, boolean> = {
+  alias: true,
+  variance: true,
+  gamut: true,
+  deprecation: true,
+  description: false,
+};
+
+/** Normalize an `IndicatorsProp` into a full enabled-map by layering over the defaults. */
+export function resolveIndicators(prop?: IndicatorsProp): Record<IndicatorName, boolean> {
+  if (prop === undefined) return { ...DEFAULT_INDICATORS };
+  if (prop === true) {
+    return { alias: true, variance: true, gamut: true, deprecation: true, description: true };
+  }
+  if (prop === false) {
+    return { alias: false, variance: false, gamut: false, deprecation: false, description: false };
+  }
+  return { ...DEFAULT_INDICATORS, ...prop };
+}

--- a/packages/blocks/test/indicator-config.browser.test.tsx
+++ b/packages/blocks/test/indicator-config.browser.test.tsx
@@ -1,0 +1,58 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { SwatchbookProvider, TokenNavigator, TokenTable } from '#/index.ts';
+import type { ProjectSnapshot, VirtualTokenShape } from '#/index.ts';
+
+const TOKENS: Record<string, VirtualTokenShape> = {
+  'color.brand': {
+    $type: 'color',
+    $value: { hex: '#00f' },
+    $description: 'Brand',
+    $deprecated: 'old',
+  },
+};
+
+function snapshot(): ProjectSnapshot {
+  const snap: ProjectSnapshot = {
+    axes: [],
+    defaultTuple: {},
+    activeTheme: 'default',
+    activeAxes: {},
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = () => TOKENS;
+  return snap;
+}
+
+afterEach(cleanup);
+
+it('TokenNavigator indicators={false} renders no strip', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <TokenNavigator searchable={false} indicators={false} />
+    </SwatchbookProvider>,
+  );
+  expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
+});
+
+it('TokenTable indicators={{ description: true }} shows the description glyph', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <TokenTable type="color" indicators={{ description: true }} />
+    </SwatchbookProvider>,
+  );
+  expect(screen.getByTestId('row-indicator-description')).toBeTruthy();
+});
+
+it('TokenTable indicators={{ deprecation: false }} drops the badge and the path strikethrough', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <TokenTable type="color" indicators={{ deprecation: false }} />
+    </SwatchbookProvider>,
+  );
+  expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
+  const pathCell = screen.getByText('color.brand').closest('td')!;
+  expect(pathCell.getAttribute('data-deprecated')).toBeNull();
+});

--- a/packages/blocks/test/resolve-indicators.test.ts
+++ b/packages/blocks/test/resolve-indicators.test.ts
@@ -1,0 +1,47 @@
+import { expect, it } from 'vitest';
+import { resolveIndicators } from '#/indicators/resolve.ts';
+
+const DEFAULTS = {
+  alias: true,
+  variance: true,
+  gamut: true,
+  deprecation: true,
+  description: false,
+};
+
+it('undefined → the established defaults', () => {
+  expect(resolveIndicators(undefined)).toEqual(DEFAULTS);
+});
+
+it('false → every indicator off', () => {
+  expect(resolveIndicators(false)).toEqual({
+    alias: false,
+    variance: false,
+    gamut: false,
+    deprecation: false,
+    description: false,
+  });
+});
+
+it('true → every indicator on, including description', () => {
+  expect(resolveIndicators(true)).toEqual({
+    alias: true,
+    variance: true,
+    gamut: true,
+    deprecation: true,
+    description: true,
+  });
+});
+
+it('object → per-key override layered over defaults', () => {
+  expect(resolveIndicators({ description: true })).toEqual({ ...DEFAULTS, description: true });
+  expect(resolveIndicators({ variance: false })).toEqual({ ...DEFAULTS, variance: false });
+});
+
+it('partial object leaves unspecified keys at their default', () => {
+  expect(resolveIndicators({ alias: false, description: true })).toEqual({
+    ...DEFAULTS,
+    alias: false,
+    description: true,
+  });
+});

--- a/packages/blocks/test/row-indicators.browser.test.tsx
+++ b/packages/blocks/test/row-indicators.browser.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, expect, it, vi } from 'vitest';
 import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
 import type { VirtualTokenShape } from '#/contexts.ts';
 import { RowIndicators } from '#/indicators/RowIndicators.tsx';
+import { resolveIndicators } from '#/indicators/resolve.ts';
 
 afterEach(cleanup);
 
@@ -336,4 +337,85 @@ it('closes the reverse popover on outside pointerdown', async () => {
   await waitFor(() => {
     expect(screen.queryByRole('menuitem', { name: 'color.a' })).toBeNull();
   });
+});
+
+it('renders a description glyph when description is enabled and present', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' }, $description: 'Brand primary' }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      canReference={inView}
+      onReferenceClick={noop}
+      enabled={resolveIndicators({ description: true })}
+    />,
+  );
+  const badge = screen.getByTestId('row-indicator-description');
+  expect(badge).toHaveAttribute('aria-label', expect.stringContaining('Brand primary'));
+});
+
+it('omits the description glyph when description is not enabled (default)', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' }, $description: 'Brand primary' }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      canReference={inView}
+      onReferenceClick={noop}
+    />,
+  );
+  expect(screen.queryByTestId('row-indicator-description')).toBeNull();
+});
+
+it('omits the description glyph when enabled but the token has no description', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' } }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      canReference={inView}
+      onReferenceClick={noop}
+      enabled={resolveIndicators({ description: true })}
+    />,
+  );
+  expect(screen.queryByTestId('row-indicator-description')).toBeNull();
+});
+
+it('hides an indicator when disabled via enabled', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' }, $deprecated: 'old' }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      canReference={inView}
+      onReferenceClick={noop}
+      enabled={resolveIndicators({ deprecation: false })}
+    />,
+  );
+  expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
+});
+
+it('renders nothing when every present indicator is disabled', () => {
+  render(
+    <RowIndicators
+      path="d"
+      token={{ $type: 'color', $value: { hex: '#000' }, aliasChain: ['x'], $deprecated: true }}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      canReference={inView}
+      onReferenceClick={noop}
+      enabled={resolveIndicators(false)}
+    />,
+  );
+  expect(screen.queryByTestId('row-indicator-alias-forward')).toBeNull();
+  expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
 });


### PR DESCRIPTION
## Summary

Adds an `indicators` prop to TokenNavigator and TokenTable to configure the per-row indicator strip, plus a new opt-in `ⓘ` `$description` indicator. Blocks-only; default behavior is unchanged.

## Full description

```ts
type IndicatorName = 'alias' | 'variance' | 'gamut' | 'deprecation' | 'description';
indicators?: boolean | Partial<Record<IndicatorName, boolean>>;
```

A pure `resolveIndicators(prop)` normalizes the prop into a full enabled-map by layering over the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off):
- `false` → all off; `true` → all on (incl. `description`); object → per-key override; omitted → defaults.

`RowIndicators` takes the resolved `enabled` map and gates each branch on `enabled.<name> && <data guard>` — config controls *eligibility*, data-presence and type still gate *rendering*, so a config can never force an empty badge. `alias` is one key for the whole alias unit (forward chain + reverse count). The deprecation strikethrough on the name/path cell is gated too, so turning `deprecation` off also drops the line-through. The new `description` indicator is a `ⓘ` glyph carrying the token's `$description` in its label, rendered only when enabled and present.

The hosts accept `indicators?`, resolve once, and pass `enabled` down. No core or wire changes; ColorTable (#1244) will inherit the same prop when it lands.

**Backward compatible:** `resolveIndicators(undefined)` reproduces today's four-on set, so every existing rendered output and test is unchanged — the existing navigator/table/strip suites are the regression guard.

Tested: `resolveIndicators` unit tests; browser tests for the description indicator and per-key gating; host-block tests (`indicators={false}` hides the strip, `{ description: true }` shows the glyph, `{ deprecation: false }` drops badge + strikethrough). Full gauntlet + Storybook + docs build green. Docs: the `indicators` prop on both block reference entries.

Milestone: Block value display + chrome consistency

Plan impact: none.

Closes #1246