### PR TITLE
fix(blocks): render standalone by owning chrome defaults instead of OS light-dark

### DIFF
--- a/.changeset/blocks-self-sufficient-chrome.md
+++ b/.changeset/blocks-self-sufficient-chrome.md
@@ -1,0 +1,6 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+Blocks render standalone: own the chrome defaults as single literals (no light-dark/OS coupling), ship them as a bundled base layer, and drop the redundant inline fallbacks

--- a/packages/blocks/src/BorderPreview.css
+++ b/packages/blocks/src/BorderPreview.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: center;
   padding: 14px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-border-preview__meta {
@@ -44,5 +44,5 @@
 }
 
 .sb-border-preview__breakdown-key {
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }

--- a/packages/blocks/src/ColorPalette.css
+++ b/packages/blocks/src/ColorPalette.css
@@ -18,7 +18,7 @@
 }
 
 .sb-color-palette__card {
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
   border-radius: 6px;
   overflow: hidden;
   display: flex;
@@ -28,7 +28,7 @@
 .sb-color-palette__swatch {
   height: 56px;
   width: 100%;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-color-palette__meta {

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -18,16 +18,16 @@
   max-width: 360px;
   padding: 6px 10px;
   border-radius: 4px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
-  background: var(--swatchbook-surface-default, Canvas);
-  color: var(--swatchbook-text-default, CanvasText);
+  border: 1px solid var(--swatchbook-border-default);
+  background: var(--swatchbook-surface-default);
+  color: var(--swatchbook-text-default);
   font-family: inherit;
   font-size: 13px;
   line-height: 1.4;
 }
 
 .sb-color-table__search-input:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: 1px;
 }
 
@@ -35,7 +35,7 @@
   caption-side: top;
   text-align: left;
   padding: 8px 0;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-size: 12px;
 }
 
@@ -45,8 +45,8 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--swatchbook-text-muted, CanvasText);
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  color: var(--swatchbook-text-muted);
+  border-bottom: 1px solid var(--swatchbook-border-default);
   white-space: nowrap;
 }
 
@@ -67,17 +67,17 @@
 }
 
 .sb-color-table__row:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: -2px;
 }
 
 .sb-color-table__row--expanded {
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.06));
+  background: var(--swatchbook-surface-muted);
 }
 
 .sb-color-table__td {
   padding: 8px 12px;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border-bottom: 1px solid var(--swatchbook-border-default);
   vertical-align: middle;
 }
 
@@ -113,8 +113,8 @@
   font-size: 10px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
-  color: var(--swatchbook-text-muted, CanvasText);
+  background: var(--swatchbook-surface-muted);
+  color: var(--swatchbook-text-muted);
   cursor: pointer;
   transition:
     background-color 120ms ease,
@@ -122,23 +122,23 @@
 }
 
 .sb-color-table__variant-pill:hover {
-  background: var(--swatchbook-surface-raised, rgba(128, 128, 128, 0.25));
-  color: var(--swatchbook-text-default, CanvasText);
+  background: var(--swatchbook-surface-raised);
+  color: var(--swatchbook-text-default);
 }
 
 .sb-color-table__variant-pill:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: 1px;
 }
 
 .sb-color-table__variant-pill--active {
-  background: var(--swatchbook-accent-bg, #1d4ed8);
-  color: var(--swatchbook-accent-fg, white);
+  background: var(--swatchbook-accent-bg);
+  color: var(--swatchbook-accent-fg);
 }
 
 .sb-color-table__variant-pill--active:hover {
-  background: var(--swatchbook-accent-bg, #1d4ed8);
-  color: var(--swatchbook-accent-fg, white);
+  background: var(--swatchbook-accent-bg);
+  color: var(--swatchbook-accent-fg);
 }
 
 .sb-color-table__swatch-cell {
@@ -150,7 +150,7 @@
   width: 20px;
   height: 20px;
   border-radius: 4px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border: 1px solid var(--swatchbook-border-default);
   background-clip: padding-box;
 }
 
@@ -198,7 +198,7 @@
 .sb-color-table__expand-cell {
   width: 28px;
   text-align: center;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-color-table__chevron {
@@ -211,7 +211,7 @@
 }
 
 .sb-color-table__detail-row {
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.06));
+  background: var(--swatchbook-surface-muted);
 }
 
 .sb-color-table__detail-cell {
@@ -223,7 +223,7 @@
   flex-direction: column;
   gap: 10px;
   font-size: 12px;
-  color: var(--swatchbook-text-default, CanvasText);
+  color: var(--swatchbook-text-default);
 }
 
 .sb-color-table__description {
@@ -236,7 +236,7 @@
   margin: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-color-table__detail-label {
@@ -249,7 +249,7 @@
 
 .sb-color-table__detail-empty {
   margin: 0;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-style: italic;
 }
 
@@ -261,7 +261,7 @@
   text-transform: uppercase;
   letter-spacing: 0.5px;
   font-size: 10px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   margin-bottom: 6px;
 }
 
@@ -279,27 +279,27 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--swatchbook-text-muted, CanvasText);
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  color: var(--swatchbook-text-muted);
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-color-table__subtd {
   padding: 4px 8px;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.1));
