### PR TITLE
refactor(blocks): split remaining blocks into pure Views + connectors

### DIFF
--- a/.changeset/blocks-view-split-phase2.md
+++ b/.changeset/blocks-view-split-phase2.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+internal: split remaining blocks into pure Views + connectors (no API change)

--- a/packages/blocks/src/BorderPreview.tsx
+++ b/packages/blocks/src/BorderPreview.tsx
@@ -3,12 +3,14 @@ import { useMemo } from 'react';
 import './BorderPreview.css';
 import { BorderSample } from '#/border-preview/BorderSample.tsx';
 import { useColorFormat } from '#/contexts.ts';
+import type { ColorFormat } from '#/format-color.ts';
 import { formatDimension, formatSubColor } from '#/internal/composite-sample-format.ts';
 import type { BorderValue } from '#/internal/composite-types.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface BorderPreviewProps {
@@ -29,34 +31,68 @@ export interface BorderPreviewProps {
   sortDir?: SortDir;
 }
 
-interface Row {
+export interface BorderRow {
   path: string;
   cssVar: string;
-  value: BorderValue;
+  width: string;
+  style: string;
+  color: string;
 }
 
-export function BorderPreview({
-  filter,
-  caption,
-  sortBy = 'path',
-  sortDir = 'asc',
-}: BorderPreviewProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
-  const colorFormat = useColorFormat();
+export interface DeriveBorderRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+  colorFormat: ColorFormat;
+}
 
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'border') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+/**
+ * Pure derivation of the preview's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveBorderRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter, sortBy, sortDir, colorFormat }: DeriveBorderRowsOptions,
+): BorderRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'border') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
+    const value = (token.$value ?? {}) as BorderValue;
+    return {
       path,
       cssVar: resolveCssVar(path, project),
-      value: (token.$value ?? {}) as BorderValue,
-    }));
-  }, [resolved, filter, project, sortBy, sortDir]);
+      width: formatDimension(value.width),
+      style: value.style != null ? String(value.style) : '—',
+      color: formatSubColor(value.color, colorFormat),
+    };
+  });
+}
 
+export interface BorderPreviewViewProps {
+  rows: BorderRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/**
+ * Pure presentation for the border preview. Renders from plain props;
+ * composes the connected `BorderSample` as a child (that child reads the
+ * project itself).
+ */
+export function BorderPreviewView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  filter,
+  caption,
+}: BorderPreviewViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} border${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -83,14 +119,47 @@ export function BorderPreview({
           </div>
           <div className="sb-border-preview__breakdown">
             <span className="sb-border-preview__breakdown-key">width</span>
-            <span>{formatDimension(row.value.width)}</span>
+            <span>{row.width}</span>
             <span className="sb-border-preview__breakdown-key">style</span>
-            <span>{row.value.style != null ? String(row.value.style) : '—'}</span>
+            <span>{row.style}</span>
             <span className="sb-border-preview__breakdown-key">color</span>
-            <span>{formatSubColor(row.value.color, colorFormat)}</span>
+            <span>{row.color}</span>
           </div>
         </div>
       ))}
     </div>
