### PR TITLE
docs: split Terrazzo dependencies into its own guide and drop the integrations section from the quickstart

### DIFF
--- a/.changeset/quickstart-terrazzo-split.md
+++ b/.changeset/quickstart-terrazzo-split.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Docs: drop the Terrazzo-dependencies and Tailwind/CSS-in-JS sections from the quickstart, moving Terrazzo deps into a dedicated guide and pointing at the existing integrations pages

--- a/apps/docs/docs/guides/quickstart.mdx
+++ b/apps/docs/docs/guides/quickstart.mdx
@@ -21,17 +21,6 @@ npm install -D @unpunnyfuns/swatchbook-addon
 
 Peer requirements: Storybook 10.1+ on the Vite builder, React 18+, Node 24+.
 
-### Terrazzo dependencies
-
-Swatchbook is built on [Terrazzo](https://terrazzo.app/)'s parser. `@terrazzo/parser`, `@terrazzo/plugin-css`, and `@terrazzo/plugin-token-listing` come along with `swatchbook-core` transitively, so you don't install them separately for the default setup. `swatchbook-core` publishes `@terrazzo/parser` and `@terrazzo/plugin-css` as peer deps on top of its own deps, so pnpm hoists to a single shared parser instance across our internal build and any Terrazzo plugins you add yourself.
-
-Two cases where you'll install more packages explicitly:
-
-- **You already run `@terrazzo/cli` in production.** Pin matching versions of `@terrazzo/cli`, `plugin-css`, etc. in your own `package.json` so both pipelines agree on options. See [Aligning with your token build](./sharing-terrazzo-options.mdx) for the shared-options module pattern.
-- **You want per-platform names (Swift, Android, Sass, JS, …) shown in doc blocks.** Install `@terrazzo/plugin-swift` / `-android` / `-sass` / `-js` at a version compatible with swatchbook's peer range, then load them via `config.terrazzoPlugins` + `config.listingOptions.platforms`. `<TokenDetail>`'s Consumer Output picks them up automatically.
-
-When in doubt, skip this section; the zero-config install is enough for everything on this page.
-
 ## Configure
 
 Register the addon with an inline config in `.storybook/main.ts`:
@@ -67,15 +56,6 @@ export default definePreview({
 ```
 
 Inline `config` is the primary path. If you'd rather keep the config in its own file (useful when the same config is consumed by a CLI or CI lint outside Storybook), write a `swatchbook.config.ts` and point at it with `options.configPath: '../swatchbook.config.ts'`; see [config reference](../reference/config.mdx) for details.
-
-### If your stories use Tailwind or a CSS-in-JS library
-
-Stories that already use CSS variables need no extra wiring: the swatchbook toolbar flips `--<prefix>-*` vars via cascade and the stories repaint automatically. Two library-specific shortcuts for everything else:
-
-- **Tailwind v4.** Add [`@unpunnyfuns/swatchbook-integrations/tailwind`](./integrations/tailwind.mdx) to the addon's `integrations[]` and `@tailwindcss/vite` to Storybook's Vite plugins. Utility classes like `bg-<prefix>-surface-default` / `p-<prefix>-md` resolve through swatchbook's tokens automatically.
-- **emotion / styled-components / any `ThemeProvider`.** Add [`@unpunnyfuns/swatchbook-integrations/css-in-js`](./integrations/css-in-js.mdx) to `integrations[]`. Stories `import { theme } from 'virtual:swatchbook/theme'` and hand it to their provider.
-
-Both integrations are preview-only: they let utility classes and theme accessors resolve correctly inside Storybook, nothing else. See the [Integrations guide](./integrations/index.mdx) for the full picture.
 
 Start Storybook:
 
@@ -141,6 +121,8 @@ The two aren't exclusive: plenty of projects run a story catalog for browsing an
 Also worth a look:
 
 - [Theme the block chrome](../reference/config.mdx#chrome): map the blocks' own surfaces, text, and accents onto your tokens so they flip with the toolbar.
+- [Integrations](./integrations/index.mdx): wiring for Tailwind v4 or a CSS-in-JS theme provider.
+- [Terrazzo dependencies](./terrazzo-dependencies.mdx): extra Terrazzo plugins for per-platform names, and aligning with a production `@terrazzo/cli` build.
 - [Blocks reference](../reference/blocks/index.mdx): every block's full prop list.
 - [Axes reference](../concepts/axes.mdx): the runtime model behind the toolbar.
 - [Live Storybook](pathname:///storybook/): the addon running against a real multi-axis fixture.

--- a/apps/docs/docs/guides/terrazzo-dependencies.mdx
+++ b/apps/docs/docs/guides/terrazzo-dependencies.mdx
@@ -1,0 +1,42 @@
+---
+id: terrazzo-dependencies
+title: Terrazzo dependencies
+sidebar_position: 6
+---
+
+# Terrazzo dependencies
+
+Swatchbook is the preview side of a [Terrazzo](https://terrazzo.app/) pipeline: it parses DTCG with Terrazzo's parser and renders what Terrazzo's plugins emit. The zero-config install needs no direct Terrazzo dependency. This page covers the cases where a project adds Terrazzo packages of its own, and why the ones it adds have to share a single parser instance.
+
+## What ships with the addon
+
+`@terrazzo/parser`, `@terrazzo/plugin-css`, and `@terrazzo/plugin-token-listing` come along with `swatchbook-core` transitively. The default install already parses tokens, emits the preview stylesheet, and derives the token listing without any Terrazzo entry in your `package.json`.
+
+`swatchbook-core` also declares `@terrazzo/parser` and `@terrazzo/plugin-css` as **peer** dependencies. pnpm hoists them to one shared instance, so swatchbook's internal build and any Terrazzo plugin you add later resolve the same parser. The failure this avoids is a second, duplicate parser: a plugin built against one instance cannot read a graph produced by another, and the symptom is plugin output that silently goes missing from the listing.
+
+## Per-platform names in doc blocks
+
+Out of the box the blocks show one identifier per token: its CSS variable name. To surface names for other platforms (Swift, Android, Sass, JS), install the matching Terrazzo plugin and register it in two places:
+
+```ts title="swatchbook.config.ts"
+import { defineSwatchbookConfig } from '@unpunnyfuns/swatchbook-core';
+import swiftPlugin from '@terrazzo/plugin-swift';
+
+export default defineSwatchbookConfig({
+  resolver: 'tokens/resolver.json',
+  cssVarPrefix: 'ds',
+  listingOptions: {
+    platforms: {
+      css:   { name: '@terrazzo/plugin-css' },
+      swift: { name: '@terrazzo/plugin-swift', description: 'UIColor' },
+    },
+  },
+  terrazzoPlugins: [swiftPlugin({ /* plugin options */ })],
+});
+```
+
+`listingOptions.platforms` names which plugins derive identifiers for the listing; `terrazzoPlugins` loads those plugins into the build so the names actually resolve. Register a platform without loading its plugin and the reference stays unresolved. `<TokenDetail>`'s Consumer Output reads the resolved names per platform. Install plugins at a version compatible with swatchbook's peer range. The field-level reference for both options is in the [config reference](../reference/config.mdx#listingoptions).
+
+## Aligning with a production Terrazzo build
+
+When `@terrazzo/cli` already builds your tokens for production, pin matching versions of `@terrazzo/cli`, `@terrazzo/plugin-css`, and any shared plugins in your own `package.json` so the production build and the preview build agree on options. The shared-options module pattern, one options file consumed by both `terrazzo.config.ts` and `swatchbook.config.ts`, is in [Aligning with your token build](./sharing-terrazzo-options.mdx).

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -22,6 +22,7 @@ const sidebars: SidebarsConfig = {
       collapsed: false,
       items: ['guides/integrations/tailwind', 'guides/integrations/css-in-js'],
     },
+    'guides/terrazzo-dependencies',
     'guides/sharing-terrazzo-options',
   ],
   reference: [


### PR DESCRIPTION
## What

The quickstart still carried two sections that are setup detail rather than getting-started steps: the Terrazzo-dependencies explainer (under Install) and the Tailwind/CSS-in-JS wiring (under Configure). The integrations already have dedicated pages under `guides/integrations/`.

- `quickstart.mdx`: removed both subsections. Install now ends at peer requirements; Configure flows straight to Start Storybook. Added two pointers under "Also worth a look" (Integrations index, new Terrazzo guide).
- `guides/terrazzo-dependencies.mdx` (new): the moved Terrazzo content, slightly expanded: transitive deps, the peer-dep single-shared-instance rationale, per-platform plugin setup, and aligning with a production `@terrazzo/cli` build. Cross-links the config reference and the existing options-alignment guide rather than duplicating them.
- `sidebars.ts`: new guide registered next to `sharing-terrazzo-options`.

## Verification

Docs build passes (new guide registers, `./terrazzo-dependencies.mdx` and the `#listingoptions` anchor resolve), format / lint / typecheck green.

Milestone: Maintenance

Closes #1274

Plan impact: none