+  border-bottom: 1px solid var(--swatchbook-border-default);
   vertical-align: middle;
 }
 
 .sb-color-table__subtd--path {
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-color-table__subrow--active {
-  background: var(--swatchbook-surface-raised, rgba(128, 128, 128, 0.12));
+  background: var(--swatchbook-surface-raised);
 }
 
 .sb-color-table__subrow--active > .sb-color-table__subtd {
   font-weight: 600;
-  color: var(--swatchbook-text-default, CanvasText);
+  color: var(--swatchbook-text-default);
 }
 
 .sb-color-table__sr-only {
@@ -315,7 +315,7 @@
 }
 
 .sb-color-table__empty-row {
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-style: italic;
   text-align: center;
   padding: 16px 12px;

--- a/packages/blocks/src/Diagnostics.css
+++ b/packages/blocks/src/Diagnostics.css
@@ -34,7 +34,7 @@
   grid-template-columns: 60px 1fr;
   gap: 12px;
   padding: 8px 4px;
-  border-top: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border-top: 1px solid var(--swatchbook-border-default);
   font-size: 12px;
 }
 
@@ -54,7 +54,7 @@
 
 .sb-diagnostics__meta {
   margin-top: 4px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-size: 11px;
   opacity: 0.7;
 }

--- a/packages/blocks/src/DimensionScale.css
+++ b/packages/blocks/src/DimensionScale.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: center;
   padding: 10px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-dimension-scale__meta {

--- a/packages/blocks/src/FontFamilyPreview.css
+++ b/packages/blocks/src/FontFamilyPreview.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: baseline;
   padding: 14px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-font-family-sample__meta {
@@ -25,7 +25,7 @@
 .sb-font-family-sample__stack {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-font-family-sample__sample {
@@ -36,5 +36,5 @@
 .sb-font-family-sample__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }

--- a/packages/blocks/src/FontWeightScale.css
+++ b/packages/blocks/src/FontWeightScale.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: baseline;
   padding: 12px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-font-weight-scale__meta {
@@ -25,7 +25,7 @@
 .sb-font-weight-scale__value {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-font-weight-scale__sample {
@@ -36,5 +36,5 @@
 .sb-font-weight-scale__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }

--- a/packages/blocks/src/GradientPalette.css
+++ b/packages/blocks/src/GradientPalette.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: center;
   padding: 16px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-gradient-palette__meta {
@@ -31,7 +31,7 @@
 .sb-gradient-palette__sample {
   height: 56px;
   border-radius: 6px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-gradient-palette__stops {
@@ -52,7 +52,7 @@
   width: 10px;
   height: 10px;
   border-radius: 2px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
   flex: 0 0 auto;
 }
 

--- a/packages/blocks/src/MotionPreview.css
+++ b/packages/blocks/src/MotionPreview.css
@@ -7,7 +7,7 @@
 
 .sb-motion-preview__control-label {
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
@@ -18,14 +18,14 @@
   padding: 4px 8px;
   background: transparent;
   color: inherit;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border: 1px solid var(--swatchbook-border-default);
   border-radius: 4px;
   cursor: pointer;
 }
 
 .sb-motion-preview__speed-btn--active {
-  background: var(--swatchbook-accent-bg, #3b82f6);
-  color: var(--swatchbook-accent-fg, #fff);
+  background: var(--swatchbook-accent-bg);
+  color: var(--swatchbook-accent-fg);
   border-color: transparent;
 }
 
@@ -35,7 +35,7 @@
   margin-left: auto;
   background: transparent;
   color: inherit;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border: 1px solid var(--swatchbook-border-default);
   border-radius: 4px;
   cursor: pointer;
 }
@@ -46,7 +46,7 @@
   gap: 16px;
   align-items: center;
   padding: 14px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-motion-preview__meta {
@@ -67,12 +67,12 @@
 .sb-motion-preview__specs {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-motion-preview__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   white-space: nowrap;
 }

--- a/packages/blocks/src/OpacityScale.css
+++ b/packages/blocks/src/OpacityScale.css
@@ -5,7 +5,7 @@
 }
 
 .sb-opacity-scale__card {
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
   border-radius: 6px;
   overflow: hidden;
   display: flex;
@@ -33,7 +33,7 @@
     0 6px,
     6px -6px,
     -6px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-opacity-scale__swatch::after {

--- a/packages/blocks/src/ShadowPreview.css
+++ b/packages/blocks/src/ShadowPreview.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: center;
   padding: 16px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-shadow-preview__meta {
@@ -45,7 +45,7 @@
 }
 
 .sb-shadow-preview__breakdown-key {
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-shadow-preview__layer {
@@ -56,7 +56,7 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   margin-top: 6px;
 }
 

--- a/packages/blocks/src/StrokeStylePreview.css
+++ b/packages/blocks/src/StrokeStylePreview.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: center;
   padding: 14px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-stroke-style-sample__meta {
@@ -25,24 +25,24 @@
 .sb-stroke-style-sample__value {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-stroke-style-sample__line {
   height: 0;
   border-top-width: 4px;
-  border-top-color: var(--swatchbook-text-default, CanvasText);
+  border-top-color: var(--swatchbook-text-default);
   width: 100%;
 }
 
 .sb-stroke-style-sample__object-fallback {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-stroke-style-sample__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -7,22 +7,22 @@
   max-width: 360px;
   padding: 6px 10px;
   border-radius: 4px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
-  background: var(--swatchbook-surface-default, Canvas);
-  color: var(--swatchbook-text-default, CanvasText);
+  border: 1px solid var(--swatchbook-border-default);
+  background: var(--swatchbook-surface-default);
+  color: var(--swatchbook-text-default);
   font-family: inherit;
   font-size: 13px;
   line-height: 1.4;
 }
 
 .sb-token-navigator__search-input:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: 1px;
 }
 
 .sb-token-navigator__caption {
   padding: 4px 0 12px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-size: 12px;
 }
 
@@ -36,7 +36,7 @@
   list-style: none;
   margin: 0;
   padding-left: 18px;
-  border-left: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-left: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-token-navigator__group-row {
@@ -59,7 +59,7 @@
  */
 .sb-token-navigator__tree li[role='treeitem']:focus-visible,
 .sb-token-navigator__nested li[role='treeitem']:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: 1px;
 }
 
@@ -78,7 +78,7 @@
   display: inline-block;
   width: 12px;
   text-align: center;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-token-navigator__tail {
@@ -93,12 +93,12 @@
   font-size: 10px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  background: var(--swatchbook-surface-muted);
 }
 
 .sb-token-navigator__value {
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   margin-left: auto;
   min-width: 0;
   text-align: right;
@@ -110,7 +110,7 @@
 .sb-token-navigator__count {
   margin-left: auto;
   font-size: 11px;
-  color: var(--swatchbook-text-default, CanvasText);
+  color: var(--swatchbook-text-default);
 }
 
 .sb-token-navigator__color-swatch {
@@ -118,7 +118,7 @@
   width: 14px;
   height: 14px;
   border-radius: 3px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
   margin-left: 8px;
 }
 

--- a/packages/blocks/src/TokenTable.css
+++ b/packages/blocks/src/TokenTable.css
@@ -12,21 +12,21 @@
   max-width: 360px;
   padding: 6px 10px;
   border-radius: 4px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
-  background: var(--swatchbook-surface-default, Canvas);
-  color: var(--swatchbook-text-default, CanvasText);
+  border: 1px solid var(--swatchbook-border-default);
+  background: var(--swatchbook-surface-default);
+  color: var(--swatchbook-text-default);
   font-family: inherit;
   font-size: 13px;
   line-height: 1.4;
 }
 
 .sb-token-table__search-input:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: 1px;
 }
 
 .sb-token-table__empty-row {
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-style: italic;
   text-align: center;
   padding: 16px 12px;
@@ -36,7 +36,7 @@
   caption-side: top;
   text-align: left;
   padding: 8px 0;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-size: 12px;
 }
 
@@ -46,8 +46,8 @@
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--swatchbook-text-muted, CanvasText);
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  color: var(--swatchbook-text-muted);
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-token-table__th--path {
@@ -63,13 +63,13 @@
 }
 
 .sb-token-table__row:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, #1d4ed8);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: -2px;
 }
 
 .sb-token-table__td {
   padding: 8px 12px;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border-bottom: 1px solid var(--swatchbook-border-default);
   vertical-align: top;
 }
 
@@ -95,8 +95,8 @@
   font-size: 10px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
-  color: var(--swatchbook-text-muted, CanvasText);
+  background: var(--swatchbook-surface-muted);
+  color: var(--swatchbook-text-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   flex-shrink: 0;
 }
@@ -106,7 +106,7 @@
   width: 16px;
   height: 16px;
   border-radius: 3px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border: 1px solid var(--swatchbook-border-default);
   flex-shrink: 0;
 }
 

--- a/packages/blocks/src/TypographyScale.css
+++ b/packages/blocks/src/TypographyScale.css
@@ -4,7 +4,7 @@
   gap: 16px;
   align-items: baseline;
   padding: 14px 0;
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-typography-scale__meta {

--- a/packages/blocks/src/indicators/indicators.css
+++ b/packages/blocks/src/indicators/indicators.css
@@ -30,7 +30,7 @@
   border-radius: 3px;
   background: none;
   font: inherit;
-  color: var(--swatchbook-accent-default, LinkText);
+  color: var(--swatchbook-accent-bg, LinkText);
   cursor: pointer;
 }
 
@@ -105,7 +105,7 @@
   font: inherit;
   text-align: left;
   white-space: nowrap;
-  color: var(--swatchbook-accent-default, LinkText);
+  color: var(--swatchbook-accent-bg, LinkText);
   cursor: pointer;
 }
 

--- a/packages/blocks/src/indicators/indicators.css
+++ b/packages/blocks/src/indicators/indicators.css
@@ -7,7 +7,7 @@
   min-width: 0;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
-  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.9));
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-indicator__alias-forward,
@@ -21,7 +21,7 @@
 }
 
 .sb-indicator__alias-arrow {
-  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.6));
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-indicator__alias-node {
@@ -30,7 +30,7 @@
   border-radius: 3px;
   background: none;
   font: inherit;
-  color: var(--swatchbook-accent-bg, LinkText);
+  color: var(--swatchbook-accent-bg);
   cursor: pointer;
 }
 
@@ -39,7 +39,7 @@
 }
 
 .sb-indicator__alias-node--offview {
-  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.6));
+  color: var(--swatchbook-text-muted);
   text-decoration: none;
   cursor: default;
 }
@@ -57,11 +57,11 @@
 
 .sb-indicator__variance-glyph,
 .sb-indicator__composes-glyph {
-  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.7));
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-indicator__composes {
-  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.8));
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-indicator__gamut {
@@ -89,8 +89,8 @@
   margin: 2px 0 0;
   padding: 4px;
   list-style: none;
-  background: var(--swatchbook-surface-raised, light-dark(#fff, #1a1a1a));
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  background: var(--swatchbook-surface-raised);
+  border: 1px solid var(--swatchbook-border-default);
   border-radius: 6px;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
@@ -105,20 +105,20 @@
   font: inherit;
   text-align: left;
   white-space: nowrap;
-  color: var(--swatchbook-accent-bg, LinkText);
+  color: var(--swatchbook-accent-bg);
   cursor: pointer;
 }
 
 .sb-indicator__reverse-item:hover:not(:disabled) {
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.12));
+  background: var(--swatchbook-surface-muted);
 }
 
 .sb-indicator__reverse-item:disabled {
-  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.6));
+  color: var(--swatchbook-text-muted);
   cursor: default;
 }
 
 .sb-indicator__description {
-  color: var(--swatchbook-text-muted, rgba(128, 128, 128, 0.8));
+  color: var(--swatchbook-text-muted);
   cursor: help;
 }

