### PR TITLE
refactor(blocks): split Diagnostics + TokenTable into pure Views + connectors

### DIFF
--- a/.changeset/blocks-view-split-phase1.md
+++ b/.changeset/blocks-view-split-phase1.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+internal: split Diagnostics + TokenTable into pure Views + connectors (no API change)

--- a/packages/blocks/src/Diagnostics.tsx
+++ b/packages/blocks/src/Diagnostics.tsx
@@ -25,7 +25,8 @@ interface DiagnosticsSummary {
   hasErrorsOrWarnings: boolean;
 }
 
-function summarize(diagnostics: readonly VirtualDiagnostic[]): DiagnosticsSummary {
+/** Aggregate diagnostics into a summary line + severity variant for the header. */
+export function summarize(diagnostics: readonly VirtualDiagnostic[]): DiagnosticsSummary {
   if (diagnostics.length === 0) {
     return { text: '✔ OK · no diagnostics', variant: 'ok', hasErrorsOrWarnings: false };
   }
@@ -53,18 +54,21 @@ function diagnosticKey(d: VirtualDiagnostic, i: number): string {
   return `${d.severity}:${d.group}:${d.filename ?? ''}:${d.line ?? ''}:${d.message}:${i}`;
 }
 
-/**
- * Render the project's load diagnostics — parser errors, resolver warnings,
- * disabled-axes validation issues, etc. — as a collapsible list. Auto-opens
- * when the project carries errors or warnings; stays collapsed for clean
- * loads and info-only loads.
- *
- * Replaces the diagnostics section from the addon's (now-retired) Design
- * Tokens panel. Consumers compose it alongside TokenNavigator / TokenTable
- * on their own MDX pages.
- */
-export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
-  const { activeAxes, cssVarPrefix, diagnostics } = useProject();
+export interface DiagnosticsViewProps {
+  /** Override the section caption. Defaults to a severity summary. */
+  caption?: string | undefined;
+  diagnostics: readonly VirtualDiagnostic[];
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+}
+
+/** Pure presentation for the diagnostics list. Renders from plain props. */
+export function DiagnosticsView({
+  caption,
+  diagnostics,
+  cssVarPrefix,
+  activeAxes,
+}: DiagnosticsViewProps): ReactElement {
   const summary = useMemo(() => summarize(diagnostics), [diagnostics]);
   const headingText = caption ?? `Diagnostics · ${summary.text}`;
 
@@ -111,5 +115,27 @@ export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
         )}
       </details>
     </div>
+  );
+}
+
+/**
+ * Render the project's load diagnostics — parser errors, resolver warnings,
+ * disabled-axes validation issues, etc. — as a collapsible list. Auto-opens
+ * when the project carries errors or warnings; stays collapsed for clean
+ * loads and info-only loads.
+ *
+ * Replaces the diagnostics section from the addon's (now-retired) Design
+ * Tokens panel. Consumers compose it alongside TokenNavigator / TokenTable
+ * on their own MDX pages.
+ */
+export function Diagnostics({ caption }: DiagnosticsProps = {}): ReactElement {
+  const { activeAxes, cssVarPrefix, diagnostics } = useProject();
+  return (
+    <DiagnosticsView
+      caption={caption}
+      diagnostics={diagnostics}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+    />
   );
 }

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -12,6 +12,8 @@ import { useBlockKey, usePersistedState } from '#/internal/persistent-state.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
+import type { ColorFormat } from '#/format-color.ts';
 import { useRootFontSize } from '#/internal/use-root-font-size.ts';
 import { RowIndicators } from '#/indicators/RowIndicators.tsx';
 import { resolveIndicators } from '#/indicators/resolve.ts';
@@ -61,69 +63,111 @@ export interface TokenTableProps {
   indicators?: IndicatorsProp;
 }
 
