### PR TITLE
feat(mcp): surface $deprecated and an axis-variance summary on get_token

### DIFF
--- a/.changeset/mcp-get-token-metadata.md
+++ b/.changeset/mcp-get-token-metadata.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-mcp": minor
+---
+
+`get_token` now reports DTCG `$deprecated` and a compact axis-variance summary (`kind` plus the axes the value flips across), so an agent sees the same at-a-glance facts the UI's row indicators surface

--- a/apps/docs/docs/reference/mcp.mdx
+++ b/apps/docs/docs/reference/mcp.mdx
@@ -69,7 +69,7 @@ The `mcpServers` shape is the same across MCP hosts; consult the host's docs for
 | `list_tokens`         | `filter?` path glob, `type?` DTCG `$type`, `theme?` name | Array of `{ path, type?, value }` from the named theme (or default). Use first to discover paths.             |
 | `search_tokens`       | `query`, `theme?`, `limit?`                               | Case-insensitive substring search across paths, descriptions, and values. Returns matches + `matchedIn` hint. |
 | `resolve_theme`       | `tuple`, `filter?`, `type?`                               | Resolved token map for an axis tuple (`{ mode: "Dark", brand: "…" }`). Fills omitted axes from defaults.      |
-| `get_token`           | `path`                                                    | Full detail: per-theme value, alias chain, aliased-by list, CSS var reference.                                |
+| `get_token`           | `path`                                                    | Full detail: per-theme value, alias chain, aliased-by list, CSS var reference, `$deprecated`, and an axis-variance summary (when the value flips across axes).             |
 | `get_alias_chain`     | `path`                                                    | Forward alias chain per theme (`path → ... → primitive`). Empty when the token is a primitive.                |
 | `get_aliased_by`      | `path`, `maxDepth?`                                       | Backward alias tree: every token that resolves through this path. Shallower aliases first; cycles in the alias graph are caught and broken.       |
 | `get_consumer_output` | `path`, `tuple?`                                          | CSS var, resolved value, compound `[data-…]` selector + HTML attrs needed to pin the tuple on `<html>`.        |

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -173,7 +173,7 @@ export function createServer(initial: Project): McpServer & {
     'get_token',
     {
       description:
-        'Get full details for a single token: resolved value in every theme, DTCG `$type`, `$description`, alias chain, aliased-by list, and CSS var reference. Use after `list_tokens` to inspect a specific path.',
+        'Get full details for a single token: resolved value in every theme, DTCG `$type`, `$description`, `$deprecated` (message or `true` when the token is deprecated), an axis-variance summary (`kind` + the axes it flips across, present only when it varies — see `get_axis_variance` for the per-axis breakdown), alias chain, aliased-by list, and CSS var reference. Use after `list_tokens` to inspect a specific path.',
       inputSchema: {
         path: z.string().describe('Dot-path of the token, e.g. `color.accent.bg`.'),
       },
@@ -185,6 +185,7 @@ export function createServer(initial: Project): McpServer & {
       > = {};
       let type: string | undefined;
       let description: string | undefined;
+      let deprecated: string | boolean | undefined;
       let aliasedBy: readonly string[] | undefined;
       let found = false;
 
@@ -194,6 +195,7 @@ export function createServer(initial: Project): McpServer & {
         found = true;
         type ??= token.$type;
         description ??= token.$description;
+        deprecated ??= token.$deprecated;
         aliasedBy ??= token.aliasedBy;
         perTheme[name] = {
           value: stringifyValue(token.$value),
@@ -206,10 +208,24 @@ export function createServer(initial: Project): McpServer & {
 
       const cssVar = `var(${cssVarName(path, project)})`;
 
+      // Compact at-a-glance variance summary (kind + the axes it flips across),
+      // present only when the token actually varies — full per-axis detail stays
+      // in `get_axis_variance`. Mirrors the UI's "show only when there's
+      // something to show" variance badge.
+      const variance = project.tokenGraph.nodes[path]
+        ? getVariance(project.tokenGraph, path)
+        : undefined;
+      const varianceSummary =
+        variance && variance.kind !== 'constant'
+          ? { kind: variance.kind, axes: variance.varyingAxes }
+          : undefined;
+
       return jsonResult({
         path,
         type,
         description,
+        deprecated,
+        variance: varianceSummary,
         cssVar,
         aliasedBy,
         perTheme,

--- a/packages/mcp/test/token-introspection.test.ts
+++ b/packages/mcp/test/token-introspection.test.ts
@@ -43,10 +43,17 @@ interface GetTokenResult {
   path: string;
   type?: string;
   description?: string;
+  deprecated?: string | boolean;
+  variance?: { kind: 'single' | 'multi'; axes: readonly string[] };
   cssVar: string;
   aliasedBy?: readonly string[];
   perTheme: Record<string, { value: string; aliasOf?: string; aliasChain?: readonly string[] }>;
 }
+
+// Fixture invariants: color.text.link carries DTCG `$deprecated` with a message;
+// color.surface.default varies with mode (Light vs Dark); palette primitives are
+// axis-constant.
+const DEPRECATED_TOKEN = 'color.text.link';
 
 it('get_token: returns the alias chain and resolved value per theme', async () => {
   const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });
@@ -105,6 +112,27 @@ it('get_token: returns the cssVar without a prefix segment when cssVarPrefix is 
 it('get_token: returns a text "not found" response for unknown paths', async () => {
   const text = await mcp.callText('get_token', { path: 'does.not.exist' });
   expect(text).toBe('Token not found: does.not.exist');
+});
+
+it('get_token: surfaces DTCG $deprecated with its message', async () => {
+  const result = await mcp.callJson<GetTokenResult>('get_token', { path: DEPRECATED_TOKEN });
+  expect(result.deprecated).toBe('Use color.text.accent instead.');
+});
+
+it('get_token: omits deprecated for a token without $deprecated', async () => {
+  const result = await mcp.callJson<GetTokenResult>('get_token', { path: PRIMITIVE_TOKEN });
+  expect(result.deprecated).toBeUndefined();
+});
+
+it('get_token: summarises axis variance for a mode-varying token', async () => {
+  const result = await mcp.callJson<GetTokenResult>('get_token', { path: ALIAS_TOKEN });
+  expect(result.variance?.kind).toMatch(/single|multi/);
+  expect(result.variance?.axes).toContain('mode');
+});
+
+it('get_token: omits the variance summary for an axis-constant primitive', async () => {
+  const result = await mcp.callJson<GetTokenResult>('get_token', { path: PRIMITIVE_TOKEN });
+  expect(result.variance).toBeUndefined();
 });
 
 interface GetAliasChainResult {


### PR DESCRIPTION
Closes the parity gap between the UI's row indicators and the MCP `get_token` output. The strip shows deprecation and axis-variance per token; an agent calling `get_token` couldn't see either.

## Changes
- `get_token` now reports `$deprecated` (message string or `true`) when the token carries it.
- Adds a compact `variance` summary — `{ kind, axes }` — present only when the value flips across axes (mirrors the UI badge's "show when there's something to show"). Reuses the same `getVariance` source as `get_axis_variance`; full per-axis detail still lives there.
- Tool description and the MCP reference table updated.
- Minor changeset.

## Verification
- TDD: four new cases in `token-introspection.test.ts` — `$deprecated` message surfaced, omitted when absent, variance summarised for a mode-varying token (`color.surface.default`), omitted for an axis-constant primitive.
- mcp gauntlet (format:check / lint / typecheck / test) green, 84 tests; docs build passes.

Composes/dependency count is deliberately out of scope here — it depends on the UI composes indicator (#1253, PR #1257) and can fold in once that lands.

Milestone: Maintenance

Closes #1245

Plan impact: none.