--- a/packages/blocks/src/internal/CopyButton.css
+++ b/packages/blocks/src/internal/CopyButton.css
@@ -6,7 +6,7 @@
   margin: 0;
   border: 0;
   background: transparent;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font: inherit;
   cursor: pointer;
   border-radius: 4px;
@@ -16,12 +16,12 @@
 }
 
 .sb-copy-button:hover {
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
-  color: var(--swatchbook-text-default, CanvasText);
+  background: var(--swatchbook-surface-muted);
+  color: var(--swatchbook-text-default);
 }
 
 .sb-copy-button:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-bg, Highlight);
+  outline: 2px solid var(--swatchbook-accent-bg);
   outline-offset: 2px;
 }
 
@@ -37,11 +37,11 @@
   font-size: 11px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.25));
+  border: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-copy-button--copied {
-  color: var(--swatchbook-accent-bg, Highlight);
+  color: var(--swatchbook-accent-bg);
 }
 
 /* Screen-reader-only live region: visually hidden, still announced by AT. */

--- a/packages/blocks/src/internal/CopyButton.css
+++ b/packages/blocks/src/internal/CopyButton.css
@@ -21,7 +21,7 @@
 }
 
 .sb-copy-button:focus-visible {
-  outline: 2px solid var(--swatchbook-accent-default, Highlight);
+  outline: 2px solid var(--swatchbook-accent-bg, Highlight);
   outline-offset: 2px;
 }
 
