### PR TITLE
refactor(blocks): dogfood muted/scrim opacity onto number.opacity tokens

### DIFF
--- a/packages/blocks/scripts/generate-internal-scales.mts
+++ b/packages/blocks/scripts/generate-internal-scales.mts
@@ -18,18 +18,32 @@ function fmtValue(v: unknown): string {
   return String(v);
 }
 
-function rootBlock(tokens: Record<string, { $value?: unknown }>, groups: string[]): string {
-  const lines = Object.keys(tokens)
-    .filter((p) => {
-      const prefix = p.split('.')[0];
-      return prefix !== undefined && groups.includes(prefix);
-    })
-    .sort()
-    .map((p) => {
-      const token = tokens[p];
-      return `  ${makeCSSVar(p, { prefix: 'swatchbook' })}: ${fmtValue(token?.$value)};`;
-    });
-  return `:root {\n${lines.join('\n')}\n}\n`;
+type Tokens = Record<string, { $value?: unknown }>;
+
+// One `  --swatchbook-<name>: <value>;` line. `name` is the var path (usually
+// the token path; opacity remaps it, below).
+function emitLine(tokens: Tokens, path: string, name: string): string {
+  return `  ${makeCSSVar(name, { prefix: 'swatchbook' })}: ${fmtValue(tokens[path]?.$value)};`;
+}
+
+// Wrap lines in a `:root {}` block, sorted by var name for stable output.
+function wrap(lines: string[]): string {
+  return `:root {\n${[...lines].sort().join('\n')}\n}\n`;
+}
+
+// Tokens whose first path segment is in `groups`, emitted at their own path.
+function group(tokens: Tokens, groups: string[]): string[] {
+  return Object.keys(tokens)
+    .filter((p) => groups.includes(p.split('.')[0] ?? ''))
+    .map((p) => emitLine(tokens, p, p));
+}
+
+// number.opacity.<role> -> --swatchbook-opacity-<role> (strip the `number.`
+// prefix so blocks reference a clean `--swatchbook-opacity-*` namespace).
+function opacity(tokens: Tokens): string[] {
+  return Object.keys(tokens)
+    .filter((p) => p.startsWith('number.opacity.'))
+    .map((p) => emitLine(tokens, p, p.slice('number.'.length)));
 }
 
 /** Resolve swatchbook-tokens and render the two bundled scale stylesheets. */
@@ -38,12 +52,12 @@ export async function generateScales() {
     { resolver: resolverPath, default: { mode: 'Light', brand: 'Default', contrast: 'Normal' } },
     tokensDir,
   );
-  const tokens: Record<string, { $value?: unknown }> = project.defaultTokens;
+  const tokens: Tokens = project.defaultTokens;
   return {
-    dimensions: HEADER('Spacing + radii') + rootBlock(tokens, ['space', 'radius']),
+    dimensions: HEADER('Spacing + radii') + wrap(group(tokens, ['space', 'radius'])),
     typography:
-      HEADER('Font sizes, line-height, tracking') +
-      rootBlock(tokens, ['type', 'leading', 'tracking']),
+      HEADER('Font sizes, line-height, tracking, opacity') +
+      wrap([...group(tokens, ['type', 'leading', 'tracking']), ...opacity(tokens)]),
   };
 }
 

--- a/packages/blocks/src/BorderPreview.css
+++ b/packages/blocks/src/BorderPreview.css
@@ -25,7 +25,7 @@
 .sb-border-preview__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-border-preview__sample-cell {

--- a/packages/blocks/src/ColorPalette.css
+++ b/packages/blocks/src/ColorPalette.css
@@ -7,7 +7,7 @@
   font-size: var(--swatchbook-type-micro);
   text-transform: uppercase;
   letter-spacing: var(--swatchbook-tracking-label);
-  opacity: 0.6;
+  opacity: var(--swatchbook-opacity-scrim);
   margin-bottom: var(--swatchbook-space-sm);
 }
 
