### PR TITLE
ci: align actions/cache hash pin with the v5 tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           cache: pnpm
 
       - name: Cache Turbo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: .turbo
           key: turbo-${{ matrix.node }}-${{ github.sha }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,7 +50,7 @@ jobs:
           cache: pnpm
 
       - name: Cache Turbo
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         with:
           path: .turbo
           key: turbo-docs-${{ github.sha }}


### PR DESCRIPTION
## What

Code scanning (zizmor `ref-version-mismatch`) flagged both Cache Turbo steps: the pin `actions/cache@27d5ce7f…` was commented `# v5`, but the `v5` tag now resolves to `caa296126883…` (the readonly-cache v5 release), so the comment no longer matched the SHA.

Bumped the pin in `ci.yml` and `docs.yml` to the SHA `v5` currently points to. Clears the alert and moves to the current v5 per the latest-deps policy.

## Verification

`v5` → `caa296126883cff596d87d8935842f9db880ef25` confirmed via the actions/cache git refs API; both workflow files now pin that SHA with the `# v5` comment.

Milestone: Maintenance

Closes #1272

Plan impact: none