### PR TITLE
feat(blocks): add an opt-in composes-N row indicator for composite tokens

### DIFF
--- a/.changeset/composes-indicator.md
+++ b/.changeset/composes-indicator.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": minor
+---
+
+Add an opt-in `composes` row indicator: composite-typed tokens (typography, border, transition, gradient, shadow) show a `⊞ N` count of the parts they bundle. Off by default; enable via `indicators={{ composes: true }}` on TokenNavigator / TokenTable

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -25,7 +25,7 @@ Most blocks in this group take:
 
 Expandable tree of the token graph. Each interior group shows its child count; each leaf shows its `$type` pill plus an inline preview (color swatch, dimension bar, shadow / border / motion sample, or a formatted value). A fuzzy-search input at the top filters leaves by path: case-insensitive, out-of-order terms, single-character typo tolerance. Matching leaves survive, groups on the way to them auto-expand. Clicking a leaf opens a slide-over with the full `<TokenDetail>`; pass `onSelect` to own the click follow-up instead.
 
-Between the type pill and the preview, a leaf carries an indicator strip when there is something to show: a forward alias chain (`→ target`, capped past two hops with the full chain on the accessible label), a reverse `← N` count of tokens that reference this one, an axis-variance badge when the resolved value differs across the project's axes (naming the axis, or a count when several), an out-of-gamut marker on colors outside sRGB for the active format, a deprecation badge with a struck-through name for tokens carrying DTCG `$deprecated`, and an opt-in `ⓘ` glyph carrying the token's `$description`. Alias references are navigable: clicking a chain node, or a single reverse referrer, moves the tree to that token; several referrers open a chooser. The chain reflects the active theme, so a token that aliases different palette entries per axis context shows the path true in the current context.
+Between the type pill and the preview, a leaf carries an indicator strip when there is something to show: a forward alias chain (`→ target`, capped past two hops with the full chain on the accessible label), a reverse `← N` count of tokens that reference this one, an axis-variance badge when the resolved value differs across the project's axes (naming the axis, or a count when several), an out-of-gamut marker on colors outside sRGB for the active format, a deprecation badge with a struck-through name for tokens carrying DTCG `$deprecated`, an opt-in `ⓘ` glyph carrying the token's `$description`, and an opt-in `⊞ N` count of the parts a composite token bundles (object fields for typography / border / transition, stops or layers for gradient / shadow). Alias references are navigable: clicking a chain node, or a single reverse referrer, moves the tree to that token; several referrers open a chooser. The chain reflects the active theme, so a token that aliases different palette entries per axis context shows the path true in the current context.
 
 Props:
 
@@ -34,7 +34,7 @@ Props:
 - `initiallyExpanded?: number`: depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
 - `searchable?: boolean`: render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
 - `onSelect?(path: string): void`: receives a leaf's full dot-path on click; suppresses the built-in overlay.
-- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present.
+- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description`, `composes` off). `false` hides the strip; `true` enables all (including `description` and `composes`); an object overrides individual keys (e.g. `{ composes: true }`, `{ deprecation: false }`). Indicators still render only when their data is present; `composes` shows only on composite-typed rows.
 
 ### TokenTable
 
@@ -44,7 +44,7 @@ Props:
 
 Compact table: **Path**, an indicators column, and **Value** (with inline type pill + color swatch). A fuzzy-search input at the top narrows rows by path, type, or value: case-insensitive, out-of-order terms, single-character typo tolerance. Each value cell has a hover-revealed copy-to-clipboard button. Clicking a row opens the same slide-over `<TokenDetail>` the tree uses; pass `onSelect` to own the follow-up. Columns follow content with per-column `min-width` floors, so the table breathes in narrow containers.
 
-The middle column carries the same indicator strip as the navigator: the forward alias chain, a reverse `← N` count of tokens that reference the row, an axis-variance badge, an out-of-gamut marker, a deprecation badge, and an opt-in `ⓘ` description glyph. A deprecated row's path is struck through. Alias references are navigable here too, but the table has no tree to expand: clicking a chain node or a reverse referent opens that token's detail overlay (a chooser when several tokens reference it). The column does not participate in sorting.
+The middle column carries the same indicator strip as the navigator: the forward alias chain, a reverse `← N` count of tokens that reference the row, an axis-variance badge, an out-of-gamut marker, a deprecation badge, an opt-in `ⓘ` description glyph, and an opt-in `⊞ N` composite-parts count. A deprecated row's path is struck through. Alias references are navigable here too, but the table has no tree to expand: clicking a chain node or a reverse referent opens that token's detail overlay (a chooser when several tokens reference it). The column does not participate in sorting.
 
 Props:
 
@@ -55,7 +55,7 @@ Props:
 - `sortDir?: 'asc' | 'desc'`: default `'asc'`.
 - `searchable?: boolean`: render a runtime search input above the table. Defaults to `true`.
 - `onSelect?(path: string): void`: suppress the built-in drawer.
-- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present.
+- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description`, `composes` off). `false` hides the strip; `true` enables all (including `description` and `composes`); an object overrides individual keys (e.g. `{ composes: true }`, `{ deprecation: false }`). Indicators still render only when their data is present; `composes` shows only on composite-typed rows.
 
 ## Per-type
 