@@ -46,7 +46,7 @@
 .sb-color-palette__value {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-color-palette__gamut-warn {

--- a/packages/blocks/src/Diagnostics.css
+++ b/packages/blocks/src/Diagnostics.css
@@ -56,5 +56,5 @@
   margin-top: var(--swatchbook-space-2xs);
   color: var(--swatchbook-text-muted);
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }

--- a/packages/blocks/src/DimensionScale.css
+++ b/packages/blocks/src/DimensionScale.css
@@ -25,7 +25,7 @@
 .sb-dimension-scale__specs {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-dimension-scale__visual-cell {
@@ -37,6 +37,6 @@
 .sb-dimension-scale__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
   white-space: nowrap;
 }

--- a/packages/blocks/src/GradientPalette.css
+++ b/packages/blocks/src/GradientPalette.css
@@ -25,7 +25,7 @@
 .sb-gradient-palette__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-gradient-palette__sample {
@@ -57,5 +57,5 @@
 }
 
 .sb-gradient-palette__stop-position {
-  opacity: 0.6;
+  opacity: var(--swatchbook-opacity-scrim);
 }

--- a/packages/blocks/src/OpacityScale.css
+++ b/packages/blocks/src/OpacityScale.css
@@ -59,11 +59,11 @@
 .sb-opacity-scale__value {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-opacity-scale__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }

--- a/packages/blocks/src/ShadowPreview.css
+++ b/packages/blocks/src/ShadowPreview.css
@@ -25,7 +25,7 @@
 .sb-shadow-preview__css-var {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-shadow-preview__sample-cell {

--- a/packages/blocks/src/TypographyScale.css
+++ b/packages/blocks/src/TypographyScale.css
@@ -21,5 +21,5 @@
 .sb-typography-scale__specs {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }

--- a/packages/blocks/src/internal/internal-typography.css
+++ b/packages/blocks/src/internal/internal-typography.css
@@ -2,20 +2,23 @@
  * GENERATED from @unpunnyfuns/swatchbook-tokens by
  * scripts/generate-internal-scales.mts. Do not edit by hand.
  * Run `pnpm --filter @unpunnyfuns/swatchbook-blocks generate:scales`.
- * Font sizes, line-height, tracking: swatchbook's own tokens styling the block UI.
+ * Font sizes, line-height, tracking, opacity: swatchbook's own tokens styling the block UI.
  */
 :root {
   --swatchbook-leading-loose: 1.5;
   --swatchbook-leading-none: 1;
   --swatchbook-leading-normal: 1.4;
   --swatchbook-leading-tight: 1.2;
+  --swatchbook-opacity-disabled: 0.4;
+  --swatchbook-opacity-muted: 0.7;
+  --swatchbook-opacity-scrim: 0.6;
   --swatchbook-tracking-label: 0.5px;
   --swatchbook-type-body: 1rem;
   --swatchbook-type-caption: 0.75rem;
   --swatchbook-type-heading: 1.25rem;
   --swatchbook-type-micro: 0.6875rem;
-  --swatchbook-type-sample: 1.5rem;
   --swatchbook-type-sample-lg: 1.75rem;
   --swatchbook-type-sample-xl: 2rem;
+  --swatchbook-type-sample: 1.5rem;
   --swatchbook-type-small: 0.875rem;
 }

--- a/packages/blocks/src/token-detail/styles.css
+++ b/packages/blocks/src/token-detail/styles.css
@@ -38,7 +38,7 @@
   font-size: var(--swatchbook-type-micro);
   text-transform: uppercase;
   letter-spacing: var(--swatchbook-tracking-label);
-  opacity: 0.6;
+  opacity: var(--swatchbook-opacity-scrim);
   margin: var(--swatchbook-space-md) 0 var(--swatchbook-space-xs);
 }
 
@@ -108,7 +108,7 @@
 
 .sb-token-detail__missing {
   padding: var(--swatchbook-space-md);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-token-detail__typography-sample {
@@ -294,7 +294,7 @@
 
 .sb-token-detail__aliased-by-truncated {
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.6;
+  opacity: var(--swatchbook-opacity-scrim);
   font-style: italic;
   margin-top: var(--swatchbook-space-2xs);
 }
@@ -311,7 +311,7 @@
 
 .sb-token-detail__tuple-indicator {
   font-size: var(--swatchbook-type-micro);
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
   margin: 0 0 var(--swatchbook-space-xs);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
@@ -331,7 +331,7 @@
   font-size: var(--swatchbook-type-micro);
   text-transform: uppercase;
   letter-spacing: var(--swatchbook-tracking-label);
-  opacity: 0.6;
+  opacity: var(--swatchbook-opacity-scrim);
   min-width: 32px;
   flex-shrink: 0;
 }
@@ -375,11 +375,11 @@
 
 .sb-token-detail__theme-cell--header {
   text-align: left;
-  opacity: 0.7;
+  opacity: var(--swatchbook-opacity-muted);
 }
 
 .sb-token-detail__constant-label-note {
-  opacity: 0.6;
+  opacity: var(--swatchbook-opacity-scrim);
   margin-left: var(--swatchbook-space-sm);
 }
 


### PR DESCRIPTION
## Summary

Tokenizes the two semantic block-UI opacities onto the existing `number.opacity` tokens: the generator now emits `--swatchbook-opacity-*`, and the 19 clean `opacity: 0.7 / 0.6` sites fold onto `muted` / `scrim`. Value-identical (zero visual change).

## Full description

- **Generator.** `generate-internal-scales.mts` emits `--swatchbook-opacity-{disabled, muted, scrim}` (from `number.opacity.*`, remapping `number.opacity.x` to a clean `--swatchbook-opacity-x`) into the bundled `internal-typography.css`, staleness-guarded like the rest.
- **Fold.** `opacity: 0.7` (x13) to `var(--swatchbook-opacity-muted)`, `opacity: 0.6` (x6) to `var(--swatchbook-opacity-scrim)`. They resolve to the same `0.7`/`0.6`, so nothing renders differently.
- **Stragglers left literal by design.** `0.5 / 0.75 / 0.8 / 0.85` are deliberate per-context contrast fine-tunes with no honest semantic home (`number.opacity` is semantic: disabled/muted/scrim, not a numbered scale). Folding them onto the nearest would flatten intentional dimming.

Pure internal refactor, value-identical: no changeset, no Chromatic diffs expected.

Milestone: Maintenance
Plan impact: none.

Closes #1304