### PR TITLE
fix(blocks): scale dimension rem previews by the real root font-size

### DIFF
--- a/.changeset/dimension-cap-root-font-size.md
+++ b/.changeset/dimension-cap-root-font-size.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Fix dimension previews to scale `rem` by the rendering context's actual root font-size (tracked across responsive breakpoints) instead of a hardcoded 16px, for both the DimensionScale render cap and the `sortBy: 'value'` order; drop the non-DTCG `em` unit

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -4,6 +4,7 @@ import './DimensionScale.css';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
 import type { DimensionVisual } from '#/dimension-scale/DimensionBar.tsx';
 import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
+import { useRootFontSize } from '#/internal/use-root-font-size.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
@@ -57,23 +58,26 @@ export function DimensionScale({
 }: DimensionScaleProps): ReactElement {
   const project = useProject();
   const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const rootFontSize = useRootFontSize();
 
   const rows = useMemo<Row[]>(() => {
     const filtered = Object.entries(resolved).filter(([path, token]) => {
       if (token.$type !== 'dimension') return false;
       return matchPath(path, filter);
     });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
-      const pxValue = toPixels(token.$value);
-      return {
-        path,
-        cssVar: resolveCssVar(path, project),
-        displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
-        pxValue,
-        capped: Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX,
-      };
-    });
-  }, [resolved, filter, project, sortBy, sortDir]);
+    return sortTokens(filtered, { by: sortBy, dir: sortDir, rootFontSizePx: rootFontSize }).map(
+      ([path, token]) => {
+        const pxValue = toPixels(token.$value, rootFontSize);
+        return {
+          path,
+          cssVar: resolveCssVar(path, project),
+          displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
+          pxValue,
+          capped: Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX,
+        };
+      },
+    );
+  }, [resolved, filter, project, sortBy, sortDir, rootFontSize]);
 
   const captionText =
     caption ??

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -12,6 +12,7 @@ import { useBlockKey, usePersistedState } from '#/internal/persistent-state.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import { useRootFontSize } from '#/internal/use-root-font-size.ts';
 import { RowIndicators } from '#/indicators/RowIndicators.tsx';
 import { resolveIndicators } from '#/indicators/resolve.ts';
 import type { IndicatorsProp } from '#/indicators/resolve.ts';
