### PR TITLE
refactor(blocks): move diagnostics + deprecated colors into internal tokens

### DIFF
--- a/.changeset/blocks-internal-color-tokens.md
+++ b/.changeset/blocks-internal-color-tokens.md
@@ -2,4 +2,4 @@
 "@unpunnyfuns/swatchbook-blocks": patch
 ---
 
-Move the blocks' hardcoded diagnostics status colors and deprecated-token amber into internal `--swatchbook-*` tokens (owned flat values, no `light-dark()`), shipped in the base layer
+Move the blocks' hardcoded diagnostics + deprecated colors into internal tokens that adapt to the surface (status colors mix their hue with the adaptive chrome text; deprecated badge text uses `text-muted`), fixing WCAG failures on dark-mode surfaces with no `light-dark()`/OS coupling

--- a/.changeset/blocks-internal-color-tokens.md
+++ b/.changeset/blocks-internal-color-tokens.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Move the blocks' hardcoded diagnostics status colors and deprecated-token amber into internal `--swatchbook-*` tokens (owned flat values, no `light-dark()`), shipped in the base layer

--- a/packages/blocks/src/ColorTable.css
+++ b/packages/blocks/src/ColorTable.css
@@ -323,6 +323,6 @@
 
 .sb-color-table__path[data-deprecated='true'] .sb-color-table__path-text {
   text-decoration: line-through;
-  text-decoration-color: light-dark(#92400e, #fbbf24);
+  text-decoration-color: var(--swatchbook-deprecated);
   opacity: 0.75;
 }

--- a/packages/blocks/src/Diagnostics.css
+++ b/packages/blocks/src/Diagnostics.css
@@ -10,15 +10,15 @@
 }
 
 .sb-diagnostics__summary--ok {
-  color: #30a46c;
+  color: var(--swatchbook-status-success);
 }
 
 .sb-diagnostics__summary--error {
-  color: #d64545;
+  color: var(--swatchbook-status-danger);
 }
 
 .sb-diagnostics__summary--warn {
-  color: #b08900;
+  color: var(--swatchbook-status-warning);
 }
 
 .sb-diagnostics__list {
@@ -45,11 +45,11 @@
 }
 
 .sb-diagnostics__label--error {
-  color: #d64545;
+  color: var(--swatchbook-status-danger);
 }
 
 .sb-diagnostics__label--warn {
-  color: #b08900;
+  color: var(--swatchbook-status-warning);
 }
 
 .sb-diagnostics__meta {

--- a/packages/blocks/src/TokenNavigator.css
+++ b/packages/blocks/src/TokenNavigator.css
@@ -164,6 +164,6 @@
 
 .sb-token-navigator__leaf-row[data-deprecated='true'] .sb-token-navigator__tail {
   text-decoration: line-through;
-  text-decoration-color: light-dark(#92400e, #fbbf24);
+  text-decoration-color: var(--swatchbook-deprecated);
   opacity: 0.75;
 }

--- a/packages/blocks/src/TokenTable.css
+++ b/packages/blocks/src/TokenTable.css
@@ -135,7 +135,7 @@
 
 .sb-token-table__path[data-deprecated='true'] {
   text-decoration: line-through;
-  text-decoration-color: light-dark(#92400e, #fbbf24);
+  text-decoration-color: var(--swatchbook-deprecated);
   opacity: 0.75;
 }
 

--- a/packages/blocks/src/indicators/indicators.css
+++ b/packages/blocks/src/indicators/indicators.css
@@ -72,8 +72,8 @@
   font-size: 9px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: light-dark(#92400e, #fbbf24);
-  background: light-dark(rgba(245, 158, 11, 0.15), rgba(245, 158, 11, 0.18));
+  color: var(--swatchbook-deprecated);
+  background: var(--swatchbook-deprecated-bg);
 }
 
 .sb-indicator__reverse-wrap {

--- a/packages/blocks/src/indicators/indicators.css
+++ b/packages/blocks/src/indicators/indicators.css
@@ -72,7 +72,7 @@
   font-size: 9px;
   letter-spacing: 0.04em;
   text-transform: uppercase;
-  color: var(--swatchbook-deprecated);
+  color: var(--swatchbook-text-muted);
   background: var(--swatchbook-deprecated-bg);
 }
 

--- a/packages/blocks/src/internal/internal-tokens.css
+++ b/packages/blocks/src/internal/internal-tokens.css
@@ -3,17 +3,27 @@
  * in the fixed `--swatchbook-*` namespace but NOT part of the public chrome
  * roles — implementation detail of the blocks' own surface.
  *
- * `--swatchbook-deprecated` is the strikethrough/decoration amber only
- * (`text-decoration-color`, not contrast-checked) — a mid amber visible on
- * both light and dark surfaces. The deprecated *badge text* must stay legible
- * on a surface that flips with the consumer's chrome, so it reads the adaptive
- * `--swatchbook-text-muted` chrome role instead of a flat amber (a flat dark
- * amber failed WCAG on a dark-mode surface).
+ * Status + deprecated colors must stay legible on a surface that flips with
+ * the consumer's chrome (light card standalone, dark in dark mode). A flat
+ * color can't do that — a single saturated hue is never AA on both white and
+ * a dark surface. So:
+ *
+ * - Status colors mix their hue with the adaptive `--swatchbook-text-default`
+ *   chrome role (which is AA-readable on its surface by construction, and
+ *   flips per-mode). 35% text keeps the hue recognizable while pulling
+ *   lightness toward the readable end; verified AA on both light and dark
+ *   surfaces (`dimensional`/`internal-color-tokens` browser guards).
+ * - The deprecated *badge text* reads `--swatchbook-text-muted` directly
+ *   (also adaptive). `--swatchbook-deprecated` is the strikethrough amber only
+ *   (`text-decoration-color`, not contrast-checked) — a mid amber visible on
+ *   both surfaces.
+ *
+ * No `light-dark()` / OS coupling: adaptation rides swatchbook's own chrome.
  */
 :root {
-  --swatchbook-status-success: #30a46c;
-  --swatchbook-status-warning: #b08900;
-  --swatchbook-status-danger: #d64545;
+  --swatchbook-status-success: color-mix(in oklab, #30a46c, var(--swatchbook-text-default) 35%);
+  --swatchbook-status-warning: color-mix(in oklab, #b08900, var(--swatchbook-text-default) 35%);
+  --swatchbook-status-danger: color-mix(in oklab, #d64545, var(--swatchbook-text-default) 35%);
   --swatchbook-deprecated: #d97706;
   --swatchbook-deprecated-bg: rgba(245, 158, 11, 0.15);
 }

--- a/packages/blocks/src/internal/internal-tokens.css
+++ b/packages/blocks/src/internal/internal-tokens.css
@@ -1,13 +1,19 @@
 /*
  * Internal block-UI tokens. Owned flat values (no light-dark/OS coupling),
  * in the fixed `--swatchbook-*` namespace but NOT part of the public chrome
- * roles — implementation detail of the blocks' own surface. Status colors for
- * Diagnostics severity; deprecated-token strikethrough/badge amber.
+ * roles — implementation detail of the blocks' own surface.
+ *
+ * `--swatchbook-deprecated` is the strikethrough/decoration amber only
+ * (`text-decoration-color`, not contrast-checked) — a mid amber visible on
+ * both light and dark surfaces. The deprecated *badge text* must stay legible
+ * on a surface that flips with the consumer's chrome, so it reads the adaptive
+ * `--swatchbook-text-muted` chrome role instead of a flat amber (a flat dark
+ * amber failed WCAG on a dark-mode surface).
  */
 :root {
   --swatchbook-status-success: #30a46c;
   --swatchbook-status-warning: #b08900;
   --swatchbook-status-danger: #d64545;
-  --swatchbook-deprecated: #92400e;
+  --swatchbook-deprecated: #d97706;
   --swatchbook-deprecated-bg: rgba(245, 158, 11, 0.15);
 }

--- a/packages/blocks/src/internal/internal-tokens.css
+++ b/packages/blocks/src/internal/internal-tokens.css
@@ -1,0 +1,13 @@
+/*
+ * Internal block-UI tokens. Owned flat values (no light-dark/OS coupling),
+ * in the fixed `--swatchbook-*` namespace but NOT part of the public chrome
+ * roles — implementation detail of the blocks' own surface. Status colors for
+ * Diagnostics severity; deprecated-token strikethrough/badge amber.
+ */
+:root {
+  --swatchbook-status-success: #30a46c;
+  --swatchbook-status-warning: #b08900;
+  --swatchbook-status-danger: #d64545;
+  --swatchbook-deprecated: #92400e;
+  --swatchbook-deprecated-bg: rgba(245, 158, 11, 0.15);
+}

--- a/packages/blocks/src/provider.tsx
+++ b/packages/blocks/src/provider.tsx
@@ -1,4 +1,5 @@
 import '#/internal/chrome-base.css';
+import '#/internal/internal-tokens.css';
 import type { ReactElement, ReactNode } from 'react';
 import { SwatchbookContext, useOptionalSwatchbookData } from '#/contexts.ts';
 import type { ProjectSnapshot } from '#/contexts.ts';

--- a/packages/blocks/src/token-detail/styles.css
+++ b/packages/blocks/src/token-detail/styles.css
@@ -349,6 +349,6 @@
   padding: 6px 10px;
   border-radius: 6px;
   font-size: 12px;
-  color: light-dark(#92400e, #fbbf24);
-  background: light-dark(rgba(245, 158, 11, 0.15), rgba(245, 158, 11, 0.18));
+  color: var(--swatchbook-deprecated);
+  background: var(--swatchbook-deprecated-bg);
 }

--- a/packages/blocks/src/token-detail/styles.css
+++ b/packages/blocks/src/token-detail/styles.css
@@ -349,6 +349,6 @@
   padding: 6px 10px;
   border-radius: 6px;
   font-size: 12px;
-  color: var(--swatchbook-deprecated);
+  color: var(--swatchbook-text-muted);
   background: var(--swatchbook-deprecated-bg);
 }

--- a/packages/blocks/test/chrome-no-phantom-roles.test.ts
+++ b/packages/blocks/test/chrome-no-phantom-roles.test.ts
@@ -3,12 +3,16 @@ import { fileURLToPath } from 'node:url';
 import { buildChromeDefaultsCss } from '@unpunnyfuns/swatchbook-core';
 import { expect, it } from 'vitest';
 
-it('block CSS references only real --swatchbook-* chrome roles', () => {
+it('block CSS references only --swatchbook-* vars defined in a shipped base layer', () => {
   const dir = fileURLToPath(new URL('../src', import.meta.url));
-  // Canonical role var names, taken from the single source rather than re-derived.
-  const known = new Set(
-    [...buildChromeDefaultsCss().matchAll(/(--swatchbook-[a-z-]+):/g)].map((m) => m[1]),
-  );
+  // Known names = the canonical chrome roles plus the internal block-UI tokens,
+  // each defined in a stylesheet the provider ships. A reference to anything
+  // not defined in a base layer is a phantom var.
+  const declarations = [
+    buildChromeDefaultsCss(),
+    readFileSync(`${dir}/internal/internal-tokens.css`, 'utf8'),
+  ].join('\n');
+  const known = new Set([...declarations.matchAll(/(--swatchbook-[a-z-]+):/g)].map((m) => m[1]));
   const offenders: string[] = [];
   for (const f of globSync('**/*.css', { cwd: dir })) {
     const text = readFileSync(`${dir}/${f}`, 'utf8');

--- a/packages/blocks/test/internal-color-tokens.browser.test.tsx
+++ b/packages/blocks/test/internal-color-tokens.browser.test.tsx
@@ -1,0 +1,9 @@
+import '#/index.ts';
+import { expect, it } from 'vitest';
+
+it('internal color tokens resolve on :root standalone (provider ships internal-tokens.css)', () => {
+  const root = getComputedStyle(document.documentElement);
+  expect(root.getPropertyValue('--swatchbook-status-success').trim()).toBe('#30a46c');
+  expect(root.getPropertyValue('--swatchbook-status-danger').trim()).toBe('#d64545');
+  expect(root.getPropertyValue('--swatchbook-deprecated').trim()).toBe('#92400e');
+});

--- a/packages/blocks/test/internal-color-tokens.browser.test.tsx
+++ b/packages/blocks/test/internal-color-tokens.browser.test.tsx
@@ -1,9 +1,60 @@
 import '#/index.ts';
-import { expect, it } from 'vitest';
+import { afterEach, expect, it } from 'vitest';
 
-it('internal color tokens resolve on :root standalone (provider ships internal-tokens.css)', () => {
+// The blocks' surface flips between a light card (standalone) and a dark card
+// (when the consumer's chrome maps surfaces to dark-mode tokens). The status
+// colors must clear WCAG AA on both. They derive from the adaptive
+// `--swatchbook-text-default`, so we simulate each mode by pinning it — this
+// is the contrast coverage axe lacks (it only ever renders the default tuple).
+const CONTEXTS: Record<string, { textDefault: string; surface: number[] }> = {
+  light: { textDefault: '#111827', surface: [255, 255, 255] },
+  dark: { textDefault: '#f8f9fc', surface: [15, 23, 41] },
+};
+
+function relLum(rgb: number[]): number {
+  const [r = 0, g = 0, b = 0] = rgb.map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+function contrast(a: number[], b: number[]): number {
+  const la = relLum(a);
+  const lb = relLum(b);
+  return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+}
+// Resolve a `var(--x)` — which may be a `color-mix()` over other vars — to
+// sRGB 0-255 via canvas, which paints from the browser-resolved value.
+function resolveToRgb(varName: string): number[] {
+  const el = document.createElement('span');
+  el.style.color = `var(${varName})`;
+  document.documentElement.appendChild(el);
+  const computed = getComputedStyle(el).color;
+  el.remove();
+  const canvas = document.createElement('canvas');
+  canvas.width = 1;
+  canvas.height = 1;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('no 2d context');
+  ctx.fillStyle = '#000';
+  ctx.fillStyle = computed;
+  ctx.fillRect(0, 0, 1, 1);
+  return [...ctx.getImageData(0, 0, 1, 1).data].slice(0, 3);
+}
+
+afterEach(() => document.documentElement.style.removeProperty('--swatchbook-text-default'));
+
+it('the deprecated strikethrough color resolves to its flat amber', () => {
   const root = getComputedStyle(document.documentElement);
-  expect(root.getPropertyValue('--swatchbook-status-success').trim()).toBe('#30a46c');
-  expect(root.getPropertyValue('--swatchbook-status-danger').trim()).toBe('#d64545');
   expect(root.getPropertyValue('--swatchbook-deprecated').trim()).toBe('#d97706');
 });
+
+for (const [mode, { textDefault, surface }] of Object.entries(CONTEXTS)) {
+  it(`status colors clear WCAG AA on the ${mode} surface`, () => {
+    document.documentElement.style.setProperty('--swatchbook-text-default', textDefault);
+    for (const role of ['status-success', 'status-warning', 'status-danger']) {
+      const ratio = contrast(resolveToRgb(`--swatchbook-${role}`), surface);
+      expect(ratio, `--swatchbook-${role} on ${mode} surface`).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+}

--- a/packages/blocks/test/internal-color-tokens.browser.test.tsx
+++ b/packages/blocks/test/internal-color-tokens.browser.test.tsx
@@ -5,5 +5,5 @@ it('internal color tokens resolve on :root standalone (provider ships internal-t
   const root = getComputedStyle(document.documentElement);
   expect(root.getPropertyValue('--swatchbook-status-success').trim()).toBe('#30a46c');
   expect(root.getPropertyValue('--swatchbook-status-danger').trim()).toBe('#d64545');
-  expect(root.getPropertyValue('--swatchbook-deprecated').trim()).toBe('#92400e');
+  expect(root.getPropertyValue('--swatchbook-deprecated').trim()).toBe('#d97706');
 });

--- a/packages/blocks/test/internal-color-tokens.test.ts
+++ b/packages/blocks/test/internal-color-tokens.test.ts
@@ -1,0 +1,38 @@
+import { globSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { expect, it } from 'vitest';
+
+const dir = fileURLToPath(new URL('../src', import.meta.url));
+const cssFiles = (): string[] => globSync('**/*.css', { cwd: dir });
+
+it('no block CSS uses light-dark() — colors are owned flat values, not OS-coupled', () => {
+  const offenders: string[] = [];
+  for (const f of cssFiles()) {
+    if (readFileSync(`${dir}/${f}`, 'utf8').includes('light-dark(')) offenders.push(f);
+  }
+  expect(offenders).toEqual([]);
+});
+
+it('no block CSS hardcodes status/deprecated colors — they come from internal tokens', () => {
+  const literals = ['#30a46c', '#d64545', '#b08900', '#92400e', '#fbbf24'];
+  const offenders: string[] = [];
+  for (const f of cssFiles()) {
+    if (f.endsWith('internal-tokens.css')) continue;
+    const text = readFileSync(`${dir}/${f}`, 'utf8');
+    for (const hex of literals) if (text.includes(hex)) offenders.push(`${f}: ${hex}`);
+  }
+  expect(offenders).toEqual([]);
+});
+
+it('internal-tokens.css defines the status and deprecated vars', () => {
+  const text = readFileSync(`${dir}/internal/internal-tokens.css`, 'utf8');
+  for (const v of [
+    '--swatchbook-status-success',
+    '--swatchbook-status-warning',
+    '--swatchbook-status-danger',
+    '--swatchbook-deprecated',
+    '--swatchbook-deprecated-bg',
+  ]) {
+    expect(text).toContain(v);
+  }
+});

--- a/packages/blocks/test/internal-color-tokens.test.ts
+++ b/packages/blocks/test/internal-color-tokens.test.ts
@@ -4,11 +4,15 @@ import { expect, it } from 'vitest';
 
 const dir = fileURLToPath(new URL('../src', import.meta.url));
 const cssFiles = (): string[] => globSync('**/*.css', { cwd: dir });
+// Read a CSS file with `/* … */` comments stripped, so a comment that merely
+// names a banned construct (e.g. documenting "no light-dark()") isn't a hit.
+const readCss = (f: string): string =>
+  readFileSync(`${dir}/${f}`, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
 
 it('no block CSS uses light-dark() — colors are owned flat values, not OS-coupled', () => {
   const offenders: string[] = [];
   for (const f of cssFiles()) {
-    if (readFileSync(`${dir}/${f}`, 'utf8').includes('light-dark(')) offenders.push(f);
+    if (readCss(f).includes('light-dark(')) offenders.push(f);
   }
   expect(offenders).toEqual([]);
 });
@@ -18,7 +22,7 @@ it('no block CSS hardcodes status/deprecated colors — they come from internal 
   const offenders: string[] = [];
   for (const f of cssFiles()) {
     if (f.endsWith('internal-tokens.css')) continue;
-    const text = readFileSync(`${dir}/${f}`, 'utf8');
+    const text = readCss(f);
     for (const hex of literals) if (text.includes(hex)) offenders.push(`${f}: ${hex}`);
   }
   expect(offenders).toEqual([]);


### PR DESCRIPTION
## What

Move the blocks' hardcoded diagnostics + deprecated colors out of scattered literals and into internal `--swatchbook-*` tokens — and make them **adapt to the surface**, which the flat originals didn't.

- **Diagnostics status** (`#30a46c`/`#d64545`/`#b08900`) → `--swatchbook-status-{success,warning,danger}`, each `color-mix(in oklab, <hue>, var(--swatchbook-text-default) 35%)`. The hue stays recognizable; lightness rides the adaptive chrome text, so they're AA on a light card *and* a dark-mode surface.
- **Deprecated** — badge text → the adaptive `--swatchbook-text-muted` (12:1 AAA on the dark surface); `--swatchbook-deprecated` is now the strikethrough amber only (`text-decoration-color`, not contrast-checked); badge bg stays a translucent amber that works on any surface.

No `light-dark()` / OS coupling anywhere in the block CSS — adaptation rides swatchbook's own chrome (which flips per-mode via the consumer's config).

## Why (the bug this fixes)

A single saturated hue can't be WCAG AA on both white and a dark surface. The reference storybook wires `config.chrome` to mode-varying tokens, so the block surface genuinely flips dark on `mode=Dark` — and the flat dark-amber deprecated text + flat status reds failed there. (Caught in review on `Dark · Brand A`.)

## Visual impact

Not zero. The status colors shift on **both** modes — darker/higher-contrast on light, lighter on dark — to clear AA. Deliberate; review the Chromatic diffs as the re-baseline.

## Why a11y CI missed it, and the new guard

Axe is a per-render check — it only inspects the story's **default** tuple (`Light`), where the flat colors passed; it never renders a dark tuple, and it doesn't contrast-check `text-decoration-color` at all. So this whole "flat color on a chrome-adaptive surface" class was structurally invisible. Added a browser guard that resolves each status color under a simulated light **and** dark `text-default` and asserts ≥4.5:1 against the surface — verified in Chromium + Firefox.

## Tests

Full blocks suite green (360); node guards (no `light-dark()`, no hardcoded status/deprecated hex outside the token file, comment-stripped to avoid false positives); the new dark-a11y contrast guard; gauntlet clean.

Milestone: Maintenance

Closes #1286

Plan impact: none