@@ -41,7 +41,7 @@
 }
 
 .sb-copy-button--copied {
-  color: var(--swatchbook-accent-default, Highlight);
+  color: var(--swatchbook-accent-bg, Highlight);
 }
 
 /* Screen-reader-only live region: visually hidden, still announced by AT. */

--- a/packages/blocks/src/internal/DetailOverlay.css
+++ b/packages/blocks/src/internal/DetailOverlay.css
@@ -12,8 +12,8 @@
   width: min(560px, 100%);
   height: 100%;
   overflow-y: auto;
-  background: var(--swatchbook-surface-default, Canvas);
-  color: var(--swatchbook-text-default, CanvasText);
+  background: var(--swatchbook-surface-default);
+  color: var(--swatchbook-text-default);
   box-shadow: -8px 0 24px rgba(0, 0, 0, 0.2);
   padding: 16px;
   position: relative;
@@ -26,7 +26,7 @@
   width: 32px;
   height: 32px;
   border-radius: 4px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  border: 1px solid var(--swatchbook-border-default);
   background: transparent;
   color: inherit;
   cursor: pointer;

--- a/packages/blocks/src/internal/chrome-base.css
+++ b/packages/blocks/src/internal/chrome-base.css
@@ -1,0 +1,12 @@
+:root {
+  --swatchbook-border-default: #e5e7eb;
+  --swatchbook-surface-default: #ffffff;
+  --swatchbook-surface-muted: #f4f4f5;
+  --swatchbook-surface-raised: #ffffff;
+  --swatchbook-text-default: #111827;
+  --swatchbook-text-muted: #4b5563;
+  --swatchbook-accent-bg: #1d4ed8;
+  --swatchbook-accent-fg: #ffffff;
+  --swatchbook-body-font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --swatchbook-body-font-size: 14px;
+}

--- a/packages/blocks/src/internal/chrome-base.css
+++ b/packages/blocks/src/internal/chrome-base.css
@@ -7,6 +7,6 @@
   --swatchbook-text-muted: #4b5563;
   --swatchbook-accent-bg: #1d4ed8;
   --swatchbook-accent-fg: #ffffff;
-  --swatchbook-body-font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --swatchbook-body-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --swatchbook-body-font-size: 14px;
 }

--- a/packages/blocks/src/internal/styles.css
+++ b/packages/blocks/src/internal/styles.css
@@ -13,22 +13,22 @@
  */
 
 .sb-block {
-  font-family: var(--swatchbook-body-font-family, system-ui);
-  font-size: var(--swatchbook-body-font-size, 14px);
-  color: var(--swatchbook-text-default, CanvasText);
-  background: var(--swatchbook-surface-default, Canvas);
+  font-family: var(--swatchbook-body-font-family);
+  font-size: var(--swatchbook-body-font-size);
+  color: var(--swatchbook-text-default);
+  background: var(--swatchbook-surface-default);
   padding: 12px;
   border-radius: 6px;
 }
 
 .sb-block__caption {
   padding: 4px 0 12px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-size: 12px;
 }
 
 .sb-block__empty {
   padding: 24px 12px;
   text-align: center;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }

--- a/packages/blocks/src/provider.tsx
+++ b/packages/blocks/src/provider.tsx
@@ -1,3 +1,4 @@
+import '#/internal/chrome-base.css';
 import type { ReactElement, ReactNode } from 'react';
 import { SwatchbookContext, useOptionalSwatchbookData } from '#/contexts.ts';
 import type { ProjectSnapshot } from '#/contexts.ts';

