### PR TITLE
fix(core): align chrome color defaults to swatchbook's neutral tokens

### DIFF
--- a/.changeset/chrome-default-color-alignment.md
+++ b/.changeset/chrome-default-color-alignment.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-core": minor
+---
+
+Align the standalone chrome color defaults to swatchbook's neutral color tokens (four drifted neutrals shift slate-ward) and guard them against future drift

--- a/packages/blocks/src/internal/chrome-base.css
+++ b/packages/blocks/src/internal/chrome-base.css
@@ -1,10 +1,10 @@
 :root {
-  --swatchbook-border-default: #e5e7eb;
+  --swatchbook-border-default: #e2e8f0;
   --swatchbook-surface-default: #ffffff;
-  --swatchbook-surface-muted: #f4f4f5;
+  --swatchbook-surface-muted: #f8fafc;
   --swatchbook-surface-raised: #ffffff;
-  --swatchbook-text-default: #111827;
-  --swatchbook-text-muted: #4b5563;
+  --swatchbook-text-default: #0f172a;
+  --swatchbook-text-muted: #475569;
   --swatchbook-accent-bg: #1d4ed8;
   --swatchbook-accent-fg: #ffffff;
   --swatchbook-body-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;

--- a/packages/blocks/test/chrome-defaults-match-tokens.test.ts
+++ b/packages/blocks/test/chrome-defaults-match-tokens.test.ts
@@ -1,0 +1,56 @@
+import { beforeAll, expect, it } from 'vitest';
+import { DEFAULT_CHROME_MAP, loadProject } from '@unpunnyfuns/swatchbook-core';
+import { resolverPath, tokensDir } from '@unpunnyfuns/swatchbook-tokens';
+
+// The standalone chrome color defaults dogfood swatchbook's own tokens: each
+// color role's DEFAULT_CHROME_MAP literal must equal the resolved color token
+// at the default tuple. This guard keeps the published `core` map honest
+// against the private dogfood tokens (which `blocks` already deps on for the
+// scale generator) without a core->tokens build dependency. `bodyFontFamily`
+// is deliberately absent: its default is a neutral `system-ui` fallback, not
+// the brand font token (a standalone block shouldn't force-load a font).
+const ROLE_TOKEN: Record<string, string> = {
+  surfaceDefault: 'color.surface.default',
+  surfaceMuted: 'color.surface.muted',
+  surfaceRaised: 'color.surface.raised',
+  textDefault: 'color.text.default',
+  textMuted: 'color.text.muted',
+  borderDefault: 'color.border.default',
+  accentBg: 'color.accent.bg',
+  accentFg: 'color.accent.fg',
+};
+
+// sRGB components (0..1) -> #rrggbb, the hex form DEFAULT_CHROME_MAP uses. The
+// palette source values are hex, so the components round to exact bytes.
+function toHex(value: unknown): string {
+  const v = value as { components: number[] };
+  return `#${v.components
+    .map((c) =>
+      Math.round(c * 255)
+        .toString(16)
+        .padStart(2, '0'),
+    )
+    .join('')}`;
+}
+
+let tokens: Record<string, { $value?: unknown }>;
+// loadProject is ~1s — resolve once (the project's allowed perf escape hatch).
+beforeAll(async () => {
+  const project = await loadProject(
+    { resolver: resolverPath, default: { mode: 'Light', brand: 'Default', contrast: 'Normal' } },
+    tokensDir,
+  );
+  tokens = project.defaultTokens;
+});
+
+it('DEFAULT_CHROME_MAP color roles equal swatchbook color tokens (hex)', () => {
+  const mismatches: string[] = [];
+  for (const [role, path] of Object.entries(ROLE_TOKEN)) {
+    const tokenHex = toHex(tokens[path]?.$value);
+    const literal = String(
+      DEFAULT_CHROME_MAP[role as keyof typeof DEFAULT_CHROME_MAP],
+    ).toLowerCase();
+    if (tokenHex !== literal) mismatches.push(`${role}: map=${literal} token=${tokenHex}`);
+  }
+  expect(mismatches).toEqual([]);
+});

--- a/packages/blocks/test/chrome-standalone.browser.test.tsx
+++ b/packages/blocks/test/chrome-standalone.browser.test.tsx
@@ -3,7 +3,7 @@ import { expect, it } from 'vitest';
 
 it('defines the chrome vars on :root with no addon, no chrome config', () => {
   const root = getComputedStyle(document.documentElement);
-  expect(root.getPropertyValue('--swatchbook-border-default').trim()).toBe('#e5e7eb');
+  expect(root.getPropertyValue('--swatchbook-border-default').trim()).toBe('#e2e8f0');
   expect(root.getPropertyValue('--swatchbook-surface-default').trim()).toBe('#ffffff');
 });
 

--- a/packages/core/src/chrome.ts
+++ b/packages/core/src/chrome.ts
@@ -48,11 +48,11 @@ export const CHROME_VAR_PREFIX = 'swatchbook';
  */
 export const DEFAULT_CHROME_MAP: Record<ChromeRole, string> = {
   surfaceDefault: '#ffffff',
-  surfaceMuted: '#f4f4f5',
+  surfaceMuted: '#f8fafc',
   surfaceRaised: '#ffffff',
-  textDefault: '#111827',
-  textMuted: '#4b5563',
-  borderDefault: '#e5e7eb',
+  textDefault: '#0f172a',
+  textMuted: '#475569',
+  borderDefault: '#e2e8f0',
   accentBg: '#1d4ed8',
   accentFg: '#ffffff',
   bodyFontFamily: "system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif",

--- a/packages/core/test/__snapshots__/css-axis-projected.css
+++ b/packages/core/test/__snapshots__/css-axis-projected.css
@@ -272,12 +272,12 @@
 }
 
 :root {
-  --swatchbook-border-default: #e5e7eb;
+  --swatchbook-border-default: #e2e8f0;
   --swatchbook-surface-default: #ffffff;
-  --swatchbook-surface-muted: #f4f4f5;
+  --swatchbook-surface-muted: #f8fafc;
   --swatchbook-surface-raised: #ffffff;
-  --swatchbook-text-default: #111827;
-  --swatchbook-text-muted: #4b5563;
+  --swatchbook-text-default: #0f172a;
+  --swatchbook-text-muted: #475569;
   --swatchbook-accent-bg: #1d4ed8;
   --swatchbook-accent-fg: #ffffff;
   --swatchbook-body-font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;

--- a/packages/core/test/chrome.test.ts
+++ b/packages/core/test/chrome.test.ts
@@ -68,8 +68,8 @@ it('default chrome values are single owned literals, never light-dark or system 
     expect(value).not.toMatch(/\b(Canvas|CanvasText|LinkText|ButtonBorder|GrayText|AccentColor)\b/);
   }
   expect(DEFAULT_CHROME_MAP.surfaceDefault).toBe('#ffffff');
-  expect(DEFAULT_CHROME_MAP.textDefault).toBe('#111827');
-  expect(DEFAULT_CHROME_MAP.borderDefault).toBe('#e5e7eb');
+  expect(DEFAULT_CHROME_MAP.textDefault).toBe('#0f172a');
+  expect(DEFAULT_CHROME_MAP.borderDefault).toBe('#e2e8f0');
   expect(DEFAULT_CHROME_MAP.accentBg).toBe('#1d4ed8');
 });
 


