### PR TITLE
chore: dedupe storybook MCP server entry in .mcp.json

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/mcp.json",
   "mcpServers": {
-    "swatchbook-storybook": {
+    "storybook": {
       "type": "http",
       "url": "http://localhost:6006/mcp",
       "description": "Storybook MCP server for swatchbook. Only reachable while `pnpm dev` (turbo run storybook) is running."


### PR DESCRIPTION
The working `.mcp.json` registered the Storybook MCP endpoint (`http://localhost:6006/mcp`) twice: as `swatchbook-storybook` and as a redundant `storybook` block. Two names against one endpoint registers the same tool family twice under different prefixes (`mcp__storybook__*` vs `mcp__swatchbook-storybook__*`), doubling the tool surface and making the call ambiguous.

Collapses to a single `storybook` entry and restores the `$schema` line and trailing newline the duplicate edit had dropped. Net diff is a one-line rename. No published-package surface changes, so no changeset.

Milestone: Maintenance

Closes #1307

Plan impact: none