--- a/packages/blocks/src/token-detail/styles.css
+++ b/packages/blocks/src/token-detail/styles.css
@@ -1,6 +1,6 @@
 .sb-token-detail {
   padding: 16px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-token-detail__heading {
@@ -25,7 +25,7 @@
   font-size: 10px;
   letter-spacing: 0.5px;
   text-transform: uppercase;
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  background: var(--swatchbook-surface-muted);
 }
 
 .sb-token-detail__description {
@@ -54,7 +54,7 @@
 .sb-token-detail__chain-node {
   padding: 2px 6px;
   border-radius: 4px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-token-detail__arrow {
@@ -69,7 +69,7 @@
 }
 
 .sb-token-detail__theme-row {
-  border-bottom: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border-bottom: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-token-detail__theme-cell {
@@ -84,14 +84,14 @@
   vertical-align: middle;
   margin-right: 6px;
   border-radius: 3px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-token-detail__snippet {
   display: block;
   padding: 8px 10px;
   border-radius: 4px;
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  background: var(--swatchbook-surface-muted);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
   white-space: pre;
@@ -118,15 +118,15 @@
 .sb-token-detail__shadow-sample {
   width: 140px;
   height: 56px;
-  background: var(--swatchbook-surface-raised, Canvas);
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  background: var(--swatchbook-surface-raised);
+  border: 1px solid var(--swatchbook-border-default);
   border-radius: 6px;
 }
 
 .sb-token-detail__border-sample {
   width: 140px;
   height: 56px;
-  background: var(--swatchbook-surface-raised, Canvas);
+  background: var(--swatchbook-surface-raised);
   border-radius: 6px;
 }
 
@@ -134,26 +134,26 @@
   width: 220px;
   height: 56px;
   border-radius: 6px;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.15));
+  border: 1px solid var(--swatchbook-border-default);
 }
 
 .sb-token-detail__stroke-style-line {
   height: 0;
   border-top-width: 4px;
-  border-top-color: var(--swatchbook-text-default, CanvasText);
+  border-top-color: var(--swatchbook-text-default);
   width: 220px;
 }
 
 .sb-token-detail__stroke-style-svg {
   width: 220px;
   height: 24px;
-  color: var(--swatchbook-text-default, CanvasText);
+  color: var(--swatchbook-text-default);
 }
 
 .sb-token-detail__stroke-style-fallback {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-token-detail__color-swatch-row {
@@ -161,7 +161,7 @@
   gap: 1px;
   border-radius: 6px;
   overflow: hidden;
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.2));
+  border: 1px solid var(--swatchbook-border-default);
   width: 220px;
   height: 56px;
 }
@@ -187,7 +187,7 @@
 }
 
 .sb-token-detail__breakdown-key {
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
 }
 
 .sb-token-detail__breakdown-value {
@@ -218,7 +218,7 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.5px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   margin-top: 4px;
 }
 
@@ -244,7 +244,7 @@
 
 .sb-token-detail__dimension-bar {
   height: 16px;
-  background: var(--swatchbook-accent-bg, #3b82f6);
+  background: var(--swatchbook-accent-bg);
   border-radius: 3px;
   max-width: 100%;
 }
@@ -254,7 +254,7 @@
   height: 32px;
   width: 100%;
   max-width: 320px;
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  background: var(--swatchbook-surface-muted);
   border-radius: 16px;
   overflow: hidden;
 }
@@ -266,7 +266,7 @@
   height: 24px;
   margin-top: -12px;
   border-radius: 50%;
-  background: var(--swatchbook-accent-bg, #3b82f6);
+  background: var(--swatchbook-accent-bg);
 }
 
 .sb-token-detail__aliased-by-list {
@@ -293,7 +293,7 @@
 
 .sb-token-detail__reduced-motion {
   font-size: 11px;
-  color: var(--swatchbook-text-muted, CanvasText);
+  color: var(--swatchbook-text-muted);
   font-style: italic;
 }
 
@@ -311,7 +311,7 @@
   padding: 6px 10px;
   margin-bottom: 4px;
   border-radius: 4px;
-  background: var(--swatchbook-surface-muted, rgba(128, 128, 128, 0.15));
+  background: var(--swatchbook-surface-muted);
 }
 
 .sb-token-detail__consumer-row-label {
@@ -336,9 +336,9 @@
   padding: 3px 8px;
   font-size: 11px;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  background: var(--swatchbook-surface-raised, Canvas);
-  color: var(--swatchbook-text-default, CanvasText);
-  border: 1px solid var(--swatchbook-border-default, rgba(128, 128, 128, 0.3));
+  background: var(--swatchbook-surface-raised);
+  color: var(--swatchbook-text-default);
+  border: 1px solid var(--swatchbook-border-default);
   border-radius: 4px;
   cursor: pointer;
   flex-shrink: 0;

--- a/packages/blocks/test/chrome-base.test.ts
+++ b/packages/blocks/test/chrome-base.test.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { buildChromeDefaultsCss } from '@unpunnyfuns/swatchbook-core';
+import { expect, it } from 'vitest';
+
+it('chrome-base.css matches the canonical chrome defaults (no drift)', () => {
+  const path = fileURLToPath(new URL('../src/internal/chrome-base.css', import.meta.url));
+  const file = readFileSync(path, 'utf8').trim();
+  expect(file).toBe(buildChromeDefaultsCss());
+});

--- a/packages/blocks/test/chrome-no-inline-fallbacks.test.ts
+++ b/packages/blocks/test/chrome-no-inline-fallbacks.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync, globSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+
+it('no block CSS uses an inline fallback on a --swatchbook-* var (base layer owns defaults)', () => {
+  const dir = fileURLToPath(new URL('../src', import.meta.url));
+  const offenders: string[] = [];
+  for (const f of globSync('**/*.css', { cwd: dir })) {
+    if (f.endsWith('chrome-base.css')) continue;
+    const text = readFileSync(`${dir}/${f}`, 'utf8');
+    // var(--swatchbook-role , <something>)  — a comma inside the var() = a fallback
+    for (const m of text.matchAll(/var\(--swatchbook-[a-z-]+\s*,/g))
+      offenders.push(`${f}: ${m[0]}`);
+  }
+  expect(offenders).toEqual([]);
+});

--- a/packages/blocks/test/chrome-no-phantom-roles.test.ts
+++ b/packages/blocks/test/chrome-no-phantom-roles.test.ts
@@ -1,0 +1,20 @@
+import { globSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { buildChromeDefaultsCss } from '@unpunnyfuns/swatchbook-core';
+import { expect, it } from 'vitest';
+
+it('block CSS references only real --swatchbook-* chrome roles', () => {
+  const dir = fileURLToPath(new URL('../src', import.meta.url));
+  // Canonical role var names, taken from the single source rather than re-derived.
+  const known = new Set(
+    [...buildChromeDefaultsCss().matchAll(/(--swatchbook-[a-z-]+):/g)].map((m) => m[1]),
+  );
+  const offenders: string[] = [];
+  for (const f of globSync('**/*.css', { cwd: dir })) {
+    const text = readFileSync(`${dir}/${f}`, 'utf8');
+    for (const m of text.matchAll(/var\((--swatchbook-[a-z-]+)/g)) {
+      if (!known.has(m[1])) offenders.push(`${f}: ${m[1]}`);
+    }
+  }
+  expect(offenders).toEqual([]);
+});

--- a/packages/blocks/test/chrome-standalone.browser.test.tsx
+++ b/packages/blocks/test/chrome-standalone.browser.test.tsx
@@ -1,0 +1,20 @@
+import '#/index.ts';
+import { expect, it } from 'vitest';
+
+it('defines the chrome vars on :root with no addon, no chrome config', () => {
+  const root = getComputedStyle(document.documentElement);
+  expect(root.getPropertyValue('--swatchbook-border-default').trim()).toBe('#e5e7eb');
+  expect(root.getPropertyValue('--swatchbook-surface-default').trim()).toBe('#ffffff');
+});
+
+it('a chrome block appended after the base layer wins (addon-overrides-default order)', () => {
+  const override = document.createElement('style');
+  override.textContent = ':root { --swatchbook-border-default: rgb(1, 2, 3); }';
+  document.head.appendChild(override);
+  try {
+    expect(getComputedStyle(document.documentElement).getPropertyValue('--swatchbook-border-default').trim())
+      .toBe('rgb(1, 2, 3)');
+  } finally {
+    override.remove();
+  }
+});

--- a/packages/blocks/test/chrome-standalone.browser.test.tsx
+++ b/packages/blocks/test/chrome-standalone.browser.test.tsx
@@ -12,8 +12,11 @@ it('a chrome block appended after the base layer wins (addon-overrides-default o
   override.textContent = ':root { --swatchbook-border-default: rgb(1, 2, 3); }';
   document.head.appendChild(override);
   try {
-    expect(getComputedStyle(document.documentElement).getPropertyValue('--swatchbook-border-default').trim())
-      .toBe('rgb(1, 2, 3)');
+    expect(
+      getComputedStyle(document.documentElement)
+        .getPropertyValue('--swatchbook-border-default')
+        .trim(),
+    ).toBe('rgb(1, 2, 3)');
   } finally {
     override.remove();
   }

--- a/packages/core/src/chrome.ts
+++ b/packages/core/src/chrome.ts
@@ -1,3 +1,4 @@
+import { makeCSSVar } from '@terrazzo/token-tools/css';
 import type { Diagnostic } from '#/types.ts';
 
 /**
@@ -58,6 +59,19 @@ export const DEFAULT_CHROME_MAP: Record<ChromeRole, string> = {
   bodyFontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
   bodyFontSize: '14px',
 };
+
+/**
+ * The chrome defaults as a standalone `:root` stylesheet block. Shipped by the
+ * blocks as a bundled base layer so `--swatchbook-*` is defined without the
+ * addon. The emitter produces a superset of this (defaults + consumer
+ * overrides) that wins via source order when the addon is present.
+ */
+export function buildChromeDefaultsCss(): string {
+  const lines = CHROME_ROLES.map(
+    (role) => `  ${makeCSSVar(role, { prefix: CHROME_VAR_PREFIX })}: ${DEFAULT_CHROME_MAP[role]};`,
+  );
+  return `:root {\n${lines.join('\n')}\n}`;
+}
 
 export interface ChromeValidationResult {
   entries: Record<string, string>;

--- a/packages/core/src/chrome.ts
+++ b/packages/core/src/chrome.ts
@@ -56,7 +56,7 @@ export const DEFAULT_CHROME_MAP: Record<ChromeRole, string> = {
   borderDefault: '#e5e7eb',
   accentBg: '#1d4ed8',
   accentFg: '#ffffff',
-  bodyFontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
+  bodyFontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",
   bodyFontSize: '14px',
 };
 

--- a/packages/core/src/chrome.ts
+++ b/packages/core/src/chrome.ts
@@ -37,26 +37,24 @@ export const CHROME_VAR_PREFIX = 'swatchbook';
  * starting from these defaults and overlaying any user-supplied `chrome`
  * entry as a `var(...)` reference on top.
  *
- * Color roles use the `light-dark()` CSS function so zero-config chrome
- * auto-flips with the active `color-scheme` (which Storybook's preview
- * iframe, MDX docs pages, the OS prefers-color-scheme chain, etc. all
- * participate in). The emitter tags the chrome `:root` block with
- * `color-scheme: light dark` so the function resolves correctly even when
- * no parent element opts in. `light-dark()` is supported in Chrome 123+,
- * Firefox 120+, and Safari 17.5+ — all evergreen.
+ * Single owned literal values. Swatchbook has no intrinsic dark axis, so the
+ * zero-config default is one committed appearance; per-axis variation comes
+ * from `config.chrome` mapping roles to the consumer's tokens. No
+ * `light-dark()` or system colors — those couple to the OS color-scheme,
+ * which is foreign to swatchbook's axis model.
  *
- * Values chosen for WCAG AA contrast in both modes. Consumers theme chrome
+ * Values meet WCAG AA on their respective surfaces. Consumers theme chrome
  * against their own tokens by filling `config.chrome`.
  */
 export const DEFAULT_CHROME_MAP: Record<ChromeRole, string> = {
-  surfaceDefault: 'light-dark(#ffffff, #0f172a)',
-  surfaceMuted: 'light-dark(#f4f4f5, #1e293b)',
-  surfaceRaised: 'light-dark(#ffffff, #111827)',
-  textDefault: 'light-dark(#111827, #f1f5f9)',
-  textMuted: 'light-dark(#4b5563, #94a3b8)',
-  borderDefault: 'light-dark(#e5e7eb, #334155)',
-  accentBg: 'light-dark(#1d4ed8, #3b82f6)',
-  accentFg: 'light-dark(#ffffff, #0b1220)',
+  surfaceDefault: '#ffffff',
+  surfaceMuted: '#f4f4f5',
+  surfaceRaised: '#ffffff',
+  textDefault: '#111827',
+  textMuted: '#4b5563',
+  borderDefault: '#e5e7eb',
+  accentBg: '#1d4ed8',
+  accentFg: '#ffffff',
   bodyFontFamily: 'system-ui, -apple-system, "Segoe UI", Roboto, sans-serif',
   bodyFontSize: '14px',
 };

--- a/packages/core/src/css-axis-projected.ts
+++ b/packages/core/src/css-axis-projected.ts
@@ -388,7 +388,7 @@ export function emitAxisProjectedCss(
 
   // 4. Chrome aliases — trailing `:root` block.
   const chrome = options.chrome ?? project.chrome;
-  const chromeLines: string[] = ['  color-scheme: light dark;'];
+  const chromeLines: string[] = [];
   for (const role of CHROME_ROLES) {
     const sourceVar = makeCSSVar(role, { prefix: CHROME_VAR_PREFIX });
     const target = chrome[role];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,9 @@
-export { CHROME_ROLES, DEFAULT_CHROME_MAP, buildChromeDefaultsCss, type ChromeRole } from '#/chrome.ts';
+export {
+  CHROME_ROLES,
+  DEFAULT_CHROME_MAP,
+  buildChromeDefaultsCss,
+  type ChromeRole,
+} from '#/chrome.ts';
 
 export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject } from '#/load.ts';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,4 @@
-export { CHROME_ROLES, DEFAULT_CHROME_MAP, type ChromeRole } from '#/chrome.ts';
+export { CHROME_ROLES, DEFAULT_CHROME_MAP, buildChromeDefaultsCss, type ChromeRole } from '#/chrome.ts';
 
 export { defineSwatchbookConfig } from '#/config.ts';
 export { loadProject } from '#/load.ts';

--- a/packages/core/test/__snapshots__/css-axis-projected.css
+++ b/packages/core/test/__snapshots__/css-axis-projected.css
@@ -245,6 +245,6 @@
   --swatchbook-text-muted: #4b5563;
   --swatchbook-accent-bg: #1d4ed8;
   --swatchbook-accent-fg: #ffffff;
-  --swatchbook-body-font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --swatchbook-body-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
   --swatchbook-body-font-size: 14px;
 }

--- a/packages/core/test/__snapshots__/css-axis-projected.css
+++ b/packages/core/test/__snapshots__/css-axis-projected.css
@@ -237,15 +237,14 @@
 }
 
 :root {
-  color-scheme: light dark;
-  --swatchbook-border-default: light-dark(#e5e7eb, #334155);
-  --swatchbook-surface-default: light-dark(#ffffff, #0f172a);
-  --swatchbook-surface-muted: light-dark(#f4f4f5, #1e293b);
-  --swatchbook-surface-raised: light-dark(#ffffff, #111827);
-  --swatchbook-text-default: light-dark(#111827, #f1f5f9);
-  --swatchbook-text-muted: light-dark(#4b5563, #94a3b8);
-  --swatchbook-accent-bg: light-dark(#1d4ed8, #3b82f6);
-  --swatchbook-accent-fg: light-dark(#ffffff, #0b1220);
+  --swatchbook-border-default: #e5e7eb;
+  --swatchbook-surface-default: #ffffff;
+  --swatchbook-surface-muted: #f4f4f5;
+  --swatchbook-surface-raised: #ffffff;
+  --swatchbook-text-default: #111827;
+  --swatchbook-text-muted: #4b5563;
+  --swatchbook-accent-bg: #1d4ed8;
+  --swatchbook-accent-fg: #ffffff;
   --swatchbook-body-font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
   --swatchbook-body-font-size: 14px;
 }

--- a/packages/core/test/chrome.test.ts
+++ b/packages/core/test/chrome.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, expect, it } from 'vitest';
 import { dirname } from 'node:path';
 import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
-import { CHROME_ROLES, DEFAULT_CHROME_MAP, validateChrome } from '#/chrome.ts';
+import { buildChromeDefaultsCss, CHROME_ROLES, DEFAULT_CHROME_MAP, validateChrome } from '#/chrome.ts';
 import { emitAxisProjectedCss } from '#/css-axis-projected.ts';
 import { loadProject } from '#/load.ts';
 import type { Project } from '#/types.ts';
@@ -138,4 +138,16 @@ it('emitAxisProjectedCss never prefixes chrome source vars with the project pref
   const css = emitAxisProjectedCss(project);
   expect(css).not.toMatch(/--sb-swatchbook-/);
   expect(css).not.toMatch(/--sb-surface-default:\s*var\(/);
+});
+
+it('buildChromeDefaultsCss declares all ten roles at their defaults, no color-scheme', () => {
+  const css = buildChromeDefaultsCss();
+  expect(css.startsWith(':root {')).toBe(true);
+  expect(css.endsWith('}')).toBe(true);
+  expect(css).not.toMatch(/color-scheme/);
+  expect(css).toContain('--swatchbook-surface-default: #ffffff;');
+  expect(css).toContain('--swatchbook-accent-bg: #1d4ed8;');
+  expect(css).toContain('--swatchbook-body-font-size: 14px;');
+  // exactly ten declarations
+  expect(css.match(/--swatchbook-/g)?.length).toBe(10);
 });

--- a/packages/core/test/chrome.test.ts
+++ b/packages/core/test/chrome.test.ts
@@ -62,6 +62,17 @@ it('CHROME_ROLES and DEFAULT_CHROME_MAP cover the same ten roles', () => {
   expect(Object.keys(DEFAULT_CHROME_MAP).toSorted()).toEqual([...CHROME_ROLES].toSorted());
 });
 
+it('default chrome values are single owned literals, never light-dark or system colors', () => {
+  for (const value of Object.values(DEFAULT_CHROME_MAP)) {
+    expect(value).not.toMatch(/light-dark\(/);
+    expect(value).not.toMatch(/\b(Canvas|CanvasText|LinkText|ButtonBorder|GrayText|AccentColor)\b/);
+  }
+  expect(DEFAULT_CHROME_MAP.surfaceDefault).toBe('#ffffff');
+  expect(DEFAULT_CHROME_MAP.textDefault).toBe('#111827');
+  expect(DEFAULT_CHROME_MAP.borderDefault).toBe('#e5e7eb');
+  expect(DEFAULT_CHROME_MAP.accentBg).toBe('#1d4ed8');
+});
+
 let project: Project;
 
 // beforeAll: loadProject against the full fixture (~1s) is shared by
@@ -97,7 +108,7 @@ it('emitAxisProjectedCss emits every chrome role — user entry as var, others a
   const rootBlocks = css.split('\n\n').filter((b) => b.startsWith(':root {'));
   const chromeBlock = rootBlocks.find((b) => b.includes('--swatchbook-surface-default:'));
   expect(chromeBlock).toBeDefined();
-  expect(chromeBlock).toContain('color-scheme: light dark;');
+  expect(chromeBlock).not.toContain('color-scheme:');
   expect(chromeBlock).toContain('--swatchbook-surface-default: var(--sb-color-palette-blue-500);');
   expect(chromeBlock).toContain(`--swatchbook-accent-bg: ${DEFAULT_CHROME_MAP.accentBg};`);
   expect(chromeBlock).toContain(`--swatchbook-body-font-size: ${DEFAULT_CHROME_MAP.bodyFontSize};`);

--- a/packages/core/test/css-axis-projected.test.ts
+++ b/packages/core/test/css-axis-projected.test.ts
@@ -100,8 +100,8 @@ it("mode-invariant tokens (e.g. size primitives, font families) still don't appe
 it('terminates with a trailing newline + emits a chrome alias block at the tail', () => {
   const css = emitAxisProjectedCss(project);
   expect(css.endsWith('\n')).toBe(true);
-  expect(css).toContain('color-scheme: light dark;');
-  expect(css).toContain('--swatchbook-surface-default:');
+  expect(css).not.toContain('color-scheme:');
+  expect(css).toContain('--swatchbook-surface-default: #ffffff;');
 });
 
 it('respects options.prefix when overriding the project default', () => {


### PR DESCRIPTION
## What

The published doc blocks consume a fixed `--swatchbook-*` chrome namespace (10 roles) that only the addon's runtime emitter defined. Used **standalone** (`<SwatchbookProvider>` + blocks, no addon — a documented path), the only defaults were ~144 scattered, divergent inline `var(--role, fallback)` literals, and `DEFAULT_CHROME_MAP` built those on `light-dark()`, which couples to the OS `color-scheme` (a single binary axis foreign to swatchbook's multi-axis model, and the source of a prior light-text-over-host-surface a11y bug).

This makes the blocks self-sufficient (Phase 1):

- **core** — flatten `DEFAULT_CHROME_MAP` to single owned literals (no `light-dark()`, no system colors); drop the emitter's `color-scheme: light dark` line; add `buildChromeDefaultsCss()` as the canonical defaults builder.
- **blocks** — ship `chrome-base.css` (pinned to `buildChromeDefaultsCss()` by an anti-drift test) imported by the provider, so `--swatchbook-*` is always defined standalone; the addon's runtime-appended block still overrides via source order, so consumer `config.chrome` keeps winning. Fix the phantom `--swatchbook-accent-default` role (never emitted → 4 sites couldn't pick up the consumer accent) → `accent-bg`. Drop the ~144 inline fallbacks.

## Verification

Full gauntlet green across core + blocks (format:check / lint / typecheck / test). New tests: anti-drift (the CSS file equals the canonical builder), standalone (chrome vars resolve on `:root` with no addon), cascade (an appended override beats the base layer), plus guard tests that no phantom role and no inline fallback remain — all derived from the single canonical role set. Every text/border-on-surface pair clears WCAG AA (tightest 6.4:1); forced-colors mode is unaffected.

## Chromatic re-baseline (deliberate)

Every default-chrome block surface/text/border shifts to the owned hexes — review the Chromatic diffs as an intended re-baseline, not noise. Precise scope: this changes both the true-standalone case **and** the addon-present-but-`config.chrome`-absent case (those blocks were `light-dark()` auto-flipping; they're now fixed light cards even in a dark Storybook theme). That is the intended OS-coupling removal, and is strictly safer than the prior a11y bug since each card now owns surface + text together.

## Scope notes

- The deprecated-token strikethrough/badge still uses a local `light-dark()` literal in 7 sites — not a chrome role, deferred to Phase 2. So "standalone without OS coupling" is true of the chrome surface, not yet that one indicator.
- The base layer relies on source order (`ensureStyleElement` appends after bundled CSS). Robust for the real path; a one-line low-priority `@layer` around `chrome-base.css` would make it order-independent as cheap insurance — considered and deferred per the spec.

## Follow-up

Phase 2 (separate PR): internal `--swatchbook-{space,radius,text,status}-*` scale replacing the dimensional magic values (~97 font-size / ~37 radius / ~185 spacing literals) and the hardcoded diagnostics status colors.

Milestone: Maintenance

Closes #1281

Plan impact: none