### PR TITLE
fix(blocks): surface the dimension cap in TokenNavigator and align OpacityScale's namespace

### DIFF
--- a/.changeset/dimension-cap-indicator.md
+++ b/.changeset/dimension-cap-indicator.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Surface the dimension 480px render cap consistently across DimensionScale and TokenNavigator by centralizing the indicator in DimensionBar

--- a/.changeset/dimension-cap-indicator.md
+++ b/.changeset/dimension-cap-indicator.md
@@ -2,4 +2,4 @@
 "@unpunnyfuns/swatchbook-blocks": patch
 ---
 
-Surface the dimension 480px render cap consistently across DimensionScale and TokenNavigator by centralizing the indicator in DimensionBar
+Surface the dimension render cap in TokenNavigator and keep dimension bars within their host cell so a capped bar (e.g. the 9999px pill) no longer overflows the preview

--- a/.changeset/opacity-scale-namespace.md
+++ b/.changeset/opacity-scale-namespace.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+Use the fixed --swatchbook- namespace for OpacityScale's inline sample vars instead of the consumer --sb- prefix

--- a/packages/blocks/src/DimensionScale.css
+++ b/packages/blocks/src/DimensionScale.css
@@ -40,10 +40,3 @@
   opacity: 0.7;
   white-space: nowrap;
 }
-
-.sb-dimension-scale__cap {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
-  opacity: 0.6;
-  margin-left: var(--swatchbook-space-xs);
-}

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 import './DimensionScale.css';
 import { DimensionBar } from '#/dimension-scale/DimensionBar.tsx';
 import type { DimensionVisual } from '#/dimension-scale/DimensionBar.tsx';
-import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
 import { useRootFontSize } from '#/internal/use-root-font-size.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
@@ -45,8 +44,6 @@ interface Row {
   path: string;
   cssVar: string;
   displayValue: string;
-  pxValue: number;
-  capped: boolean;
 }
 
 export function DimensionScale({
@@ -66,16 +63,11 @@ export function DimensionScale({
       return matchPath(path, filter);
     });
     return sortTokens(filtered, { by: sortBy, dir: sortDir, rootFontSizePx: rootFontSize }).map(
-      ([path, token]) => {
-        const pxValue = toPixels(token.$value, rootFontSize);
-        return {
-          path,
-          cssVar: resolveCssVar(path, project),
-          displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
-          pxValue,
-          capped: Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX,
-        };
-      },
+      ([path, token]) => ({
+        path,
+        cssVar: resolveCssVar(path, project),
+        displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
+      }),
     );
   }, [resolved, filter, project, sortBy, sortDir, rootFontSize]);
 
