### PR TITLE
ci: skip chromatic on dependabot pull requests

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -20,9 +20,14 @@ jobs:
   chromatic:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Don't block on a missing secret — forks and draft PRs without
-    # access to CHROMATIC_PROJECT_TOKEN should skip cleanly.
-    if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    # Don't block on a missing secret — runs without access to
+    # CHROMATIC_PROJECT_TOKEN should skip cleanly. Forks fail the
+    # same-repo check; Dependabot branches live in-repo but GitHub runs
+    # their pull_request event in a restricted context that withholds
+    # Actions secrets, so the token is empty and the job would fail. A
+    # job skipped via `if:` reports a neutral result, so neither case
+    # blocks the PR.
+    if: ${{ github.actor != 'dependabot[bot]' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository) }}
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
Dependabot PRs (e.g. #1260) fail the Chromatic check with `✖ Missing project token`: GitHub runs Dependabot `pull_request` events in a restricted context that withholds repository Actions secrets, so `CHROMATIC_PROJECT_TOKEN` is empty and the job fails on every run, re-runs included.

The job already skips forks via its `if:` (same-repo check), but Dependabot branches live in this repo and pass that guard. This extends the same job-level `if:` to also skip `dependabot[bot]`.

A job skipped via `if:` reports a neutral result — the existing fork-skip path already proves this doesn't leave a required check hanging — so Dependabot PRs go green without Chromatic. Those PRs only bump deps/actions, so there's no UI to visually diff anyway.

Storing the token as a Dependabot secret (so Chromatic could actually run) is the orthogonal maintainer-side alternative; this guard is the durable repo-side fix.

Milestone: Maintenance

Closes #1262

Plan impact: none.