+  );
+}
+
+export function BorderPreview({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: BorderPreviewProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const colorFormat = useColorFormat();
+
+  const rows = useMemo(
+    () =>
+      deriveBorderRows(resolved, project, {
+        filter,
+        sortBy,
+        sortDir,
+        colorFormat,
+      }),
+    [resolved, project, filter, sortBy, sortDir, colorFormat],
+  );
+
+  return (
+    <BorderPreviewView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/ColorPalette.tsx
+++ b/packages/blocks/src/ColorPalette.tsx
@@ -2,10 +2,12 @@ import type { ReactElement } from 'react';
 import { useMemo } from 'react';
 import './ColorPalette.css';
 import { useColorFormat } from '#/contexts.ts';
+import type { ColorFormat } from '#/format-color.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface ColorPaletteProps {
@@ -41,12 +43,17 @@ export interface ColorPaletteProps {
   sortDir?: SortDir;
 }
 
-interface Swatch {
+export interface ColorPaletteSwatch {
   path: string;
   leaf: string;
   cssVar: string;
   value: string;
   outOfGamut: boolean;
+}
+
+export interface ColorPaletteGroup {
+  group: string;
+  swatches: ColorPaletteSwatch[];
 }
 
 // Count segments in the filter before the first glob (`*` / `**`).
@@ -62,52 +69,76 @@ function fixedPrefixLength(filter: string | undefined): number {
   return fixed;
 }
 
-export function ColorPalette({
-  filter,
-  groupBy,
-  caption,
-  sortBy = 'path',
-  sortDir = 'asc',
-}: ColorPaletteProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
-  const colorFormat = useColorFormat();
+export interface DeriveColorPaletteGroupsOptions {
+  filter?: string | undefined;
+  groupBy?: number | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+  colorFormat: ColorFormat;
+}
 
-  const groups = useMemo(() => {
-    const projectFields = { listing, cssVarPrefix };
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'color') return false;
-      return matchPath(path, filter);
+/**
+ * Pure derivation of the palette's grouped swatch rows from resolved project
+ * data. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveColorPaletteGroups(
+  resolved: ProjectData['resolved'],
+  listing: ProjectData['listing'],
+  cssVarPrefix: ProjectData['cssVarPrefix'],
+  { filter, groupBy, sortBy, sortDir, colorFormat }: DeriveColorPaletteGroupsOptions,
+): ColorPaletteGroup[] {
+  const projectFields = { listing, cssVarPrefix };
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'color') return false;
+    return matchPath(path, filter);
+  });
+  const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
+
+  const maxDepth = entries.reduce((m, [p]) => Math.max(m, p.split('.').length), 0);
+  const effectiveGroupBy =
+    groupBy ?? Math.min(fixedPrefixLength(filter) + 1, Math.max(maxDepth - 1, 1));
+
+  const bucket = new Map<string, ColorPaletteSwatch[]>();
+  for (const [path, token] of entries) {
+    const segments = path.split('.');
+    const groupKey = segments.slice(0, effectiveGroupBy).join('.');
+    const leaf = segments.slice(effectiveGroupBy).join('.') || segments.at(-1) || path;
+    const list = bucket.get(groupKey) ?? [];
+    const formatted = resolveColorValue(path, token.$value, colorFormat, projectFields);
+    list.push({
+      path,
+      leaf,
+      cssVar: resolveCssVar(path, projectFields),
+      value: formatted.value,
+      outOfGamut: formatted.outOfGamut,
     });
-    const entries = sortTokens(filtered, { by: sortBy, dir: sortDir });
+    bucket.set(groupKey, list);
+  }
 
-    const maxDepth = entries.reduce((m, [p]) => Math.max(m, p.split('.').length), 0);
-    const effectiveGroupBy =
-      groupBy ?? Math.min(fixedPrefixLength(filter) + 1, Math.max(maxDepth - 1, 1));
+  return [...bucket.entries()]
+    .toSorted(([a], [b]) => a.localeCompare(b, undefined, { numeric: true }))
+    .map(([group, swatches]) => ({ group, swatches }));
+}
 
-    const bucket = new Map<string, Swatch[]>();
-    for (const [path, token] of entries) {
-      const segments = path.split('.');
-      const groupKey = segments.slice(0, effectiveGroupBy).join('.');
-      const leaf = segments.slice(effectiveGroupBy).join('.') || segments.at(-1) || path;
-      const list = bucket.get(groupKey) ?? [];
-      const formatted = resolveColorValue(path, token.$value, colorFormat, projectFields);
-      list.push({
-        path,
-        leaf,
-        cssVar: resolveCssVar(path, projectFields),
-        value: formatted.value,
-        outOfGamut: formatted.outOfGamut,
-      });
-      bucket.set(groupKey, list);
-    }
+export interface ColorPaletteViewProps {
+  groups: ColorPaletteGroup[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
 
-    return [...bucket.entries()].toSorted(([a], [b]) =>
-      a.localeCompare(b, undefined, { numeric: true }),
-    );
-  }, [resolved, listing, cssVarPrefix, filter, groupBy, colorFormat, sortBy, sortDir]);
-
-  const totalCount = groups.reduce((acc, [, swatches]) => acc + swatches.length, 0);
+/** Pure presentation for the color palette. Renders from plain props. */
+export function ColorPaletteView({
+  groups,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  filter,
+  caption,
+}: ColorPaletteViewProps): ReactElement {
+  const totalCount = groups.reduce((acc, { swatches }) => acc + swatches.length, 0);
   const captionText =
     caption ??
     `${totalCount} color${totalCount === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -123,7 +154,7 @@ export function ColorPalette({
   return (
     <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
       <div className="sb-block__caption">{captionText}</div>
-      {groups.map(([group, swatches]) => (
+      {groups.map(({ group, swatches }) => (
         <section key={group} className="sb-color-palette__group">
           <div className="sb-color-palette__group-header">{group}</div>
           <div className="sb-color-palette__grid">
@@ -156,5 +187,40 @@ export function ColorPalette({
         </section>
       ))}
     </div>
+  );
+}
+
+export function ColorPalette({
+  filter,
+  groupBy,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: ColorPaletteProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
+  const colorFormat = useColorFormat();
+
+  const groups = useMemo(
+    () =>
+      deriveColorPaletteGroups(resolved, listing, cssVarPrefix, {
+        filter,
+        groupBy,
+        sortBy,
+        sortDir,
+        colorFormat,
+      }),
+    [resolved, listing, cssVarPrefix, filter, groupBy, sortBy, sortDir, colorFormat],
+  );
+
+  return (
+    <ColorPaletteView
+      groups={groups}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/ColorTable.tsx
+++ b/packages/blocks/src/ColorTable.tsx
@@ -1,11 +1,9 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
-import type { AxisVarianceResult } from '@unpunnyfuns/swatchbook-core';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { memo, useCallback, useDeferredValue, useMemo } from 'react';
 import './ColorTable.css';
 import { useColorFormat } from '#/contexts.ts';
-import type { VirtualTokenShape } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
 import type { ColorFormat, NormalizedColor } from '#/format-color.ts';
 import { RowIndicators } from '#/indicators/RowIndicators.tsx';
@@ -17,6 +15,7 @@ import { useBlockKey, usePersistedState } from '#/internal/persistent-state.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveColorValue, resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 const NOOP_REFERENCE = (): void => {};
@@ -80,12 +79,12 @@ export interface ColorTableProps {
   indicators?: IndicatorsProp;
 }
 
-interface Variant {
+export interface ColorVariant {
   label: string;
   path: string;
   cssVar: string;
-  token: VirtualTokenShape;
-  variance: AxisVarianceResult | undefined;
+  token: ProjectData['resolved'][string];
+  variance: ProjectData['varianceByPath'][string] | undefined;
   // The display value in the currently-active color format.
   value: string;
   outOfGamut: boolean;
@@ -93,37 +92,121 @@ interface Variant {
   hex: string;
   hsl: string;
   oklch: string;
+  isDeprecated: boolean;
   description?: string;
   aliasOf?: string;
   aliasChain?: readonly string[];
 }
 
-interface Group {
+export interface ColorGroup {
   base: string;
-  variants: Variant[];
+  variants: ColorVariant[];
   searchText: string;
 }
 
-export function ColorTable({
+export interface DeriveColorGroupsOptions {
+  filter?: string | undefined;
+  variants?: Record<string, string> | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+  colorFormat: ColorFormat;
+}
+
+/**
+ * Pure derivation of the table's display groups from resolved project data.
+ * Carries per-variant `isDeprecated` / `token` / `variance` so the View
+ * renders the indicator strip and deprecation state without reaching back
+ * into the project. Extracted so it is unit-testable without React or a
+ * store.
+ */
+export function deriveColorGroups(
+  resolved: ProjectData['resolved'],
+  listing: ProjectData['listing'],
+  cssVarPrefix: string,
+  varianceByPath: ProjectData['varianceByPath'],
+  { filter, variants, sortBy, sortDir, colorFormat }: DeriveColorGroupsOptions,
+): ColorGroup[] {
+  const defs = buildVariantDefs(variants);
+  const projectFields = { listing, cssVarPrefix };
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'color') return false;
+    return matchPath(path, filter);
+  });
+  const sorted = sortTokens(filtered, { by: sortBy, dir: sortDir });
+
+  const groupMap = new Map<string, { base: string; variants: ColorVariant[] }>();
+  for (const [path, token] of sorted) {
+    const raw = token.$value as NormalizedColor;
+    const hex = resolveColorValue(path, raw, 'hex', projectFields);
+    const hsl = formatColor(raw, 'hsl');
+    const oklch = formatColor(raw, 'oklch');
+    const active = pickActiveFormat(raw, colorFormat, hex, hsl, oklch);
+    const match = matchVariant(path, defs.matchOrder);
+    const dep = token.$deprecated;
+    const variant: ColorVariant = {
+      label: match?.label ?? BASE_LABEL,
+      path,
+      token,
+      variance: varianceByPath[path],
+      cssVar: resolveCssVar(path, projectFields),
+      value: active.value,
+      outOfGamut: active.outOfGamut,
+      hex: hex.value,
+      hsl: hsl.value,
+      oklch: oklch.value,
+      isDeprecated: dep === true || (typeof dep === 'string' && dep.length > 0),
+      ...(token.$description !== undefined && { description: token.$description }),
+      ...(token.aliasOf !== undefined && { aliasOf: token.aliasOf }),
+      ...(token.aliasChain !== undefined && { aliasChain: token.aliasChain }),
+    };
+    const basePath = match?.basePath ?? path;
+    const existing = groupMap.get(basePath);
+    if (existing) existing.variants.push(variant);
+    else groupMap.set(basePath, { base: basePath, variants: [variant] });
+  }
+
+  const out: ColorGroup[] = [];
+  for (const { base, variants: vs } of groupMap.values()) {
+    vs.sort((a, b) => orderIndex(a.label, defs) - orderIndex(b.label, defs));
+    const searchText = vs.map((v) => `${v.path} ${v.value}`).join(' ');
+    out.push({ base, variants: vs, searchText });
+  }
+  return out;
+}
+
+export interface ColorTableViewProps {
+  groups: ColorGroup[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  colorFormat: ColorFormat;
+  enabledIndicators: ReturnType<typeof resolveIndicators>;
+  /** Stable persistence key for this table's search + selection + expansion state. */
+  blockKey: string;
+  filter?: string | undefined;
+  caption?: string | undefined;
+  searchable?: boolean;
+  onSelect?: ((path: string) => void) | undefined;
+}
+
+/**
+ * Pure presentation for the color table. Owns its own search, variant
+ * selection, and row-expansion UI state; renders from the derived `groups`
+ * view-model.
+ */
+export function ColorTableView({
+  groups,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  colorFormat,
+  enabledIndicators,
+  blockKey,
   filter,
   caption,
-  sortBy = 'path',
-  sortDir = 'asc',
   searchable = true,
   onSelect,
-  variants,
-  id,
-  indicators,
-}: ColorTableProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing, varianceByPath } = project;
-  const colorFormat = useColorFormat();
-  const enabledIndicators = useMemo(
-    () => ({ ...resolveIndicators(indicators), gamut: false }),
-    [indicators],
-  );
-  // Persist search + variant selection + expansion across docs-mode remounts.
-  const blockKey = useBlockKey('ColorTable', [filter, caption, id]);
+}: ColorTableViewProps): ReactElement {
   const [query, setQuery] = usePersistedState(`${blockKey}::query`, '');
   const deferredQuery = useDeferredValue(query);
   const [selectedByBase, setSelectedByBase] = usePersistedState<Record<string, string>>(
@@ -134,54 +217,6 @@ export function ColorTable({
     `${blockKey}::expanded`,
     () => new Set(),
   );
-
-  const defs = useMemo(() => buildVariantDefs(variants), [variants]);
-
-  const groups = useMemo<Group[]>(() => {
-    const projectFields = { listing, cssVarPrefix };
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'color') return false;
-      return matchPath(path, filter);
-    });
-    const sorted = sortTokens(filtered, { by: sortBy, dir: sortDir });
-
-    const groupMap = new Map<string, { base: string; variants: Variant[] }>();
-    for (const [path, token] of sorted) {
-      const raw = token.$value as NormalizedColor;
-      const hex = resolveColorValue(path, raw, 'hex', projectFields);
-      const hsl = formatColor(raw, 'hsl');
-      const oklch = formatColor(raw, 'oklch');
-      const active = pickActiveFormat(raw, colorFormat, hex, hsl, oklch);
-      const match = matchVariant(path, defs.matchOrder);
-      const variant: Variant = {
-        label: match?.label ?? BASE_LABEL,
-        path,
-        token,
-        variance: varianceByPath[path],
-        cssVar: resolveCssVar(path, projectFields),
-        value: active.value,
-        outOfGamut: active.outOfGamut,
-        hex: hex.value,
-        hsl: hsl.value,
-        oklch: oklch.value,
-        ...(token.$description !== undefined && { description: token.$description }),
-        ...(token.aliasOf !== undefined && { aliasOf: token.aliasOf }),
-        ...(token.aliasChain !== undefined && { aliasChain: token.aliasChain }),
-      };
-      const basePath = match?.basePath ?? path;
-      const existing = groupMap.get(basePath);
-      if (existing) existing.variants.push(variant);
-      else groupMap.set(basePath, { base: basePath, variants: [variant] });
-    }
-
-    const out: Group[] = [];
-    for (const { base, variants: vs } of groupMap.values()) {
-      vs.sort((a, b) => orderIndex(a.label, defs) - orderIndex(b.label, defs));
-      const searchText = vs.map((v) => `${v.path} ${v.value}`).join(' ');
-      out.push({ base, variants: vs, searchText });
-    }
-    return out;
-  }, [resolved, listing, cssVarPrefix, varianceByPath, filter, sortBy, sortDir, defs, colorFormat]);
 
   const visibleGroups = useMemo(() => {
     if (!searchable || deferredQuery.trim() === '') return groups;
@@ -289,8 +324,72 @@ export function ColorTable({
   );
 }
 
+/**
+ * A grouped, searchable table of `$type: color` tokens. Suffix-matched
+ * variants (see `variants` prop) collapse into a single row with a pill
+ * selector; clicking a row expands it in place to show the description,
+ * alias chain, and (for grouped rows) every variant's hex/HSL/OKLCH values.
+ */
+export function ColorTable({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+  searchable = true,
+  onSelect,
+  variants,
+  id,
+  indicators,
+}: ColorTableProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing, varianceByPath } = project;
+  const colorFormat = useColorFormat();
+  const enabledIndicators = useMemo(
+    () => ({ ...resolveIndicators(indicators), gamut: false }),
+    [indicators],
+  );
+  // Persist search + variant selection + expansion across docs-mode remounts.
+  const blockKey = useBlockKey('ColorTable', [filter, caption, id]);
+  const groups = useMemo(
+    () =>
+      deriveColorGroups(resolved, listing, cssVarPrefix, varianceByPath, {
+        filter,
+        variants,
+        sortBy,
+        sortDir,
+        colorFormat,
+      }),
+    [
+      resolved,
+      listing,
+      cssVarPrefix,
+      varianceByPath,
+      filter,
+      variants,
+      sortBy,
+      sortDir,
+      colorFormat,
+    ],
+  );
+  return (
+    <ColorTableView
+      groups={groups}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      colorFormat={colorFormat}
+      enabledIndicators={enabledIndicators}
+      blockKey={blockKey}
+      filter={filter}
+      caption={caption}
+      searchable={searchable}
+      onSelect={onSelect}
+    />
+  );
+}
+
 interface GroupRowProps {
-  group: Group;
+  group: ColorGroup;
   selectedLabel: string | undefined;
   expanded: boolean;
   onToggleExpand(base: string): void;
@@ -312,11 +411,10 @@ const GroupRow = memo(function GroupRow({
 }: GroupRowProps): ReactElement {
   const multi = group.variants.length > 1;
   const active =
-    group.variants.find((v) => v.label === selectedLabel) ?? (group.variants[0] as Variant);
+    group.variants.find((v) => v.label === selectedLabel) ?? (group.variants[0] as ColorVariant);
   const nameText = multi ? group.base : active.path;
 
-  const dep = active.token.$deprecated;
-  const isDeprecated = dep === true || (typeof dep === 'string' && dep.length > 0);
+  const isDeprecated = active.isDeprecated;
 
   const handleRowActivate = (): void => {
     if (onSelect) onSelect(active.path);
@@ -434,7 +532,13 @@ const GroupRow = memo(function GroupRow({
   );
 });
 
-function ExpandedDetail({ group, active }: { group: Group; active: Variant }): ReactElement {
+function ExpandedDetail({
+  group,
+  active,
+}: {
+  group: ColorGroup;
+  active: ColorVariant;
+}): ReactElement {
   const hasDescription = active.description !== undefined && active.description.length > 0;
   const chain = active.aliasChain && active.aliasChain.length > 0 ? active.aliasChain : undefined;
   const multi = group.variants.length > 1;

--- a/packages/blocks/src/DimensionScale.tsx
+++ b/packages/blocks/src/DimensionScale.tsx
@@ -9,6 +9,7 @@ import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export type { DimensionVisual };
@@ -40,37 +41,65 @@ export interface DimensionScaleProps {
   sortDir?: SortDir;
 }
 
-interface Row {
+export interface DimensionRow {
   path: string;
   cssVar: string;
   displayValue: string;
 }
 
-export function DimensionScale({
+export interface DeriveDimensionRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+  rootFontSizePx: number;
+}
+
+/**
+ * Pure derivation of the scale's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveDimensionRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter, sortBy, sortDir, rootFontSizePx }: DeriveDimensionRowsOptions,
+): DimensionRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'dimension') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir, rootFontSizePx }).map(
+    ([path, token]) => ({
+      path,
+      cssVar: resolveCssVar(path, project),
+      displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
+    }),
+  );
+}
+
+export interface DimensionScaleViewProps {
+  rows: DimensionRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  visual: DimensionVisual;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/**
+ * Pure presentation for the dimension scale. Renders from plain props;
+ * composes the connected `DimensionBar` as a child (that child reads the
+ * project itself).
+ */
+export function DimensionScaleView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  visual,
   filter,
-  visual = 'length',
   caption,
-  sortBy = 'value',
-  sortDir = 'asc',
-}: DimensionScaleProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
-  const rootFontSize = useRootFontSize();
-
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'dimension') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir, rootFontSizePx: rootFontSize }).map(
-      ([path, token]) => ({
-        path,
-        cssVar: resolveCssVar(path, project),
-        displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
-      }),
-    );
-  }, [resolved, filter, project, sortBy, sortDir, rootFontSize]);
-
+}: DimensionScaleViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} dimension${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -99,5 +128,40 @@ export function DimensionScale({
         </div>
       ))}
     </div>
+  );
+}
+
+export function DimensionScale({
+  filter,
+  visual = 'length',
+  caption,
+  sortBy = 'value',
+  sortDir = 'asc',
+}: DimensionScaleProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const rootFontSize = useRootFontSize();
+
+  const rows = useMemo(
+    () =>
+      deriveDimensionRows(resolved, project, {
+        filter,
+        sortBy,
+        sortDir,
+        rootFontSizePx: rootFontSize,
+      }),
+    [resolved, project, filter, sortBy, sortDir, rootFontSize],
+  );
+
+  return (
+    <DimensionScaleView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      visual={visual}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/FontFamilyPreview.tsx
+++ b/packages/blocks/src/FontFamilyPreview.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import './FontFamilyPreview.css';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
@@ -27,7 +28,7 @@ export interface FontFamilyPreviewProps {
   sortDir?: SortDir;
 }
 
-interface Row {
+export interface FontFamilyRow {
   path: string;
   cssVar: string;
   stack: string;
@@ -39,28 +40,52 @@ function stackString(raw: unknown): string {
   return '';
 }
 
-export function FontFamilyPreview({
+export interface DeriveFontFamilyRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+}
+
+/**
+ * Pure derivation of the preview's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveFontFamilyRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter, sortBy, sortDir }: DeriveFontFamilyRowsOptions,
+): FontFamilyRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'fontFamily') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+    path,
+    cssVar: resolveCssVar(path, project),
+    stack: stackString(token.$value),
+  }));
+}
+
+export interface FontFamilyPreviewViewProps {
+  rows: FontFamilyRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  sample: string;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/** Pure presentation for the font-family preview. Renders from plain props. */
+export function FontFamilyPreviewView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  sample,
   filter,
-  sample = 'The quick brown fox jumps over the lazy dog.',
   caption,
-  sortBy = 'path',
-  sortDir = 'asc',
-}: FontFamilyPreviewProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
-
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'fontFamily') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
-      path,
-      cssVar: resolveCssVar(path, project),
-      stack: stackString(token.$value),
-    }));
-  }, [resolved, filter, project, sortBy, sortDir]);
-
+}: FontFamilyPreviewViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} fontFamily token${rows.length === 1 ? '' : 's'}${filter && filter !== 'fontFamily' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -89,5 +114,33 @@ export function FontFamilyPreview({
         </div>
       ))}
     </div>
+  );
+}
+
+export function FontFamilyPreview({
+  filter,
+  sample = 'The quick brown fox jumps over the lazy dog.',
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: FontFamilyPreviewProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+
+  const rows = useMemo(
+    () => deriveFontFamilyRows(resolved, project, { filter, sortBy, sortDir }),
+    [resolved, project, filter, sortBy, sortDir],
+  );
+
+  return (
+    <FontFamilyPreviewView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      sample={sample}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/FontWeightScale.tsx
+++ b/packages/blocks/src/FontWeightScale.tsx
@@ -6,6 +6,7 @@ import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface FontWeightScaleProps {
@@ -29,7 +30,7 @@ export interface FontWeightScaleProps {
   sortDir?: SortDir;
 }
 
-interface Row {
+export interface FontWeightRow {
   path: string;
   cssVar: string;
   display: string;
@@ -45,29 +46,53 @@ function toWeight(raw: unknown): number {
   return Number.NaN;
 }
 
-export function FontWeightScale({
+export interface DeriveFontWeightRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+}
+
+/**
+ * Pure derivation of the scale's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveFontWeightRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter, sortBy, sortDir }: DeriveFontWeightRowsOptions,
+): FontWeightRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'fontWeight') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+    path,
+    cssVar: resolveCssVar(path, project),
+    display: token.$value == null ? '' : String(token.$value),
+    weight: toWeight(token.$value),
+  }));
+}
+
+export interface FontWeightScaleViewProps {
+  rows: FontWeightRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  sample: string;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/** Pure presentation for the font-weight scale. Renders from plain props. */
+export function FontWeightScaleView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  sample,
   filter,
-  sample = 'Aa',
   caption,
-  sortBy = 'value',
-  sortDir = 'asc',
-}: FontWeightScaleProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
-
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'fontWeight') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
-      path,
-      cssVar: resolveCssVar(path, project),
-      display: token.$value == null ? '' : String(token.$value),
-      weight: toWeight(token.$value),
-    }));
-  }, [resolved, filter, project, sortBy, sortDir]);
-
+}: FontWeightScaleViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} fontWeight token${rows.length === 1 ? '' : 's'}${filter && filter !== 'fontWeight' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -99,5 +124,33 @@ export function FontWeightScale({
         </div>
       ))}
     </div>
+  );
+}
+
+export function FontWeightScale({
+  filter,
+  sample = 'Aa',
+  caption,
+  sortBy = 'value',
+  sortDir = 'asc',
+}: FontWeightScaleProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+
+  const rows = useMemo(
+    () => deriveFontWeightRows(resolved, project, { filter, sortBy, sortDir }),
+    [resolved, project, filter, sortBy, sortDir],
+  );
+
+  return (
+    <FontWeightScaleView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      sample={sample}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/GradientPalette.tsx
+++ b/packages/blocks/src/GradientPalette.tsx
@@ -3,11 +3,13 @@ import { useMemo } from 'react';
 import './GradientPalette.css';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
+import type { ColorFormat } from '#/format-color.ts';
 import { parseColor } from '@unpunnyfuns/swatchbook-core/format-color';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface GradientPaletteProps {
@@ -37,10 +39,17 @@ interface GradientStop {
   position?: number;
 }
 
-interface Row {
+export interface GradientRowStop {
+  key: string;
+  cssColor: string;
+  value: string;
+  positionPercent: string;
+}
+
+export interface GradientRow {
   path: string;
   cssVar: string;
-  stops: GradientStop[];
+  stops: GradientRowStop[];
 }
 
 function asStops(raw: unknown): GradientStop[] {
@@ -62,29 +71,61 @@ function stopKey(path: string, stop: GradientStop, fallback: number): string {
   return `${path}|${stop.position ?? fallback}|${stopCssColor(stop)}`;
 }
 
-export function GradientPalette({
-  filter,
-  caption,
-  sortBy = 'path',
-  sortDir = 'asc',
-}: GradientPaletteProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
-  const colorFormat = useColorFormat();
+export interface DeriveGradientRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+  colorFormat: ColorFormat;
+}
 
-  const rows = useMemo<Row[]>(() => {
-    const projectFields = { listing, cssVarPrefix };
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'gradient') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+/**
+ * Pure derivation of the palette's gradient rows from resolved project
+ * data. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveGradientRows(
+  resolved: ProjectData['resolved'],
+  listing: ProjectData['listing'],
+  cssVarPrefix: ProjectData['cssVarPrefix'],
+  { filter, sortBy, sortDir, colorFormat }: DeriveGradientRowsOptions,
+): GradientRow[] {
+  const projectFields = { listing, cssVarPrefix };
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'gradient') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
+    const stops = asStops(token.$value);
+    return {
       path,
       cssVar: resolveCssVar(path, projectFields),
-      stops: asStops(token.$value),
-    }));
-  }, [resolved, listing, cssVarPrefix, filter, sortBy, sortDir]);
+      stops: stops.map((stop, i) => ({
+        key: stopKey(path, stop, i),
+        cssColor: stopCssColor(stop),
+        value: formatColor(stop.color, colorFormat).value,
+        positionPercent: ((stop.position ?? 0) * 100).toFixed(0),
+      })),
+    };
+  });
+}
 
+export interface GradientPaletteViewProps {
+  rows: GradientRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/** Pure presentation for the gradient palette. Renders from plain props. */
+export function GradientPaletteView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  filter,
+  caption,
+}: GradientPaletteViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} gradient${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -112,16 +153,16 @@ export function GradientPalette({
             aria-hidden
           />
           <div className="sb-gradient-palette__stops">
-            {row.stops.map((stop, i) => (
-              <div key={stopKey(row.path, stop, i)} className="sb-gradient-palette__stop-row">
+            {row.stops.map((stop) => (
+              <div key={stop.key} className="sb-gradient-palette__stop-row">
                 <span
                   className="sb-gradient-palette__stop-swatch"
-                  style={{ background: stopCssColor(stop) }}
+                  style={{ background: stop.cssColor }}
                   aria-hidden
                 />
-                <span>{formatColor(stop.color, colorFormat).value}</span>
+                <span>{stop.value}</span>
                 <span className="sb-gradient-palette__stop-position">
-                  @ {((stop.position ?? 0) * 100).toFixed(0)}%
+                  @ {stop.positionPercent}%
                 </span>
               </div>
             ))}
@@ -129,5 +170,38 @@ export function GradientPalette({
         </div>
       ))}
     </div>
+  );
+}
+
+export function GradientPalette({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: GradientPaletteProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix, listing } = project;
+  const colorFormat = useColorFormat();
+
+  const rows = useMemo(
+    () =>
+      deriveGradientRows(resolved, listing, cssVarPrefix, {
+        filter,
+        sortBy,
+        sortDir,
+        colorFormat,
+      }),
+    [resolved, listing, cssVarPrefix, filter, sortBy, sortDir, colorFormat],
+  );
+
+  return (
+    <GradientPaletteView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/MotionPreview.tsx
+++ b/packages/blocks/src/MotionPreview.tsx
@@ -5,6 +5,7 @@ import './MotionPreview.css';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { MotionSample, resolveMotionSpec } from '#/motion-preview/MotionSample.tsx';
 import type { MotionSpeed } from '#/motion-preview/MotionSample.tsx';
@@ -23,7 +24,7 @@ export interface MotionPreviewProps {
 
 const SPEEDS: MotionSpeed[] = [0.25, 0.5, 1, 2];
 
-interface Row {
+export interface MotionRow {
   path: string;
   cssVar: string;
   durationMs: number;
@@ -31,7 +32,11 @@ interface Row {
   kind: 'transition' | 'duration' | 'cubicBezier';
 }
 
-function formatSpec(row: Row): string {
+export interface DeriveMotionRowsOptions {
+  filter?: string | undefined;
+}
+
+function formatSpec(row: MotionRow): string {
   switch (row.kind) {
     case 'transition':
       return `transition · ${Math.round(row.durationMs)}ms · ${row.easing}`;
@@ -42,38 +47,67 @@ function formatSpec(row: Row): string {
   }
 }
 
-export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+/**
+ * Pure derivation of the preview's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveMotionRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter }: DeriveMotionRowsOptions,
+): MotionRow[] {
+  const collected: MotionRow[] = [];
+  for (const [path, token] of Object.entries(resolved)) {
+    if (filter && !matchPath(path, filter)) continue;
+    if (!filter && !['transition', 'duration', 'cubicBezier'].includes(token.$type ?? '')) {
+      continue;
+    }
+    const kind = token.$type as MotionRow['kind'] | undefined;
+    if (!kind) continue;
+    const spec = resolveMotionSpec(token, resolved);
+    if (!spec) continue;
+    collected.push({
+      path,
+      cssVar: resolveCssVar(path, project),
+      durationMs: spec.durationMs,
+      easing: spec.easing,
+      kind,
+    });
+  }
+  collected.sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
+    return a.path.localeCompare(b.path, undefined, { numeric: true });
+  });
+  return collected;
+}
+
+export interface MotionPreviewViewProps {
+  rows: MotionRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/**
+ * Pure presentation for the motion preview. Owns the speed/replay controls'
+ * local UI state and the `prefers-reduced-motion` read (a browser-environment
+ * concern, not project data); renders from the derived `rows` view-model.
+ * Composes the connected `MotionSample` as a child (that child reads the
+ * project itself).
+ */
+export function MotionPreviewView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  filter,
+  caption,
+}: MotionPreviewViewProps): ReactElement {
   const [speed, setSpeed] = useState<MotionSpeed>(1);
   const [run, setRun] = useState(0);
   const reducedMotion = usePrefersReducedMotion();
-
-  const rows = useMemo(() => {
-    const collected: Row[] = [];
-    for (const [path, token] of Object.entries(resolved)) {
-      if (filter && !matchPath(path, filter)) continue;
-      if (!filter && !['transition', 'duration', 'cubicBezier'].includes(token.$type ?? '')) {
-        continue;
-      }
-      const kind = token.$type as Row['kind'] | undefined;
-      if (!kind) continue;
-      const spec = resolveMotionSpec(token, resolved);
-      if (!spec) continue;
-      collected.push({
-        path,
-        cssVar: resolveCssVar(path, project),
-        durationMs: spec.durationMs,
-        easing: spec.easing,
-        kind,
-      });
-    }
-    collected.sort((a, b) => {
-      if (a.kind !== b.kind) return a.kind.localeCompare(b.kind);
-      return a.path.localeCompare(b.path, undefined, { numeric: true });
-    });
-    return collected;
-  }, [resolved, filter, project]);
 
   const captionText =
     caption ??
@@ -125,5 +159,26 @@ export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactEle
         </div>
       ))}
     </div>
+  );
+}
+
+export function MotionPreview({ filter, caption }: MotionPreviewProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+
+  const rows = useMemo(
+    () => deriveMotionRows(resolved, project, { filter }),
+    [resolved, project, filter],
+  );
+
+  return (
+    <MotionPreviewView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/OpacityScale.tsx
+++ b/packages/blocks/src/OpacityScale.tsx
@@ -5,6 +5,7 @@ import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 
 export interface OpacityScaleProps {
@@ -40,7 +41,7 @@ export interface OpacityScaleProps {
   sortDir?: SortDir;
 }
 
-interface Row {
+export interface OpacityRow {
   path: string;
   cssVar: string;
   opacity: number;
@@ -52,45 +53,62 @@ function toOpacity(raw: unknown): number {
   return Number.NaN;
 }
 
+export interface DeriveOpacityRowsOptions {
+  filter?: string | undefined;
+  type: 'number' | 'opacity';
+  sortBy: SortBy;
+  sortDir: SortDir;
+}
+
 /**
- * Render each opacity token as a colored sample at that opacity over a
- * checkerboard backdrop, so the transparency is visually readable. The
- * number by itself (`0.4`) doesn't convey what the token looks like
- * applied to a surface; the sample does.
- *
- * Only tokens whose `$value` is a finite number between 0 and 1
- * inclusive are rendered — non-opacity `number` siblings (`line-height`,
- * `z-index`) fall out naturally.
+ * Pure derivation of the scale's display rows from resolved project data.
+ * Only tokens whose `$value` is a finite number between 0 and 1 inclusive
+ * are included — non-opacity `number` siblings (`line-height`, `z-index`)
+ * fall out naturally. Extracted so it is unit-testable without React or
+ * a store.
  */
-export function OpacityScale({
+export function deriveOpacityRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter, type, sortBy, sortDir }: DeriveOpacityRowsOptions,
+): OpacityRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== type) return false;
+    const v = toOpacity(token.$value);
+    if (!Number.isFinite(v) || v < 0 || v > 1) return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
+    const opacity = toOpacity(token.$value);
+    return {
+      path,
+      cssVar: resolveCssVar(path, project),
+      opacity,
+      displayValue: String(opacity),
+    };
+  });
+}
+
+export interface OpacityScaleViewProps {
+  rows: OpacityRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  sampleColorVar: string;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/** Pure presentation for the opacity scale. Renders from plain props. */
+export function OpacityScaleView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  sampleColorVar,
   filter,
-  type = 'number',
-  sampleColor = 'color.accent.bg',
   caption,
-  sortBy = 'value',
-  sortDir = 'asc',
-}: OpacityScaleProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
-
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== type) return false;
-      const v = toOpacity(token.$value);
-      if (!Number.isFinite(v) || v < 0 || v > 1) return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
-      const opacity = toOpacity(token.$value);
-      return {
-        path,
-        cssVar: resolveCssVar(path, project),
-        opacity,
-        displayValue: String(opacity),
-      };
-    });
-  }, [resolved, filter, type, project, sortBy, sortDir]);
-
+}: OpacityScaleViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} opacity token${rows.length === 1 ? '' : 's'}${
@@ -104,8 +122,6 @@ export function OpacityScale({
       </div>
     );
   }
-
-  const sampleColorVar = resolveCssVar(sampleColor, project);
 
   return (
     <div {...blockWrapperAttrs(cssVarPrefix, activeAxes)}>
@@ -132,5 +148,42 @@ export function OpacityScale({
         ))}
       </div>
     </div>
+  );
+}
+
+/**
+ * Render each opacity token as a colored sample at that opacity over a
+ * checkerboard backdrop, so the transparency is visually readable. The
+ * number by itself (`0.4`) doesn't convey what the token looks like
+ * applied to a surface; the sample does.
+ */
+export function OpacityScale({
+  filter,
+  type = 'number',
+  sampleColor = 'color.accent.bg',
+  caption,
+  sortBy = 'value',
+  sortDir = 'asc',
+}: OpacityScaleProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+
+  const rows = useMemo(
+    () => deriveOpacityRows(resolved, project, { filter, type, sortBy, sortDir }),
+    [resolved, project, filter, type, sortBy, sortDir],
+  );
+
+  const sampleColorVar = resolveCssVar(sampleColor, project);
+
+  return (
+    <OpacityScaleView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      sampleColorVar={sampleColorVar}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/ShadowPreview.tsx
+++ b/packages/blocks/src/ShadowPreview.tsx
@@ -10,6 +10,7 @@ import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { ShadowSample } from '#/shadow-preview/ShadowSample.tsx';
 
@@ -31,10 +32,30 @@ export interface ShadowPreviewProps {
   sortDir?: SortDir;
 }
 
-interface Row {
+/** One shadow layer's breakdown fields, formatted for display. */
+export interface ShadowLayerRow {
+  offset: string;
+  blur: string;
+  spread: string;
+  color: string;
+  inset?: string | undefined;
+}
+
+export interface ShadowRow {
   path: string;
   cssVar: string;
-  layers: ShadowLayer[];
+  layers: ShadowLayerRow[];
+}
+
+export interface DeriveShadowRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+  colorFormat: ColorFormat;
+}
+
+function layerKey(path: string, layer: ShadowLayerRow, fallback: number): string {
+  return `${path}|${layer.offset}|${layer.blur}|${layer.spread}|${fallback}`;
 }
 
 function asLayers(raw: unknown): ShadowLayer[] {
@@ -43,35 +64,58 @@ function asLayers(raw: unknown): ShadowLayer[] {
   return [];
 }
 
-function layerKey(path: string, layer: ShadowLayer, fallback: number): string {
-  const off = `${formatDimension(layer.offsetX)},${formatDimension(layer.offsetY)}`;
-  const blur = formatDimension(layer.blur);
-  const spread = formatDimension(layer.spread);
-  return `${path}|${off}|${blur}|${spread}|${fallback}`;
+function formatLayer(layer: ShadowLayer, colorFormat: ColorFormat): ShadowLayerRow {
+  return {
+    offset: `${formatDimension(layer.offsetX)} ${formatDimension(layer.offsetY)}`,
+    blur: formatDimension(layer.blur),
+    spread: formatDimension(layer.spread),
+    color: formatSubColor(layer.color, colorFormat),
+    inset: layer.inset ? String(layer.inset) : undefined,
+  };
 }
 
-export function ShadowPreview({
+/**
+ * Pure derivation of the preview's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveShadowRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter, sortBy, sortDir, colorFormat }: DeriveShadowRowsOptions,
+): ShadowRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'shadow') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+    path,
+    cssVar: resolveCssVar(path, project),
+    layers: asLayers(token.$value).map((layer) => formatLayer(layer, colorFormat)),
+  }));
+}
+
+export interface ShadowPreviewViewProps {
+  rows: ShadowRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/**
+ * Pure presentation for the shadow preview. Renders from plain props;
+ * composes the connected `ShadowSample` as a child (that child reads the
+ * project itself).
+ */
+export function ShadowPreviewView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
   filter,
   caption,
-  sortBy = 'path',
-  sortDir = 'asc',
-}: ShadowPreviewProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
-  const colorFormat = useColorFormat();
-
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'shadow') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
-      path,
-      cssVar: resolveCssVar(path, project),
-      layers: asLayers(token.$value),
-    }));
-  }, [resolved, filter, project, sortBy, sortDir]);
-
+}: ShadowPreviewViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} shadow${rows.length === 1 ? '' : 's'}${filter ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -98,14 +142,13 @@ export function ShadowPreview({
           </div>
           <div className="sb-shadow-preview__breakdown">
             {row.layers.length === 1
-              ? renderLayer(row.layers[0], colorFormat)
+              ? renderLayerEntries(row.layers[0])
               : row.layers.map((layer, i) => (
                   <Layer
                     key={layerKey(row.path, layer, i)}
                     layer={layer}
                     index={i}
                     total={row.layers.length}
-                    colorFormat={colorFormat}
                   />
                 ))}
           </div>
@@ -115,15 +158,15 @@ export function ShadowPreview({
   );
 }
 
-function renderLayer(layer: ShadowLayer | undefined, format: ColorFormat): ReactElement[] {
+function renderLayerEntries(layer: ShadowLayerRow | undefined): ReactElement[] {
   if (!layer) return [];
   const entries: [string, string][] = [
-    ['offset', `${formatDimension(layer.offsetX)} ${formatDimension(layer.offsetY)}`],
-    ['blur', formatDimension(layer.blur)],
-    ['spread', formatDimension(layer.spread)],
-    ['color', formatSubColor(layer.color, format)],
+    ['offset', layer.offset],
+    ['blur', layer.blur],
+    ['spread', layer.spread],
+    ['color', layer.color],
   ];
-  if (layer.inset) entries.push(['inset', String(layer.inset)]);
+  if (layer.inset) entries.push(['inset', layer.inset]);
   return entries.flatMap(([k, v]) => [
     <span key={`k-${k}`} className="sb-shadow-preview__breakdown-key">
       {k}
@@ -136,12 +179,10 @@ function Layer({
   layer,
   index,
   total,
-  colorFormat,
 }: {
-  layer: ShadowLayer;
+  layer: ShadowLayerRow;
   index: number;
   total: number;
-  colorFormat: ColorFormat;
 }): ReactElement {
   return (
     <div className="sb-shadow-preview__layer">
@@ -149,8 +190,41 @@ function Layer({
         layer {index + 1} of {total}
       </div>
       <div className={cx('sb-shadow-preview__breakdown', 'sb-shadow-preview__layer-breakdown')}>
-        {renderLayer(layer, colorFormat)}
+        {renderLayerEntries(layer)}
       </div>
     </div>
+  );
+}
+
+export function ShadowPreview({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: ShadowPreviewProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+  const colorFormat = useColorFormat();
+
+  const rows = useMemo(
+    () =>
+      deriveShadowRows(resolved, project, {
+        filter,
+        sortBy,
+        sortDir,
+        colorFormat,
+      }),
+    [resolved, project, filter, sortBy, sortDir, colorFormat],
+  );
+
+  return (
+    <ShadowPreviewView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/StrokeStylePreview.tsx
+++ b/packages/blocks/src/StrokeStylePreview.tsx
@@ -4,6 +4,7 @@ import './StrokeStylePreview.css';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
@@ -37,7 +38,7 @@ const STRING_STYLES = new Set([
   'inset',
 ]);
 
-interface Row {
+export interface StrokeStyleRow {
   path: string;
   cssVar: string;
   displayValue: string;
@@ -49,28 +50,51 @@ function extractCssStyle(value: unknown): string | null {
   return null;
 }
 
-export function StrokeStylePreview({
+export interface DeriveStrokeStyleRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+}
+
+/**
+ * Pure derivation of the preview's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveStrokeStyleRows(
+  resolved: ProjectData['resolved'],
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+  { filter, sortBy, sortDir }: DeriveStrokeStyleRowsOptions,
+): StrokeStyleRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'strokeStyle') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
+    path,
+    cssVar: resolveCssVar(path, project),
+    displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
+    cssStyle: extractCssStyle(token.$value),
+  }));
+}
+
+export interface StrokeStylePreviewViewProps {
+  rows: StrokeStyleRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/** Pure presentation for the stroke-style preview. Renders from plain props. */
+export function StrokeStylePreviewView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
   filter,
   caption,
-  sortBy = 'path',
-  sortDir = 'asc',
-}: StrokeStylePreviewProps): ReactElement {
-  const project = useProject();
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
-
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'strokeStyle') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => ({
-      path,
-      cssVar: resolveCssVar(path, project),
-      displayValue: formatTokenValue(token.$value, token.$type, 'raw', project.listing[path]),
-      cssStyle: extractCssStyle(token.$value),
-    }));
-  }, [resolved, filter, project, sortBy, sortDir]);
-
+}: StrokeStylePreviewViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} strokeStyle token${rows.length === 1 ? '' : 's'}${filter && filter !== 'strokeStyle' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -109,5 +133,31 @@ export function StrokeStylePreview({
         </div>
       ))}
     </div>
+  );
+}
+
+export function StrokeStylePreview({
+  filter,
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: StrokeStylePreviewProps): ReactElement {
+  const project = useProject();
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = project;
+
+  const rows = useMemo(
+    () => deriveStrokeStyleRows(resolved, project, { filter, sortBy, sortDir }),
+    [resolved, project, filter, sortBy, sortDir],
+  );
+
+  return (
+    <StrokeStylePreviewView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/TokenDetail.tsx
+++ b/packages/blocks/src/TokenDetail.tsx
@@ -2,10 +2,12 @@ import cx from 'clsx';
 import type { ReactElement } from 'react';
 import { useColorFormat } from '#/contexts.ts';
 import { formatColor } from '#/format-color.ts';
+import type { ColorFormat } from '#/format-color.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { formatTokenValue } from '#/internal/format-token-value.ts';
 import { useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { AliasChain } from '#/token-detail/AliasChain.tsx';
 import { AliasedBy } from '#/token-detail/AliasedBy.tsx';
 import { AxisVariance } from '#/token-detail/AxisVariance.tsx';
@@ -15,6 +17,7 @@ import { ConsumerOutput } from '#/token-detail/ConsumerOutput.tsx';
 import { TokenHeader } from '#/token-detail/TokenHeader.tsx';
 import { TokenUsageSnippet } from '#/token-detail/TokenUsageSnippet.tsx';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
+import type { DetailToken } from '#/token-detail/internal.ts';
 import '#/token-detail/styles.css';
 
 export interface TokenDetailProps {
@@ -24,10 +27,81 @@ export interface TokenDetailProps {
   heading?: string;
 }
 
-export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
-  const { token, cssVar, activeTheme, activeAxes, cssVarPrefix } = useTokenDetailData(path);
-  const colorFormat = useColorFormat();
-  const { listing } = useProject();
+export interface TokenDetailDerived {
+  /** Single-line display string, also what `<CopyButton>` copies. */
+  value: string;
+  outOfGamut: boolean;
+  isColor: boolean;
+  isDeprecated: boolean;
+  /** `undefined` for a boolean `$deprecated: true` with no message. */
+  deprecationMessage: string | undefined;
+}
+
+const EMPTY_DERIVED: TokenDetailDerived = {
+  value: '',
+  outOfGamut: false,
+  isColor: false,
+  isDeprecated: false,
+  deprecationMessage: undefined,
+};
+
+/**
+ * Pure derivation of the token's display value and status flags. Mirrors
+ * `formatTokenValue` + `formatColor`'s gamut check, both of which need the
+ * resolved token's raw `$value`/`$type` — the listing alone (no `$value`)
+ * can't drive this. Extracted so it is unit-testable without React or a
+ * store; the View renders purely from this shape plus the token's presence.
+ */
+export function deriveTokenDetail(
+  path: string,
+  token: DetailToken | undefined,
+  listing: ProjectData['listing'],
+  colorFormat: ColorFormat,
+): TokenDetailDerived {
+  if (!token) return EMPTY_DERIVED;
+
+  const isColor = token.$type === 'color';
+  const gamut = isColor ? formatColor(token.$value, colorFormat) : null;
+  const value = formatTokenValue(token.$value, token.$type, colorFormat, listing[path]);
+  const outOfGamut = gamut?.outOfGamut ?? false;
+  const dep = token.$deprecated;
+  const isDeprecated = dep === true || (typeof dep === 'string' && dep.length > 0);
+  const deprecationMessage = typeof dep === 'string' ? dep : undefined;
+
+  return { value, outOfGamut, isColor, isDeprecated, deprecationMessage };
+}
+
+export interface TokenDetailViewProps extends TokenDetailDerived {
+  path: string;
+  heading?: string | undefined;
+  token: DetailToken | undefined;
+  cssVar: string;
+  activeTheme: string;
+  activeAxes: Record<string, string>;
+  cssVarPrefix: string;
+}
+
+/**
+ * Pure presentation for the token detail panel. Renders from plain props;
+ * composes the connected `TokenHeader` / `CompositePreview` /
+ * `CompositeBreakdown` / `AliasChain` / `AliasedBy` / `TokenUsageSnippet` /
+ * `ConsumerOutput` / `AxisVariance` as children (each reads the project
+ * itself for `path`).
+ */
+export function TokenDetailView({
+  path,
+  heading,
+  token,
+  cssVar,
+  activeTheme,
+  activeAxes,
+  cssVarPrefix,
+  value,
+  outOfGamut,
+  isColor,
+  isDeprecated,
+  deprecationMessage,
+}: TokenDetailViewProps): ReactElement {
   const wrapperAttrs = blockWrapperAttrs(cssVarPrefix, activeAxes);
 
   if (!token) {
@@ -40,13 +114,6 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
     );
   }
 
-  const isColor = token.$type === 'color';
-  const gamut = isColor ? formatColor(token.$value, colorFormat) : null;
-  const value = formatTokenValue(token.$value, token.$type, colorFormat, listing[path]);
-  const outOfGamut = gamut?.outOfGamut ?? false;
-  const dep = token.$deprecated;
-  const isDeprecated = dep === true || (typeof dep === 'string' && dep.length > 0);
-
   return (
     <div {...wrapperAttrs} className={cx(wrapperAttrs['className'], 'sb-token-detail')}>
       <TokenHeader path={path} {...(heading !== undefined && { heading })} />
@@ -57,7 +124,7 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
           role="note"
         >
           <span aria-hidden>⚠ </span>
-          Deprecated{typeof dep === 'string' ? `: ${dep}` : ''}
+          Deprecated{deprecationMessage ? `: ${deprecationMessage}` : ''}
         </div>
       )}
 
@@ -87,5 +154,25 @@ export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
       <ConsumerOutput path={path} />
       <AxisVariance path={path} />
     </div>
+  );
+}
+
+export function TokenDetail({ path, heading }: TokenDetailProps): ReactElement {
+  const { token, cssVar, activeTheme, activeAxes, cssVarPrefix } = useTokenDetailData(path);
+  const colorFormat = useColorFormat();
+  const { listing } = useProject();
+  const derived = deriveTokenDetail(path, token, listing, colorFormat);
+
+  return (
+    <TokenDetailView
+      path={path}
+      {...(heading !== undefined && { heading })}
+      token={token}
+      cssVar={cssVar}
+      activeTheme={activeTheme}
+      activeAxes={activeAxes}
+      cssVarPrefix={cssVarPrefix}
+      {...derived}
+    />
   );
 }

--- a/packages/blocks/src/TokenNavigator.tsx
+++ b/packages/blocks/src/TokenNavigator.tsx
@@ -61,23 +61,30 @@ export interface TokenNavigatorProps {
   indicators?: IndicatorsProp;
 }
 
-interface LeafNode {
+export interface LeafNode {
   kind: 'leaf';
   segment: string;
   path: string;
   token: VirtualToken;
 }
 
-interface GroupNode {
+export interface GroupNode {
   kind: 'group';
   segment: string;
   path: string;
   children: TreeNode[];
 }
 
-type TreeNode = LeafNode | GroupNode;
+export type TreeNode = LeafNode | GroupNode;
 
-function buildTree(
+/**
+ * Pure derivation of the navigator's tree from the resolved token map:
+ * groups paths by dotted segment (scoped to `root` when set, restricted to
+ * `typeFilter`'s `$type`s when set), producing nested `GroupNode`s down to
+ * `LeafNode`s, sorted groups-before-leaves and alphanumeric within a level.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function buildTree(
   resolved: Record<string, VirtualToken>,
   root: string | undefined,
   typeFilter: ReadonlySet<string> | undefined,
@@ -167,14 +174,20 @@ function collectLeafPaths(nodes: TreeNode[], out: string[]): void {
 // users + arrow-key users navigate them: depth-first, only descending
 // into expanded groups. Each entry carries enough metadata for the
 // keyboard handler to compute parent / first-child / next / prev.
-interface FlatTreeItem {
+export interface FlatTreeItem {
   path: string;
   kind: 'group' | 'leaf';
   // Dot-path of the parent group, or `null` for top-level entries.
   parentPath: string | null;
 }
 
-function flattenVisible(
+/**
+ * Pure derivation of the flattened, currently-visible treeitem order from a
+ * tree plus the set of expanded group paths — depth-first, only descending
+ * into expanded groups. Appends to `out` (caller passes `[]`). Extracted so
+ * it is unit-testable without React or a store.
+ */
+export function flattenVisible(
   nodes: TreeNode[],
   expanded: Set<string>,
   parentPath: string | null,
@@ -211,39 +224,45 @@ function pruneTreeForMatches(
   return out;
 }
 
-export function TokenNavigator({
+export interface TokenNavigatorViewProps {
+  resolved: Record<string, VirtualToken>;
+  root?: string | undefined;
+  enabledIndicators: ReturnType<typeof resolveIndicators>;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  activeTheme: string;
+  /** Stable persistence key for this navigator's expand/select/search state. */
+  blockKey: string;
+  type?: string | readonly string[] | undefined;
+  initiallyExpanded?: number;
+  searchable?: boolean;
+  onSelect?: ((path: string) => void) | undefined;
+}
+
+/**
+ * Pure presentation for the token navigator. Owns its own expand/collapse,
+ * selection, search, and roving-tabindex keyboard-nav state; renders the
+ * tree from the `resolved` view-model. Composes the connected `RowIndicators`
+ * / `DetailOverlay` / sample previews as children (those read the project
+ * themselves).
+ */
+export function TokenNavigatorView({
+  resolved,
   root,
+  enabledIndicators,
+  cssVarPrefix,
+  activeAxes,
+  activeTheme,
+  blockKey,
   type,
   initiallyExpanded = 1,
   searchable = true,
   onSelect,
-  id,
-  indicators,
-}: TokenNavigatorProps): ReactElement {
-  const {
-    resolved,
-    activeTheme,
-    activeAxes,
-    cssVarPrefix,
-    indicators: indicatorBaseline,
-  } = useProject();
-
-  // Persist UI state (expand/collapse, selection, search) across docs-mode
-  // remounts. Keyed on the props that distinguish one navigator from another
-  // (plus the optional `id`); excludes `initiallyExpanded`/`searchable`, whose
-  // changes are handled by the re-seed effect below rather than a fresh key.
-  const typeKey = type === undefined ? '' : typeof type === 'string' ? type : type.join(',');
-  const blockKey = useBlockKey('TokenNavigator', [root, typeKey, id]);
-
+}: TokenNavigatorViewProps): ReactElement {
   const typeFilter = useMemo<ReadonlySet<string> | undefined>(() => {
     if (type === undefined) return undefined;
     return new Set(Array.isArray(type) ? type : [type]);
   }, [type]);
-
-  const enabledIndicators = useMemo(
-    () => resolveIndicators(indicators, indicatorBaseline),
-    [indicators, indicatorBaseline],
-  );
 
   const tree = useMemo(() => buildTree(resolved, root, typeFilter), [resolved, root, typeFilter]);
 
@@ -600,6 +619,57 @@ export function TokenNavigator({
         />
       )}
     </div>
+  );
+}
+
+/**
+ * A collapsible, searchable tree of tokens with roving-tabindex keyboard
+ * navigation. Click a leaf to inspect it in a slide-over (unless `onSelect`
+ * is provided, which hands the follow-up to the consumer).
+ */
+export function TokenNavigator({
+  root,
+  type,
+  initiallyExpanded = 1,
+  searchable = true,
+  onSelect,
+  id,
+  indicators,
+}: TokenNavigatorProps): ReactElement {
+  const {
+    resolved,
+    activeTheme,
+    activeAxes,
+    cssVarPrefix,
+    indicators: indicatorBaseline,
+  } = useProject();
+
+  // Persist UI state (expand/collapse, selection, search) across docs-mode
+  // remounts. Keyed on the props that distinguish one navigator from another
+  // (plus the optional `id`); excludes `initiallyExpanded`/`searchable`, whose
+  // changes are handled by the re-seed effect in `TokenNavigatorView`.
+  const typeKey = type === undefined ? '' : typeof type === 'string' ? type : type.join(',');
+  const blockKey = useBlockKey('TokenNavigator', [root, typeKey, id]);
+
+  const enabledIndicators = useMemo(
+    () => resolveIndicators(indicators, indicatorBaseline),
+    [indicators, indicatorBaseline],
+  );
+
+  return (
+    <TokenNavigatorView
+      resolved={resolved}
+      root={root}
+      enabledIndicators={enabledIndicators}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      activeTheme={activeTheme}
+      blockKey={blockKey}
+      type={type}
+      initiallyExpanded={initiallyExpanded}
+      searchable={searchable}
+      onSelect={onSelect}
+    />
   );
 }
 

--- a/packages/blocks/src/TypographyScale.tsx
+++ b/packages/blocks/src/TypographyScale.tsx
@@ -4,6 +4,7 @@ import './TypographyScale.css';
 import type { TypographyValue } from '#/internal/composite-types.ts';
 import { blockWrapperAttrs } from '#/internal/data-attr.ts';
 import { useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { matchPath } from '@unpunnyfuns/swatchbook-core/match-path';
 import { sortTokens } from '#/internal/sort-tokens.ts';
 import type { SortBy, SortDir } from '#/internal/sort-tokens.ts';
@@ -36,7 +37,7 @@ export interface TypographyScaleProps {
   sortDir?: SortDir;
 }
 
-interface Row {
+export interface TypographyRow {
   path: string;
   sampleStyle: CSSProperties;
   specs: string;
@@ -58,7 +59,7 @@ function asFontFamily(raw: unknown): string | undefined {
   return undefined;
 }
 
-function buildRow(path: string, composite: TypographyValue): Row {
+function buildRow(path: string, composite: TypographyValue): TypographyRow {
   const fontFamily = asFontFamily(composite.fontFamily);
   const fontSize = asDimension(composite.fontSize);
   const fontWeight = composite.fontWeight == null ? undefined : String(composite.fontWeight);
@@ -83,29 +84,53 @@ function buildRow(path: string, composite: TypographyValue): Row {
   return { path, sampleStyle, specs: parts };
 }
 
-export function TypographyScale({
+export interface DeriveTypographyRowsOptions {
+  filter?: string | undefined;
+  sortBy: SortBy;
+  sortDir: SortDir;
+}
+
+/**
+ * Pure derivation of the scale's display rows from resolved project data.
+ * Extracted so it is unit-testable without React or a store.
+ */
+export function deriveTypographyRows(
+  resolved: ProjectData['resolved'],
+  { filter, sortBy, sortDir }: DeriveTypographyRowsOptions,
+): TypographyRow[] {
+  const filtered = Object.entries(resolved).filter(([path, token]) => {
+    if (token.$type !== 'typography') return false;
+    return matchPath(path, filter);
+  });
+  return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
+    const value = token.$value;
+    if (!value || typeof value !== 'object') {
+      return { path, sampleStyle: {}, specs: '' };
+    }
+    return buildRow(path, value as TypographyValue);
+  });
+}
+
+export interface TypographyScaleViewProps {
+  rows: TypographyRow[];
+  activeTheme: string;
+  cssVarPrefix: string;
+  activeAxes: Record<string, string>;
+  sample: string;
+  filter?: string | undefined;
+  caption?: string | undefined;
+}
+
+/** Pure presentation for the typography scale. Renders from plain props. */
+export function TypographyScaleView({
+  rows,
+  activeTheme,
+  cssVarPrefix,
+  activeAxes,
+  sample,
   filter,
-  sample = 'The quick brown fox jumps over the lazy dog.',
   caption,
-  sortBy = 'path',
-  sortDir = 'asc',
-}: TypographyScaleProps): ReactElement {
-  const { resolved, activeTheme, activeAxes, cssVarPrefix } = useProject();
-
-  const rows = useMemo<Row[]>(() => {
-    const filtered = Object.entries(resolved).filter(([path, token]) => {
-      if (token.$type !== 'typography') return false;
-      return matchPath(path, filter);
-    });
-    return sortTokens(filtered, { by: sortBy, dir: sortDir }).map(([path, token]) => {
-      const value = token.$value;
-      if (!value || typeof value !== 'object') {
-        return { path, sampleStyle: {}, specs: '' };
-      }
-      return buildRow(path, value as TypographyValue);
-    });
-  }, [resolved, filter, sortBy, sortDir]);
-
+}: TypographyScaleViewProps): ReactElement {
   const captionText =
     caption ??
     `${rows.length} typography token${rows.length === 1 ? '' : 's'}${filter && filter !== 'typography' ? ` matching \`${filter}\`` : ''} · ${activeTheme}`;
@@ -131,5 +156,32 @@ export function TypographyScale({
         </div>
       ))}
     </div>
+  );
+}
+
+export function TypographyScale({
+  filter,
+  sample = 'The quick brown fox jumps over the lazy dog.',
+  caption,
+  sortBy = 'path',
+  sortDir = 'asc',
+}: TypographyScaleProps): ReactElement {
+  const { resolved, activeTheme, activeAxes, cssVarPrefix } = useProject();
+
+  const rows = useMemo(
+    () => deriveTypographyRows(resolved, { filter, sortBy, sortDir }),
+    [resolved, filter, sortBy, sortDir],
+  );
+
+  return (
+    <TypographyScaleView
+      rows={rows}
+      activeTheme={activeTheme}
+      cssVarPrefix={cssVarPrefix}
+      activeAxes={activeAxes}
+      sample={sample}
+      filter={filter}
+      caption={caption}
+    />
   );
 }

--- a/packages/blocks/src/border-preview/BorderSample.tsx
+++ b/packages/blocks/src/border-preview/BorderSample.tsx
@@ -1,14 +1,38 @@
 import type { ReactElement } from 'react';
 import './BorderSample.css';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 
 export interface BorderSampleProps {
   /** Full dot-path of the border token to preview. */
   path: string;
 }
 
+export interface BorderSampleData {
+  /** CSS var reference for the token's border (listing name, or prefix fallback). */
+  cssVar: string;
+}
+
+/**
+ * Pure derivation of a single border token's sample data from resolved
+ * project data. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveBorderSample(
+  path: string,
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+): BorderSampleData {
+  return { cssVar: resolveCssVar(path, project) };
+}
+
+export type BorderSampleViewProps = BorderSampleData;
+
+/** Pure presentation for a single border token's sample. Renders from plain props. */
+export function BorderSampleView({ cssVar }: BorderSampleViewProps): ReactElement {
+  return <div className="sb-border-sample" style={{ border: cssVar }} aria-hidden />;
+}
+
 export function BorderSample({ path }: BorderSampleProps): ReactElement {
   const project = useProject();
-  const cssVar = resolveCssVar(path, project);
-  return <div className="sb-border-sample" style={{ border: cssVar }} aria-hidden />;
+  const { cssVar } = deriveBorderSample(path, project);
+  return <BorderSampleView cssVar={cssVar} />;
 }

--- a/packages/blocks/src/dimension-scale/DimensionBar.tsx
+++ b/packages/blocks/src/dimension-scale/DimensionBar.tsx
@@ -3,6 +3,7 @@ import './DimensionBar.css';
 import { MAX_RENDER_PX, toPixels } from '#/dimension-scale/dimension-px.ts';
 import { useRootFontSize } from '#/internal/use-root-font-size.ts';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 
 export type DimensionVisual = 'length' | 'radius' | 'size';
 
@@ -16,6 +17,34 @@ export interface DimensionBarProps {
    * - `'size'`: a square sized to the token's dimension.
    */
   visual?: DimensionVisual;
+}
+
+export interface DimensionBarData {
+  /** CSS var reference for the token's dimension (listing name, or prefix fallback). */
+  cssVar: string;
+  /** The resolved value in pixels, for cap comparison against {@link MAX_RENDER_PX}. `NaN` for non-`px`/`rem` units. */
+  pxValue: number;
+  /** Whether the resolved px exceeds {@link MAX_RENDER_PX}. */
+  capped: boolean;
+  /** The style value to render: `cssVar`, or the capped px literal when `capped`. */
+  cappedValue: string;
+}
+
+/**
+ * Pure derivation of a single dimension token's bar geometry from resolved
+ * project data. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveDimensionBar(
+  path: string,
+  project: Pick<ProjectData, 'resolved' | 'listing' | 'cssVarPrefix'>,
+  rootFontSizePx: number,
+): DimensionBarData {
+  const cssVar = resolveCssVar(path, project);
+  const token = project.resolved[path];
+  const pxValue = toPixels(token?.$value, rootFontSizePx);
+  const capped = Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX;
+  const cappedValue = capped ? `${MAX_RENDER_PX}px` : cssVar;
+  return { cssVar, pxValue, capped, cappedValue };
 }
 
 // Wrap a clamped visual with the cap affordance so every consumer (the scale
@@ -36,16 +65,17 @@ function withCap(visual: ReactElement): ReactElement {
   );
 }
 
-export function DimensionBar({ path, visual = 'length' }: DimensionBarProps): ReactElement {
-  const project = useProject();
-  const { resolved } = project;
-  const rootFontSize = useRootFontSize();
-  const cssVar = resolveCssVar(path, project);
-  const token = resolved[path];
-  const pxValue = toPixels(token?.$value, rootFontSize);
-  const capped = Number.isFinite(pxValue) && pxValue > MAX_RENDER_PX;
-  const cappedValue = capped ? `${MAX_RENDER_PX}px` : cssVar;
+export type DimensionBarViewProps = Pick<DimensionBarData, 'cssVar' | 'capped' | 'cappedValue'> & {
+  visual: DimensionVisual;
+};
 
+/** Pure presentation for a single dimension token's bar/sample. Renders from plain props. */
+export function DimensionBarView({
+  cssVar,
+  capped,
+  cappedValue,
+  visual,
+}: DimensionBarViewProps): ReactElement {
   switch (visual) {
     // A fixed 56×56 box: border-radius can't overflow it, so the cap never
     // applies to the radius sample.
@@ -75,4 +105,13 @@ export function DimensionBar({ path, visual = 'length' }: DimensionBarProps): Re
       return capped ? withCap(bar) : bar;
     }
   }
+}
+
+export function DimensionBar({ path, visual = 'length' }: DimensionBarProps): ReactElement {
+  const project = useProject();
+  const rootFontSize = useRootFontSize();
+  const { cssVar, capped, cappedValue } = deriveDimensionBar(path, project, rootFontSize);
+  return (
+    <DimensionBarView cssVar={cssVar} capped={capped} cappedValue={cappedValue} visual={visual} />
+  );
 }

--- a/packages/blocks/src/motion-preview/MotionSample.tsx
+++ b/packages/blocks/src/motion-preview/MotionSample.tsx
@@ -1,9 +1,10 @@
 import type { ReactElement } from 'react';
 import './MotionSample.css';
 import clsx from 'clsx';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import { useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 
 export type MotionSpeed = 0.25 | 0.5 | 1 | 2;
 
@@ -23,7 +24,7 @@ export interface MotionSampleProps {
 const DEFAULT_DURATION_MS = 300;
 const DEFAULT_EASING = 'cubic-bezier(0.2, 0, 0, 1)';
 
-interface Spec {
+export interface Spec {
   durationMs: number;
   easing: string;
 }
@@ -112,11 +113,33 @@ export function resolveMotionSpec(
   return null;
 }
 
-export function MotionSample({ path, speed = 1, runKey = 0 }: MotionSampleProps): ReactElement {
-  const { resolved } = useProject();
-  const reducedMotion = usePrefersReducedMotion();
+export interface MotionSampleData {
+  /** Resolved duration/easing for the token at `path`, or `null` when unresolved. */
+  spec: Spec | null;
+}
 
-  const spec = useMemo(() => resolveMotionSpec(resolved[path], resolved), [resolved, path]);
+/**
+ * Pure derivation of a single motion token's animation spec from resolved
+ * project data. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveMotionSample(
+  path: string,
+  project: Pick<ProjectData, 'resolved'>,
+): MotionSampleData {
+  return {
+    spec: resolveMotionSpec(project.resolved[path], project.resolved),
+  };
+}
+
+export interface MotionSampleViewProps {
+  spec: Spec | null;
+  speed: MotionSpeed;
+  runKey: number;
+}
+
+/** Pure presentation + animation for a single motion token's sample. Renders from plain props. */
+export function MotionSampleView({ spec, speed, runKey }: MotionSampleViewProps): ReactElement {
+  const reducedMotion = usePrefersReducedMotion();
 
   const durationMs = spec?.durationMs ?? DEFAULT_DURATION_MS;
   const easing = spec?.easing ?? DEFAULT_EASING;
@@ -157,4 +180,10 @@ export function MotionSample({ path, speed = 1, runKey = 0 }: MotionSampleProps)
       />
     </div>
   );
+}
+
+export function MotionSample({ path, speed = 1, runKey = 0 }: MotionSampleProps): ReactElement {
+  const project = useProject();
+  const { spec } = deriveMotionSample(path, project);
+  return <MotionSampleView spec={spec} speed={speed} runKey={runKey} />;
 }

--- a/packages/blocks/src/shadow-preview/ShadowSample.tsx
+++ b/packages/blocks/src/shadow-preview/ShadowSample.tsx
@@ -1,14 +1,38 @@
 import type { ReactElement } from 'react';
 import './ShadowSample.css';
 import { resolveCssVar, useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 
 export interface ShadowSampleProps {
   /** Full dot-path of the shadow token to preview. */
   path: string;
 }
 
+export interface ShadowSampleData {
+  /** CSS var reference for the token's shadow (listing name, or prefix fallback). */
+  cssVar: string;
+}
+
+/**
+ * Pure derivation of a single shadow token's sample data from resolved
+ * project data. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveShadowSample(
+  path: string,
+  project: Pick<ProjectData, 'listing' | 'cssVarPrefix'>,
+): ShadowSampleData {
+  return { cssVar: resolveCssVar(path, project) };
+}
+
+export type ShadowSampleViewProps = ShadowSampleData;
+
+/** Pure presentation for a single shadow token's sample. Renders from plain props. */
+export function ShadowSampleView({ cssVar }: ShadowSampleViewProps): ReactElement {
+  return <div className="sb-shadow-sample" style={{ boxShadow: cssVar }} aria-hidden />;
+}
+
 export function ShadowSample({ path }: ShadowSampleProps): ReactElement {
   const project = useProject();
-  const cssVar = resolveCssVar(path, project);
-  return <div className="sb-shadow-sample" style={{ boxShadow: cssVar }} aria-hidden />;
+  const { cssVar } = deriveShadowSample(path, project);
+  return <ShadowSampleView cssVar={cssVar} />;
 }

--- a/packages/blocks/src/token-detail/ConsumerOutput.tsx
+++ b/packages/blocks/src/token-detail/ConsumerOutput.tsx
@@ -1,6 +1,7 @@
 import type { ReactElement } from 'react';
 import { useState } from 'react';
 import { useProject } from '#/internal/use-project.ts';
+import type { ProjectData } from '#/internal/use-project.ts';
 import { useTokenDetailData } from '#/token-detail/internal.ts';
 
 export interface ConsumerOutputProps {
@@ -8,24 +9,64 @@ export interface ConsumerOutputProps {
   path: string;
 }
 
-export function ConsumerOutput({ path }: ConsumerOutputProps): ReactElement | null {
-  const { token, cssVar, activeAxes } = useTokenDetailData(path);
-  const { listing } = useProject();
+/** One non-`css` platform row: the consumer's listed name for this token under that platform. */
+export interface ConsumerOutputPlatformEntry {
+  platform: string;
+  label: string;
+  value: string;
+}
 
-  if (!token) return null;
+export interface ConsumerOutputData {
+  /**
+   * Platforms beyond `css`. Populated only when the consumer has loaded
+   * extra plugins (`@terrazzo/plugin-swift`, `-android`, `-sass`, …) via
+   * `config.terrazzoPlugins` + `config.listingOptions.platforms`. Empty
+   * otherwise — the row set falls back to Path + CSS.
+   */
+  extraPlatforms: ConsumerOutputPlatformEntry[];
+}
+
+/**
+ * Pure derivation of the consumer-output platform rows from the Token
+ * Listing. Extracted so it is unit-testable without React or a store.
+ */
+export function deriveConsumerOutput(
+  path: string,
+  listing: ProjectData['listing'],
+): ConsumerOutputData {
+  const names = listing[path]?.names ?? {};
+  const extraPlatforms = Object.keys(names)
+    .filter((platform) => platform !== 'css' && names[platform])
+    .toSorted()
+    .map((platform) => ({
+      platform,
+      label: formatPlatformLabel(platform),
+      value: names[platform]!,
+    }));
+  return { extraPlatforms };
+}
+
+export interface ConsumerOutputViewProps extends ConsumerOutputData {
+  path: string;
+  cssVar: string;
+  activeAxes: Record<string, string>;
+  /** Whether the token resolves in the active theme; `false` renders nothing. */
+  hasToken: boolean;
+}
+
+/** Pure presentation for the consumer-output section. Renders from plain props; owns the copy-button's local feedback state. */
+export function ConsumerOutputView({
+  path,
+  cssVar,
+  activeAxes,
+  hasToken,
+  extraPlatforms,
+}: ConsumerOutputViewProps): ReactElement | null {
+  if (!hasToken) return null;
 
   const tupleLabel = Object.entries(activeAxes)
     .map(([k, v]) => `${k}=${v}`)
     .join(', ');
-
-  // Platforms beyond `css`. Populated only when the consumer has loaded
-  // extra plugins (`@terrazzo/plugin-swift`, `-android`, `-sass`, …) via
-  // `config.terrazzoPlugins` + `config.listingOptions.platforms`. Always
-  // empty otherwise — the row set falls back to Path + CSS.
-  const names = listing[path]?.names ?? {};
-  const extraPlatforms = Object.keys(names)
-    .filter((platform) => platform !== 'css' && names[platform])
-    .toSorted();
 
   return (
     <>
@@ -37,15 +78,31 @@ export function ConsumerOutput({ path }: ConsumerOutputProps): ReactElement | nu
       )}
       <OutputRow label="Path" value={path} testId="consumer-output-path" />
       <OutputRow label="CSS" value={cssVar} testId="consumer-output-css" />
-      {extraPlatforms.map((platform) => (
+      {extraPlatforms.map((entry) => (
         <OutputRow
-          key={platform}
-          label={formatPlatformLabel(platform)}
-          value={names[platform]!}
-          testId={`consumer-output-${platform}`}
+          key={entry.platform}
+          label={entry.label}
+          value={entry.value}
+          testId={`consumer-output-${entry.platform}`}
         />
       ))}
     </>
+  );
+}
+
+export function ConsumerOutput({ path }: ConsumerOutputProps): ReactElement | null {
+  const { token, cssVar, activeAxes } = useTokenDetailData(path);
+  const { listing } = useProject();
+  const { extraPlatforms } = deriveConsumerOutput(path, listing);
+
+  return (
+    <ConsumerOutputView
+      path={path}
+      cssVar={cssVar}
+      activeAxes={activeAxes}
+      hasToken={Boolean(token)}
+      extraPlatforms={extraPlatforms}
+    />
   );
 }
 

--- a/packages/blocks/test/border-preview-view.browser.test.tsx
+++ b/packages/blocks/test/border-preview-view.browser.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { BorderPreviewView } from '#/BorderPreview.tsx';
+import type { BorderPreviewViewProps, BorderRow } from '#/BorderPreview.tsx';
+
+function rows(): BorderRow[] {
+  return [
+    {
+      path: 'border.default',
+      cssVar: 'var(--sb-border-default)',
+      width: '1px',
+      style: 'solid',
+      color: '#000000',
+    },
+    {
+      path: 'border.focus',
+      cssVar: 'var(--sb-border-focus)',
+      width: '2px',
+      style: 'dashed',
+      color: '#0066ff',
+    },
+  ];
+}
+
+// The View renders from plain props — no provider, no store. BorderSample
+// (rendered per-row) is a connected child that reads the project itself; it
+// falls back to an empty snapshot with no provider mounted, which is fine
+// here since only the View's own output is under test.
+function setup(extra: Partial<BorderPreviewViewProps> = {}) {
+  return render(
+    <BorderPreviewView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a row per border token with its css var and breakdown', () => {
+  setup();
+  screen.getByText('border.default');
+  screen.getByText('var(--sb-border-default)');
+  screen.getByText('1px');
+  screen.getByText('solid');
+  screen.getByText('#000000');
+  screen.getByText('border.focus');
+  screen.getByText('var(--sb-border-focus)');
+  screen.getByText('2px');
+  screen.getByText('dashed');
+  screen.getByText('#0066ff');
+});
+
+it('shows a default caption naming the count and active theme', () => {
+  setup();
+  screen.getByText('2 borders · Light');
+});
+
+it('honors a caption override', () => {
+  setup({ caption: 'Custom caption' });
+  screen.getByText('Custom caption');
+});
+
+it('mentions the filter in the default caption when set', () => {
+  setup({ filter: 'border.*' });
+  screen.getByText('2 borders matching `border.*` · Light');
+});
+
+it('renders the empty state when there are no rows', () => {
+  setup({ rows: [] });
+  screen.getByText('No border tokens match this filter.');
+});

--- a/packages/blocks/test/border-sample-view.browser.test.tsx
+++ b/packages/blocks/test/border-sample-view.browser.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { BorderSampleView } from '#/border-preview/BorderSample.tsx';
+
+// The View renders from plain props — no provider, no store.
+function setup(cssVar = 'var(--sb-border-focus)') {
+  return render(<BorderSampleView cssVar={cssVar} />);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a sample with the css var applied as the border', () => {
+  const { container } = setup();
+  const sample = container.querySelector<HTMLElement>('.sb-border-sample');
+  expect(sample?.style.border).toBe('var(--sb-border-focus)');
+});
+
+it('is decorative', () => {
+  const { container } = setup();
+  const sample = container.querySelector<HTMLElement>('.sb-border-sample');
+  expect(sample?.getAttribute('aria-hidden')).toBe('true');
+});

--- a/packages/blocks/test/build-tree.test.ts
+++ b/packages/blocks/test/build-tree.test.ts
@@ -1,0 +1,75 @@
+import { expect, it } from 'vitest';
+import { buildTree, flattenVisible } from '#/TokenNavigator.tsx';
+import type { VirtualTokenShape } from '#/contexts.ts';
+
+// Hand-built resolved map: two nested color groups plus one top-level
+// dimension leaf, enough to exercise nesting, sibling ordering, and the
+// group-vs-leaf split without a real project.
+const resolved: Record<string, VirtualTokenShape> = {
+  'color.palette.blue.600': { $type: 'color', $value: { hex: '#006' } },
+  'color.palette.blue.500': { $type: 'color', $value: { hex: '#005' } },
+  'color.brand.primary': { $type: 'color', $value: { hex: '#00f' } },
+  'space.md': { $type: 'dimension', $value: '8px' },
+};
+
+it('groups paths into a nested tree, sorted with groups before leaves', () => {
+  const tree = buildTree(resolved, undefined, undefined);
+
+  expect(tree.map((n) => n.segment)).toEqual(['color', 'space']);
+  const color = tree[0];
+  if (color?.kind !== 'group') throw new Error('expected color to be a group');
+  expect(color.children.map((n) => n.segment)).toEqual(['brand', 'palette']);
+
+  const palette = color.children.find((n) => n.segment === 'palette');
+  if (palette?.kind !== 'group') throw new Error('expected palette to be a group');
+  expect(palette.path).toBe('color.palette');
+
+  const blue = palette.children[0];
+  if (blue?.kind !== 'group') throw new Error('expected blue to be a group');
+  expect(blue.path).toBe('color.palette.blue');
+  // Numeric sort keeps 500 before 600, not lexicographic '500' > '600'-adjacent oddities.
+  expect(blue.children.map((n) => n.segment)).toEqual(['500', '600']);
+  expect(blue.children.every((n) => n.kind === 'leaf')).toBe(true);
+});
+
+it('scopes the tree to a root subtree and rewrites paths relative to it', () => {
+  const tree = buildTree(resolved, 'color.palette', undefined);
+
+  expect(tree.map((n) => n.segment)).toEqual(['blue']);
+  const blue = tree[0];
+  if (blue?.kind !== 'group') throw new Error('expected blue to be a group');
+  expect(blue.path).toBe('color.palette.blue');
+  expect(blue.children.map((n) => (n.kind === 'leaf' ? n.path : null))).toEqual([
+    'color.palette.blue.500',
+    'color.palette.blue.600',
+  ]);
+});
+
+it('drops leaves outside the type filter and prunes groups left empty', () => {
+  const tree = buildTree(resolved, undefined, new Set(['dimension']));
+
+  expect(tree.map((n) => n.segment)).toEqual(['space']);
+  const space = tree[0];
+  if (space?.kind !== 'group') throw new Error('expected space to be a group');
+  expect(space.children).toEqual([
+    { kind: 'leaf', segment: 'md', path: 'space.md', token: resolved['space.md'] },
+  ]);
+});
+
+it('flattens only expanded groups, depth-first, in tree order', () => {
+  const tree = buildTree(resolved, undefined, undefined);
+  const out: Parameters<typeof flattenVisible>[3] = [];
+  flattenVisible(tree, new Set(['color', 'color.brand', 'space']), null, out);
+
+  // 'palette' stays collapsed since it isn't in the expanded set, so its
+  // 'blue' child never appears — but its sibling 'brand' and the top-level
+  // 'space' group, both expanded, reveal their leaves.
+  expect(out).toEqual([
+    { path: 'color', kind: 'group', parentPath: null },
+    { path: 'color.brand', kind: 'group', parentPath: 'color' },
+    { path: 'color.brand.primary', kind: 'leaf', parentPath: 'color.brand' },
+    { path: 'color.palette', kind: 'group', parentPath: 'color' },
+    { path: 'space', kind: 'group', parentPath: null },
+    { path: 'space.md', kind: 'leaf', parentPath: 'space' },
+  ]);
+});

--- a/packages/blocks/test/color-palette-view.browser.test.tsx
+++ b/packages/blocks/test/color-palette-view.browser.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { ColorPaletteView } from '#/ColorPalette.tsx';
+import type { ColorPaletteGroup, ColorPaletteViewProps } from '#/ColorPalette.tsx';
+
+function groups(): ColorPaletteGroup[] {
+  return [
+    {
+      group: 'color.brand',
+      swatches: [
+        {
+          path: 'color.brand.bg',
+          leaf: 'bg',
+          cssVar: 'var(--sb-color-brand-bg)',
+          value: '#0066ff',
+          outOfGamut: false,
+        },
+        {
+          path: 'color.brand.fg',
+          leaf: 'fg',
+          cssVar: 'var(--sb-color-brand-fg)',
+          value: 'rgb(300 0 0)',
+          outOfGamut: true,
+        },
+      ],
+    },
+  ];
+}
+
+// The View renders + groups from plain props — no provider, no store.
+function setup(extra: Partial<ColorPaletteViewProps> = {}) {
+  return render(
+    <ColorPaletteView
+      groups={groups()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a swatch card per token, grouped under its section header', () => {
+  setup();
+  screen.getByText('color.brand');
+  screen.getByText('bg');
+  screen.getByText('fg');
+  screen.getByText('#0066ff', { exact: false });
+});
+
+it('shows the out-of-gamut marker on a flagged swatch', () => {
+  setup();
+  screen.getByLabelText('out of gamut');
+});
+
+it('shows a derived caption with the total count and active theme', () => {
+  setup();
+  screen.getByText('2 colors · Light');
+});
+
+it('renders an explicit caption override', () => {
+  setup({ caption: 'Brand colors' });
+  screen.getByText('Brand colors');
+});
+
+it('shows the empty state when there are no groups', () => {
+  setup({ groups: [] });
+  screen.getByText('No color tokens match this filter.');
+  expect(screen.queryByText('color.brand')).toBeNull();
+});

--- a/packages/blocks/test/color-table-view.browser.test.tsx
+++ b/packages/blocks/test/color-table-view.browser.test.tsx
@@ -1,0 +1,82 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, expect, it } from 'vitest';
+import { ColorTableView } from '#/ColorTable.tsx';
+import type { ColorGroup, ColorTableViewProps, ColorVariant } from '#/ColorTable.tsx';
+import { resolveIndicators } from '#/indicators/resolve.ts';
+
+function groups(): ColorGroup[] {
+  const brand: ColorVariant = {
+    label: 'base',
+    path: 'color.brand',
+    cssVar: 'var(--sb-color-brand)',
+    token: {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0, 0.4, 1] },
+    } as ColorVariant['token'],
+    variance: undefined,
+    value: '#0066ff',
+    outOfGamut: false,
+    hex: '#0066ff',
+    hsl: 'hsl(216 100% 50%)',
+    oklch: 'oklch(0.55 0.2 250)',
+    isDeprecated: false,
+  };
+  const legacy: ColorVariant = {
+    label: 'base',
+    path: 'color.legacy',
+    cssVar: 'var(--sb-color-legacy)',
+    token: {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [1, 0, 0] },
+      $deprecated: 'use color.brand',
+    } as ColorVariant['token'],
+    variance: undefined,
+    value: '#ff0000',
+    outOfGamut: false,
+    hex: '#ff0000',
+    hsl: 'hsl(0 100% 50%)',
+    oklch: 'oklch(0.63 0.26 29)',
+    isDeprecated: true,
+  };
+  return [
+    { base: 'color.brand', variants: [brand], searchText: 'color.brand #0066ff' },
+    { base: 'color.legacy', variants: [legacy], searchText: 'color.legacy #ff0000' },
+  ];
+}
+
+// The View renders + filters from plain props — no provider, no store. Row
+// activation only toggles the built-in inline expansion (no project access
+// needed), so that stays covered by the connector-level expansion tests.
+function setup(extra: Partial<ColorTableViewProps> = {}) {
+  return render(
+    <ColorTableView
+      groups={groups()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      colorFormat="hex"
+      enabledIndicators={resolveIndicators(undefined, {})}
+      blockKey="test::ColorTable"
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a row per group with its active value', () => {
+  setup();
+  screen.getByText('color.brand');
+  screen.getByText('color.legacy');
+  expect(screen.getAllByTestId('color-table-row')).toHaveLength(2);
+});
+
+it('narrows visible rows via the search input', async () => {
+  setup();
+  await userEvent.type(screen.getByTestId('color-table-search'), 'brand');
+  expect(screen.getAllByTestId('color-table-row')).toHaveLength(1);
+  screen.getByText('color.brand');
+});

--- a/packages/blocks/test/consumer-output-view.browser.test.tsx
+++ b/packages/blocks/test/consumer-output-view.browser.test.tsx
@@ -1,0 +1,76 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { userEvent } from '@vitest/browser/context';
+import { afterEach, expect, it, vi } from 'vitest';
+import { ConsumerOutputView } from '#/token-detail/ConsumerOutput.tsx';
+import type { ConsumerOutputViewProps } from '#/token-detail/ConsumerOutput.tsx';
+
+// The View renders from plain props — no provider, no store.
+function setup(extra: Partial<ConsumerOutputViewProps> = {}) {
+  return render(
+    <ConsumerOutputView
+      path="color.accent.bg"
+      cssVar="var(--sb-color-accent-bg)"
+      activeAxes={{}}
+      hasToken
+      extraPlatforms={[]}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders Path + CSS rows with no extra platforms', () => {
+  setup();
+  expect(screen.getByTestId('consumer-output-path').textContent).toBe('color.accent.bg');
+  expect(screen.getByTestId('consumer-output-css').textContent).toBe('var(--sb-color-accent-bg)');
+  expect(screen.queryByTestId('consumer-output-swift')).toBeNull();
+});
+
+it('renders one row per extra platform entry', () => {
+  setup({
+    extraPlatforms: [
+      { platform: 'android', label: 'Android', value: '@color/accent_bg' },
+      { platform: 'swift', label: 'Swift', value: 'Color.accentBg' },
+    ],
+  });
+  expect(screen.getByTestId('consumer-output-android').textContent).toBe('@color/accent_bg');
+  expect(screen.getByTestId('consumer-output-swift').textContent).toBe('Color.accentBg');
+});
+
+it('shows the active tuple label derived from activeAxes', () => {
+  setup({ activeAxes: { theme: 'Light', brand: 'acme' } });
+  screen.getByText('theme=Light, brand=acme', { exact: false });
+});
+
+it('renders nothing when hasToken is false', () => {
+  const { container } = setup({ hasToken: false });
+  expect(container.textContent).toBe('');
+});
+
+it('toggles the copy button feedback to "Copied" when clicked, using local state', async () => {
+  // Headless Chromium denies the clipboard-write permission outright, so
+  // `navigator.clipboard.writeText` rejects regardless of the click. Stub it
+  // to isolate what this test actually checks: the View's own local
+  // `copied` state toggle, not the browser's clipboard permission model.
+  const originalClipboard = navigator.clipboard;
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    configurable: true,
+  });
+
+  try {
+    setup();
+    const button = screen.getByTestId('consumer-output-path-copy');
+    expect(button.textContent).toBe('Copy');
+    await userEvent.click(button);
+    await expect.poll(() => button.textContent).toBe('Copied');
+  } finally {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+  }
+});

--- a/packages/blocks/test/derive-border-rows.test.ts
+++ b/packages/blocks/test/derive-border-rows.test.ts
@@ -1,0 +1,69 @@
+import { expect, it } from 'vitest';
+import { deriveBorderRows } from '#/BorderPreview.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: two border tokens, one non-border token
+// that must be filtered out.
+const resolved = {
+  'border.default': {
+    $type: 'border',
+    $value: {
+      color: { colorSpace: 'srgb', components: [0, 0, 0] },
+      width: { value: 1, unit: 'px' },
+      style: 'solid',
+    },
+  },
+  'border.focus': {
+    $type: 'border',
+    $value: {
+      color: { colorSpace: 'srgb', components: [0, 0.4, 1] },
+      width: { value: 2, unit: 'px' },
+      style: 'dashed',
+    },
+  },
+  'color.brand.bg': { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+} as unknown as ProjectData['resolved'];
+
+const listing = {
+  'border.default': { names: { css: '--sb-border-default' } },
+} as unknown as ProjectData['listing'];
+
+const cssVarPrefix = 'sb';
+const project = { listing, cssVarPrefix };
+
+const opts = { sortBy: 'path', sortDir: 'asc', colorFormat: 'hex' } as const;
+
+it('filters to border tokens only, sorted by path', () => {
+  const rows = deriveBorderRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['border.default', 'border.focus']);
+});
+
+it('derives the css var from the listing when present', () => {
+  const rows = deriveBorderRows(resolved, project, opts);
+  const row = rows.find((r) => r.path === 'border.default');
+  expect(row?.cssVar).toBe('var(--sb-border-default)');
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const rows = deriveBorderRows(resolved, project, opts);
+  const row = rows.find((r) => r.path === 'border.focus');
+  expect(row?.cssVar).toBe('var(--sb-border-focus)');
+});
+
+it('formats the width, style and color per the given colorFormat', () => {
+  const rows = deriveBorderRows(resolved, project, opts);
+  const row = rows.find((r) => r.path === 'border.focus');
+  expect(row?.width).toBe('2px');
+  expect(row?.style).toBe('dashed');
+  expect(row?.color).toBe('#0066ff');
+});
+
+it('applies the path filter', () => {
+  const rows = deriveBorderRows(resolved, project, { ...opts, filter: 'border.focus' });
+  expect(rows.map((r) => r.path)).toEqual(['border.focus']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveBorderRows(resolved, project, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['border.focus', 'border.default']);
+});

--- a/packages/blocks/test/derive-border-sample.test.ts
+++ b/packages/blocks/test/derive-border-sample.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from 'vitest';
+import { deriveBorderSample } from '#/border-preview/BorderSample.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+function makeProject(
+  listing: Pick<ProjectData, 'listing'>['listing'] = {},
+): Pick<ProjectData, 'listing' | 'cssVarPrefix'> {
+  return { listing, cssVarPrefix: 'sb' };
+}
+
+it('resolves the css var from the listing when present', () => {
+  const project = makeProject({
+    'border.focus': { names: { css: '--tz-border-focus' } },
+  } as unknown as ProjectData['listing']);
+  const sample = deriveBorderSample('border.focus', project);
+  expect(sample.cssVar).toBe('var(--tz-border-focus)');
+});
+
+it('falls back to the prefix-derived css var when the listing has no entry', () => {
+  const sample = deriveBorderSample('border.focus', makeProject());
+  expect(sample.cssVar).toContain('--sb-border-focus');
+});

--- a/packages/blocks/test/derive-color-groups.test.ts
+++ b/packages/blocks/test/derive-color-groups.test.ts
@@ -1,0 +1,73 @@
+import { expect, it } from 'vitest';
+import { deriveColorGroups } from '#/ColorTable.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: two colors (one deprecated), one non-color.
+const resolved = {
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+  'color.legacy': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [1, 0, 0] },
+    $deprecated: 'use color.brand',
+  },
+  'space.md': { $type: 'dimension', $value: { value: 16, unit: 'px' } },
+} as unknown as ProjectData['resolved'];
+const listing = {} as ProjectData['listing'];
+const varianceByPath = {} as ProjectData['varianceByPath'];
+const opts = { sortBy: 'path', sortDir: 'asc', colorFormat: 'hex' } as const;
+
+it('produces one group per resolved color token, skipping non-color types', () => {
+  const groups = deriveColorGroups(resolved, listing, 'sb', varianceByPath, opts);
+  expect(groups.map((g) => g.base)).toEqual(['color.brand', 'color.legacy']);
+});
+
+it('carries per-variant isDeprecated, cssVar, and the active-format value', () => {
+  const groups = deriveColorGroups(resolved, listing, 'sb', varianceByPath, opts);
+  const brand = groups.find((g) => g.base === 'color.brand')!.variants[0]!;
+  expect(brand.isDeprecated).toBe(false);
+  expect(brand.cssVar).toContain('--sb-color-brand');
+  expect(brand.value).toMatch(/^#/);
+
+  const legacy = groups.find((g) => g.base === 'color.legacy')!.variants[0]!;
+  expect(legacy.isDeprecated).toBe(true);
+});
+
+it('applies the path filter', () => {
+  const groups = deriveColorGroups(resolved, listing, 'sb', varianceByPath, {
+    ...opts,
+    filter: 'color.brand',
+  });
+  expect(groups.map((g) => g.base)).toEqual(['color.brand']);
+});
+
+it('threads colorFormat into the active-format value', () => {
+  const groups = deriveColorGroups(resolved, listing, 'sb', varianceByPath, {
+    ...opts,
+    colorFormat: 'hsl',
+    filter: 'color.brand',
+  });
+  expect(groups[0]!.variants[0]!.value).toMatch(/^hsl/);
+});
+
+it('groups suffix-matched variants under a shared base with pill labels', () => {
+  const withVariants = {
+    ...resolved,
+    'color.bg.hi': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0, 0] } },
+    'color.bg.hi-d': {
+      $type: 'color',
+      $value: { colorSpace: 'srgb', components: [0.2, 0.2, 0.2] },
+    },
+  } as unknown as ProjectData['resolved'];
+
+  const groups = deriveColorGroups(withVariants, listing, 'sb', varianceByPath, {
+    ...opts,
+    filter: 'color.bg.**',
+    variants: { disabled: 'd' },
+  });
+
+  expect(groups).toHaveLength(1);
+  const group = groups[0]!;
+  expect(group.base).toBe('color.bg.hi');
+  expect(group.variants.map((v) => v.label)).toEqual(['base', 'disabled']);
+  expect(group.variants.map((v) => v.path)).toEqual(['color.bg.hi', 'color.bg.hi-d']);
+});

--- a/packages/blocks/test/derive-color-palette-groups.test.ts
+++ b/packages/blocks/test/derive-color-palette-groups.test.ts
@@ -1,0 +1,73 @@
+import { expect, it } from 'vitest';
+import { deriveColorPaletteGroups } from '#/ColorPalette.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: three color tokens across two branches,
+// one non-color token that must be filtered out.
+const resolved = {
+  'color.brand.bg': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+  'color.brand.fg': { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+  'color.text.muted': {
+    $type: 'color',
+    $value: { colorSpace: 'srgb', components: [0.5, 0.5, 0.5] },
+  },
+  'radius.sm': { $type: 'dimension', $value: { value: 4, unit: 'px' } },
+} as unknown as ProjectData['resolved'];
+
+const listing = {
+  'color.brand.bg': { names: { css: '--sb-color-brand-bg' } },
+} as unknown as ProjectData['listing'];
+
+const cssVarPrefix = 'sb';
+
+const opts = { sortBy: 'path', sortDir: 'asc', colorFormat: 'hex' } as const;
+
+it('groups color tokens under the derived default groupBy, excluding other types', () => {
+  const groups = deriveColorPaletteGroups(resolved, listing, cssVarPrefix, opts);
+  expect(groups.map((g) => g.group)).toEqual(['color']);
+  expect(groups[0]?.swatches.map((s) => s.path)).toEqual([
+    'color.brand.bg',
+    'color.brand.fg',
+    'color.text.muted',
+  ]);
+});
+
+it('derives the css var from the listing and formats the color value for the given colorFormat', () => {
+  const groups = deriveColorPaletteGroups(resolved, listing, cssVarPrefix, opts);
+  const bg = groups[0]?.swatches.find((s) => s.path === 'color.brand.bg');
+  expect(bg?.cssVar).toBe('var(--sb-color-brand-bg)');
+  expect(bg?.value).toBe('#0066ff');
+  expect(bg?.outOfGamut).toBe(false);
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const groups = deriveColorPaletteGroups(resolved, listing, cssVarPrefix, opts);
+  const muted = groups[0]?.swatches.find((s) => s.path === 'color.text.muted');
+  expect(muted?.cssVar).toBe('var(--sb-color-text-muted)');
+});
+
+it('applies an explicit groupBy over the derived default', () => {
+  const groups = deriveColorPaletteGroups(resolved, listing, cssVarPrefix, { ...opts, groupBy: 2 });
+  expect(groups.map((g) => g.group)).toEqual(['color.brand', 'color.text']);
+  expect(groups[0]?.swatches.map((s) => s.leaf)).toEqual(['bg', 'fg']);
+  expect(groups[1]?.swatches.map((s) => s.leaf)).toEqual(['muted']);
+});
+
+it('applies the path filter', () => {
+  const groups = deriveColorPaletteGroups(resolved, listing, cssVarPrefix, {
+    ...opts,
+    filter: 'color.brand.**',
+  });
+  expect(groups.map((g) => g.group)).toEqual(['color.brand']);
+  expect(groups[0]?.swatches.map((s) => s.path)).toEqual(['color.brand.bg', 'color.brand.fg']);
+});
+
+it('applies sortDir desc within a group', () => {
+  const groups = deriveColorPaletteGroups(resolved, listing, cssVarPrefix, {
+    ...opts,
+    groupBy: 2,
+    sortDir: 'desc',
+  });
+  const brand = groups.find((g) => g.group === 'color.brand');
+  expect(brand?.swatches.map((s) => s.path)).toEqual(['color.brand.fg', 'color.brand.bg']);
+});

--- a/packages/blocks/test/derive-consumer-output.test.ts
+++ b/packages/blocks/test/derive-consumer-output.test.ts
@@ -1,0 +1,43 @@
+import { expect, it } from 'vitest';
+import { deriveConsumerOutput } from '#/token-detail/ConsumerOutput.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+it('returns no extra platforms when the path is absent from the listing', () => {
+  const listing = {} as ProjectData['listing'];
+  const derived = deriveConsumerOutput('color.accent.bg', listing);
+  expect(derived.extraPlatforms).toEqual([]);
+});
+
+it('returns one entry per non-css platform, sorted alphabetically', () => {
+  const listing = {
+    'color.accent.bg': {
+      names: {
+        css: '--sb-color-accent-bg',
+        swift: 'Color.accentBg',
+        android: '@color/accent_bg',
+        sass: '$accent-bg',
+      },
+    },
+  } as unknown as ProjectData['listing'];
+
+  const derived = deriveConsumerOutput('color.accent.bg', listing);
+  expect(derived.extraPlatforms).toEqual([
+    { platform: 'android', label: 'Android', value: '@color/accent_bg' },
+    { platform: 'sass', label: 'Sass', value: '$accent-bg' },
+    { platform: 'swift', label: 'Swift', value: 'Color.accentBg' },
+  ]);
+});
+
+it('skips platforms whose listing value is empty', () => {
+  const listing = {
+    'color.accent.bg': {
+      names: {
+        css: '--sb-color-accent-bg',
+        swift: '',
+      },
+    },
+  } as unknown as ProjectData['listing'];
+
+  const derived = deriveConsumerOutput('color.accent.bg', listing);
+  expect(derived.extraPlatforms).toEqual([]);
+});

--- a/packages/blocks/test/derive-dimension-bar.test.ts
+++ b/packages/blocks/test/derive-dimension-bar.test.ts
@@ -1,0 +1,45 @@
+import { expect, it } from 'vitest';
+import { deriveDimensionBar } from '#/dimension-scale/DimensionBar.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one dimension token, 2rem.
+const resolved = {
+  'space.lg': { $type: 'dimension', $value: { value: 2, unit: 'rem' } },
+} as unknown as ProjectData['resolved'];
+
+function makeProject(
+  listing: Pick<ProjectData, 'listing'>['listing'] = {},
+): Pick<ProjectData, 'resolved' | 'listing' | 'cssVarPrefix'> {
+  return { resolved, listing, cssVarPrefix: 'sb' };
+}
+
+it('resolves the css var from the listing when present', () => {
+  const project = makeProject({
+    'space.lg': { names: { css: '--tz-space-lg' } },
+  } as unknown as ProjectData['listing']);
+  const bar = deriveDimensionBar('space.lg', project, 16);
+  expect(bar.cssVar).toBe('var(--tz-space-lg)');
+});
+
+it('falls back to the prefix-derived css var when the listing has no entry', () => {
+  const bar = deriveDimensionBar('space.lg', makeProject(), 16);
+  expect(bar.cssVar).toContain('--sb-space-lg');
+});
+
+it('converts the resolved value to px using the given rootFontSizePx', () => {
+  expect(deriveDimensionBar('space.lg', makeProject(), 16).pxValue).toBe(32);
+  expect(deriveDimensionBar('space.lg', makeProject(), 8).pxValue).toBe(16);
+});
+
+it('caps at MAX_RENDER_PX (480) once the resolved px exceeds it', () => {
+  // 2rem at a 300px root = 600px, over the 480 cap.
+  const bar = deriveDimensionBar('space.lg', makeProject(), 300);
+  expect(bar.capped).toBe(true);
+  expect(bar.cappedValue).toBe('480px');
+});
+
+it('leaves cappedValue equal to the css var when under the cap', () => {
+  const bar = deriveDimensionBar('space.lg', makeProject(), 16);
+  expect(bar.capped).toBe(false);
+  expect(bar.cappedValue).toBe(bar.cssVar);
+});

--- a/packages/blocks/test/derive-dimension-rows.test.ts
+++ b/packages/blocks/test/derive-dimension-rows.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from 'vitest';
+import { deriveDimensionRows } from '#/DimensionScale.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: two dimensions (one rem, one px) and a
+// non-dimension token that must be filtered out.
+const resolved = {
+  'space.sm': { $type: 'dimension', $value: { value: 0.5, unit: 'rem' } },
+  'space.lg': { $type: 'dimension', $value: { value: 32, unit: 'px' } },
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+const project = { listing: {}, cssVarPrefix: 'sb' };
+const opts = { sortBy: 'value', sortDir: 'asc', rootFontSizePx: 16 } as const;
+
+it('includes only dimension tokens with a resolved css var and display value', () => {
+  const rows = deriveDimensionRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['space.sm', 'space.lg']);
+  const sm = rows.find((r) => r.path === 'space.sm')!;
+  expect(sm.cssVar).toContain('--sb-space-sm');
+  expect(sm.displayValue).toBe('0.5rem');
+});
+
+it('applies the path filter', () => {
+  const spaceOnly = deriveDimensionRows(resolved, project, { ...opts, filter: 'space.*' });
+  expect(spaceOnly.map((r) => r.path)).toEqual(['space.sm', 'space.lg']);
+  const colorOnly = deriveDimensionRows(resolved, project, { ...opts, filter: 'color.*' });
+  expect(colorOnly).toEqual([]);
+});
+
+it('sorts by value using the given rootFontSizePx to convert rem to px', () => {
+  // At a 16px root, 0.5rem = 8px, under space.lg's 32px.
+  const at16 = deriveDimensionRows(resolved, project, { ...opts, rootFontSizePx: 16 });
+  expect(at16.map((r) => r.path)).toEqual(['space.sm', 'space.lg']);
+
+  // At a 96px root, 0.5rem = 48px, over space.lg's 32px — order flips.
+  const at96 = deriveDimensionRows(resolved, project, { ...opts, rootFontSizePx: 96 });
+  expect(at96.map((r) => r.path)).toEqual(['space.lg', 'space.sm']);
+});

--- a/packages/blocks/test/derive-font-family-rows.test.ts
+++ b/packages/blocks/test/derive-font-family-rows.test.ts
@@ -1,0 +1,48 @@
+import { expect, it } from 'vitest';
+import { deriveFontFamilyRows } from '#/FontFamilyPreview.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one string-form family, one array-form
+// stack, one non-fontFamily token that must be filtered out.
+const resolved = {
+  'font.family.body': { $type: 'fontFamily', $value: 'Inter' },
+  'font.family.mono': { $type: 'fontFamily', $value: ['Fira Code', 'monospace'] },
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+
+const project = {
+  listing: { 'font.family.body': { names: { css: '--sb-font-family-body' } } },
+  cssVarPrefix: 'sb',
+} as unknown as Pick<ProjectData, 'listing' | 'cssVarPrefix'>;
+
+const opts = { sortBy: 'path', sortDir: 'asc' } as const;
+
+it('produces one row per fontFamily token, excluding other types', () => {
+  const rows = deriveFontFamilyRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['font.family.body', 'font.family.mono']);
+});
+
+it('derives the css var from the listing and the stack string from the value', () => {
+  const rows = deriveFontFamilyRows(resolved, project, opts);
+  const body = rows.find((r) => r.path === 'font.family.body')!;
+  expect(body.cssVar).toBe('var(--sb-font-family-body)');
+  expect(body.stack).toBe('Inter');
+  const mono = rows.find((r) => r.path === 'font.family.mono')!;
+  expect(mono.stack).toBe('Fira Code, monospace');
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const rows = deriveFontFamilyRows(resolved, project, opts);
+  const mono = rows.find((r) => r.path === 'font.family.mono')!;
+  expect(mono.cssVar).toBe('var(--sb-font-family-mono)');
+});
+
+it('applies the path filter', () => {
+  const rows = deriveFontFamilyRows(resolved, project, { ...opts, filter: '**.mono' });
+  expect(rows.map((r) => r.path)).toEqual(['font.family.mono']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveFontFamilyRows(resolved, project, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['font.family.mono', 'font.family.body']);
+});

--- a/packages/blocks/test/derive-font-weight-rows.test.ts
+++ b/packages/blocks/test/derive-font-weight-rows.test.ts
@@ -1,0 +1,55 @@
+import { expect, it } from 'vitest';
+import { deriveFontWeightRows } from '#/FontWeightScale.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one numeric weight, one string weight,
+// one non-fontWeight token that must be filtered out.
+const resolved = {
+  'font.weight.regular': { $type: 'fontWeight', $value: 400 },
+  'font.weight.bold': { $type: 'fontWeight', $value: '700' },
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+
+const project = {
+  listing: { 'font.weight.regular': { names: { css: '--sb-font-weight-regular' } } },
+  cssVarPrefix: 'sb',
+} as unknown as Pick<ProjectData, 'listing' | 'cssVarPrefix'>;
+
+const opts = { sortBy: 'value', sortDir: 'asc' } as const;
+
+it('produces one row per fontWeight token, excluding other types', () => {
+  const rows = deriveFontWeightRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['font.weight.regular', 'font.weight.bold']);
+});
+
+it('derives the css var from the listing and the numeric weight from the value', () => {
+  const rows = deriveFontWeightRows(resolved, project, opts);
+  const regular = rows.find((r) => r.path === 'font.weight.regular')!;
+  expect(regular.cssVar).toBe('var(--sb-font-weight-regular)');
+  expect(regular.display).toBe('400');
+  expect(regular.weight).toBe(400);
+  const bold = rows.find((r) => r.path === 'font.weight.bold')!;
+  expect(bold.display).toBe('700');
+  expect(bold.weight).toBe(700);
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const rows = deriveFontWeightRows(resolved, project, opts);
+  const bold = rows.find((r) => r.path === 'font.weight.bold')!;
+  expect(bold.cssVar).toBe('var(--sb-font-weight-bold)');
+});
+
+it('applies the path filter', () => {
+  const rows = deriveFontWeightRows(resolved, project, { ...opts, filter: '**.bold' });
+  expect(rows.map((r) => r.path)).toEqual(['font.weight.bold']);
+});
+
+it('sorts ascending by numeric weight by default', () => {
+  const rows = deriveFontWeightRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['font.weight.regular', 'font.weight.bold']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveFontWeightRows(resolved, project, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['font.weight.bold', 'font.weight.regular']);
+});

--- a/packages/blocks/test/derive-gradient-rows.test.ts
+++ b/packages/blocks/test/derive-gradient-rows.test.ts
@@ -1,0 +1,76 @@
+import { expect, it } from 'vitest';
+import { deriveGradientRows } from '#/GradientPalette.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: two gradient tokens across two branches,
+// one non-gradient token that must be filtered out.
+const resolved = {
+  'gradient.brand': {
+    $type: 'gradient',
+    $value: [
+      { color: { colorSpace: 'srgb', components: [0, 0.4, 1] }, position: 0 },
+      { color: { colorSpace: 'srgb', components: [1, 1, 1] }, position: 1 },
+    ],
+  },
+  'gradient.accent': {
+    $type: 'gradient',
+    $value: [
+      { color: { colorSpace: 'srgb', components: [0, 0, 0] }, position: 0 },
+      { color: { colorSpace: 'display-p3', components: [1, 0, 0] }, position: 1 },
+    ],
+  },
+  'color.brand.bg': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+
+const listing = {
+  'gradient.brand': { names: { css: '--sb-gradient-brand' } },
+} as unknown as ProjectData['listing'];
+
+const cssVarPrefix = 'sb';
+
+const opts = { sortBy: 'path', sortDir: 'asc', colorFormat: 'hex' } as const;
+
+it('filters to gradient tokens, excluding other types', () => {
+  const rows = deriveGradientRows(resolved, listing, cssVarPrefix, opts);
+  expect(rows.map((r) => r.path)).toEqual(['gradient.accent', 'gradient.brand']);
+});
+
+it('derives the css var from the listing', () => {
+  const rows = deriveGradientRows(resolved, listing, cssVarPrefix, opts);
+  const brand = rows.find((r) => r.path === 'gradient.brand');
+  expect(brand?.cssVar).toBe('var(--sb-gradient-brand)');
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const rows = deriveGradientRows(resolved, listing, cssVarPrefix, opts);
+  const accent = rows.find((r) => r.path === 'gradient.accent');
+  expect(accent?.cssVar).toBe('var(--sb-gradient-accent)');
+});
+
+it('formats each stop for the given colorFormat and derives its position percent', () => {
+  const rows = deriveGradientRows(resolved, listing, cssVarPrefix, opts);
+  const brand = rows.find((r) => r.path === 'gradient.brand');
+  expect(brand?.stops.map((s) => s.value)).toEqual(['#0066ff', '#ffffff']);
+  expect(brand?.stops.map((s) => s.positionPercent)).toEqual(['0', '100']);
+});
+
+it('renders each stop in its own color space rather than flattening to sRGB', () => {
+  const rows = deriveGradientRows(resolved, listing, cssVarPrefix, opts);
+  const accent = rows.find((r) => r.path === 'gradient.accent');
+  const p3Stop = accent?.stops[1];
+  expect(p3Stop?.cssColor).toContain('display-p3');
+  expect(p3Stop?.cssColor).not.toMatch(/%/);
+});
+
+it('applies the path filter', () => {
+  const rows = deriveGradientRows(resolved, listing, cssVarPrefix, {
+    ...opts,
+    filter: 'gradient.brand',
+  });
+  expect(rows.map((r) => r.path)).toEqual(['gradient.brand']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveGradientRows(resolved, listing, cssVarPrefix, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['gradient.brand', 'gradient.accent']);
+});

--- a/packages/blocks/test/derive-motion-rows.test.ts
+++ b/packages/blocks/test/derive-motion-rows.test.ts
@@ -1,0 +1,38 @@
+import { expect, it } from 'vitest';
+import { deriveMotionRows } from '#/MotionPreview.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: a transition, a duration, a cubicBezier,
+// and a non-motion token that must be filtered out by default.
+const resolved = {
+  'transition.fade': {
+    $type: 'transition',
+    $value: { duration: { value: 200, unit: 'ms' }, timingFunction: [0.2, 0, 0, 1] },
+  },
+  'duration.short': { $type: 'duration', $value: { value: 100, unit: 'ms' } },
+  'easing.standard': { $type: 'cubicBezier', $value: [0.2, 0, 0, 1] },
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+const project = { listing: {}, cssVarPrefix: 'sb' };
+
+it('includes only motion tokens by default, with a resolved css var and spec', () => {
+  const rows = deriveMotionRows(resolved, project, {});
+  expect(rows.map((r) => r.path)).toEqual(['easing.standard', 'duration.short', 'transition.fade']);
+  const fade = rows.find((r) => r.path === 'transition.fade')!;
+  expect(fade.cssVar).toContain('--sb-transition-fade');
+  expect(fade.durationMs).toBe(200);
+  expect(fade.easing).toBe('cubic-bezier(0.200, 0.000, 0.000, 1.000)');
+  expect(fade.kind).toBe('transition');
+});
+
+it('applies the path filter', () => {
+  const transitionOnly = deriveMotionRows(resolved, project, { filter: 'transition.*' });
+  expect(transitionOnly.map((r) => r.path)).toEqual(['transition.fade']);
+  const colorOnly = deriveMotionRows(resolved, project, { filter: 'color.*' });
+  expect(colorOnly).toEqual([]);
+});
+
+it('sorts by kind first, then path', () => {
+  const rows = deriveMotionRows(resolved, project, {});
+  expect(rows.map((r) => r.kind)).toEqual(['cubicBezier', 'duration', 'transition']);
+});

--- a/packages/blocks/test/derive-motion-sample.test.ts
+++ b/packages/blocks/test/derive-motion-sample.test.ts
@@ -1,0 +1,32 @@
+import { expect, it } from 'vitest';
+import { deriveMotionSample } from '#/motion-preview/MotionSample.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one transition token, 200ms with a
+// cubic-bezier timing function.
+const resolved = {
+  'transition.fade': {
+    $type: 'transition',
+    $value: {
+      duration: { value: 200, unit: 'ms' },
+      timingFunction: [0.2, 0, 0, 1],
+    },
+  },
+} as unknown as ProjectData['resolved'];
+
+function makeProject(): Pick<ProjectData, 'resolved'> {
+  return { resolved };
+}
+
+it('resolves the duration/easing spec from a transition token', () => {
+  const data = deriveMotionSample('transition.fade', makeProject());
+  expect(data.spec).toEqual({
+    durationMs: 200,
+    easing: 'cubic-bezier(0.200, 0.000, 0.000, 1.000)',
+  });
+});
+
+it('returns a null spec for a path with no resolved token', () => {
+  const data = deriveMotionSample('transition.missing', makeProject());
+  expect(data.spec).toBeNull();
+});

--- a/packages/blocks/test/derive-opacity-rows.test.ts
+++ b/packages/blocks/test/derive-opacity-rows.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from 'vitest';
+import { deriveOpacityRows } from '#/OpacityScale.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: two in-range opacity tokens, one
+// number token outside [0, 1] (must be filtered out by range), one
+// non-number token (must be filtered out by type).
+const resolved = {
+  'number.opacity.subtle': { $type: 'number', $value: 0.2 },
+  'number.opacity.strong': { $type: 'number', $value: 0.8 },
+  'number.z-index.modal': { $type: 'number', $value: 10 },
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+
+const project = {
+  listing: { 'number.opacity.subtle': { names: { css: '--sb-number-opacity-subtle' } } },
+  cssVarPrefix: 'sb',
+} as unknown as Pick<ProjectData, 'listing' | 'cssVarPrefix'>;
+
+const opts = { type: 'number', sortBy: 'value', sortDir: 'asc' } as const;
+
+it('produces one row per in-range number token, excluding other types and out-of-range values', () => {
+  const rows = deriveOpacityRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['number.opacity.subtle', 'number.opacity.strong']);
+});
+
+it('derives the css var from the listing and the numeric opacity from the value', () => {
+  const rows = deriveOpacityRows(resolved, project, opts);
+  const subtle = rows.find((r) => r.path === 'number.opacity.subtle')!;
+  expect(subtle.cssVar).toBe('var(--sb-number-opacity-subtle)');
+  expect(subtle.opacity).toBe(0.2);
+  expect(subtle.displayValue).toBe('0.2');
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const rows = deriveOpacityRows(resolved, project, opts);
+  const strong = rows.find((r) => r.path === 'number.opacity.strong')!;
+  expect(strong.cssVar).toBe('var(--sb-number-opacity-strong)');
+});
+
+it('applies the path filter', () => {
+  const rows = deriveOpacityRows(resolved, project, { ...opts, filter: '**.strong' });
+  expect(rows.map((r) => r.path)).toEqual(['number.opacity.strong']);
+});
+
+it('sorts ascending by numeric opacity by default', () => {
+  const rows = deriveOpacityRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['number.opacity.subtle', 'number.opacity.strong']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveOpacityRows(resolved, project, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['number.opacity.strong', 'number.opacity.subtle']);
+});
+
+it('honors an explicit type filter of opacity', () => {
+  const opacityResolved = {
+    'opacity.subtle': { $type: 'opacity', $value: 0.5 },
+    'number.opacity.strong': { $type: 'number', $value: 0.8 },
+  } as unknown as ProjectData['resolved'];
+  const rows = deriveOpacityRows(opacityResolved, project, { ...opts, type: 'opacity' });
+  expect(rows.map((r) => r.path)).toEqual(['opacity.subtle']);
+});

--- a/packages/blocks/test/derive-shadow-rows.test.ts
+++ b/packages/blocks/test/derive-shadow-rows.test.ts
@@ -1,0 +1,93 @@
+import { expect, it } from 'vitest';
+import { deriveShadowRows } from '#/ShadowPreview.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one single-layer shadow, one layered
+// (array) shadow with an inset second layer, and one non-shadow token that
+// must be filtered out.
+const resolved = {
+  'shadow.default': {
+    $type: 'shadow',
+    $value: {
+      offsetX: { value: 0, unit: 'px' },
+      offsetY: { value: 2, unit: 'px' },
+      blur: { value: 4, unit: 'px' },
+      spread: { value: 0, unit: 'px' },
+      color: { colorSpace: 'srgb', components: [0, 0, 0] },
+    },
+  },
+  'shadow.layered': {
+    $type: 'shadow',
+    $value: [
+      {
+        offsetX: { value: 0, unit: 'px' },
+        offsetY: { value: 1, unit: 'px' },
+        blur: { value: 2, unit: 'px' },
+        spread: { value: 0, unit: 'px' },
+        color: { colorSpace: 'srgb', components: [0, 0, 0] },
+      },
+      {
+        offsetX: { value: 0, unit: 'px' },
+        offsetY: { value: 4, unit: 'px' },
+        blur: { value: 8, unit: 'px' },
+        spread: { value: 0, unit: 'px' },
+        color: { colorSpace: 'srgb', components: [0, 0.4, 1] },
+        inset: true,
+      },
+    ],
+  },
+  'color.brand.bg': { $type: 'color', $value: { colorSpace: 'srgb', components: [1, 1, 1] } },
+} as unknown as ProjectData['resolved'];
+
+const listing = {
+  'shadow.default': { names: { css: '--sb-shadow-default' } },
+} as unknown as ProjectData['listing'];
+
+const cssVarPrefix = 'sb';
+const project = { listing, cssVarPrefix };
+
+const opts = { sortBy: 'path', sortDir: 'asc', colorFormat: 'hex' } as const;
+
+it('filters to shadow tokens only, sorted by path', () => {
+  const rows = deriveShadowRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['shadow.default', 'shadow.layered']);
+});
+
+it('derives the css var from the listing when present', () => {
+  const rows = deriveShadowRows(resolved, project, opts);
+  const row = rows.find((r) => r.path === 'shadow.default');
+  expect(row?.cssVar).toBe('var(--sb-shadow-default)');
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const rows = deriveShadowRows(resolved, project, opts);
+  const row = rows.find((r) => r.path === 'shadow.layered');
+  expect(row?.cssVar).toBe('var(--sb-shadow-layered)');
+});
+
+it('formats a single-layer shadow value and color per the given colorFormat', () => {
+  const rows = deriveShadowRows(resolved, project, opts);
+  const row = rows.find((r) => r.path === 'shadow.default');
+  expect(row?.layers).toEqual([
+    { offset: '0px 2px', blur: '4px', spread: '0px', color: '#000000', inset: undefined },
+  ]);
+});
+
+it('formats every layer of a multi-layer shadow, carrying inset only where set', () => {
+  const rows = deriveShadowRows(resolved, project, opts);
+  const row = rows.find((r) => r.path === 'shadow.layered');
+  expect(row?.layers).toEqual([
+    { offset: '0px 1px', blur: '2px', spread: '0px', color: '#000000', inset: undefined },
+    { offset: '0px 4px', blur: '8px', spread: '0px', color: '#0066ff', inset: 'true' },
+  ]);
+});
+
+it('applies the path filter', () => {
+  const rows = deriveShadowRows(resolved, project, { ...opts, filter: 'shadow.layered' });
+  expect(rows.map((r) => r.path)).toEqual(['shadow.layered']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveShadowRows(resolved, project, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['shadow.layered', 'shadow.default']);
+});

--- a/packages/blocks/test/derive-shadow-sample.test.ts
+++ b/packages/blocks/test/derive-shadow-sample.test.ts
@@ -1,0 +1,22 @@
+import { expect, it } from 'vitest';
+import { deriveShadowSample } from '#/shadow-preview/ShadowSample.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+function makeProject(
+  listing: Pick<ProjectData, 'listing'>['listing'] = {},
+): Pick<ProjectData, 'listing' | 'cssVarPrefix'> {
+  return { listing, cssVarPrefix: 'sb' };
+}
+
+it('resolves the css var from the listing when present', () => {
+  const project = makeProject({
+    'shadow.default': { names: { css: '--tz-shadow-default' } },
+  } as unknown as ProjectData['listing']);
+  const sample = deriveShadowSample('shadow.default', project);
+  expect(sample.cssVar).toBe('var(--tz-shadow-default)');
+});
+
+it('falls back to the prefix-derived css var when the listing has no entry', () => {
+  const sample = deriveShadowSample('shadow.default', makeProject());
+  expect(sample.cssVar).toContain('--sb-shadow-default');
+});

--- a/packages/blocks/test/derive-stroke-style-rows.test.ts
+++ b/packages/blocks/test/derive-stroke-style-rows.test.ts
@@ -1,0 +1,72 @@
+import { expect, it } from 'vitest';
+import { deriveStrokeStyleRows } from '#/StrokeStylePreview.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one string strokeStyle, one object-form
+// (dashed) strokeStyle, one non-strokeStyle token that must be filtered out.
+const resolved = {
+  'stroke.style.solid': { $type: 'strokeStyle', $value: 'solid' },
+  'stroke.style.dashed': {
+    $type: 'strokeStyle',
+    $value: {
+      dashArray: [
+        { value: 4, unit: 'px' },
+        { value: 2, unit: 'px' },
+      ],
+      lineCap: 'round',
+    },
+  },
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+
+const project = {
+  listing: { 'stroke.style.solid': { names: { css: '--sb-stroke-style-solid' } } },
+  cssVarPrefix: 'sb',
+} as unknown as Pick<ProjectData, 'listing' | 'cssVarPrefix'>;
+
+const opts = { sortBy: 'path', sortDir: 'asc' } as const;
+
+it('produces one row per strokeStyle token, excluding other types', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['stroke.style.dashed', 'stroke.style.solid']);
+});
+
+it('derives the css var from the listing and the display value from the formatter', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, opts);
+  const solid = rows.find((r) => r.path === 'stroke.style.solid')!;
+  expect(solid.cssVar).toBe('var(--sb-stroke-style-solid)');
+  expect(solid.displayValue).toBe('solid');
+});
+
+it('falls back to a prefix-derived css var when the listing has no entry', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, opts);
+  const dashed = rows.find((r) => r.path === 'stroke.style.dashed')!;
+  expect(dashed.cssVar).toBe('var(--sb-stroke-style-dashed)');
+});
+
+it('extracts a border-style keyword for string-form values', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, opts);
+  const solid = rows.find((r) => r.path === 'stroke.style.solid')!;
+  expect(solid.cssStyle).toBe('solid');
+});
+
+it('has no css-style keyword for object-form (dashed) values', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, opts);
+  const dashed = rows.find((r) => r.path === 'stroke.style.dashed')!;
+  expect(dashed.cssStyle).toBeNull();
+});
+
+it('applies the path filter', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, { ...opts, filter: '**.solid' });
+  expect(rows.map((r) => r.path)).toEqual(['stroke.style.solid']);
+});
+
+it('sorts lexicographically by path by default', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, opts);
+  expect(rows.map((r) => r.path)).toEqual(['stroke.style.dashed', 'stroke.style.solid']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveStrokeStyleRows(resolved, project, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['stroke.style.solid', 'stroke.style.dashed']);
+});

--- a/packages/blocks/test/derive-token-detail.test.ts
+++ b/packages/blocks/test/derive-token-detail.test.ts
@@ -1,0 +1,64 @@
+import { expect, it } from 'vitest';
+import { deriveTokenDetail } from '#/TokenDetail.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+import type { DetailToken } from '#/token-detail/internal.ts';
+
+const colorToken: DetailToken = {
+  $type: 'color',
+  $value: { colorSpace: 'srgb', components: [0, 0.4, 1] },
+};
+
+const deprecatedDimension: DetailToken = {
+  $type: 'dimension',
+  $value: { value: 16, unit: 'px' },
+  $deprecated: 'use space.4',
+};
+
+it('prefers the listing preview value for hex format', () => {
+  const listing = {
+    'color.brand': { previewValue: '#0066ff' },
+  } as unknown as ProjectData['listing'];
+  const derived = deriveTokenDetail('color.brand', colorToken, listing, 'hex');
+  expect(derived.value).toBe('#0066ff');
+  expect(derived.isColor).toBe(true);
+  expect(derived.outOfGamut).toBe(false);
+});
+
+it('falls back to formatColor when the listing lacks the path', () => {
+  const listing = {} as ProjectData['listing'];
+  const derived = deriveTokenDetail('color.brand', colorToken, listing, 'hex');
+  expect(derived.value).toBe('#0066ff');
+});
+
+it('falls back to formatColor for a non-hex format even when the listing has a preview', () => {
+  // formatTokenValue only trusts the listing preview for hex — plugin-css's
+  // previewValue has no other-format equivalent, so oklch/rgb/hsl must
+  // recompute from the raw $value via colorjs.io.
+  const listing = {
+    'color.brand': { previewValue: '#0066ff' },
+  } as unknown as ProjectData['listing'];
+  const derived = deriveTokenDetail('color.brand', colorToken, listing, 'oklch');
+  expect(derived.value).not.toBe('#0066ff');
+  expect(derived.value.startsWith('oklch(')).toBe(true);
+});
+
+it('flags a deprecated token with its message', () => {
+  const listing = {} as ProjectData['listing'];
+  const derived = deriveTokenDetail('space.md', deprecatedDimension, listing, 'hex');
+  expect(derived.isColor).toBe(false);
+  expect(derived.isDeprecated).toBe(true);
+  expect(derived.deprecationMessage).toBe('use space.4');
+  expect(derived.value).toBe('16px');
+});
+
+it('returns empty defaults when the token is missing', () => {
+  const listing = {} as ProjectData['listing'];
+  const derived = deriveTokenDetail('color.missing', undefined, listing, 'hex');
+  expect(derived).toEqual({
+    value: '',
+    outOfGamut: false,
+    isColor: false,
+    isDeprecated: false,
+    deprecationMessage: undefined,
+  });
+});

--- a/packages/blocks/test/derive-typography-rows.test.ts
+++ b/packages/blocks/test/derive-typography-rows.test.ts
@@ -1,0 +1,47 @@
+import { expect, it } from 'vitest';
+import { deriveTypographyRows } from '#/TypographyScale.tsx';
+import type { ProjectData } from '#/internal/use-project.ts';
+
+// Minimal hand-built resolved map: one full typography spec, one
+// non-typography token that must be filtered out.
+const resolved = {
+  'typography.heading': {
+    $type: 'typography',
+    $value: {
+      fontFamily: 'Inter',
+      fontSize: { value: 24, unit: 'px' },
+      fontWeight: 700,
+      lineHeight: 1.2,
+    },
+  },
+  'typography.body': {
+    $type: 'typography',
+    $value: { fontFamily: 'Inter', fontSize: { value: 16, unit: 'px' } },
+  },
+  'color.brand': { $type: 'color', $value: { colorSpace: 'srgb', components: [0, 0.4, 1] } },
+} as unknown as ProjectData['resolved'];
+const opts = { sortBy: 'path', sortDir: 'asc' } as const;
+
+it('produces one row per typography token, excluding other types', () => {
+  const rows = deriveTypographyRows(resolved, opts);
+  expect(rows.map((r) => r.path)).toEqual(['typography.body', 'typography.heading']);
+});
+
+it('derives the sample style and specs summary from the composite value', () => {
+  const rows = deriveTypographyRows(resolved, opts);
+  const heading = rows.find((r) => r.path === 'typography.heading')!;
+  expect(heading.sampleStyle.fontFamily).toBe('Inter');
+  expect(heading.sampleStyle.fontSize).toBe('24px');
+  expect(heading.sampleStyle.fontWeight).toBe('700');
+  expect(heading.specs).toBe('24px · w700 · lh 1.2');
+});
+
+it('applies the path filter', () => {
+  const rows = deriveTypographyRows(resolved, { ...opts, filter: '*.heading' });
+  expect(rows.map((r) => r.path)).toEqual(['typography.heading']);
+});
+
+it('applies sortDir desc', () => {
+  const rows = deriveTypographyRows(resolved, { ...opts, sortDir: 'desc' });
+  expect(rows.map((r) => r.path)).toEqual(['typography.heading', 'typography.body']);
+});

--- a/packages/blocks/test/dimension-bar-view.browser.test.tsx
+++ b/packages/blocks/test/dimension-bar-view.browser.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { DimensionBarView } from '#/dimension-scale/DimensionBar.tsx';
+import type { DimensionBarViewProps } from '#/dimension-scale/DimensionBar.tsx';
+
+// The View renders from plain props — no provider, no store.
+function setup(extra: Partial<DimensionBarViewProps> = {}) {
+  return render(
+    <DimensionBarView
+      cssVar="var(--sb-space-lg)"
+      capped={false}
+      cappedValue="var(--sb-space-lg)"
+      visual="length"
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a length bar sized to the (possibly capped) value', () => {
+  const { container } = setup();
+  const bar = container.querySelector<HTMLElement>('.sb-dimension-bar__bar');
+  expect(bar?.style.width).toBe('var(--sb-space-lg)');
+});
+
+it('renders a radius sample using the css var as border-radius', () => {
+  const { container } = setup({ visual: 'radius' });
+  const sample = container.querySelector<HTMLElement>('.sb-dimension-bar__radius-sample');
+  expect(sample?.style.borderRadius).toBe('var(--sb-space-lg)');
+});
+
+it('renders a size sample sized to width and height', () => {
+  const { container } = setup({ visual: 'size' });
+  const sample = container.querySelector<HTMLElement>('.sb-dimension-bar__size-sample');
+  expect(sample?.style.width).toBe('var(--sb-space-lg)');
+  expect(sample?.style.height).toBe('var(--sb-space-lg)');
+});
+
+it('shows the cap marker with a title when capped', () => {
+  const { container } = setup({ capped: true, cappedValue: '480px' });
+  const wrap = container.querySelector('.sb-dimension-bar--capped');
+  expect(wrap?.getAttribute('title')).toContain('capped at 480px');
+  expect(container.querySelector('.sb-dimension-bar__cap')).not.toBeNull();
+  const bar = wrap?.querySelector<HTMLElement>('div');
+  expect(bar?.style.width).toBe('480px');
+});
+
+it('renders no cap marker when under the cap', () => {
+  const { container } = setup();
+  expect(container.querySelector('.sb-dimension-bar--capped')).toBeNull();
+  expect(container.querySelector('.sb-dimension-bar__cap')).toBeNull();
+});

--- a/packages/blocks/test/dimension-scale-view.browser.test.tsx
+++ b/packages/blocks/test/dimension-scale-view.browser.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { DimensionScaleView } from '#/DimensionScale.tsx';
+import type { DimensionRow, DimensionScaleViewProps } from '#/DimensionScale.tsx';
+
+function rows(): DimensionRow[] {
+  return [
+    { path: 'space.sm', cssVar: 'var(--sb-space-sm)', displayValue: '0.5rem' },
+    { path: 'space.lg', cssVar: 'var(--sb-space-lg)', displayValue: '32px' },
+  ];
+}
+
+// The View renders from plain props — no provider, no store. DimensionBar
+// (rendered per-row) is a connected child that reads the project itself; it
+// falls back to an empty snapshot with no provider mounted, which is fine
+// here since only the View's own output is under test.
+function setup(extra: Partial<DimensionScaleViewProps> = {}) {
+  return render(
+    <DimensionScaleView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      visual="length"
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a row per dimension token with its css var and display value', () => {
+  setup();
+  screen.getByText('space.sm');
+  screen.getByText('0.5rem');
+  screen.getByText('space.lg');
+  screen.getByText('32px');
+  screen.getByText('var(--sb-space-sm)');
+  screen.getByText('var(--sb-space-lg)');
+});
+
+it('shows a default caption naming the count and active theme', () => {
+  setup();
+  screen.getByText('2 dimensions · Light');
+});
+
+it('honors a caption override', () => {
+  setup({ caption: 'Custom caption' });
+  screen.getByText('Custom caption');
+});
+
+it('mentions the filter in the default caption when set', () => {
+  setup({ filter: 'space.*' });
+  screen.getByText('2 dimensions matching `space.*` · Light');
+});
+
+it('renders the empty state when there are no rows', () => {
+  setup({ rows: [] });
+  screen.getByText('No dimension tokens match this filter.');
+});

--- a/packages/blocks/test/font-family-preview-view.browser.test.tsx
+++ b/packages/blocks/test/font-family-preview-view.browser.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { FontFamilyPreviewView } from '#/FontFamilyPreview.tsx';
+import type { FontFamilyRow } from '#/FontFamilyPreview.tsx';
+
+function rows(): FontFamilyRow[] {
+  return [
+    {
+      path: 'font.family.body',
+      cssVar: 'var(--sb-font-family-body)',
+      stack: 'Inter, sans-serif',
+    },
+  ];
+}
+
+// The View renders from plain props — no SwatchbookProvider, no store.
+it('renders a row per token with its path, stack, and css var', () => {
+  render(
+    <FontFamilyPreviewView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      sample="Hello"
+    />,
+  );
+  screen.getByText('font.family.body');
+  screen.getByText('Inter, sans-serif');
+  screen.getByText('Hello');
+  screen.getByText('var(--sb-font-family-body)');
+});
+
+it('honors the caption override', () => {
+  render(
+    <FontFamilyPreviewView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sample="Hello"
+      caption="Font stacks"
+    />,
+  );
+  screen.getByText('Font stacks');
+});
+
+it('renders the empty state when there are no rows', () => {
+  render(
+    <FontFamilyPreviewView
+      rows={[]}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sample="Hello"
+    />,
+  );
+  screen.getByText('No fontFamily tokens match this filter.');
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/blocks/test/font-weight-scale-view.browser.test.tsx
+++ b/packages/blocks/test/font-weight-scale-view.browser.test.tsx
@@ -1,0 +1,63 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { FontWeightScaleView } from '#/FontWeightScale.tsx';
+import type { FontWeightRow } from '#/FontWeightScale.tsx';
+
+function rows(): FontWeightRow[] {
+  return [
+    {
+      path: 'font.weight.regular',
+      cssVar: 'var(--sb-font-weight-regular)',
+      display: '400',
+      weight: 400,
+    },
+  ];
+}
+
+// The View renders from plain props — no SwatchbookProvider, no store.
+it('renders a row per token with its path, weight, and css var', () => {
+  render(
+    <FontWeightScaleView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      sample="Aa"
+    />,
+  );
+  screen.getByText('font.weight.regular');
+  screen.getByText('400');
+  screen.getByText('Aa');
+  screen.getByText('var(--sb-font-weight-regular)');
+});
+
+it('honors the caption override', () => {
+  render(
+    <FontWeightScaleView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sample="Aa"
+      caption="Font weights"
+    />,
+  );
+  screen.getByText('Font weights');
+});
+
+it('renders the empty state when there are no rows', () => {
+  render(
+    <FontWeightScaleView
+      rows={[]}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sample="Aa"
+    />,
+  );
+  screen.getByText('No fontWeight tokens match this filter.');
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/blocks/test/gradient-palette-view.browser.test.tsx
+++ b/packages/blocks/test/gradient-palette-view.browser.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { GradientPaletteView } from '#/GradientPalette.tsx';
+import type { GradientPaletteViewProps, GradientRow } from '#/GradientPalette.tsx';
+
+function rows(): GradientRow[] {
+  return [
+    {
+      path: 'gradient.brand',
+      cssVar: 'var(--sb-gradient-brand)',
+      stops: [
+        {
+          key: 'gradient.brand|0|rgb(0% 40% 100%)',
+          cssColor: 'rgb(0% 40% 100%)',
+          value: '#0066ff',
+          positionPercent: '0',
+        },
+        {
+          key: 'gradient.brand|1|rgb(100% 100% 100%)',
+          cssColor: 'rgb(100% 100% 100%)',
+          value: '#ffffff',
+          positionPercent: '100',
+        },
+      ],
+    },
+  ];
+}
+
+// The View renders + rows from plain props — no provider, no store.
+function setup(extra: Partial<GradientPaletteViewProps> = {}) {
+  return render(
+    <GradientPaletteView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a row per gradient token with its path, css var, and stops', () => {
+  setup();
+  screen.getByText('gradient.brand');
+  screen.getByText('var(--sb-gradient-brand)');
+  screen.getByText('#0066ff');
+  screen.getByText('#ffffff');
+});
+
+it('shows a derived caption with the total count and active theme', () => {
+  setup();
+  screen.getByText('1 gradient · Light');
+});
+
+it('renders an explicit caption override', () => {
+  setup({ caption: 'Brand gradients' });
+  screen.getByText('Brand gradients');
+});
+
+it('shows the empty state when there are no rows', () => {
+  setup({ rows: [] });
+  screen.getByText('No gradient tokens match this filter.');
+  expect(screen.queryByText('gradient.brand')).toBeNull();
+});

--- a/packages/blocks/test/motion-preview-view.browser.test.tsx
+++ b/packages/blocks/test/motion-preview-view.browser.test.tsx
@@ -1,0 +1,88 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { userEvent } from '@vitest/browser/context';
+import { MotionPreviewView } from '#/MotionPreview.tsx';
+import type { MotionPreviewViewProps, MotionRow } from '#/MotionPreview.tsx';
+
+function rows(): MotionRow[] {
+  return [
+    {
+      path: 'transition.fade',
+      cssVar: 'var(--sb-transition-fade)',
+      durationMs: 200,
+      easing: 'cubic-bezier(0.2, 0, 0, 1)',
+      kind: 'transition',
+    },
+    {
+      path: 'duration.short',
+      cssVar: 'var(--sb-duration-short)',
+      durationMs: 100,
+      easing: 'cubic-bezier(0.2, 0, 0, 1)',
+      kind: 'duration',
+    },
+  ];
+}
+
+// The View renders from plain props — no provider, no store. MotionSample
+// (rendered per-row) is a connected child that reads the project itself; it
+// falls back to an empty snapshot with no provider mounted, which is fine
+// here since only the View's own output (rows, caption, speed control) is
+// under test.
+function setup(extra: Partial<MotionPreviewViewProps> = {}) {
+  return render(
+    <MotionPreviewView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a row per motion token with its path, spec, and css var', () => {
+  setup();
+  screen.getByText('transition.fade');
+  screen.getByText('transition · 200ms · cubic-bezier(0.2, 0, 0, 1)');
+  screen.getByText('duration.short');
+  screen.getByText('duration · 100ms');
+  screen.getByText('var(--sb-transition-fade)');
+  screen.getByText('var(--sb-duration-short)');
+});
+
+it('shows a default caption naming the count and active theme', () => {
+  setup();
+  screen.getByText('2 motion tokens · Light');
+});
+
+it('honors a caption override', () => {
+  setup({ caption: 'Custom caption' });
+  screen.getByText('Custom caption');
+});
+
+it('mentions the filter in the default caption when set', () => {
+  setup({ filter: 'transition.*' });
+  screen.getByText('2 motion tokens matching `transition.*` · Light');
+});
+
+it('renders the empty state when there are no rows', () => {
+  setup({ rows: [] });
+  screen.getByText('No motion tokens match this filter.');
+});
+
+it('toggles the active speed button when clicked — local UI state lives in the View', async () => {
+  setup();
+  const oneX = screen.getByRole('button', { name: '1×' });
+  const twoX = screen.getByRole('button', { name: '2×' });
+  expect(oneX.className).toContain('sb-motion-preview__speed-btn--active');
+  expect(twoX.className).not.toContain('sb-motion-preview__speed-btn--active');
+
+  await userEvent.click(twoX);
+
+  expect(twoX.className).toContain('sb-motion-preview__speed-btn--active');
+  expect(oneX.className).not.toContain('sb-motion-preview__speed-btn--active');
+});

--- a/packages/blocks/test/motion-sample-view.browser.test.tsx
+++ b/packages/blocks/test/motion-sample-view.browser.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { MotionSampleView } from '#/motion-preview/MotionSample.tsx';
+import type { MotionSampleViewProps } from '#/motion-preview/MotionSample.tsx';
+
+// The View renders from plain props — no provider, no store.
+function setup(extra: Partial<MotionSampleViewProps> = {}) {
+  return render(
+    <MotionSampleView
+      spec={{ durationMs: 200, easing: 'cubic-bezier(0.2, 0, 0, 1)' }}
+      speed={1}
+      runKey={0}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders the animated track/ball when a spec is resolved', () => {
+  const { container } = setup();
+  expect(container.querySelector('.sb-motion-sample__track')).not.toBeNull();
+  expect(container.querySelector('.sb-motion-sample__ball')).not.toBeNull();
+});
+
+it('falls back to default duration/easing when spec is null', () => {
+  const { container } = setup({ spec: null });
+  const ball = container.querySelector<HTMLElement>('.sb-motion-sample__ball');
+  expect(ball).not.toBeNull();
+});

--- a/packages/blocks/test/opacity-scale-view.browser.test.tsx
+++ b/packages/blocks/test/opacity-scale-view.browser.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { OpacityScaleView } from '#/OpacityScale.tsx';
+import type { OpacityRow } from '#/OpacityScale.tsx';
+
+function rows(): OpacityRow[] {
+  return [
+    {
+      path: 'number.opacity.subtle',
+      cssVar: 'var(--sb-number-opacity-subtle)',
+      opacity: 0.2,
+      displayValue: '0.2',
+    },
+  ];
+}
+
+// The View renders from plain props — no SwatchbookProvider, no store.
+it('renders a card per token with its path, value, and css var', () => {
+  render(
+    <OpacityScaleView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      sampleColorVar="var(--sb-color-accent-bg)"
+    />,
+  );
+  screen.getByText('number.opacity.subtle');
+  screen.getByText('0.2');
+  screen.getByText('var(--sb-number-opacity-subtle)');
+});
+
+it('honors the caption override', () => {
+  render(
+    <OpacityScaleView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sampleColorVar="var(--sb-color-accent-bg)"
+      caption="Opacity scale"
+    />,
+  );
+  screen.getByText('Opacity scale');
+});
+
+it('renders the empty state when there are no rows', () => {
+  render(
+    <OpacityScaleView
+      rows={[]}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sampleColorVar="var(--sb-color-accent-bg)"
+    />,
+  );
+  screen.getByText('No opacity tokens match this filter.');
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/blocks/test/shadow-preview-view.browser.test.tsx
+++ b/packages/blocks/test/shadow-preview-view.browser.test.tsx
@@ -1,0 +1,86 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { ShadowPreviewView } from '#/ShadowPreview.tsx';
+import type { ShadowPreviewViewProps, ShadowRow } from '#/ShadowPreview.tsx';
+
+function rows(): ShadowRow[] {
+  return [
+    {
+      path: 'shadow.default',
+      cssVar: 'var(--sb-shadow-default)',
+      layers: [{ offset: '0px 2px', blur: '4px', spread: '0px', color: '#000000' }],
+    },
+    {
+      path: 'shadow.layered',
+      cssVar: 'var(--sb-shadow-layered)',
+      layers: [
+        { offset: '0px 1px', blur: '2px', spread: '0px', color: '#000000' },
+        { offset: '0px 4px', blur: '8px', spread: '0px', color: '#0066ff', inset: 'true' },
+      ],
+    },
+  ];
+}
+
+// The View renders from plain props — no provider, no store. ShadowSample
+// (rendered per-row) is a connected child that reads the project itself; it
+// falls back to an empty snapshot with no provider mounted, which is fine
+// here since only the View's own output is under test.
+function setup(extra: Partial<ShadowPreviewViewProps> = {}) {
+  return render(
+    <ShadowPreviewView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a row per shadow token with its css var and flat breakdown for a single layer', () => {
+  setup();
+  const row = screen.getByText('shadow.default').closest('.sb-shadow-preview__row') as HTMLElement;
+  const scoped = within(row);
+  scoped.getByText('var(--sb-shadow-default)');
+  scoped.getByText('0px 2px');
+  scoped.getByText('4px');
+  scoped.getByText('0px');
+  scoped.getByText('#000000');
+});
+
+it('renders a numbered layer breakdown for a multi-layer shadow, including inset', () => {
+  setup();
+  const row = screen.getByText('shadow.layered').closest('.sb-shadow-preview__row') as HTMLElement;
+  const scoped = within(row);
+  scoped.getByText('var(--sb-shadow-layered)');
+  scoped.getByText((_, node) => node?.textContent === 'layer 1 of 2');
+  scoped.getByText((_, node) => node?.textContent === 'layer 2 of 2');
+  scoped.getByText('0px 1px');
+  scoped.getByText('0px 4px');
+  scoped.getByText('#0066ff');
+  scoped.getByText('true');
+});
+
+it('shows a default caption naming the count and active theme', () => {
+  setup();
+  screen.getByText('2 shadows · Light');
+});
+
+it('honors a caption override', () => {
+  setup({ caption: 'Custom caption' });
+  screen.getByText('Custom caption');
+});
+
+it('mentions the filter in the default caption when set', () => {
+  setup({ filter: 'shadow.*' });
+  screen.getByText('2 shadows matching `shadow.*` · Light');
+});
+
+it('renders the empty state when there are no rows', () => {
+  setup({ rows: [] });
+  screen.getByText('No shadow tokens match this filter.');
+});

--- a/packages/blocks/test/shadow-sample-view.browser.test.tsx
+++ b/packages/blocks/test/shadow-sample-view.browser.test.tsx
@@ -1,0 +1,24 @@
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { ShadowSampleView } from '#/shadow-preview/ShadowSample.tsx';
+
+// The View renders from plain props — no provider, no store.
+function setup(cssVar = 'var(--sb-shadow-default)') {
+  return render(<ShadowSampleView cssVar={cssVar} />);
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders a sample with the css var applied as the box-shadow', () => {
+  const { container } = setup();
+  const sample = container.querySelector<HTMLElement>('.sb-shadow-sample');
+  expect(sample?.style.boxShadow).toBe('var(--sb-shadow-default)');
+});
+
+it('is decorative', () => {
+  const { container } = setup();
+  const sample = container.querySelector<HTMLElement>('.sb-shadow-sample');
+  expect(sample?.getAttribute('aria-hidden')).toBe('true');
+});

--- a/packages/blocks/test/stroke-style-preview-view.browser.test.tsx
+++ b/packages/blocks/test/stroke-style-preview-view.browser.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { StrokeStylePreviewView } from '#/StrokeStylePreview.tsx';
+import type { StrokeStyleRow } from '#/StrokeStylePreview.tsx';
+
+function rows(): StrokeStyleRow[] {
+  return [
+    {
+      path: 'stroke.style.solid',
+      cssVar: 'var(--sb-stroke-style-solid)',
+      displayValue: 'solid',
+      cssStyle: 'solid',
+    },
+  ];
+}
+
+// The View renders from plain props — no SwatchbookProvider, no store.
+it('renders a row per token with its path, value, and css var', () => {
+  render(
+    <StrokeStylePreviewView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+    />,
+  );
+  screen.getByText('stroke.style.solid');
+  screen.getByText('solid');
+  screen.getByText('var(--sb-stroke-style-solid)');
+});
+
+it('falls back to the object-form message when the row has no css style keyword', () => {
+  const dashedRows: StrokeStyleRow[] = [
+    {
+      path: 'stroke.style.dashed',
+      cssVar: 'var(--sb-stroke-style-dashed)',
+      displayValue: 'dashed 4px 2px · round',
+      cssStyle: null,
+    },
+  ];
+  render(
+    <StrokeStylePreviewView
+      rows={dashedRows}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+    />,
+  );
+  screen.getByText('Object-form (dashArray + lineCap) — no pure CSS `border-style` equivalent.');
+});
+
+it('honors the caption override', () => {
+  render(
+    <StrokeStylePreviewView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      caption="Stroke styles"
+    />,
+  );
+  screen.getByText('Stroke styles');
+});
+
+it('renders the empty state when there are no rows', () => {
+  render(
+    <StrokeStylePreviewView rows={[]} activeTheme="Light" cssVarPrefix="sb" activeAxes={{}} />,
+  );
+  screen.getByText('No strokeStyle tokens match this filter.');
+});
+
+afterEach(() => {
+  cleanup();
+});

--- a/packages/blocks/test/token-detail-view.browser.test.tsx
+++ b/packages/blocks/test/token-detail-view.browser.test.tsx
@@ -1,0 +1,69 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it, expect } from 'vitest';
+import { TokenDetailView } from '#/TokenDetail.tsx';
+import type { TokenDetailViewProps } from '#/TokenDetail.tsx';
+import type { DetailToken } from '#/token-detail/internal.ts';
+
+const colorToken: DetailToken = {
+  $type: 'color',
+  $value: { colorSpace: 'srgb', components: [0, 0.4, 1] },
+};
+
+// The View renders from plain props — no provider, no store. TokenHeader /
+// CompositePreview / CompositeBreakdown / AliasChain / AliasedBy /
+// TokenUsageSnippet / ConsumerOutput / AxisVariance are connected children
+// that read the project themselves; with no provider mounted they fall back
+// to their own empty states, which is fine here since only the View's own
+// output — the resolved-value section header and the copy button — is
+// under test.
+function setup(extra: Partial<TokenDetailViewProps> = {}) {
+  return render(
+    <TokenDetailView
+      path="color.brand"
+      token={colorToken}
+      cssVar="var(--sb-color-brand)"
+      activeTheme="Light"
+      activeAxes={{ theme: 'Light' }}
+      cssVarPrefix="sb"
+      value="#0066ff"
+      outOfGamut={false}
+      isColor
+      isDeprecated={false}
+      deprecationMessage={undefined}
+      {...extra}
+    />,
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+it('renders the resolved-value section header naming the active theme', () => {
+  setup();
+  screen.getByText('Resolved value · Light');
+});
+
+it('renders the value and a copy button for it', () => {
+  setup();
+  screen.getByText('#0066ff');
+  const button = screen.getByRole('button', { name: 'Copy value #0066ff' });
+  expect(button).toBeDefined();
+});
+
+it('shows the out-of-gamut warning icon when flagged', () => {
+  setup({ outOfGamut: true });
+  screen.getByLabelText('out of gamut');
+});
+
+it('shows the deprecation notice with its message', () => {
+  setup({ isDeprecated: true, deprecationMessage: 'use color.new instead' });
+  expect(screen.getByTestId('token-detail-deprecated').textContent).toContain(
+    'use color.new instead',
+  );
+});
+
+it('renders the missing message instead when there is no token', () => {
+  setup({ token: undefined });
+  screen.getByText(/not found in theme/);
+});

--- a/packages/blocks/test/typography-scale-view.browser.test.tsx
+++ b/packages/blocks/test/typography-scale-view.browser.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, it } from 'vitest';
+import { TypographyScaleView } from '#/TypographyScale.tsx';
+import type { TypographyRow } from '#/TypographyScale.tsx';
+
+function rows(): TypographyRow[] {
+  return [
+    {
+      path: 'typography.heading',
+      sampleStyle: { fontFamily: 'Inter', fontSize: '24px' },
+      specs: '24px · w700',
+    },
+  ];
+}
+
+// The View renders from plain props — no SwatchbookProvider, no store.
+it('renders a row per token with its path, specs, and sample', () => {
+  render(
+    <TypographyScaleView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{ theme: 'Light' }}
+      sample="Hello"
+    />,
+  );
+  screen.getByText('typography.heading');
+  screen.getByText('24px · w700');
+  screen.getByText('Hello');
+});
+
+it('honors the caption override', () => {
+  render(
+    <TypographyScaleView
+      rows={rows()}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sample="Hello"
+      caption="Type scale"
+    />,
+  );
+  screen.getByText('Type scale');
+});
+
+it('renders the empty state when there are no rows', () => {
+  render(
+    <TypographyScaleView
+      rows={[]}
+      activeTheme="Light"
+      cssVarPrefix="sb"
+      activeAxes={{}}
+      sample="Hello"
+    />,
+  );
+  screen.getByText('No typography tokens match this filter.');
+});
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
Phase 2 of the blocks view/container split — fans the pattern proven in Phase 1 (#1316, merged: Diagnostics + TokenTable) out to every remaining ambient-reading block. 19 components, one commit each.

Each block now has three co-located, internal exports: a pure `deriveX`/builder function, a pure `*View` that renders from plain props, and a thin connector that reads ambient state (`useProject` / `useColorFormat` / `useRootFontSize`), derives, and renders the View. Views and derive functions stay internal — `index.ts` is untouched across all 19 commits, so the public connector API is byte-identical.

## What's here

- **Tier 1 (simple):** TypographyScale, FontFamilyPreview, FontWeightScale, OpacityScale, StrokeStylePreview, ColorPalette, GradientPalette, DimensionScale (+ DimensionBar), BorderPreview (+ BorderSample), ShadowPreview (+ ShadowSample)
- **Tier 2 (medium):** ColorTable, TokenDetail (+ ConsumerOutput), MotionPreview (+ MotionSample)
- **Tier 3 (complex):** TokenNavigator — pure tree builders (`buildTree`/`flattenVisible`) extracted and unit-tested; the entire interactive apparatus (focus-repair effect, keyboard nav, expand/selection state) moved into the View verbatim with unchanged dependency arrays.

## Conventions upheld

- **Views take only what their render uses.** Local UI state (search, selection, focus, animation) stays in the View; connected children (`RowIndicators`, `DetailOverlay`, `*Sample`) are rendered by Views as-is.
- Each block adds a node derive test (pure function, no React) and, where useful, a provider-free View test.
- Existing browser test suites are preserved unchanged and now serve as connector-level integration coverage.

## Verification

- Every block was gated (index-unchanged, View-hookless, tsc + its own tests green) as it landed. ColorTable and TokenNavigator additionally got dedicated reviews; the whole branch got a final cross-cutting review.
- Two dead-field defects were caught and fixed during review (an unused `validPaths` prop on ColorTableView; a computed-but-unused `cssVar` on MotionSampleData) — no dead props remain.
- Full gauntlet green, including after merging current `main` (so this sits cleanly on top of the Storybook-decouple work).

Internal-only refactor; semantic equivalence (not byte-for-byte markup) is the regression gate.

Milestone: Maintenance

Closes #1319

Plan impact: none