@@ -102,9 +94,6 @@ export function DimensionScale({
           </div>
           <div className="sb-dimension-scale__visual-cell">
             <DimensionBar path={row.path} visual={visual} />
-            {row.capped && (
-              <span className="sb-dimension-scale__cap">capped at {MAX_RENDER_PX}px</span>
-            )}
           </div>
           <span className="sb-dimension-scale__css-var">{row.cssVar}</span>
         </div>

--- a/packages/blocks/src/OpacityScale.css
+++ b/packages/blocks/src/OpacityScale.css
@@ -40,8 +40,8 @@
   content: '';
   position: absolute;
   inset: 0;
-  background: var(--sb-opacity-scale-color);
-  opacity: var(--sb-opacity-scale-alpha);
+  background: var(--swatchbook-opacity-scale-color);
+  opacity: var(--swatchbook-opacity-scale-alpha);
 }
 
 .sb-opacity-scale__meta {

--- a/packages/blocks/src/OpacityScale.tsx
+++ b/packages/blocks/src/OpacityScale.tsx
@@ -117,8 +117,8 @@ export function OpacityScale({
               className="sb-opacity-scale__swatch"
               style={
                 {
-                  '--sb-opacity-scale-color': sampleColorVar,
-                  '--sb-opacity-scale-alpha': String(row.opacity),
+                  '--swatchbook-opacity-scale-color': sampleColorVar,
+                  '--swatchbook-opacity-scale-alpha': String(row.opacity),
                 } as CSSProperties
               }
               aria-hidden

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -19,6 +19,17 @@ export interface DimensionBarProps {
 }
 
 const styles = {
+  cappedWrap: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: 'var(--swatchbook-space-3xs)',
+  } satisfies CSSProperties,
+  cap: {
+    color: 'var(--swatchbook-text-muted)',
+    fontSize: 11,
+    lineHeight: 1,
+    userSelect: 'none',
+  } satisfies CSSProperties,
   bar: {
     height: 14,
     background: 'var(--swatchbook-accent-bg, #3b82f6)',
@@ -39,6 +50,25 @@ const styles = {
   } satisfies CSSProperties,
 };
 
+// Wrap a clamped visual with the cap affordance so every consumer (the scale
+// block and TokenNavigator) surfaces truncation identically. The visual itself
+// is decorative — the token's real value is shown as adjacent text — so the
+// marker is `aria-hidden` and the title carries the hint for sighted hover.
+function withCap(visual: ReactElement): ReactElement {
+  return (
+    <span
+      className="sb-dimension-bar sb-dimension-bar--capped"
+      style={styles.cappedWrap}
+      title={`capped at ${MAX_RENDER_PX}px`}
+    >
+      {visual}
+      <span className="sb-dimension-bar__cap" aria-hidden>
+        …
+      </span>
+    </span>
+  );
+}
+
 export function DimensionBar({ path, visual = 'length' }: DimensionBarProps): ReactElement {
   const project = useProject();
   const { resolved } = project;
@@ -50,17 +80,23 @@ export function DimensionBar({ path, visual = 'length' }: DimensionBarProps): Re
   const cappedValue = capped ? `${MAX_RENDER_PX}px` : cssVar;
 
   switch (visual) {
+    // A fixed 56×56 box: border-radius can't overflow it, so the cap never
+    // applies to the radius sample.
     case 'radius':
       return <div style={{ ...styles.radiusSample, borderRadius: cssVar }} aria-hidden />;
-    case 'size':
-      return (
+    case 'size': {
+      const sample = (
         <div
           style={{ ...styles.sizeSample, width: cappedValue, height: cappedValue }}
           aria-hidden
         />
       );
+      return capped ? withCap(sample) : sample;
+    }
     case 'length':
-    default:
-      return <div style={{ ...styles.bar, width: cappedValue }} aria-hidden />;
+    default: {
+      const bar = <div style={{ ...styles.bar, width: cappedValue }} aria-hidden />;
+      return capped ? withCap(bar) : bar;
+    }
   }
 }

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -23,6 +23,8 @@ const styles = {
     display: 'inline-flex',
     alignItems: 'center',
     gap: 'var(--swatchbook-space-3xs)',
+    maxWidth: '100%',
+    minWidth: 0,
   } satisfies CSSProperties,
   cap: {
     color: 'var(--swatchbook-text-muted)',
@@ -35,6 +37,10 @@ const styles = {
     background: 'var(--swatchbook-accent-bg, #3b82f6)',
     borderRadius: 2,
     minWidth: 1,
+    // Never exceed the host cell: the px width conveys magnitude in the wide
+    // DimensionScale rows, but the bar also renders in TokenNavigator's narrow
+    // preview cell, where a 480px-capped bar would otherwise overflow.
+    maxWidth: '100%',
   } satisfies CSSProperties,
   radiusSample: {
     width: 56,

--- a/packages/blocks/test/chrome-no-phantom-roles.test.ts
+++ b/packages/blocks/test/chrome-no-phantom-roles.test.ts
@@ -3,17 +3,24 @@ import { fileURLToPath } from 'node:url';
 import { buildChromeDefaultsCss } from '@unpunnyfuns/swatchbook-core';
 import { expect, it } from 'vitest';
 
-it('block CSS references only --swatchbook-* vars defined in a shipped base layer', () => {
+it('block CSS references only --swatchbook-* vars defined in a base layer or inline', () => {
   const dir = fileURLToPath(new URL('../src', import.meta.url));
   // Known names = the canonical chrome roles plus the internal block-UI tokens,
-  // each defined in a stylesheet the provider ships. A reference to anything
-  // not defined in a base layer is a phantom var.
+  // each defined in a stylesheet the provider ships...
   const declarations = [
     buildChromeDefaultsCss(),
     readFileSync(`${dir}/internal/internal-tokens.css`, 'utf8'),
     readFileSync(`${dir}/internal/internal-dimensions.css`, 'utf8'),
   ].join('\n');
   const known = new Set([...declarations.matchAll(/(--swatchbook-[a-z0-9-]+):/g)].map((m) => m[1]));
+  // ...plus vars a component injects inline as a style-object key — per-instance
+  // runtime values (e.g. the opacity sample's color/alpha) that can't live in a
+  // static base layer but are just as defined. Match the `'--swatchbook-x':` key
+  // form, not `var(...)` references.
+  for (const f of globSync('**/*.{ts,tsx}', { cwd: dir })) {
+    const text = readFileSync(`${dir}/${f}`, 'utf8');
+    for (const m of text.matchAll(/['"](--swatchbook-[a-z0-9-]+)['"]\s*:/g)) known.add(m[1]);
+  }
   const offenders: string[] = [];
   for (const f of globSync('**/*.css', { cwd: dir })) {
     const text = readFileSync(`${dir}/${f}`, 'utf8');

--- a/packages/blocks/test/dimension-scale-cap.browser.test.tsx
+++ b/packages/blocks/test/dimension-scale-cap.browser.test.tsx
@@ -1,6 +1,6 @@
 import { cleanup, render, waitFor } from '@testing-library/react';
 import { afterEach, expect, it } from 'vitest';
-import { DimensionScale, SwatchbookProvider } from '#/index.ts';
+import { DimensionBar, DimensionScale, SwatchbookProvider } from '#/index.ts';
 import type { ProjectSnapshot } from '#/index.ts';
 import { makeResolveAt } from './_snapshot-helpers.ts';
 
@@ -36,7 +36,7 @@ it('does not cap a 25rem token at a 16px root (400px is under the 480 cap)', () 
       <DimensionScale />
     </SwatchbookProvider>,
   );
-  expect(container.querySelector('.sb-dimension-scale__cap')).toBeNull();
+  expect(container.querySelector('.sb-dimension-bar__cap')).toBeNull();
 });
 
 it('caps the same 25rem token when the root font-size is 20px (500px exceeds 480)', () => {
@@ -46,9 +46,10 @@ it('caps the same 25rem token when the root font-size is 20px (500px exceeds 480
       <DimensionScale />
     </SwatchbookProvider>,
   );
-  expect(container.querySelector('.sb-dimension-scale__cap')?.textContent).toContain(
+  expect(container.querySelector('.sb-dimension-bar--capped')?.getAttribute('title')).toContain(
     'capped at 480px',
   );
+  expect(container.querySelector('.sb-dimension-bar__cap')).not.toBeNull();
   const bar = container.querySelector<HTMLElement>('.sb-dimension-scale__visual-cell div');
   expect(bar?.style.width).toBe('480px');
 });
@@ -60,15 +61,41 @@ it('re-evaluates the cap when a responsive breakpoint changes the root font-size
       <DimensionScale />
     </SwatchbookProvider>,
   );
-  expect(container.querySelector('.sb-dimension-scale__cap')).toBeNull();
+  expect(container.querySelector('.sb-dimension-bar__cap')).toBeNull();
 
   // A media query bumps the root at a breakpoint: 25rem is now 600px (> 480).
   document.documentElement.style.fontSize = '24px';
   window.dispatchEvent(new Event('resize'));
 
   await waitFor(() => {
-    expect(container.querySelector('.sb-dimension-scale__cap')?.textContent).toContain(
-      'capped at 480px',
-    );
+    expect(container.querySelector('.sb-dimension-bar__cap')).not.toBeNull();
   });
+});
+
+// The cap indicator now lives in DimensionBar, so every consumer surfaces it
+// the same way — including TokenNavigator, which previously clamped the bar
+// silently. Rendering DimensionBar directly locks the shared behavior.
+it('DimensionBar surfaces the cap marker for an oversized length token', () => {
+  document.documentElement.style.fontSize = '20px';
+  const { container } = render(
+    <SwatchbookProvider value={makeSnapshot()}>
+      <DimensionBar path="dimension.wide" visual="length" />
+    </SwatchbookProvider>,
+  );
+  const wrap = container.querySelector('.sb-dimension-bar--capped');
+  expect(wrap?.getAttribute('title')).toContain('capped at 480px');
+  expect(container.querySelector('.sb-dimension-bar__cap')).not.toBeNull();
+  const bar = wrap?.querySelector<HTMLElement>('div');
+  expect(bar?.style.width).toBe('480px');
+});
+
+it('DimensionBar renders a bare bar (no cap marker) when under the cap', () => {
+  document.documentElement.style.fontSize = '16px';
+  const { container } = render(
+    <SwatchbookProvider value={makeSnapshot()}>
+      <DimensionBar path="dimension.wide" visual="length" />
+    </SwatchbookProvider>,
+  );
+  expect(container.querySelector('.sb-dimension-bar--capped')).toBeNull();
+  expect(container.querySelector('.sb-dimension-bar__cap')).toBeNull();
 });

--- a/packages/blocks/test/dimension-scale-cap.browser.test.tsx
+++ b/packages/blocks/test/dimension-scale-cap.browser.test.tsx
@@ -99,3 +99,23 @@ it('DimensionBar renders a bare bar (no cap marker) when under the cap', () => {
   expect(container.querySelector('.sb-dimension-bar--capped')).toBeNull();
   expect(container.querySelector('.sb-dimension-bar__cap')).toBeNull();
 });
+
+// A capped bar carries a 480px inline width, which would overflow a narrow
+// host like TokenNavigator's preview cell. The bar must fit its container
+// (max-width: 100%) so it never blows out the layout, while the cap marker
+// stays visible. Regression for the pill (9999px) bar overflowing the cell.
+it('a capped bar fits inside a narrow host cell instead of overflowing', () => {
+  document.documentElement.style.fontSize = '20px';
+  const { container } = render(
+    <div style={{ width: 120, maxWidth: 120, display: 'inline-block' }}>
+      <SwatchbookProvider value={makeSnapshot()}>
+        <DimensionBar path="dimension.wide" visual="length" />
+      </SwatchbookProvider>
+    </div>,
+  );
+  const bar = container.querySelector<HTMLElement>('.sb-dimension-bar--capped div');
+  // Inline width still records the 480px cap; the rendered width fits the cell.
+  expect(bar?.style.width).toBe('480px');
+  expect(bar?.getBoundingClientRect().width).toBeLessThanOrEqual(120);
+  expect(container.querySelector('.sb-dimension-bar__cap')).not.toBeNull();
+});


### PR DESCRIPTION
## Summary

Three small pre-release blocks fixes, all surfaced during the dimensional-scale work.

## Full description

**Dimension 480px cap (#1291).** The render cap math lived in `DimensionBar`, but the "capped" indicator lived only in `DimensionScale` (with a duplicate `capped` computation), so `TokenNavigator` — which renders a bare `DimensionBar` — clamped the bar to 480px with no signal it was truncated. The cap is now centralized in `DimensionBar`: a capped `length`/`size` visual renders a compact marker (`…`) with `title="capped at 480px"`, shown identically in both blocks. `DimensionScale`'s duplicate computation, its separate text label, and the dead `.sb-dimension-scale__cap` CSS are removed. The `radius` visual is a fixed 56×56 box, so it intentionally doesn't cap.

**Dimension bar overflow (#1291, follow-up).** The 480px cap is sized for `DimensionScale`'s wide rows; in `TokenNavigator`'s 120px preview cell a capped bar (e.g. the 9999px `radius.pill`) still overflowed because the bar used a fixed px width with no `max-width`. The bar now carries `max-width: 100%` so it fits any host cell while the cap marker stays visible — verified by rendering `DimensionBar` in a 120px container and asserting the rendered width stays within it.

**OpacityScale namespace (#1290).** `OpacityScale` set its per-row sample color/alpha as inline `--sb-opacity-scale-*` custom properties — the consumer's `--sb-` prefix, the only `--sb-` left in the blocks. Renamed to the fixed `--swatchbook-opacity-scale-*` namespace. The `chrome-no-phantom-roles` guard now also recognizes `--swatchbook-*` vars defined inline in a component style object (per-instance runtime values that can't live in a static base layer), not just base-layer stylesheets — so it stops false-positiving on this legitimate pattern while still catching truly-undefined phantom vars.

All land before v0.67.0 so the base-CSS arc ships clean.

Milestone: Maintenance
Plan impact: none.

Closes #1290
Closes #1291