### PR TITLE
feat(blocks): add a config.indicators baseline for the row-indicator strip

### DIFF
--- a/.changeset/config-indicators-baseline.md
+++ b/.changeset/config-indicators-baseline.md
@@ -1,0 +1,6 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+"@unpunnyfuns/swatchbook-blocks": minor
+---
+
+Add a project-wide config.indicators baseline for the block row-indicator strip; per-block indicators props override it

--- a/apps/docs/docs/reference/blocks/overview.mdx
+++ b/apps/docs/docs/reference/blocks/overview.mdx
@@ -34,7 +34,7 @@ Props:
 - `initiallyExpanded?: number`: depth open on first render. `0` all collapsed, `1` top-level groups open (default), `2` one deeper, etc.
 - `searchable?: boolean`: render a runtime search input above the tree. Defaults to `true`. Pass `false` to hide the input (the `root` / `type` props still apply at authoring time).
 - `onSelect?(path: string): void`: receives a leaf's full dot-path on click; suppresses the built-in overlay.
-- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present.
+- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present. A project-wide default for the strip can be set via [`config.indicators`](../config.mdx#indicators); this per-block prop overrides it.
 
 ### TokenTable
 
@@ -55,7 +55,7 @@ Props:
 - `sortDir?: 'asc' | 'desc'`: default `'asc'`.
 - `searchable?: boolean`: render a runtime search input above the table. Defaults to `true`.
 - `onSelect?(path: string): void`: suppress the built-in drawer.
-- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present.
+- `indicators?: boolean | Partial<Record<IndicatorName, boolean>>`: configure the per-row indicator strip. Omit for the defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off). `false` hides the strip; `true` enables all (including `description`); an object overrides individual keys (e.g. `{ description: true }`, `{ deprecation: false }`). Indicators still render only when their data is present. A project-wide default for the strip can be set via [`config.indicators`](../config.mdx#indicators); this per-block prop overrides it.
 
 ## Per-type
 

--- a/apps/docs/docs/reference/config.mdx
+++ b/apps/docs/docs/reference/config.mdx
@@ -66,7 +66,7 @@ Exactly three shapes are legal:
 - **Layered** (`LayeredConfig`): `axes: [...]` + `tokens: [...]`. For projects without a resolver document. You declare axes inline; each context names overlay files that layer onto the base `tokens`.
 - **Plain parse** (`PlainConfig`): `tokens: [...]` alone. Single synthetic `theme` axis; every token loaded as one tuple. Useful for smoke-testing a token set before adopting a resolver.
 
-All three variants extend a shared base (`cssVarPrefix`, `presets`, `disabledAxes`, `chrome`, `cssOptions`, `listingOptions`, `terrazzoPlugins`, `maxJointArity`, `default`, `outDir`).
+All three variants extend a shared base (`cssVarPrefix`, `presets`, `disabledAxes`, `chrome`, `indicators`, `cssOptions`, `listingOptions`, `terrazzoPlugins`, `maxJointArity`, `default`, `outDir`).
 
 ## Fields
 
@@ -211,6 +211,23 @@ Produces a single `:root` chrome block with all ten roles declared: overrides be
 **Composite sub-field targets are accepted.** `typography.body` is a composite token that emits one sub-variable per field; the chrome map can target those directly (`bodyFontSize: 'typography.body.font-size'`) even though the sub-field isn't a standalone token ID.
 
 Unknown role keys (outside the ten above) and target paths that don't resolve to any token or composite sub-field in any theme produce `warn` diagnostics (group `swatchbook/chrome`) and are dropped; the corresponding chrome slot falls back to its hard-coded literal default. The validated entries land on `Project.chrome` for downstream tooling.
+
+### `indicators`
+
+Type: `Record<string, boolean>`, optional.
+
+Project-wide baseline for the row-indicator strip on `<TokenNavigator>` and `<TokenTable>` (the per-row alias / variance / gamut / deprecation / description glyphs). Each key toggles one indicator: `alias`, `variance`, `gamut`, `deprecation`, `description`, `composes`. Unlike `chrome`, which travels as CSS variables, this baseline reaches blocks as runtime data over the same path `cssVarPrefix` follows.
+
+```ts
+defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  indicators: {
+    description: true,
+  },
+});
+```
+
+Precedence runs lowest to highest: the hard-coded indicator defaults (`alias`, `variance`, `gamut`, `deprecation` on; `description` off), then this `config.indicators` baseline, then a block's own `indicators` prop. A block that sets `indicators={{ description: false }}` overrides the baseline above for that block; a block with no prop inherits the baseline.
 
 ### `cssOptions`
 

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -19,6 +19,7 @@ import {
   defaultTuple as virtualDefaultTuple,
   diagnostics,
   disabledAxes as virtualDisabledAxes,
+  indicators as virtualIndicators,
   listing as virtualListing,
   presets as virtualPresets,
   tokenGraph as virtualTokenGraph,
@@ -59,6 +60,7 @@ registerTokenSource({
   diagnostics,
   css,
   cssVarPrefix,
+  indicators: virtualIndicators,
   listing: virtualListing,
   tokenGraph: virtualTokenGraph,
   defaultTuple: virtualDefaultTuple,
@@ -409,6 +411,7 @@ interface HmrSnapshot {
   diagnostics: typeof diagnostics;
   css: string;
   cssVarPrefix: string;
+  indicators: typeof virtualIndicators;
   listing: typeof virtualListing;
   tokenGraph: typeof virtualTokenGraph;
   defaultTuple: typeof virtualDefaultTuple;

--- a/packages/addon/src/virtual.d.ts
+++ b/packages/addon/src/virtual.d.ts
@@ -21,6 +21,7 @@ declare module 'virtual:swatchbook/tokens' {
   export const diagnostics: readonly VirtualDiagnostic[];
   export const css: string;
   export const cssVarPrefix: string;
+  export const indicators: Readonly<Record<string, boolean>>;
   export const listing: Readonly<Record<string, VirtualListingEntry>>;
   export const defaultTuple: Record<string, string>;
   export const tokenGraph: TokenGraph;

--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -188,6 +188,7 @@ export function swatchbookTokensPlugin({
         `export const diagnostics = ${JSON.stringify(snap.diagnostics)};`,
         `export const css = ${JSON.stringify(snap.css)};`,
         `export const cssVarPrefix = ${JSON.stringify(snap.cssVarPrefix)};`,
+        `export const indicators = ${JSON.stringify(snap.indicators)};`,
         `export const listing = ${JSON.stringify(snap.listing)};`,
         `export const defaultTuple = ${JSON.stringify(snap.defaultTuple)};`,
         `export const tokenGraph = ${JSON.stringify(snap.tokenGraph)};`,

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -221,7 +221,13 @@ export function TokenNavigator({
   id,
   indicators,
 }: TokenNavigatorProps): ReactElement {
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = useProject();
+  const {
+    resolved,
+    activeTheme,
+    activeAxes,
+    cssVarPrefix,
+    indicators: indicatorBaseline,
+  } = useProject();
 
   // Persist UI state (expand/collapse, selection, search) across docs-mode
   // remounts. Keyed on the props that distinguish one navigator from another
@@ -235,7 +241,10 @@ export function TokenNavigator({
     return new Set(Array.isArray(type) ? type : [type]);
   }, [type]);
 
-  const enabledIndicators = useMemo(() => resolveIndicators(indicators), [indicators]);
+  const enabledIndicators = useMemo(
+    () => resolveIndicators(indicators, indicatorBaseline),
+    [indicators, indicatorBaseline],
+  );
 
   const tree = useMemo(() => buildTree(resolved, root, typeFilter), [resolved, root, typeFilter]);
 

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -72,11 +72,22 @@ export function TokenTable({
   indicators,
 }: TokenTableProps): ReactElement {
   const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing, varianceByPath } = project;
+  const {
+    resolved,
+    activeTheme,
+    activeAxes,
+    cssVarPrefix,
+    listing,
+    varianceByPath,
+    indicators: indicatorBaseline,
+  } = project;
   const colorFormat = useColorFormat();
   // Persist selection + search across docs-mode remounts (see persistent-state).
   const blockKey = useBlockKey('TokenTable', [filter, type, caption, id]);
-  const enabledIndicators = useMemo(() => resolveIndicators(indicators), [indicators]);
+  const enabledIndicators = useMemo(
+    () => resolveIndicators(indicators, indicatorBaseline),
+    [indicators, indicatorBaseline],
+  );
   const [selectedPath, setSelectedPath] = usePersistedState<string | null>(
     `${blockKey}::selected`,
     null,

--- a/packages/blocks/src/contexts.ts
+++ b/packages/blocks/src/contexts.ts
@@ -84,6 +84,13 @@ export interface ProjectSnapshot {
   activeTheme: string;
   activeAxes: Readonly<Record<string, string>>;
   cssVarPrefix: string;
+  /**
+   * Project-wide baseline for the row-indicator strip from
+   * `config.indicators`. Sits between the hard-coded indicator defaults
+   * and a block's `indicators` prop. Optional — hand-built snapshots
+   * (tests, MDX) omit it and blocks fall back to the bare defaults.
+   */
+  indicators?: Readonly<Record<string, boolean>>;
   diagnostics: readonly VirtualDiagnosticShape[];
   css: string;
   /**

--- a/packages/blocks/src/indicators/resolve.ts
+++ b/packages/blocks/src/indicators/resolve.ts
@@ -19,14 +19,23 @@ const DEFAULT_INDICATORS: Record<IndicatorName, boolean> = {
   description: false,
 };
 
-/** Normalize an `IndicatorsProp` into a full enabled-map by layering over the defaults. */
-export function resolveIndicators(prop?: IndicatorsProp): Record<IndicatorName, boolean> {
-  if (prop === undefined) return { ...DEFAULT_INDICATORS };
+/**
+ * Normalize an `IndicatorsProp` into a full enabled-map. Precedence
+ * (lowest→highest): `DEFAULT_INDICATORS` → `baseline` (the project-wide
+ * `config.indicators` default) → per-block `prop`. An explicit boolean
+ * `prop` (`true`/`false`) forces every key on/off and wins over the
+ * baseline; an object `prop` overlays on top of defaults+baseline; an
+ * absent `prop` leaves the result at defaults overlaid with baseline.
+ */
+export function resolveIndicators(
+  prop?: IndicatorsProp,
+  baseline?: Partial<Record<IndicatorName, boolean>>,
+): Record<IndicatorName, boolean> {
   if (prop === true) {
     return { alias: true, variance: true, gamut: true, deprecation: true, description: true };
   }
   if (prop === false) {
     return { alias: false, variance: false, gamut: false, deprecation: false, description: false };
   }
-  return { ...DEFAULT_INDICATORS, ...prop };
+  return { ...DEFAULT_INDICATORS, ...baseline, ...prop };
 }

--- a/packages/blocks/src/internal/channel-tokens.ts
+++ b/packages/blocks/src/internal/channel-tokens.ts
@@ -33,6 +33,8 @@ export interface TokenSnapshot {
   readonly diagnostics: readonly VirtualDiagnostic[];
   readonly css: string;
   readonly cssVarPrefix: string;
+  /** Project-wide baseline for the row-indicator strip from `config.indicators`. */
+  readonly indicators: Readonly<Record<string, boolean>>;
   readonly listing: Readonly<Record<string, VirtualTokenListingShape>>;
   readonly tokenGraph: VirtualTokenGraph;
   readonly defaultTuple: Record<string, string>;
@@ -53,6 +55,7 @@ const EMPTY_SNAPSHOT: TokenSnapshot = {
   diagnostics: [],
   css: '',
   cssVarPrefix: '',
+  indicators: {},
   listing: {},
   tokenGraph: EMPTY_TOKEN_GRAPH,
   defaultTuple: {},
@@ -74,6 +77,7 @@ function applyPatch(patch: Partial<TokenSnapshot>): void {
     diagnostics: patch.diagnostics ?? snapshot.diagnostics,
     css: patch.css ?? snapshot.css,
     cssVarPrefix: patch.cssVarPrefix ?? snapshot.cssVarPrefix,
+    indicators: patch.indicators ?? snapshot.indicators,
     listing: patch.listing ?? snapshot.listing,
     tokenGraph: patch.tokenGraph ?? snapshot.tokenGraph,
     defaultTuple: patch.defaultTuple ?? snapshot.defaultTuple,

--- a/packages/blocks/src/internal/use-project.ts
+++ b/packages/blocks/src/internal/use-project.ts
@@ -43,6 +43,13 @@ export interface ProjectData {
   diagnostics: readonly VirtualDiagnostic[];
   cssVarPrefix: string;
   /**
+   * Project-wide baseline for the row-indicator strip from
+   * `config.indicators`. `{}` when absent. Strip-hosting blocks pass it as
+   * the baseline arg to `resolveIndicators` so a per-block `indicators`
+   * prop overrides it.
+   */
+  indicators: Readonly<Record<string, boolean>>;
+  /**
    * Path-indexed Token Listing data. Empty when absent (non-resolver
    * projects, hand-built snapshots that don't populate it). Blocks read
    * authoritative CSS var names from `listing[path].names.css` and
@@ -130,6 +137,7 @@ export function useProject(): ProjectData {
   const activeTheme = snapshot?.activeTheme;
   const diagnostics = snapshot?.diagnostics;
   const cssVarPrefix = snapshot?.cssVarPrefix;
+  const indicators = snapshot?.indicators;
   const listing = snapshot?.listing;
   const tokenGraph = snapshot?.tokenGraph;
   const resolveAt = useMemo(() => {
@@ -157,6 +165,7 @@ export function useProject(): ProjectData {
       resolved: resolveAt(activeAxes as Record<string, string>),
       diagnostics: diagnostics ?? [],
       cssVarPrefix: cssVarPrefix ?? '',
+      indicators: indicators ?? {},
       listing: listing ?? {},
       varianceByPath: derivedVarianceByPath,
       resolveAt,
@@ -170,6 +179,7 @@ export function useProject(): ProjectData {
     activeAxes,
     diagnostics,
     cssVarPrefix,
+    indicators,
     listing,
     derivedVarianceByPath,
     tokenGraph,
@@ -229,6 +239,7 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
       resolved: resolveAt(activeAxes),
       diagnostics: tokens.diagnostics,
       cssVarPrefix: tokens.cssVarPrefix,
+      indicators: tokens.indicators,
       listing: tokens.listing,
       varianceByPath: fallbackVarianceByPath,
       resolveAt,
@@ -239,6 +250,7 @@ function useVirtualModuleFallback(enabled: boolean): ProjectData {
       tokens.axes,
       tokens.diagnostics,
       tokens.cssVarPrefix,
+      tokens.indicators,
       tokens.listing,
       fallbackVarianceByPath,
       resolveAt,

--- a/packages/blocks/src/virtual.d.ts
+++ b/packages/blocks/src/virtual.d.ts
@@ -22,6 +22,7 @@ declare module 'virtual:swatchbook/tokens' {
   export const diagnostics: readonly VirtualDiagnosticShape[];
   export const css: string;
   export const cssVarPrefix: string;
+  export const indicators: Readonly<Record<string, boolean>>;
   export const listing: Readonly<Record<string, VirtualTokenListingShape>>;
   export const defaultTuple: Record<string, string>;
   export const tokenGraph: VirtualTokenGraph;

--- a/packages/blocks/test/indicator-config.browser.test.tsx
+++ b/packages/blocks/test/indicator-config.browser.test.tsx
@@ -12,7 +12,7 @@ const TOKENS: Record<string, VirtualTokenShape> = {
   },
 };
 
-function snapshot(): ProjectSnapshot {
+function snapshot(indicators?: Record<string, boolean>): ProjectSnapshot {
   const snap: ProjectSnapshot = {
     axes: [],
     defaultTuple: {},
@@ -22,6 +22,7 @@ function snapshot(): ProjectSnapshot {
     diagnostics: [],
     css: '',
   };
+  if (indicators) snap.indicators = indicators;
   snap.resolveAt = () => TOKENS;
   return snap;
 }
@@ -55,4 +56,22 @@ it('TokenTable indicators={{ deprecation: false }} drops the badge and the path 
   expect(screen.queryByTestId('row-indicator-deprecated')).toBeNull();
   const pathCell = screen.getByText('color.brand').closest('td')!;
   expect(pathCell.getAttribute('data-deprecated')).toBeNull();
+});
+
+it('config.indicators baseline shows the description glyph with no per-block prop', () => {
+  render(
+    <SwatchbookProvider value={snapshot({ description: true })}>
+      <TokenTable type="color" />
+    </SwatchbookProvider>,
+  );
+  expect(screen.getByTestId('row-indicator-description')).toBeTruthy();
+});
+
+it('per-block indicators prop overrides a config.indicators baseline back off', () => {
+  render(
+    <SwatchbookProvider value={snapshot({ description: true })}>
+      <TokenTable type="color" indicators={{ description: false }} />
+    </SwatchbookProvider>,
+  );
+  expect(screen.queryByTestId('row-indicator-description')).toBeNull();
 });

--- a/packages/blocks/test/resolve-indicators.test.ts
+++ b/packages/blocks/test/resolve-indicators.test.ts
@@ -45,3 +45,45 @@ it('partial object leaves unspecified keys at their default', () => {
     description: true,
   });
 });
+
+it('baseline overlays the defaults when no prop is passed', () => {
+  expect(resolveIndicators(undefined, { description: true })).toEqual({
+    ...DEFAULTS,
+    description: true,
+  });
+});
+
+it('object prop overrides the baseline', () => {
+  expect(resolveIndicators({ description: false }, { description: true })).toEqual({
+    ...DEFAULTS,
+    description: false,
+  });
+});
+
+it('prop===false beats a baseline that turned something on', () => {
+  expect(resolveIndicators(false, { description: true })).toEqual({
+    alias: false,
+    variance: false,
+    gamut: false,
+    deprecation: false,
+    description: false,
+  });
+});
+
+it('prop===true beats a baseline that turned something off', () => {
+  expect(resolveIndicators(true, { gamut: false })).toEqual({
+    alias: true,
+    variance: true,
+    gamut: true,
+    deprecation: true,
+    description: true,
+  });
+});
+
+it('undefined prop with baseline equals defaults overlaid with baseline', () => {
+  expect(resolveIndicators(undefined, { alias: false, description: true })).toEqual({
+    ...DEFAULTS,
+    alias: false,
+    description: true,
+  });
+});

--- a/packages/core/src/snapshot-for-wire.ts
+++ b/packages/core/src/snapshot-for-wire.ts
@@ -50,6 +50,8 @@ export interface SnapshotForWire {
   presets: Project['presets'];
   diagnostics: Project['diagnostics'];
   cssVarPrefix: string;
+  /** Project-wide baseline for the block row-indicator strip; `config.indicators` passed through verbatim. */
+  indicators: Readonly<Record<string, boolean>>;
   css: string;
   listing: Readonly<Record<string, SlimListedToken>>;
   defaultTuple: Project['defaultTuple'];
@@ -69,6 +71,7 @@ export function snapshotForWire(project: Project, css: string): SnapshotForWire 
     presets: project.presets,
     diagnostics: project.diagnostics,
     cssVarPrefix: project.config.cssVarPrefix ?? '',
+    indicators: project.config.indicators ?? {},
     css,
     listing: slimListing(project.listing),
     defaultTuple: project.defaultTuple,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -202,6 +202,18 @@ interface CommonConfig {
    */
   chrome?: Partial<Record<ChromeRole, string>>;
   /**
+   * Project-wide baseline for the block row-indicator strip (the
+   * `<TokenNavigator>` / `<TokenTable>` per-row alias / variance / gamut /
+   * deprecation / description glyphs). Known keys are `alias`, `variance`,
+   * `gamut`, `deprecation`, `description`, `composes`; each maps to a
+   * boolean. Sits between the hard-coded indicator defaults and a block's
+   * own `indicators` prop — a per-block prop overrides this baseline.
+   *
+   * Typed loosely as `Record<string, boolean>` so core stays free of a
+   * blocks dependency; blocks narrows the keys at the use-site.
+   */
+  indicators?: Readonly<Record<string, boolean>>;
+  /**
    * Options forwarded to the `@terrazzo/plugin-css` instance swatchbook
    * runs internally (for the stylesheet it emits and for the Token
    * Listing's `names.css` derivation). Line this up with the consumer's


### PR DESCRIPTION
Adds a project-wide `config.indicators` baseline for the block row-indicator strip on `<TokenNavigator>` and `<TokenTable>` (the per-row alias / variance / gamut / deprecation / description glyphs).

Three-tier precedence, lowest to highest: the hard-coded indicator defaults, then the `config.indicators` baseline, then a block's own `indicators` prop. `resolveIndicators` gains an optional baseline second arg layered between defaults and the per-block prop; a boolean prop still forces all-on/all-off and wins over the baseline.

Delivery note: unlike `config.chrome`, which reaches blocks as CSS custom properties baked into the emitted stylesheet, indicator toggling is runtime React logic. So the baseline travels as data along the same pipeline `cssVarPrefix` already follows: core `Config` to the wire snapshot, through the addon's virtual module and channel, into blocks' `ProjectSnapshot` / `ProjectData`, and on to the components. Core's `Config` carries the field typed loosely as `Record<string, boolean>` so core takes no dependency on blocks.

Milestone: Block value display + chrome consistency

Closes #1252

Plan impact: none.