### PR TITLE
chore: override webpack-dev-server and http-proxy-middleware to clear GHSA advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,8 @@ overrides:
   launch-editor: ^2.14.1
   js-yaml@>=4: ^4.2.0
   '@babel/core': ^7.29.6
+  webpack-dev-server: 5.2.5
+  http-proxy-middleware: ^3.0.6
 
 importers:
 
@@ -6161,14 +6163,9 @@ packages:
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
 
-  http-proxy-middleware@2.0.9:
-    resolution: {integrity: sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@types/express': ^4.17.13
-    peerDependenciesMeta:
-      '@types/express':
-        optional: true
+  http-proxy-middleware@3.0.7:
+    resolution: {integrity: sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==}
+    engines: {node: ^14.18.0 || ^16.10.0 || >=18.0.0}
 
   http-proxy@1.18.1:
     resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
@@ -6359,16 +6356,16 @@ packages:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
     engines: {node: '>=8'}
 
-  is-plain-obj@3.0.0:
-    resolution: {integrity: sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==}
-    engines: {node: '>=10'}
-
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
   is-plain-object@2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+
+  is-plain-object@5.0.0:
+    resolution: {integrity: sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==}
     engines: {node: '>=0.10.0'}
 
   is-promise@4.0.0:
@@ -9045,8 +9042,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.4:
-    resolution: {integrity: sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==}
+  webpack-dev-server@5.2.5:
+    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -10788,7 +10785,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.106.2(@swc/core@1.15.26)(esbuild@0.28.1)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.4(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26)(esbuild@0.28.1))
+      webpack-dev-server: 5.2.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26)(esbuild@0.28.1))
       webpack-merge: 6.0.1
     optionalDependencies:
       '@docusaurus/faster': 3.10.0(@docusaurus/types@3.10.0(@swc/core@1.15.26)(esbuild@0.28.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(esbuild@0.28.1)
@@ -10799,7 +10796,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -10913,7 +10909,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -10955,7 +10950,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -10995,7 +10989,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11025,7 +11018,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11050,7 +11042,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - react
@@ -11080,7 +11071,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11106,7 +11096,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11133,7 +11122,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11159,7 +11147,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11190,7 +11177,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11220,7 +11206,6 @@ snapshots:
       - '@swc/css'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11259,7 +11244,6 @@ snapshots:
       - '@types/react'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - search-insights
@@ -11313,7 +11297,6 @@ snapshots:
       - '@types/react'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - supports-color
@@ -11378,7 +11361,6 @@ snapshots:
       - '@types/react'
       - bufferutil
       - csso
-      - debug
       - esbuild
       - lightningcss
       - search-insights
@@ -15445,7 +15427,9 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   form-data-encoder@2.1.4: {}
 
@@ -15815,22 +15799,21 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-middleware@2.0.9(@types/express@4.17.25):
+  http-proxy-middleware@3.0.7:
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      debug: 4.4.3
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
-      is-plain-obj: 3.0.0
+      is-plain-object: 5.0.0
       micromatch: 4.0.8
-    optionalDependencies:
-      '@types/express': 4.17.25
     transitivePeerDependencies:
-      - debug
+      - supports-color
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -15962,13 +15945,13 @@ snapshots:
 
   is-path-inside@3.0.3: {}
 
-  is-plain-obj@3.0.0: {}
-
   is-plain-obj@4.1.0: {}
 
   is-plain-object@2.0.4:
     dependencies:
       isobject: 3.0.1
+
+  is-plain-object@5.0.0: {}
 
   is-promise@4.0.0: {}
 
@@ -19112,7 +19095,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.4(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26)(esbuild@0.28.1)):
+  webpack-dev-server@5.2.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26)(esbuild@0.28.1)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -19130,7 +19113,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.1
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.25)
+      http-proxy-middleware: 3.0.7
       ipaddr.js: 2.3.0
       launch-editor: 2.14.1
       open: 10.2.0
@@ -19146,7 +19129,6 @@ snapshots:
       webpack: 5.106.2(@swc/core@1.15.26)(esbuild@0.28.1)
     transitivePeerDependencies:
       - bufferutil
-      - debug
       - supports-color
       - tslib
       - utf-8-validate

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -39,3 +39,11 @@ overrides:
   'js-yaml@>=4': ^4.2.0
   # GHSA-4x5r-pxfx-6jf8 (#1223)
   '@babel/core': ^7.29.6
+  # GHSA-mx8g-39q3-5c79 (#1255), via @docusaurus/core dev server
+  webpack-dev-server: 5.2.5
+  # GHSA-64mm-vxmg-q3vj (#1255), forced major: webpack-dev-server@5.2.5 still
+  # declares ^2.0.9 and calls the v2 two-arg createProxyMiddleware(context,
+  # config) form that v3 dropped, but that path runs only with a configured
+  # dev-server proxy, and no workspace sets one — so it is dead here. Pinned to
+  # the minimum patched major (not v4) to stay closest to wds's expected API.
+  http-proxy-middleware: ^3.0.6


### PR DESCRIPTION
Clears the two moderate Dependabot advisories on the default branch via `pnpm-workspace.yaml` overrides, matching the established advisory-pin pattern. Both are dev-only transitives of the `apps/docs` Docusaurus dev server — never bundled into any published package.

## Changes
- `webpack-dev-server: 5.2.5` — GHSA-mx8g-39q3-5c79 (HMR WebSocket interception). Clean supported patch from 5.2.4.
- `http-proxy-middleware: ^3.0.6` — GHSA-64mm-vxmg-q3vj (`router` Host-header routing bypass). Resolves to 3.0.7. Forced major: wds@5.2.5 still declares `^2.0.9` and calls the v2 two-arg `createProxyMiddleware(context, config)` form that v3 dropped, but that call runs only when a dev-server proxy is configured and no workspace sets one — so the path is dead. Pinned to the minimum patched major (not v4) to stay closest to wds's expected API.

## Verification
- `pnpm install` resolves cleanly; `pnpm why` confirms `http-proxy-middleware@3.0.7` / `webpack-dev-server@5.2.5`, no v2/5.2.4 remnants.
- Docs dev server boots on the patched stack; docs site build passes.

No changeset — dev-only transitives of a private workspace, nothing reaches a published dist.

Milestone: Maintenance

Closes #1255

Plan impact: none.