### PR TITLE
test(storybook): add ColorPalette swatch + semantic views to Tokens/Colors

### DIFF
--- a/apps/storybook/src/stories/tokens/Colors.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Colors.stories.tsx
@@ -1,10 +1,12 @@
-import { ColorTable } from '@unpunnyfuns/swatchbook-blocks';
+import { ColorPalette, ColorTable } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
 import preview from '../../../.storybook/preview.tsx';
 
-// Catalog story for $type: color. Mounts <ColorTable> (the existing block);
-// this is the consumer-facing pattern, distinct from Blocks/ColorTable which
-// exercises the component's variants/tests.
+// Catalog stories for $type: color. The swatch-grid views use <ColorPalette>
+// (Palette = the primitive ramps, Semantic = the role tier), mirroring the
+// Colors docs page; <ColorTable> carries the detailed/searchable form. This is
+// the consumer-facing pattern, distinct from Blocks/ColorPalette and
+// Blocks/ColorTable, which exercise each component's variants and tests.
 const meta = preview.meta({
   title: 'Tokens/Colors',
   component: ColorTable,
@@ -28,7 +30,21 @@ async function assertRenders(canvas: HTMLElement): Promise<void> {
   });
 }
 
+// Swatch grid of the primitive ramps (`color.palette.*`).
 export const Palette = meta.story({
+  render: () => <ColorPalette filter="color.palette.**" />,
+  play: async ({ canvasElement }) => assertRenders(canvasElement),
+});
+
+// Swatch grid grouped by role — the semantic tier (`color.surface.*`,
+// `color.text.*`, `color.accent.*`, …) alongside the ramps.
+export const Semantic = meta.story({
+  render: () => <ColorPalette filter="color.**" />,
+  play: async ({ canvasElement }) => assertRenders(canvasElement),
+});
+
+// Detailed, sortable, searchable table over every color token.
+export const Table = meta.story({
   args: { filter: 'color.**' },
   play: async ({ canvasElement }) => assertRenders(canvasElement),
 });


### PR DESCRIPTION
## Summary

`Tokens/Colors` only mounted `<ColorTable>` (and the story named `Palette` was a table). Adds the missing `<ColorPalette>` swatch-grid views, mirroring the Colors docs page.

## Full description

- **`Palette`** now renders `<ColorPalette filter="color.palette.**">` (the primitive ramps) instead of a table.
- **`Semantic`** (new) renders `<ColorPalette filter="color.**">` — the role tier grouped by sub-path.
- **`Table`** keeps the detailed/sortable/searchable `<ColorTable filter="color.**">` (the renamed former "Palette").
- `RefBlue` (carries the a11y check) and `DarkBrandA` (theme-pin demo) unchanged.

apps/storybook is private (no changeset). Story tests pass.

Milestone: Maintenance
Plan impact: none.

Closes #1301