### PR TITLE
feat(blocks): render the indicator strip in ColorTable

### DIFF
--- a/.changeset/colortable-indicators.md
+++ b/.changeset/colortable-indicators.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": minor
+---
+
+ColorTable renders the shared per-row indicator strip (alias chain, reverse referents, axis-variance, deprecation, opt-in `$description`) in place of the old Alias column, strikes through deprecated names, and accepts the same `indicators` prop to configure it

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -75,7 +75,9 @@ Swatch grid grouped by dot-path prefix. `groupBy` is auto-derived from the filte
 <ColorTable filter="color.**" />
 ```
 
-Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and alias-target columns. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
+Tabular, color-only companion to `TokenTable`. One row per `$type: color` token with swatch, name, value (in the active color format from the toolbar toggle), CSS var, and an indicators column. Each value cell has a hover-revealed copy-to-clipboard button. Fuzzy search across path + value.
+
+The indicators column carries the same strip as `TokenTable` and the navigator: the forward alias chain (replacing the old standalone Alias column), a reverse `← N` referent count, an axis-variance badge, a deprecation badge, and an opt-in `ⓘ` description glyph. The out-of-gamut marker is the one exception: it stays in the Value cell beside the colour it qualifies, so it is not part of this strip. A deprecated row's name is struck through. Alias references are navigable: clicking a chain node or reverse referent opens that token's row.
 
 Clicking a row expands it inline: the detail panel surfaces `$description`, the token's alias chain, and (for grouped variants) a sub-table comparing every variant's HEX / HSL / OKLCH at once. That side-by-side comparison is the one place per-format density earns its weight; the collapsed row only shows the format the user already picked.
 
@@ -99,6 +101,7 @@ Props:
 - `searchable?: boolean`: render a fuzzy-search input above the table. Defaults to `true`.
 - `onSelect?(path: string): void`: replaces the expand-in-place default with a consumer-driven callback, invoked with the currently-selected variant's path.
 - `variants?: Record<string, string>`: label-to-suffix map for grouping. Accepts both DTCG dot-segment (`hi.disabled`) and Backmarket hyphen-tail (`hi-d`) conventions. Single-member groups render as plain rows; empty / omitted map disables grouping entirely.
+- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys. Gamut is not part of this strip — it renders in the Value cell — so toggling it here has no effect. Indicators still render only when their data is present.
 
 ### TypographyScale
 

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -191,19 +191,8 @@
   margin-left: 6px;
 }
 
-.sb-color-table__alias {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12px;
-  color: var(--swatchbook-text-muted, CanvasText);
+.sb-color-table__refs {
   white-space: nowrap;
-}
-
-.sb-color-table__alias-text {
-  font-style: italic;
-}
-
-.sb-color-table__alias-empty {
-  opacity: 0.4;
 }
 
 .sb-color-table__expand-cell {

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -320,3 +320,9 @@
   text-align: center;
   padding: 16px 12px;
 }
+
+.sb-color-table__path[data-deprecated='true'] .sb-color-table__path-text {
+  text-decoration: line-through;
+  text-decoration-color: light-dark(#92400e, #fbbf24);
+  opacity: 0.75;
+}

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,11 +1,16 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
+import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { memo, useCallback, useDeferredValue, useMemo } from 'react';
 import './ColorTable.css';
 import { useColorFormat } from '#/contexts.ts';
+import type { VirtualTokenShape } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import type { ColorFormat, NormalizedColor } from '#/format-color.ts';
+import { RowIndicators } from '#/indicators/RowIndicators.tsx';
+import { resolveIndicators } from '#/indicators/resolve.ts';
+import type { IndicatorName, IndicatorsProp } from '#/indicators/resolve.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { useBlockKey, usePersistedState } from '#/internal/persistent-state.ts';
@@ -13,6 +18,8 @@ import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
+
+const NOOP_REFERENCE = (): void => {};
 
 const BASE_LABEL = 'base';
 const COLUMN_COUNT = 6;
@@ -69,12 +76,16 @@ export interface ColorTableProps {
   variants?: Record<string, string>;
   /** Disambiguates persisted UI state for two identical-prop tables on a page. */
   id?: string;
+  /** Configure the per-row indicator strip. See `IndicatorsProp`. Gamut stays in the Value cell, so it is not part of this strip. */
+  indicators?: IndicatorsProp;
 }
 
 interface Variant {
   label: string;
   path: string;
   cssVar: string;
+  token: VirtualTokenShape;
+  variance: AxisVarianceResult | undefined;
   // The display value in the currently-active color format.
   value: string;
   outOfGamut: boolean;
@@ -102,10 +113,15 @@ export function ColorTable({
   onSelect,
   variants,
   id,
+  indicators,
 }: ColorTableProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing, varianceByPath } = project;
   const colorFormat = useColorFormat();
+  const enabledIndicators = useMemo(
+    () => ({ ...resolveIndicators(indicators), gamut: false }),
+    [indicators],
+  );
   // Persist search + variant selection + expansion across docs-mode remounts.
   const blockKey = useBlockKey('ColorTable', [filter, caption, id]);
   const [query, setQuery] = usePersistedState(`${blockKey}::query`, '');
@@ -140,6 +156,8 @@ export function ColorTable({
       const variant: Variant = {
         label: match?.label ?? BASE_LABEL,
         path,
+        token,
+        variance: varianceByPath[path],
         cssVar: resolveCssVar(path, projectFields),
         value: active.value,
         outOfGamut: active.outOfGamut,
@@ -163,7 +181,7 @@ export function ColorTable({
       out.push({ base, variants: vs, searchText });
     }
     return out;
-  }, [resolved, listing, cssVarPrefix, filter, sortBy, sortDir, defs, colorFormat]);
+  }, [resolved, listing, cssVarPrefix, varianceByPath, filter, sortBy, sortDir, defs, colorFormat]);
 
   const visibleGroups = useMemo(() => {
     if (!searchable || deferredQuery.trim() === '') return groups;
@@ -235,7 +253,9 @@ export function ColorTable({
               <th className="sb-color-table__th sb-color-table__th--path">Name</th>
               <th className="sb-color-table__th">Value</th>
               <th className="sb-color-table__th">CSS var</th>
-              <th className="sb-color-table__th">Alias</th>
+              <th className="sb-color-table__th sb-color-table__th--refs">
+                <span className="sb-color-table__sr-only">References and status</span>
+              </th>
               <th className="sb-color-table__th sb-color-table__th--expand">
                 <span className="sb-color-table__sr-only">Expand</span>
               </th>
@@ -257,6 +277,8 @@ export function ColorTable({
                 expanded={expandedByBase.has(group.base)}
                 onToggleExpand={toggleExpand}
                 onSelectVariant={selectVariant}
+                enabled={enabledIndicators}
+                colorFormat={colorFormat}
                 {...(onSelect !== undefined && { onSelect })}
               />
             ))}
@@ -274,6 +296,8 @@ interface GroupRowProps {
   onToggleExpand(base: string): void;
   onSelectVariant(base: string, label: string): void;
   onSelect?(path: string): void;
+  enabled: Record<IndicatorName, boolean>;
+  colorFormat: ColorFormat;
 }
 
 const GroupRow = memo(function GroupRow({
@@ -283,6 +307,8 @@ const GroupRow = memo(function GroupRow({
   onToggleExpand,
   onSelectVariant,
   onSelect,
+  enabled,
+  colorFormat,
 }: GroupRowProps): ReactElement {
   const multi = group.variants.length > 1;
   const active =
@@ -366,14 +392,17 @@ const GroupRow = memo(function GroupRow({
           )}
         </ValueCell>
         <ValueCell value={active.cssVar} label={`Copy CSS var ${active.cssVar}`} />
-        <td className="sb-color-table__td sb-color-table__alias">
-          {active.aliasOf ? (
-            <span className="sb-color-table__alias-text">{active.aliasOf}</span>
-          ) : (
-            <span className="sb-color-table__alias-empty" aria-hidden>
-              —
-            </span>
-          )}
+        <td className="sb-color-table__td sb-color-table__refs">
+          <RowIndicators
+            path={active.path}
+            token={active.token}
+            root={undefined}
+            variance={active.variance}
+            colorFormat={colorFormat}
+            canReference={() => false}
+            onReferenceClick={NOOP_REFERENCE}
+            enabled={enabled}
+          />
         </td>
         <td className="sb-color-table__td sb-color-table__expand-cell">
           {!onSelect && (

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -315,6 +315,9 @@ const GroupRow = memo(function GroupRow({
     group.variants.find((v) => v.label === selectedLabel) ?? (group.variants[0] as Variant);
   const nameText = multi ? group.base : active.path;
 
+  const dep = active.token.$deprecated;
+  const isDeprecated = dep === true || (typeof dep === 'string' && dep.length > 0);
+
   const handleRowActivate = (): void => {
     if (onSelect) onSelect(active.path);
     else onToggleExpand(group.base);
@@ -353,7 +356,10 @@ const GroupRow = memo(function GroupRow({
             aria-hidden
           />
         </td>
-        <td className={cx('sb-color-table__td', 'sb-color-table__path')}>
+        <td
+          className={cx('sb-color-table__td', 'sb-color-table__path')}
+          data-deprecated={enabled.deprecation && isDeprecated ? 'true' : undefined}
+        >
           <span className="sb-color-table__path-text">{nameText}</span>
           {multi && (
             <span

--- a/packages/blocks/test/color-table-indicators.browser.test.tsx
+++ b/packages/blocks/test/color-table-indicators.browser.test.tsx
@@ -87,3 +87,23 @@ it('hides the strip when indicators={false}', () => {
   expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
   expect(screen.queryByTestId('row-indicator-alias-forward')).toBeNull();
 });
+
+it("strikes through a deprecated color row's name cell", () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <ColorTable />
+    </SwatchbookProvider>,
+  );
+  const nameCell = within(rowFor('color.legacy')).getByText('color.legacy').closest('td')!;
+  expect(nameCell.getAttribute('data-deprecated')).toBe('true');
+});
+
+it('drops the name strikethrough when deprecation is disabled', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <ColorTable indicators={{ deprecation: false }} />
+    </SwatchbookProvider>,
+  );
+  const nameCell = within(rowFor('color.legacy')).getByText('color.legacy').closest('td')!;
+  expect(nameCell.getAttribute('data-deprecated')).toBeNull();
+});

--- a/packages/blocks/test/color-table-indicators.browser.test.tsx
+++ b/packages/blocks/test/color-table-indicators.browser.test.tsx
@@ -1,0 +1,89 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { SwatchbookProvider, ColorTable } from '#/index.ts';
+import type { ProjectSnapshot, VirtualTokenShape } from '#/index.ts';
+
+const TOKENS: Record<string, VirtualTokenShape> = {
+  'color.primary': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0, 0, 1], alpha: 1 },
+    aliasChain: ['color.palette.blue.500'],
+  },
+  'color.palette.blue.500': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0, 0, 1], alpha: 1 },
+    aliasedBy: ['color.primary'],
+  },
+  'color.legacy': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [1, 0, 0], alpha: 1 },
+    $deprecated: 'use color.primary',
+  },
+  'color.wide': {
+    $type: 'color',
+    $value: { colorSpace: 'display-p3', components: [1, 0, 0], alpha: 1 },
+  },
+};
+
+function snapshot(): ProjectSnapshot {
+  const snap: ProjectSnapshot = {
+    axes: [],
+    defaultTuple: {},
+    activeTheme: 'default',
+    activeAxes: {},
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = () => TOKENS;
+  return snap;
+}
+
+afterEach(cleanup);
+
+function rowFor(path: string) {
+  return screen
+    .getAllByTestId('color-table-row')
+    .find((el) => el.getAttribute('data-path') === path)!;
+}
+
+it('renders the alias chain indicator in a ColorTable row', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <ColorTable />
+    </SwatchbookProvider>,
+  );
+  expect(within(rowFor('color.primary')).getByTestId('row-indicator-alias-forward')).toBeTruthy();
+});
+
+it('alias refs are informational (plain text, not buttons)', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <ColorTable />
+    </SwatchbookProvider>,
+  );
+  const fwd = within(rowFor('color.primary')).getByTestId('row-indicator-alias-forward');
+  const node = within(fwd).getAllByTestId('alias-node')[0] as HTMLElement;
+  expect(node.tagName.toLowerCase()).not.toBe('button');
+});
+
+it('keeps the value-cell gamut warning and shows no gamut badge in the strip', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <ColorTable />
+    </SwatchbookProvider>,
+  );
+  const row = rowFor('color.wide');
+  expect(within(row).getByLabelText('out of gamut')).toBeTruthy();
+  expect(within(row).getAllByLabelText('out of gamut').length).toBe(1);
+});
+
+it('hides the strip when indicators={false}', () => {
+  render(
+    <SwatchbookProvider value={snapshot()}>
+      <ColorTable indicators={false} />
+    </SwatchbookProvider>,
+  );
+  expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
+  expect(screen.queryByTestId('row-indicator-alias-forward')).toBeNull();
+});

--- a/packages/blocks/test/color-table.browser.test.tsx
+++ b/packages/blocks/test/color-table.browser.test.tsx
@@ -41,15 +41,14 @@ describe('ColorTable — base rendering', () => {
     expect(within(row).queryByLabelText(/Copy OKLCH/)).toBeNull();
   });
 
-  it('renders an em-dash in the alias column for non-aliased tokens', () => {
+  it('renders no indicator strip for tokens with no alias, variance, or deprecation', () => {
     render(
       <SwatchbookProvider value={makeColorTableSnapshot()}>
         <ColorTable filter="color.surface.**" />
       </SwatchbookProvider>,
     );
     const row = screen.getByTestId('color-table-row');
-    const alias = row.querySelector('.sb-color-table__alias');
-    expect(alias?.textContent?.trim()).toBe('—');
+    expect(row.querySelector('.sb-indicator__indicators')).toBeNull();
   });
 
   it('fuzzy search narrows rows with out-of-order terms', async () => {


### PR DESCRIPTION
Brings ColorTable in line with `TokenTable` / `TokenNavigator`: the per-row indicator strip replaces the old standalone Alias column, deprecated rows strike through their name, and the same `indicators` prop configures the strip.

Gamut is the one indicator left out of the strip — it stays in the Value cell beside the colour it qualifies, so `resolveIndicators` is overridden with `gamut: false` for this block.

## Changes
- `ColorTable` renders `RowIndicators` (alias chain + reverse referents, axis-variance, deprecation, opt-in `$description`) in the references column; accepts `indicators?: IndicatorsProp`.
- Deprecation strikethrough on the name cell.
- Docs: rewrote the ColorTable section of the blocks overview (dropped the stale "alias-target columns" line, documented the strip and the `indicators` prop with the gamut caveat).
- Minor changeset for the blocks feature.

## Verification
- `pnpm turbo run format:check lint typecheck test` — all 37 tasks pass (blocks 315 tests, incl. `color-table`, `color-table-expansion`, `indicator-config`, `row-indicators`).
- Docs site build passes.

Milestone: Block value display + chrome consistency

Closes #1244

Plan impact: none — completes the ColorTable task as planned.