### PR TITLE
docs: refocus the quickstart on install + configure and lift the storybook section map to the landing page

### DIFF
--- a/.changeset/quickstart-install-focus.md
+++ b/.changeset/quickstart-install-focus.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Docs: refocus the quickstart on install and configure, routing to the MDX and stories guides for presentation; move the surface comparison to the quickstart fork

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 The doc blocks from `@unpunnyfuns/swatchbook-blocks` are React components that render against the active token graph. Use them in MDX doc pages to compose reference pages (a `ColorPalette`, a `TypographyScale`, a `TokenTable` filtered to a subpath), all of which update live as the toolbar changes axes.
 
-For a sidebar catalog of browsable, testable token views instead of prose pages, see [Displaying tokens as stories](./displaying-tokens-as-stories.mdx). The two surfaces render the same blocks and coexist.
+For a sidebar catalog of browsable, testable token views instead of prose pages, see [Displaying tokens as stories](./displaying-tokens-as-stories.mdx). The two surfaces render the same blocks, and a project can run both.
 
 ## Prerequisite
 

--- a/apps/docs/docs/guides/displaying-tokens-as-stories.mdx
+++ b/apps/docs/docs/guides/displaying-tokens-as-stories.mdx
@@ -45,11 +45,6 @@ The pin takes priority over the toolbar for that story and reverts when you navi
 
 Primitive types (`color`, `fontFamily`, `fontWeight`, `dimension`, `strokeStyle`) hold a single value. Composite types (`typography`, `shadow`, `border`, `gradient`, `transition`) bundle several values: a `typography` token, for instance, composes a `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, and `letterSpacing`. Composite rows carry the `composes` indicator (a `⊞ N` parts count) in the table and tree blocks, so the bundling is visible at a glance.
 
-## Stories or MDX doc pages?
+## MDX or stories?
 
-Both surfaces render the same blocks; pick by what you want around them:
-
-- **Stories** put the catalog in the sidebar, add Controls, and make each view testable. Reach for them when the token reference should sit alongside your component stories and be covered by the same test runs.
-- **[MDX doc pages](./authoring-doc-stories.mdx)** put blocks inside prose. Reach for them when the tokens need narrative around them: a usage guide, a rationale, a migration note.
-
-They coexist; many projects keep a story catalog for browsing and testing and an MDX page or two for the narrative reference.
+The same blocks render in both surfaces. The [quickstart's "Where to next"](./quickstart.mdx#where-to-next) covers when to reach for each: in short, stories for a browsable, testable catalog, [MDX doc pages](./authoring-doc-stories.mdx) for blocks wrapped in narrative. A project can run both.

--- a/apps/docs/docs/guides/quickstart.mdx
+++ b/apps/docs/docs/guides/quickstart.mdx
@@ -87,82 +87,6 @@ pnpm storybook
 
 **Toolbar**: a single Swatchbook icon button in the top bar. Click it to open a popover containing preset pills, one dropdown per modifier in your resolver, and a color-format picker. If you've written a single `theme` modifier with `Light`/`Dark` contexts, you get one dropdown inside the popover; if you have `mode × brand`, you get two. Escape or outside-click closes it.
 
-## Your first doc page
-
-Tokens can be presented two ways, both rendering the same blocks: an MDX doc page (blocks inside prose, for a narrative reference) or stories (a browsable, testable catalog in the sidebar). They coexist. This quickstart builds an MDX page; [Displaying tokens as stories](./displaying-tokens-as-stories.mdx) covers the story catalog, and [Authoring MDX doc pages](./authoring-doc-stories.mdx) has the full MDX patterns.
-
-Create an MDX file under your stories glob. The addon's blocks render against whichever tuple the toolbar has active, so everything below re-renders live as you flip modifiers:
-
-```tsx title="src/docs/Tokens.mdx"
-import { Meta } from '@storybook/addon-docs/blocks';
-import {
-  ColorPalette,
-  Diagnostics,
-  TokenDetail,
-  TokenNavigator,
-  TokenTable,
-} from '@unpunnyfuns/swatchbook-addon';
-
-<Meta title="Docs/Tokens" />
-
-# Tokens
-
-<Diagnostics />
-
-## Palette
-<ColorPalette filter="color.palette.**" />
-
-## Semantic roles
-<ColorPalette filter="color.**" />
-
-## Everything
-<TokenNavigator initiallyExpanded={0} />
-
-## Inspect a single token
-<TokenDetail path="color.accent.bg" />
-```
-
-Each block takes filter/scoping props so you can pick what shows up:
-
-- **`<ColorPalette filter="…" />`**: swatch grid grouped by sub-path. Filter by a glob (`"color.palette.*"`, `"color.brand.*"`).
-- **`<TokenTable filter="…" type="…" />`**: searchable two-column table (path + value). Filter by path glob, scope by DTCG `$type`.
-- **`<TokenNavigator root="…" type="…" initiallyExpanded={0..∞} />`**: expandable tree. Scope to a subtree (`root="color"`) and/or a `$type`; `initiallyExpanded={0}` opens fully collapsed.
-- **`<TokenDetail path="…" />`**: alias chain, per-theme values, CSS var reference, and `useToken` snippet for one token.
-- **`<Diagnostics />`**: collapsible list of parser / resolver / validation warnings. Auto-opens when anything's non-zero.
-- **`<TypographyScale>`, `<DimensionScale>`, `<FontFamilyPreview>`, `<FontWeightScale>`, `<BorderPreview>`, `<ShadowPreview>`, `<GradientPalette>`, `<MotionPreview>`, `<StrokeStylePreview>`**: type-specific blocks with built-in samples. Filter by path glob when you want a subset.
-
-The [blocks reference](../reference/blocks/index.mdx) has the full prop list for each. The [MDX authoring guide](./authoring-doc-stories.mdx) walks through composing them in real pages.
-
-## Theme the block chrome against your tokens
-
-The MDX doc blocks read their surfaces, text, and accent colours from a fixed `--swatchbook-*` CSS-variable namespace. By default, those variables fall back to light/dark literals that flip with the active `color-scheme`, which means the blocks render legibly before you wire anything up. To have them reflect your own tokens, supply a `chrome` map with one entry per role, each pointing at a token path in your project:
-
-```ts title=".storybook/main.ts"
-{
-  name: '@unpunnyfuns/swatchbook-addon',
-  options: {
-    config: {
-      resolver: 'tokens/resolver.json',
-      cssVarPrefix: 'ds',
-      chrome: {
-        surfaceDefault: 'color.surface.default',
-        surfaceMuted:   'color.surface.muted',
-        surfaceRaised:  'color.surface.raised',
-        textDefault:    'color.text.default',
-        textMuted:      'color.text.muted',
-        borderDefault:  'color.border.default',
-        accentBg:       'color.accent.bg',
-        accentFg:       'color.accent.fg',
-        bodyFontFamily: 'typography.body.font-family',
-        bodyFontSize:   'typography.body.font-size',
-      },
-    },
-  },
-},
-```
-
-With a `chrome` map in place the blocks track every toolbar flip: switch any axis (e.g. brand or contrast) and the block chrome repaints alongside your stories. The closed set of roles (and what each maps to internally) is in the [`chrome` config reference](../reference/config.mdx#chrome).
-
 ## No resolver yet?
 
 If you haven't written a DTCG 2025.10 resolver, you can use the **layered** config form instead:
@@ -188,9 +112,35 @@ export default defineSwatchbookConfig({
 
 Each context names an ordered list of file paths (or globs) that layer on top of the base `tokens` files for that context. See the [config reference](../reference/config.mdx) for the resolver vs layered trade-off.
 
-## Next
+## Render your first block
 
-- Embed [doc blocks in MDX doc pages](./authoring-doc-stories.mdx) to build a narrative reference page.
-- Or present them as a [sidebar story catalog](./displaying-tokens-as-stories.mdx), browsable and testable alongside your component stories.
-- Read the [axes reference](../concepts/axes.mdx) for the runtime model behind the toolbar.
-- Poke at the [live Storybook](pathname:///storybook/) to see the addon running against a real multi-axis fixture.
+The addon's blocks render against whichever tuple the toolbar has active. Drop one into an MDX file under your stories glob to confirm the wiring is live:
+
+```tsx title="src/docs/Tokens.mdx"
+import { Meta } from '@storybook/addon-docs/blocks';
+import { TokenNavigator } from '@unpunnyfuns/swatchbook-addon';
+
+<Meta title="Docs/Tokens" />
+
+# Tokens
+
+<TokenNavigator initiallyExpanded={0} />
+```
+
+Open `Docs / Tokens` in the sidebar: the tree lists every token in your project and repaints when you flip an axis. That confirms the install end to end. From here it's a question of how you want to present the catalog.
+
+## Where to next
+
+Tokens render through two surfaces, both built from the same blocks. Pick by what you want around them:
+
+- **MDX doc pages** put blocks inside prose: a usage guide, a rationale, a migration note. Reach for them when the tokens need narrative around them. [Authoring MDX doc pages](./authoring-doc-stories.mdx) has the patterns.
+- **Stories** put the catalog in the sidebar, add a Controls panel, and bring each view under the same interaction, a11y, and visual-regression runs as your component stories. Reach for them when the token reference should sit alongside your components and be covered by the same tests. [Displaying tokens as stories](./displaying-tokens-as-stories.mdx) walks through it.
+
+The two aren't exclusive: plenty of projects run a story catalog for browsing and testing alongside an MDX page or two for the narrative reference.
+
+Also worth a look:
+
+- [Theme the block chrome](../reference/config.mdx#chrome): map the blocks' own surfaces, text, and accents onto your tokens so they flip with the toolbar.
+- [Blocks reference](../reference/blocks/index.mdx): every block's full prop list.
+- [Axes reference](../concepts/axes.mdx): the runtime model behind the toolbar.
+- [Live Storybook](pathname:///storybook/): the addon running against a real multi-axis fixture.

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -51,6 +51,7 @@ export default definePreview({
             'StrokeStyles',
           ],
           'Blocks',
+          ['Introduction', '*'],
           '*',
         ],
       },

--- a/apps/storybook/src/docs/Blocks.mdx
+++ b/apps/storybook/src/docs/Blocks.mdx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Blocks/Introduction" />
+
+# Blocks
+
+The component stories behind every swatchbook block. Each entry under **Blocks**
+mounts one block from `@unpunnyfuns/swatchbook-blocks` on its own, with the
+variants and Controls that exercise it as a component, independent of any page
+or token type. The play-function assertions on each story double as its
+interaction and a11y tests.
+
+## What is here
+
+- **Inspectors**: `TokenTable`, `TokenNavigator`, and `TokenDetail`: the
+  searchable, tree, and single-token views of the active graph.
+- **Color**: `ColorPalette` and `ColorTable`.
+- **Type previews**: `TypographyScale`, `DimensionScale`, `OpacityScale`,
+  `BorderPreview`, `ShadowPreview`, `GradientPalette`, and `MotionPreview`.
+
+Every block's full prop list is in the
+[blocks reference](https://unpunnyfuns.github.io/swatchbook/reference/blocks).

--- a/apps/storybook/src/docs/Introduction.mdx
+++ b/apps/storybook/src/docs/Introduction.mdx
@@ -12,24 +12,20 @@ semantic roles at `color.<role>.*`, plus `mode × brand × contrast`
 modifier axes via a DTCG resolver), through the addon and dogfoods every
 block in the library.
 
-## Pages
+## Sections
 
-- **[Dashboard](?path=/docs/docs-dashboard--docs)**: the recommended
-  composition: `<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />`
-  on one page. This is the pattern that replaces the old in-manager
-  Design Tokens panel.
-- **[Colors](?path=/docs/docs-colors--docs)**: `ColorPalette` grids.
-- **[Typography](?path=/docs/docs-typography--docs)**: `TypographyScale`
-  rendering composites with real sub-values.
-- **[Fonts](?path=/docs/docs-fonts--docs)**: `FontFamilyPreview` and
-  `FontWeightScale` for the primitives that back typography composites.
-- **[Dimensions](?path=/docs/docs-dimensions--docs)**: `DimensionScale`
-  for spacing and radius scales.
-- **[Borders](?path=/docs/docs-borders--docs)**,
-  **[Shadows](?path=/docs/docs-shadows--docs)**,
-  **[StrokeStyles](?path=/docs/docs-strokestyles--docs)**,
-  **[Gradients](?path=/docs/docs-gradients--docs)**,
-  **[Motion](?path=/docs/docs-motion--docs)**: per-type preview blocks.
+The sidebar holds three views of the same token set and the same blocks:
+
+- **[Docs](?path=/docs/docs-dashboard--docs)**: the blocks composed inside
+  prose, a narrative reference with rationale and usage around the tokens.
+  The [Dashboard](?path=/docs/docs-dashboard--docs) is the recommended
+  composition (`<Diagnostics />` + `<TokenNavigator />` + `<TokenTable />`);
+  the rest drill into one `$type` each.
+- **[Tokens](?path=/docs/tokens-introduction--docs)**: a story catalog of the
+  project's tokens, one browsable and testable view per `$type`, each rendered
+  through its matching block.
+- **[Blocks](?path=/docs/blocks-introduction--docs)**: each block component on
+  its own, with its variants, Controls, and interaction and a11y tests.
 
 ## Live theme switching
 
@@ -39,23 +35,8 @@ preset pills, one dropdown per modifier declared in the resolver
 `oklch` / `raw`). Every block on every page re-renders against the
 active tuple, and color-display formats flip live too.
 
-## Blocks
+## Blocks reference
 
-Every block ships from `@unpunnyfuns/swatchbook-blocks`. Highlights:
-
-- **`TokenTable`** / **`TokenNavigator`**: searchable tabular and tree
-  views of the active theme's graph. Both carry `filter` and `sortBy`
-  props for scoping and ordering.
-- **`TokenDetail`**: single-token inspector: composite preview, alias
-  chain, aliased-by tree, per-axis variance matrix, CSS-var snippet.
-- **`ColorPalette`**: swatch grid, auto-groups by path depth.
-- **`TypographyScale`** / **`FontFamilyPreview`** / **`FontWeightScale`**:
-  type primitives and composites rendered at their own values.
-- **`Diagnostics`**: collapsible list of parser/resolver warnings. Green
-  OK when clean; auto-expands on errors.
-- **`DimensionScale`** / **`BorderPreview`** / **`ShadowPreview`** /
-  **`StrokeStylePreview`** / **`GradientPalette`** / **`MotionPreview`**:
-  per-type visual previews.
-
-See the [blocks reference](https://unpunnyfuns.github.io/swatchbook/reference/blocks)
-for the full list and every prop.
+Every block ships from `@unpunnyfuns/swatchbook-blocks`. The
+[blocks reference](https://unpunnyfuns.github.io/swatchbook/reference/blocks)
+has the full list and every prop.

--- a/apps/storybook/src/docs/Tokens.mdx
+++ b/apps/storybook/src/docs/Tokens.mdx
@@ -33,13 +33,5 @@ that draws from it) sit apart. Composite rows carry the `composes` indicator
   theme pins it per-story via `parameters.swatchbook.axes` (see
   `Tokens/Colors` → `DarkBrandA`).
 
-## How this relates to the other sections
-
-- **Docs** pages compose the same blocks inside prose: narrative reference with
-  rationale and usage around the tokens.
-- **Blocks** stories exercise each block component and its variants and tests.
-- **Tokens** is the catalog: the project's tokens themselves, one browsable,
-  testable view per type.
-
 The authoring pattern (mounting the blocks as stories) is written up in the
 **Displaying tokens as stories** guide on the documentation site.


### PR DESCRIPTION
## What

Quickstart was carrying a full MDX catalog walkthrough and a block-chrome section that duplicated the config reference, and the MDX-vs-stories decision sat at the bottom of the stories guide. In the reference storybook, the Docs/Tokens/Blocks orientation lived inside `Tokens/Introduction` rather than the landing page a visitor hits first.

**Docs site**
- `quickstart.mdx`: trimmed to install / configure / what-you-see / a one-block smoke test / a "Where to next" fork. Dropped the inline MDX catalog, the block list, and the chrome section.
- `displaying-tokens-as-stories.mdx`: "Stories or MDX?" reduced to a one-line back-link to the quickstart fork.
- `authoring-doc-stories.mdx`: small wording change.

**Reference storybook**
- `Introduction.mdx`: now leads with the Docs/Tokens/Blocks section map.
- `Tokens.mdx`: dropped the now-redundant cross-section pointer.
- `Blocks.mdx`: new `Blocks/Introduction`, mirroring `Tokens/Introduction`.
- `preview.tsx`: storySort puts `Blocks/Introduction` first.

Chrome theming is now single-sourced in the config reference (`reference/config.mdx#chrome`), which already held the full narrative.

## Verification

Docs-site build (links/anchors resolve), storybook build (MDX compiles, all four section IDs register), format / lint / typecheck / test green across both workspaces.

Milestone: Maintenance

Closes #1269

Plan impact: none