### PR DESCRIPTION
## Summary

The standalone chrome color defaults (`DEFAULT_CHROME_MAP`) had drifted from swatchbook's own color tokens: 4 of 8 were hand-copied from a **gray** ramp where the tokens resolve to the project's **neutral (slate)** palette. This corrects them and adds a drift guard, finishing the "our tokens style our chrome" arc (space/radius/type already generate from tokens).

## Full description

The 4 *matching* roles matched the tokens exactly (`accent-bg #1d4ed8` etc.), so the neutrals were an accidental hand-copy, not a deliberate generic palette. Corrected to the resolved token values:

| role | was | now (resolved token) |
|------|-----|----------------------|
| text-default | `#111827` | `#0f172a` |
| text-muted | `#4b5563` | `#475569` |
| surface-muted | `#f4f4f5` | `#f8fafc` |
| border-default | `#e5e7eb` | `#e2e8f0` |

**Drift guard (not generation).** Unlike the scales — which the *blocks* generator emits (blocks deps on the dogfood tokens) — these defaults live in `DEFAULT_CHROME_MAP` in **core**, the published engine, so generating them would force a core->private-tokens build dependency. Instead a new `blocks` test resolves the color tokens and asserts the map matches (TDD: it failed on exactly the 4 drifted roles, passes after the correction). Tokens are the enforced source of truth, no core build-dep.

`bodyFontFamily` is left as the deliberate `system-ui` neutral default (a standalone block shouldn't force-load the brand font), so the guard covers colors only.

**Chromatic:** a re-baseline is expected on standalone-chrome stories (the 4 neutrals shift slate-ward). Stories whose chrome is consumer-mapped (the dogfood maps roles to `color.*`) are unaffected — they already used the token values.

Minor (core ships the new defaults; user-visible for standalone consumers).

Milestone: Maintenance
Plan impact: none.

Closes #1303