--- a/packages/blocks/src/indicators/RowIndicators.tsx
+++ b/packages/blocks/src/indicators/RowIndicators.tsx
@@ -31,6 +31,26 @@ function relativeLabel(path: string, root: string | undefined): string {
   return path;
 }
 
+// DTCG composite `$type`s — the same set core's token-graph build keys on
+// (build.ts COMPOSITE_TYPES). Only these carry a meaningful sub-part count;
+// other object-valued tokens (a 2025-spec color, say) must not be badged.
+const COMPOSITE_TYPES = new Set(['border', 'typography', 'transition', 'gradient', 'shadow']);
+
+// Number of constituent parts a composite token bundles: object fields for
+// typography / border / transition / object-form shadow, stops/layers for an
+// array-form gradient or shadow. `undefined` for non-composites and for an
+// aliased composite (string `$value`), which compose nothing locally.
+function compositeFieldCount(token: VirtualTokenShape): number | undefined {
+  if (!token.$type || !COMPOSITE_TYPES.has(token.$type)) return undefined;
+  const v = token.$value;
+  if (Array.isArray(v)) return v.length > 0 ? v.length : undefined;
+  if (v !== null && typeof v === 'object') {
+    const n = Object.keys(v).length;
+    return n > 0 ? n : undefined;
+  }
+  return undefined;
+}
+
 interface ForwardChainProps {
   chain: readonly string[];
   root: string | undefined;
@@ -255,6 +275,7 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
     typeof token.$description === 'string' && token.$description.length > 0
       ? token.$description
       : undefined;
+  const composesCount = en.composes ? compositeFieldCount(token) : undefined;
 
   const showDeprecated = en.deprecation && isDeprecated;
   const showForward = en.alias && aliasChain !== undefined;
@@ -262,6 +283,7 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
   const showVariance = en.variance && isVarying;
   const showGamut = en.gamut && outOfGamut;
   const showDescription = en.description && description !== undefined;
+  const showComposes = composesCount !== undefined;
 
   if (
     !showDeprecated &&
@@ -269,7 +291,8 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
     !showReverse &&
     !showVariance &&
     !showGamut &&
-    !showDescription
+    !showDescription &&
+    !showComposes
   ) {
     return null;
   }
@@ -291,6 +314,19 @@ export function RowIndicators(props: RowIndicatorsProps): ReactElement | null {
           canReference={canReference}
           onReferenceClick={onReferenceClick}
         />
+      )}
+      {showComposes && composesCount !== undefined && (
+        <span
+          className="sb-indicator__composes"
+          data-testid="row-indicator-composes"
+          title={`composes ${composesCount} parts`}
+          aria-label={`composes ${composesCount} parts`}
+        >
+          <span className="sb-indicator__composes-glyph" aria-hidden>
+            ⊞
+          </span>
+          {composesCount}
+        </span>
       )}
       {showVariance && variance && <VarianceBadge variance={variance} />}
       {showGamut && (

--- a/packages/blocks/src/indicators/indicators.css
+++ b/packages/blocks/src/indicators/indicators.css
@@ -45,6 +45,7 @@
 }
 
 .sb-indicator__variance,
+.sb-indicator__composes,
 .sb-indicator__deprecated {
   display: inline-flex;
   align-items: center;
@@ -54,8 +55,13 @@
   white-space: nowrap;
 }
 
-.sb-indicator__variance-glyph {
+.sb-indicator__variance-glyph,
+.sb-indicator__composes-glyph {
   color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.7));
+}
+
+.sb-indicator__composes {
+  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.8));
 }
 
 .sb-indicator__gamut {

--- a/packages/blocks/src/indicators/resolve.ts
+++ b/packages/blocks/src/indicators/resolve.ts
@@ -1,5 +1,11 @@
 /** The individually-toggleable indicators in the row strip. `alias` covers the whole alias unit (forward chain + reverse count). */
-export type IndicatorName = 'alias' | 'variance' | 'gamut' | 'deprecation' | 'description';
+export type IndicatorName =
+  | 'alias'
+  | 'variance'
+  | 'gamut'
+  | 'deprecation'
+  | 'description'
+  | 'composes';
 
 /**
  * Consumer-facing indicator config for the strip-hosting blocks:
@@ -10,23 +16,38 @@ export type IndicatorName = 'alias' | 'variance' | 'gamut' | 'deprecation' | 'de
  */
 export type IndicatorsProp = boolean | Partial<Record<IndicatorName, boolean>>;
 
-/** Established-on set; `description` is opt-in. */
+/** Established-on set; `description` and `composes` are opt-in. */
 const DEFAULT_INDICATORS: Record<IndicatorName, boolean> = {
   alias: true,
   variance: true,
   gamut: true,
   deprecation: true,
   description: false,
+  composes: false,
 };
 
 /** Normalize an `IndicatorsProp` into a full enabled-map by layering over the defaults. */
 export function resolveIndicators(prop?: IndicatorsProp): Record<IndicatorName, boolean> {
   if (prop === undefined) return { ...DEFAULT_INDICATORS };
   if (prop === true) {
-    return { alias: true, variance: true, gamut: true, deprecation: true, description: true };
+    return {
+      alias: true,
+      variance: true,
+      gamut: true,
+      deprecation: true,
+      description: true,
+      composes: true,
+    };
   }
   if (prop === false) {
-    return { alias: false, variance: false, gamut: false, deprecation: false, description: false };
+    return {
+      alias: false,
+      variance: false,
+      gamut: false,
+      deprecation: false,
+      description: false,
+      composes: false,
+    };
   }
   return { ...DEFAULT_INDICATORS, ...prop };
 }

--- a/packages/blocks/test/resolve-indicators.test.ts
+++ b/packages/blocks/test/resolve-indicators.test.ts
@@ -7,6 +7,7 @@ const DEFAULTS = {
   gamut: true,
   deprecation: true,
   description: false,
+  composes: false,
 };
 
 it('undefined → the established defaults', () => {
@@ -20,6 +21,7 @@ it('false → every indicator off', () => {
     gamut: false,
     deprecation: false,
     description: false,
+    composes: false,
   });
 });
 
@@ -30,7 +32,13 @@ it('true → every indicator on, including description', () => {
     gamut: true,
     deprecation: true,
     description: true,
+    composes: true,
   });
+});
+
+it('composes is opt-in: off by default, settable via object', () => {
+  expect(resolveIndicators(undefined).composes).toBe(false);
+  expect(resolveIndicators({ composes: true })).toEqual({ ...DEFAULTS, composes: true });
 });
 
 it('object → per-key override layered over defaults', () => {

--- a/packages/blocks/test/row-indicators.browser.test.tsx
+++ b/packages/blocks/test/row-indicators.browser.test.tsx
@@ -419,3 +419,75 @@ it('renders nothing when every present indicator is disabled', () => {
   expect(screen.queryByTestId('row-indicator-alias-forward')).toBeNull();
   expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
 });
+
+function renderEnabled(
+  path: string,
+  token: VirtualTokenShape,
+  enabled: ReturnType<typeof resolveIndicators>,
+) {
+  return render(
+    <RowIndicators
+      path={path}
+      token={token}
+      root={undefined}
+      variance={undefined}
+      colorFormat="hex"
+      canReference={inView}
+      onReferenceClick={noop}
+      enabled={enabled}
+    />,
+  );
+}
+
+it('shows a composes count for a composite object value when enabled', () => {
+  renderEnabled(
+    'typography.body',
+    {
+      $type: 'typography',
+      $value: {
+        fontFamily: 'Inter',
+        fontSize: '1rem',
+        fontWeight: 400,
+        lineHeight: 1.5,
+        letterSpacing: '0',
+      },
+    },
+    resolveIndicators({ composes: true }),
+  );
+  expect(screen.getByTestId('row-indicator-composes').textContent).toContain('5');
+});
+
+it('counts gradient stops as the composes total', () => {
+  renderEnabled(
+    'gradient.brand',
+    { $type: 'gradient', $value: [{ color: '#000' }, { color: '#fff' }, { color: '#f00' }] },
+    resolveIndicators({ composes: true }),
+  );
+  expect(screen.getByTestId('row-indicator-composes').textContent).toContain('3');
+});
+
+it('off by default: no composes badge even for a composite token', () => {
+  renderRow('typography.body', {
+    $type: 'typography',
+    $value: { fontFamily: 'Inter', fontSize: '1rem' },
+  });
+  expect(screen.queryByTestId('row-indicator-composes')).toBeNull();
+});
+
+it('never badges a non-composite object value such as a color', () => {
+  renderEnabled(
+    'color.brand',
+    { $type: 'color', $value: { hex: '#00f' } },
+    resolveIndicators({ composes: true }),
+  );
+  expect(screen.queryByTestId('row-indicator-composes')).toBeNull();
+});
+
+it('no composes badge for an aliased composite whose value is a string', () => {
+  renderEnabled(
+    'typography.alias',
+    { $type: 'typography', $value: '{typography.body}' },
+    resolveIndicators({ composes: true }),
+  );
+  expect(screen.queryByTestId('row-indicator-composes')).toBeNull();
+});


### PR DESCRIPTION
Adds a `composes` member to the row-indicator strip. Composite-typed tokens show a `⊞ N` badge counting the parts they bundle: object fields for typography / border / transition / object-form shadow, stops or layers for gradient / array-form shadow.

Off by default (opt-in, like the `ⓘ` description glyph). Enable per block: `<TokenNavigator indicators={{ composes: true }} />`, same on `TokenTable`.

## Design notes
- Gated strictly on the composite `$type` set (`typography`, `border`, `transition`, `gradient`, `shadow`) — the same set core's token-graph build keys on. A 2025-spec color's `$value` is also an object, so a type-blind "value is structured" check would have falsely badged every color row; the type gate prevents that.
- An aliased composite (string `$value`) composes nothing locally, so it gets no badge.
- The richer per-field-alias breakdown already lives in `partialAliasOf` / `CompositeBreakdown`; this badge stays a plain count and doesn't overlap it.
- Not added to `ColorTable` — color is never composite there.

## Changes
- `composes` added to `IndicatorName` + `DEFAULT_INDICATORS` (off); `resolveIndicators` true/false branches updated.
- `compositeFieldCount` helper + render branch in `RowIndicators`, with CSS badge styling mirroring the variance badge.
- Docs: strip descriptions + `indicators` prop default lists for TokenNavigator / TokenTable.
- Minor changeset.

## Verification
- New unit coverage in `resolve-indicators.test.ts` (composes in defaults / true / false / object override) and five browser cases in `row-indicators.browser.test.tsx` (object count, gradient stops, off-by-default, color-not-badged, aliased-composite-not-badged).
- Blocks gauntlet (format:check / lint / typecheck / test) green, 314 tests; docs build passes.

Milestone: Block value display + chrome consistency

Closes #1253

Plan impact: none.