### PR TITLE
docs: standardize consumer-facing guides on importing from swatchbook-addon

### DIFF
--- a/.changeset/tokens-stories-import-source.md
+++ b/.changeset/tokens-stories-import-source.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Docs: standardize consumer-facing guides on importing blocks and hooks from `swatchbook-addon` (the umbrella the quickstart installs and that re-exports the surface); package reference pages keep `swatchbook-blocks`

--- a/apps/docs/docs/guides/authoring-doc-stories.mdx
+++ b/apps/docs/docs/guides/authoring-doc-stories.mdx
@@ -12,19 +12,13 @@ For a sidebar catalog of browsable, testable token views instead of prose pages,
 
 ## Prerequisite
 
-Install the blocks package:
-
-```bash
-npm install -D @unpunnyfuns/swatchbook-blocks
-```
-
-The blocks read the active token graph from a `SwatchbookProvider`. The addon's preview decorator mounts that provider for every story, so blocks render inside MDX as long as `@unpunnyfuns/swatchbook-addon` is registered in your Storybook.
+These doc blocks ship with `@unpunnyfuns/swatchbook-addon` (the [quickstart](./quickstart.mdx) installs and registers it) and are re-exported from its entry, so you import them from the addon with no separate dependency. They read the active token graph from a `SwatchbookProvider` that the addon's preview decorator mounts for every story, so they render inside MDX as long as the addon is registered in your Storybook.
 
 ## A minimal docs page
 
 ```tsx title="src/docs/colors.mdx"
 import { Meta } from '@storybook/addon-docs/blocks';
-import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+import { ColorPalette, ColorTable, TokenTable } from '@unpunnyfuns/swatchbook-addon';
 
 <Meta title="Docs/Colors" />
 
@@ -51,7 +45,7 @@ One page with diagnostics, tree, and table gives a top-to-bottom view: project h
 
 ```tsx title="src/docs/tokens.mdx"
 import { Meta } from '@storybook/addon-docs/blocks';
-import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
+import { Diagnostics, TokenNavigator, TokenTable } from '@unpunnyfuns/swatchbook-addon';
 
 <Meta title="Docs/Tokens" />
 

--- a/apps/docs/docs/guides/consuming-the-active-theme.mdx
+++ b/apps/docs/docs/guides/consuming-the-active-theme.mdx
@@ -33,7 +33,7 @@ For CSS-in-JS libraries whose theme values can be `var(--…)` strings (styled-c
 If the consumer is a React story / block / decorator running inside the Storybook preview, use the hooks the addon already ships:
 
 ```tsx
-import { useActiveAxes, useActiveTheme, useColorFormat } from '@unpunnyfuns/swatchbook-blocks';
+import { useActiveAxes, useActiveTheme, useColorFormat } from '@unpunnyfuns/swatchbook-addon';
 
 function ThemeBridge({ children }: { children: ReactNode }) {
   const axes = useActiveAxes();   // { mode: 'Dark', brand: 'Brand A', contrast: 'Normal' }


### PR DESCRIPTION
## What

The convention for consumer-facing docs is to import blocks and hooks from `@unpunnyfuns/swatchbook-addon` — the umbrella package the quickstart installs, which re-exports the whole surface (blocks, hooks, switcher). Two guides still imported from `@unpunnyfuns/swatchbook-blocks`, contradicting that convention (and, in one case, their own prose):

- `consuming-the-active-theme.mdx` — the hooks example said "use the hooks **the addon already ships**" but imported them from `-blocks`. Now imports from `-addon`.
- `authoring-doc-stories.mdx` — imported the doc blocks from `-blocks` and had a separate `install -D …-blocks` prerequisite. The blocks ship with (and re-export from) the addon the quickstart already installs, so the prerequisite now points at the quickstart and the examples import from `-addon`.

Package **reference** pages (`reference/blocks/*`) keep `-blocks` — they document that package's API, so importing from it there is correct.

## Why this direction

`apps/storybook`'s reference stories import from `-blocks` because the monorepo has blocks as a direct workspace dep — an internal detail, not what a consumer does. A consumer follows the quickstart (installs `-addon`), so consumer-facing docs import from `-addon`. The guide-vs-reference difference is deliberate, not drift.

## Verification

Docs site builds cleanly; no consumer-facing `-blocks` imports remain in guides/concepts.

## Follow-up

The optional `#preview` deep-import alias (item 2 of #1280, low priority) is carved out to #1284 so it isn't lost.

Milestone: Maintenance

Closes #1280

Plan impact: none