-export function TokenTable({
+export interface TokenRow {
+  path: string;
+  type: string;
+  value: string;
+  outOfGamut: boolean;
+  cssVar: string;
+  isColor: boolean;
+  isDeprecated: boolean;
+  token: ProjectData['resolved'][string];
+  variance: ProjectData['varianceByPath'][string] | undefined;
+}
+
+export interface DeriveTokenRowsOptions {
+  filter?: string | undefined;
+  type?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+  colorFormat: ColorFormat;
+  rootFontSizePx: number;
+}
+
+/**
+ * Pure derivation of the table's display rows from resolved project data.
+ * Carries per-row `isDeprecated` / `token` / `variance` so the View renders
+ * the indicator strip and deprecation state without reaching back into the
+ * project. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveTokenRows(
+  resolved: ProjectData['resolved'],
+  listing: ProjectData['listing'],
+  cssVarPrefix: string,
+  varianceByPath: ProjectData['varianceByPath'],
+  { filter, type, sortBy, sortDir, colorFormat, rootFontSizePx }: DeriveTokenRowsOptions,
+): TokenRow[] {
+  const projectFields = { listing, cssVarPrefix };
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (!matchPath(path, filter)) return false;
+    if (type && token.$type !== type) return false;
+    return true;
+  });
+  const entries = sortTokens(filtered, { by: sortBy, dir: sortDir, rootFontSizePx });
+  return entries.map(([path, token]) => {
+    const isColor = token.$type === 'color';
+    const color = isColor
+      ? resolveColorValue(path, token.$value, colorFormat, projectFields)
+      : null;
+    const dep = token.$deprecated;
+    return {
+      path,
+      type: token.$type ?? '',
+      value: formatTokenValue(token.$value, token.$type, colorFormat, listing[path]),
+      outOfGamut: color?.outOfGamut ?? false,
+      cssVar: resolveCssVar(path, projectFields),
+      isColor,
+      isDeprecated: dep === true || (typeof dep === 'string' && dep.length > 0),
+      token,
+      variance: varianceByPath[path],
+    };
+  });
+}
+
+export interface TokenTableViewProps {
+  rows: TokenRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  colorFormat: ColorFormat;
+  enabledIndicators: ReturnType<typeof resolveIndicators>;
+  /** Paths that can be linked to from the indicator strip (membership check). */
+  validPaths: ReadonlySet<string>;
+  /** Stable persistence key for this table's search + selection state. */
+  blockKey: string;
+  filter?: string | undefined;
+  type?: string | undefined;
+  caption?: string | undefined;
+  searchable?: boolean;
+  onSelect?: ((path: string) => void) | undefined;
+}
+
+/**
+ * Pure presentation for the token table. Owns its own search + selection UI
+ * state; renders from the derived `rows` view-model. Composes the connected
+ * DetailOverlay as a child (that child reads the project itself).
+ */
+export function TokenTableView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  colorFormat,
+  enabledIndicators,
+  validPaths,
+  blockKey,
   filter,
   type,
   caption,
-  sortBy = 'path',
-  sortDir = 'asc',
   searchable = true,
   onSelect,
-  id,
-  indicators,
-}: TokenTableProps): ReactElement {
-  const project = useProject();
-  const {
-    resolved,
-    activeTheme,
-    activeAxes,
-    cssVarPrefix,
-    listing,
-    varianceByPath,
-    indicators: indicatorBaseline,
-  } = project;
-  const colorFormat = useColorFormat();
-  const rootFontSize = useRootFontSize();
-  // Persist selection + search across docs-mode remounts (see persistent-state).
-  const blockKey = useBlockKey('TokenTable', [filter, type, caption, id]);
-  const enabledIndicators = useMemo(
-    () => resolveIndicators(indicators, indicatorBaseline),
-    [indicators, indicatorBaseline],
-  );
+}: TokenTableViewProps): ReactElement {
   const [selectedPath, setSelectedPath] = usePersistedState<string | null>(
     `${blockKey}::selected`,
     null,
   );
   const [query, setQuery] = usePersistedState(`${blockKey}::query`, '');
   const deferredQuery = useDeferredValue(query);
-
-  const rows = useMemo(() => {
-    const projectFields = { listing, cssVarPrefix };
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (!matchPath(path, filter)) return false;
-      if (type && token.$type !== type) return false;
-      return true;
-    });
-    const entries = sortTokens(filtered, {
-      by: sortBy,
-      dir: sortDir,
-      rootFontSizePx: rootFontSize,
-    });
-    return entries.map(([path, token]) => {
-      const isColor = token.$type === 'color';
-      const color = isColor
-        ? resolveColorValue(path, token.$value, colorFormat, projectFields)
-        : null;
-      return {
-        path,
-        type: token.$type ?? '',
-        value: formatTokenValue(token.$value, token.$type, colorFormat, listing[path]),
-        outOfGamut: color?.outOfGamut ?? false,
-        cssVar: resolveCssVar(path, projectFields),
-        isColor,
-      };
-    });
-  }, [resolved, listing, cssVarPrefix, filter, type, colorFormat, sortBy, sortDir, rootFontSize]);
 
   const visibleRows = useMemo(() => {
     if (!searchable || deferredQuery.trim() === '') return rows;
@@ -196,9 +240,7 @@ export function TokenTable({
             </tr>
           )}
           {visibleRows.map((row) => {
-            const token = resolved[row.path];
-            const dep = token?.$deprecated;
-            const isDeprecated = dep === true || (typeof dep === 'string' && dep.length > 0);
+            const token = row.token;
             return (
               <tr
                 key={row.path}
@@ -219,7 +261,7 @@ export function TokenTable({
                 <td
                   className={cx('sb-token-table__td', 'sb-token-table__path')}
                   data-deprecated={
-                    enabledIndicators.deprecation && isDeprecated ? 'true' : undefined
+                    enabledIndicators.deprecation && row.isDeprecated ? 'true' : undefined
                   }
                 >
                   {row.path}
@@ -270,9 +312,9 @@ export function TokenTable({
                       path={row.path}
                       token={token}
                       root={undefined}
-                      variance={varianceByPath[row.path]}
+                      variance={row.variance}
                       colorFormat={colorFormat}
-                      canReference={(p) => p in resolved}
+                      canReference={(p) => validPaths.has(p)}
                       onReferenceClick={(p) => setSelectedPath(p)}
                       enabled={enabledIndicators}
                     />
@@ -292,5 +334,83 @@ export function TokenTable({
         />
       )}
     </div>
+  );
+}
+
+/**
+ * A sortable, searchable table of tokens. Click a row to inspect it in a
+ * slide-over (unless `onSelect` is provided, which hands the follow-up to the
+ * consumer).
+ */
+export function TokenTable({
+  filter,
+  type,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+  searchable = true,
+  onSelect,
+  id,
+  indicators,
+}: TokenTableProps): ReactElement {
+  const project = useProject();
+  const {
+    resolved,
+    activeTheme,
+    activeAxes,
+    cssVarPrefix,
+    listing,
+    varianceByPath,
+    indicators: indicatorBaseline,
+  } = project;
+  const colorFormat = useColorFormat();
+  const rootFontSize = useRootFontSize();
+  // Persist selection + search across docs-mode remounts (see persistent-state).
+  const blockKey = useBlockKey('TokenTable', [filter, type, caption, id]);
+  const enabledIndicators = useMemo(
+    () => resolveIndicators(indicators, indicatorBaseline),
+    [indicators, indicatorBaseline],
+  );
+  const rows = useMemo(
+    () =>
+      deriveTokenRows(resolved, listing, cssVarPrefix, varianceByPath, {
+        filter,
+        type,
+        sortBy,
+        sortDir,
+        colorFormat,
+        rootFontSizePx: rootFontSize,
+      }),
+    [
+      resolved,
+      listing,
+      cssVarPrefix,
+      varianceByPath,
+      filter,
+      type,
+      sortBy,
+      sortDir,
+      colorFormat,
+      rootFontSize,
+    ],
+  );
+  const validPaths = useMemo(() => new Set(Object.keys(resolved)), [resolved]);
+
+  return (
+    <TokenTableView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      colorFormat={colorFormat}
+      enabledIndicators={enabledIndicators}
+      validPaths={validPaths}
+      blockKey={blockKey}
+      filter={filter}
+      type={type}
+      caption={caption}
+      searchable={searchable}
+      onSelect={onSelect}
+    />
   );
 }

--- a/packages/blocks/test/derive-token-rows.test.ts
+++ b/packages/blocks/test/derive-token-rows.test.ts
@@ -1,0 +1,40 @@
+import { expect, it } from 'vitest';
+import { deriveTokenRows } from '#/TokenTable.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one color, one deprecated dimension.
+const resolved = {
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+  'space.md': { $type: 'dimension', $value: { value: 16, unit: 'px' }, $deprecated: 'use space.4' },
+} as unknown as ProjectData['resolved'];
+const listing = {} as ProjectData['listing'];
+const varianceByPath = {} as ProjectData['varianceByPath'];
+const opts = { sortBy: 'path', sortDir: 'asc', colorFormat: 'hex', rootFontSizePx: 16 } as const;
+
+it('produces one row per resolved token with derived flags', () => {
+  const rows = deriveTokenRows(resolved, listing, 'sb', varianceByPath, opts);
+  expect(rows.map((r) => r.path)).toEqual(['color.brand', 'space.md']);
+  const color = rows.find((r) => r.path === 'color.brand')!;
+  expect(color.isColor).toBe(true);
+  expect(color.isDeprecated).toBe(false);
+  expect(color.cssVar).toContain('--sb-color-brand');
+  const dim = rows.find((r) => r.path === 'space.md')!;
+  expect(dim.isColor).toBe(false);
+  expect(dim.isDeprecated).toBe(true);
+});
+
+it('applies the path filter', () => {
+  const rows = deriveTokenRows(resolved, listing, 'sb', varianceByPath, {
+    ...opts,
+    filter: 'color.*',
+  });
+  expect(rows.map((r) => r.path)).toEqual(['color.brand']);
+});
+
+it('applies the $type filter', () => {
+  const rows = deriveTokenRows(resolved, listing, 'sb', varianceByPath, {
+    ...opts,
+    type: 'dimension',
+  });
+  expect(rows.map((r) => r.path)).toEqual(['space.md']);
+});

--- a/packages/blocks/test/diagnostics-summarize.test.ts
+++ b/packages/blocks/test/diagnostics-summarize.test.ts
@@ -1,0 +1,25 @@
+import { expect, it } from 'vitest';
+import { summarize } from '#/Diagnostics.tsx';
+
+it('reports OK for no diagnostics', () => {
+  const s = summarize([]);
+  expect(s.text).toBe('✔ OK · no diagnostics');
+  expect(s.variant).toBe('ok');
+  expect(s.hasErrorsOrWarnings).toBe(false);
+});
+
+it('aggregates counts and flags errors/warnings', () => {
+  const s = summarize([
+    { severity: 'error', group: 'parser', message: 'a' },
+    { severity: 'warn', group: 'parser', message: 'b' },
+    { severity: 'info', group: 'parser', message: 'c' },
+  ]);
+  expect(s.text).toBe('✖ 1 error · ⚠ 1 warning · 1 info');
+  expect(s.variant).toBe('error');
+  expect(s.hasErrorsOrWarnings).toBe(true);
+});
+
+it('picks the warn variant when there are warnings but no errors', () => {
+  const s = summarize([{ severity: 'warn', group: 'parser', message: 'b' }]);
+  expect(s.variant).toBe('warn');
+});

--- a/packages/blocks/test/diagnostics-view.browser.test.tsx
+++ b/packages/blocks/test/diagnostics-view.browser.test.tsx
@@ -1,0 +1,27 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { DiagnosticsView } from '#/Diagnostics.tsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+// The View renders from plain props — no SwatchbookProvider, no snapshot,
+// no channel. That is the whole point of the split.
+it('renders rows and auto-expands on errors, from plain props', () => {
+  render(
+    <DiagnosticsView
+      diagnostics={[{ severity: 'error', group: 'parser', message: 'boom' }]}
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+    />,
+  );
+  screen.getByText('boom');
+  const details = screen.getByText(/✖ 1 error/).closest('details');
+  expect(details?.hasAttribute('open')).toBe(true);
+});
+
+it('honors the caption override', () => {
+  render(<DiagnosticsView diagnostics={[]} cssVarPrefix="sb" activeAxes={{}} caption="Health" />);
+  screen.getByText('Health');
+});

--- a/packages/blocks/test/token-table-view.browser.test.tsx
+++ b/packages/blocks/test/token-table-view.browser.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, expect, it } from 'vitest';
+import { TokenTableView } from '#/TokenTable.tsx';
+import type { TokenRow, TokenTableViewProps } from '#/TokenTable.tsx';
+import { resolveIndicators } from '#/indicators/resolve.ts';
+
+function rows(): TokenRow[] {
+  return [
+    {
+      path: 'color.brand',
+      type: 'color',
+      value: '#0066ff',
+      outOfGamut: false,
+      cssVar: 'var(--sb-color-brand)',
+      isColor: true,
+      isDeprecated: false,
+      token: {
+        $type: 'color',
+        $value: { colorSpace: 'srgb', components: [0, 0.4, 1] },
+      } as TokenRow['token'],
+      variance: undefined,
+    },
+    {
+      path: 'space.md',
+      type: 'dimension',
+      value: '16px',
+      outOfGamut: false,
+      cssVar: 'var(--sb-space-md)',
+      isColor: false,
+      isDeprecated: false,
+      token: { $type: 'dimension', $value: { value: 16, unit: 'px' } } as TokenRow['token'],
+      variance: undefined,
+    },
+  ];
+}
+
+// The View renders + filters from plain props — no provider, no store.
+// (Row-click opens the connected DetailOverlay, which needs a project; that
+// interaction stays covered by the connector-level detail-overlay tests.)
+function setup(extra: Partial<TokenTableViewProps> = {}) {
+  return render(
+    <TokenTableView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      colorFormat="hex"
+      enabledIndicators={resolveIndicators(undefined, {})}
+      validPaths={new Set(['color.brand', 'space.md'])}
+      blockKey="test::TokenTable"
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a row per token with its value', () => {
+  setup();
+  screen.getByText('color.brand');
+  screen.getByText('space.md');
+  expect(screen.getAllByTestId('token-table-row')).toHaveLength(2);
+});
+
+it('narrows visible rows via the search input', async () => {
+  setup();
+  await userEvent.type(screen.getByTestId('token-table-search'), 'brand');
+  expect(screen.getAllByTestId('token-table-row')).toHaveLength(1);
+  screen.getByText('color.brand');
+});


### PR DESCRIPTION
Phase 1 of splitting blocks into pure Views + connectors — the two proving blocks (Diagnostics, TokenTable). Establishes the convention before fanning out to the remaining ~14.

Each block now has three co-located exports: a pure `derive`/`summarize` function, a pure `*View` that renders from plain props, and a thin connector that reads ambient state (`useProject` et al.), derives, and renders the View. Views + derive functions stay internal — `index.ts` is unchanged, so the public API is byte-identical.

## What's here

- **Diagnostics** — `summarize` exported; `DiagnosticsView` renders from props; connector rewired. Simple archetype (single ambient input, no local state).
- **TokenTable** — `deriveTokenRows` + `TokenRow` extracted and unit-tested; `TokenTableView` owns its search + selection state and renders from the derived rows; connector rewired. Medium archetype that surfaces the real tensions.

## Decisions validated (the point of proving on two blocks)

- **Local UI state stays in the View.** TokenTable's search query + row selection live in `TokenTableView` — it's pure of its *data* props, not `useState`-free.
- **Composed connected children are allowed.** `TokenTableView` renders `DetailOverlay`, which reads the project itself. A View is pure of its own props, not required to have an ambient-free subtree.
- **View-model slimness.** Rows carry `isDeprecated` / `token` / `variance`, so the View never reaches back into the project for the indicator strip or deprecation state.

## Testing

New pure-function tests (`diagnostics-summarize`, `derive-token-rows`) run with no React. New View tests (`diagnostics-view`, `token-table-view`) render with no `SwatchbookProvider`, no store, no channel — the payoff. The existing connector browser tests are unchanged and now serve as integration coverage (real `useProject` → real render), including the DetailOverlay row-click path.

Full gauntlet green. No public API change; internal-only.

Milestone: Maintenance

Closes #1316

Plan impact: none