@@ -82,6 +83,7 @@ export function TokenTable({
     indicators: indicatorBaseline,
   } = project;
   const colorFormat = useColorFormat();
+  const rootFontSize = useRootFontSize();
   // Persist selection + search across docs-mode remounts (see persistent-state).
   const blockKey = useBlockKey('TokenTable', [filter, type, caption, id]);
   const enabledIndicators = useMemo(
@@ -102,7 +104,11 @@ export function TokenTable({
       if (type && token.$type !== type) return false;
       return true;
     });
-    const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
+    const entries = sortTokens(filtered, {
+      by: sortBy,
+      dir: sortDir,
+      rootFontSizePx: rootFontSize,
+    });
     return entries.map(([path, token]) => {
       const isColor = token.$type === 'color';
       const color = isColor
@@ -117,7 +123,7 @@ export function TokenTable({
         isColor,
       };
     });
-  }, [resolved, listing, cssVarPrefix, filter, type, colorFormat, sortBy, sortDir]);
+  }, [resolved, listing, cssVarPrefix, filter, type, colorFormat, sortBy, sortDir, rootFontSize]);
 
   const visibleRows = useMemo(() => {
     if (!searchable || deferredQuery.trim() === '') return rows;

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -1,5 +1,6 @@
 import type { CSSProperties, ReactElement } from 'react';
 import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
+import { useRootFontSize } from '#/internal/use-root-font-size.ts';
 import { BORDER_STRONG } from '#/internal/styles.tsx';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
 
@@ -41,9 +42,10 @@ const styles = {
 export function DimensionBar({ path, visual = 'length' }: DimensionBarProps): ReactElement {
   const project = useProject();
   const { resolved } = project;
+  const rootFontSize = useRootFontSize();
   const cssVar = resolveCssVar(path, project);
   const token = resolved[path];
-  const pxValue = toPixels(token?.$value);
+  const pxValue = toPixels(token?.$value, rootFontSize);
   const capped = Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX;
   const cappedValue = capped ? `${MAX_RENDER_PX}px` : cssVar;
 

--- a/packages/blocks/src/dimension-scale/dimension-px.ts
+++ b/packages/blocks/src/dimension-scale/dimension-px.ts
@@ -3,11 +3,16 @@ export const MAX_RENDER_PX = 480;
 
 /**
  * Convert a DTCG dimension `$value` (`{ value, unit }`) to pixels for the
- * purpose of deciding whether to cap the rendered size. Returns `NaN` for
- * units we can't reasonably approximate (ex / ch / %), which the caller
- * treats as "render at cssVar but don't cap".
+ * purpose of deciding whether to cap the rendered size. `rootFontSizePx`
+ * scales `rem` against the rendering context's actual root font-size
+ * (default 16 for the no-DOM / SSR path); the bar paints at the same
+ * context's `var()`, so passing the measured root keeps the cap decision
+ * aligned with what's drawn. Returns `NaN` for anything other than `px` /
+ * `rem` — `ex` / `ch` / `%`, and the non-DTCG `em` (the `dimension` type
+ * permits only `px | rem`) — which the caller treats as "render at cssVar
+ * but don't cap".
  */
-export function toPixels(raw: unknown): number {
+export function toPixels(raw: unknown, rootFontSizePx = 16): number {
   if (raw == null || typeof raw !== 'object') return Number.NaN;
   const v = raw as { value?: unknown; unit?: unknown };
   if (typeof v.value !== 'number' || typeof v.unit !== 'string') return Number.NaN;
@@ -15,8 +20,7 @@ export function toPixels(raw: unknown): number {
     case 'px':
       return v.value;
     case 'rem':
-    case 'em':
-      return v.value * 16;
+      return v.value * rootFontSizePx;
     default:
       return Number.NaN;
   }

--- a/packages/blocks/src/internal/sort-tokens.ts
+++ b/packages/blocks/src/internal/sort-tokens.ts
@@ -7,6 +7,14 @@ export type SortDir = 'asc' | 'desc';
 export interface SortOptions {
   by?: SortBy;
   dir?: SortDir;
+  /**
+   * Root font-size (px) used to convert `rem` dimension values to a pixel
+   * magnitude for `by: 'value'`. Defaults to 16. Dimension-bearing blocks
+   * pass the measured rendering-context root so a value sort matches the
+   * rendered sizes; the same `rem` resolves differently under a different
+   * root (a Storybook Docs page vs the canvas).
+   */
+  rootFontSizePx?: number;
 }
 
 type Entry = readonly [string, VirtualToken];
@@ -50,11 +58,11 @@ const NUMERIC_TYPES = new Set([
 
 const STRING_TYPES = new Set(['fontFamily', 'strokeStyle']);
 
-function computeSortKey(token: VirtualToken): SortKey {
+function computeSortKey(token: VirtualToken, rootFontSizePx: number): SortKey {
   const type = token.$type;
   if (!type) return { kind: 'none' };
   if (NUMERIC_TYPES.has(type)) {
-    const value = toMagnitude(token.$value);
+    const value = toMagnitude(token.$value, rootFontSizePx);
     return { kind: 'numeric', value, valid: Number.isFinite(value) };
   }
   if (type === 'color') {
@@ -84,9 +92,10 @@ export function sortTokens(entries: readonly Entry[], options: SortOptions = {})
   }
 
   // by === 'value' — pre-compute per-token sort keys once.
+  const rootFontSizePx = options.rootFontSizePx ?? 16;
   const keys = new Map<VirtualToken, SortKey>();
   for (const [, token] of entries) {
-    keys.set(token, computeSortKey(token));
+    keys.set(token, computeSortKey(token, rootFontSizePx));
   }
 
   return [...entries].toSorted(([aPath, aTok], [bPath, bTok]) => {
@@ -137,7 +146,7 @@ function compareValue(
   return 0;
 }
 
-function toMagnitude(v: unknown): number {
+function toMagnitude(v: unknown, rootFontSizePx: number): number {
   if (typeof v === 'number') return v;
   if (v && typeof v === 'object') {
     const d = v as { value?: unknown; unit?: unknown };
@@ -150,8 +159,9 @@ function toMagnitude(v: unknown): number {
       case 's':
         return d.value * 1000;
       case 'rem':
-      case 'em':
-        return d.value * 16;
+        return d.value * rootFontSizePx;
+      // `em` is not a DTCG dimension unit (px | rem); it falls through to its
+      // raw value rather than being scaled.
       default:
         return d.value;
     }

--- a/packages/blocks/src/internal/use-root-font-size.ts
+++ b/packages/blocks/src/internal/use-root-font-size.ts
@@ -1,0 +1,31 @@
+import { useSyncExternalStore } from 'react';
+
+// Read the rendering context's root font-size in px; 16 with no DOM or an
+// unparseable value (SSR, hand-built snapshots).
+function readRootFontSize(): number {
+  if (typeof document === 'undefined') return 16;
+  const fontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+  return Number.isFinite(fontSize) && fontSize > 0 ? fontSize : 16;
+}
+
+// Re-read on viewport resize: a responsive root (a media query swapping
+// `html { font-size }` at a breakpoint) changes the root after mount, and the
+// `var()`-based bar re-resolves with it. `useSyncExternalStore` bails out when
+// the value is unchanged, so a resize that doesn't move the root is a no-op.
+function subscribe(onChange: () => void): () => void {
+  if (typeof window === 'undefined') return () => {};
+  window.addEventListener('resize', onChange);
+  return () => window.removeEventListener('resize', onChange);
+}
+
+/**
+ * Root font-size (px) of the context a block renders in, tracked across
+ * viewport changes. `rem` dimension values resolve their `var()` against this
+ * root, so the cap math (`toPixels`) and value sort (`sortTokens`) must scale
+ * `rem` by it rather than a literal 16: a Storybook Docs page, or a responsive
+ * desktop/tablet/mobile breakpoint, can apply a different root to the same
+ * token. Falls back to 16 with no DOM.
+ */
+export function useRootFontSize(): number {
+  return useSyncExternalStore(subscribe, readRootFontSize, () => 16);
+}

--- a/packages/blocks/test/dimension-px.test.ts
+++ b/packages/blocks/test/dimension-px.test.ts
@@ -1,14 +1,21 @@
 import { expect, it } from 'vitest';
 import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
 
-it('converts px / rem / em dimension values to pixels', () => {
+it('converts px and rem dimension values to pixels', () => {
   expect(toPixels({ value: 16, unit: 'px' })).toBe(16);
   expect(toPixels({ value: 1, unit: 'rem' })).toBe(16);
-  expect(toPixels({ value: 2, unit: 'em' })).toBe(32);
+});
+
+it('scales rem against the supplied root font-size; px stays absolute', () => {
+  expect(toPixels({ value: 1, unit: 'rem' }, 20)).toBe(20);
+  expect(toPixels({ value: 2, unit: 'rem' }, 10)).toBe(20);
+  expect(toPixels({ value: 16, unit: 'px' }, 20)).toBe(16);
 });
 
 it('returns NaN for units it cannot approximate and for malformed values', () => {
   expect(toPixels({ value: 5, unit: '%' })).toBeNaN();
+  // `em` is not a DTCG dimension unit (px | rem only): treat it as uncappable.
+  expect(toPixels({ value: 2, unit: 'em' })).toBeNaN();
   expect(toPixels({ value: '5', unit: 'px' })).toBeNaN();
   expect(toPixels(null)).toBeNaN();
   expect(toPixels('16px')).toBeNaN();

--- a/packages/blocks/test/dimension-scale-cap.browser.test.tsx
+++ b/packages/blocks/test/dimension-scale-cap.browser.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, waitFor } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { DimensionScale, SwatchbookProvider } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import { makeResolveAt } from './_snapshot-helpers.ts';
+
+// A 25rem token sits at 400px under a 16px root (below the 480 cap) and 500px
+// under a 20px root (above it). Whether it caps proves the cap math reads the
+// real rendering-context root font-size instead of a hardcoded 16.
+function makeSnapshot(): ProjectSnapshot {
+  const tokens = {
+    'dimension.wide': { $type: 'dimension', $value: { value: 25, unit: 'rem' } },
+  };
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = makeResolveAt(tokens);
+  return snap;
+}
+
+afterEach(() => {
+  cleanup();
+  document.documentElement.style.fontSize = '';
+});
+
+it('does not cap a 25rem token at a 16px root (400px is under the 480 cap)', () => {
+  document.documentElement.style.fontSize = '16px';
+  const { container } = render(
+    <SwatchbookProvider value={makeSnapshot()}>
+      <DimensionScale />
+    </SwatchbookProvider>,
+  );
+  expect(container.querySelector('.sb-dimension-scale__cap')).toBeNull();
+});
+
+it('caps the same 25rem token when the root font-size is 20px (500px exceeds 480)', () => {
+  document.documentElement.style.fontSize = '20px';
+  const { container } = render(
+    <SwatchbookProvider value={makeSnapshot()}>
+      <DimensionScale />
+    </SwatchbookProvider>,
+  );
+  expect(container.querySelector('.sb-dimension-scale__cap')?.textContent).toContain(
+    'capped at 480px',
+  );
+  const bar = container.querySelector<HTMLElement>('.sb-dimension-scale__visual-cell div');
+  expect(bar?.style.width).toBe('480px');
+});
+
+it('re-evaluates the cap when a responsive breakpoint changes the root font-size', async () => {
+  document.documentElement.style.fontSize = '16px';
+  const { container } = render(
+    <SwatchbookProvider value={makeSnapshot()}>
+      <DimensionScale />
+    </SwatchbookProvider>,
+  );
+  expect(container.querySelector('.sb-dimension-scale__cap')).toBeNull();
+
+  // A media query bumps the root at a breakpoint: 25rem is now 600px (> 480).
+  document.documentElement.style.fontSize = '24px';
+  window.dispatchEvent(new Event('resize'));
+
+  await waitFor(() => {
+    expect(container.querySelector('.sb-dimension-scale__cap')?.textContent).toContain(
+      'capped at 480px',
+    );
+  });
+});

--- a/packages/blocks/test/sort-tokens.test.ts
+++ b/packages/blocks/test/sort-tokens.test.ts
@@ -118,4 +118,28 @@ describe('sortTokens', () => {
     const out = sortTokens(input, { by: 'value' });
     expect(out.map(([p]) => p)).toEqual(['a.col', 'y.dim', 'z.dim']);
   });
+
+  it('scales rem against rootFontSizePx in a value sort; defaults to 16', () => {
+    const input = [
+      entry('a.px', 'dimension', { value: 20, unit: 'px' }),
+      entry('b.rem', 'dimension', { value: 1, unit: 'rem' }),
+    ];
+    // Default 16px root: 1rem = 16px < 20px, so the rem token sorts first.
+    expect(sortTokens(input, { by: 'value' }).map(([p]) => p)).toEqual(['b.rem', 'a.px']);
+    // 24px root: 1rem = 24px > 20px, so the order flips.
+    expect(sortTokens(input, { by: 'value', rootFontSizePx: 24 }).map(([p]) => p)).toEqual([
+      'a.px',
+      'b.rem',
+    ]);
+  });
+
+  it('treats the non-DTCG em unit as a raw magnitude, not 16x', () => {
+    const input = [
+      entry('a.em', 'dimension', { value: 2, unit: 'em' }),
+      entry('b.px', 'dimension', { value: 5, unit: 'px' }),
+    ];
+    // em is not a DTCG dimension unit: it falls through to its raw value (2),
+    // so it sorts below 5px rather than being multiplied to 32px.
+    expect(sortTokens(input, { by: 'value' }).map(([p]) => p)).toEqual(['a.em', 'b.px']);
+  });
 });


### PR DESCRIPTION
## What

Dimension previews convert `rem` to pixels in two JS spots: `toPixels()` (the 480px render cap) and `sortTokens()`'s `toMagnitude` (the `sortBy: 'value'` order). Both used a literal `* 16`. The bar itself paints at `var()`, resolved against the *actual* rendering-context root font-size, so in any context where the root isn't 16px (a Storybook Docs page applies its own typography; a responsive design swaps `html { font-size }` at a breakpoint) the cap decision and the value sort diverge from what's drawn: a large `rem` blows past the cap uncapped, or mixed px/rem tokens sort in the wrong order.

- `useRootFontSize()` (`#/internal/`): reads `getComputedStyle(document.documentElement).fontSize`, **reactive** via `useSyncExternalStore` over `resize` so it tracks responsive breakpoint changes; 16 fallback with no DOM. The `var()` bar re-resolves on a breakpoint automatically, and this keeps the JS cap/sort decisions in step with it.
- `toPixels(raw, rootFontSizePx = 16)` and `SortOptions.rootFontSizePx` (default 16) take the measured root. `DimensionScale` and `TokenTable` supply it via the hook.
- Dropped `em`: not a DTCG dimension unit (`px | rem` only). It returns `NaN` from `toPixels` (rendered at `var()`, uncapped) and its raw value from `toMagnitude`.

Bars stay true-to-context (rendering at `var()` is correct for a preview host); only the JS cap/sort decisions are realigned to match, and to track the root across breakpoints.

## Tests

- `dimension-px.test.ts` / `sort-tokens.test.ts` (node): `rem` scales by the supplied root, `px` absolute, `em` → `NaN` (cap) / raw (sort). Watched both fail against the old code first.
- `dimension-scale-cap.browser.test.tsx` (chromium + firefox): a 25rem token caps at a 20px root but not a 16px one, and **re-evaluates** when a simulated breakpoint changes the root post-mount (resize event).

Full blocks suite green (344 tests), lint / format / typecheck clean.

Milestone: Maintenance

Closes #1267
Closes #1277

Plan impact: none