### PR TITLE
fix: pin js-yaml 3.x to the patched 3.15.0 (CVE-2026-53550)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   esbuild: ^0.28.1
   launch-editor: ^2.14.1
   js-yaml@>=4: ^4.2.0
+  js-yaml@3: ^3.15.0
   '@babel/core': ^7.29.6
   webpack-dev-server: 5.2.5
   http-proxy-middleware: ^3.0.6
@@ -6466,8 +6467,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.2:
-    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -15584,7 +15585,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -16043,7 +16044,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.2:
+  js-yaml@3.15.0:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
@@ -17843,7 +17844,7 @@ snapshots:
   read-yaml-file@1.1.0:
     dependencies:
       graceful-fs: 4.2.11
-      js-yaml: 3.14.2
+      js-yaml: 3.15.0
       pify: 4.0.1
       strip-bom: 3.0.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,11 @@ overrides:
   # GHSA-h67p-54hq-rp68 (#1223). Scoped to 4.x: Docusaurus's front-matter
   # parser needs js-yaml 3.x; a blanket override breaks `docs#build`.
   'js-yaml@>=4': ^4.2.0
+  # Same advisory (CVE-2026-53550) on the 3.x line, alert #35: Docusaurus's
+  # gray-matter parser pins js-yaml `^3.13.1` and 3.14.2 is still vulnerable.
+  # 3.15.0 is the patched 3.x (same major, API-compatible), so it clears the
+  # alert without the blanket-override breakage noted above.
+  'js-yaml@3': ^3.15.0
   # GHSA-4x5r-pxfx-6jf8 (#1223)
   '@babel/core': ^7.29.6
   # GHSA-mx8g-39q3-5c79 (#1255), via @docusaurus/core dev server


### PR DESCRIPTION
## Summary

Clears Dependabot alert #35 (CVE-2026-53550 / GHSA-h67p-54hq-rp68, medium): a quadratic-complexity DoS in js-yaml's merge-key handling. `js-yaml@3.14.2` was pulled transitively (dev-only) by `gray-matter@4.0.3` under the Docusaurus tree.

## Full description

The existing override for this advisory pins only `js-yaml@>=4` to `^4.2.0`, because forcing the 3.x line to 4.x breaks `docs#build` (gray-matter uses the js-yaml 3.x API). So the 3.x branch stayed on the vulnerable 3.14.2.

This adds a second scoped override, `'js-yaml@3': ^3.15.0`. 3.15.0 is the patched release on the 3.x line, satisfies gray-matter's `^3.13.1`, and is API-compatible.

Verified locally:
- `js-yaml@3.14.2` no longer resolves in the lockfile; `3.15.0` does. The `4.2.0` consumers are unaffected.
- `docs#build` passes (the load-bearing check that the blanket override would have failed).

No changeset: dev-only transitive override, not bundled into any published package's dist.

Milestone: Maintenance
Plan impact: none.

Closes #1299