### PR TITLE
chore: release blocks Storybook decouple as a minor bump

### DIFF
--- a/.changeset/decouple-blocks-storybook.md
+++ b/.changeset/decouple-blocks-storybook.md
@@ -1,6 +1,6 @@
 ---
-"@unpunnyfuns/swatchbook-blocks": patch
-"@unpunnyfuns/swatchbook-addon": patch
+"@unpunnyfuns/swatchbook-blocks": minor
+"@unpunnyfuns/swatchbook-addon": minor
 ---
 
 blocks no longer depend on Storybook; the addon injects the preview channel


### PR DESCRIPTION
Elevates the Storybook-decouple changeset from `patch` to `minor`.

The decouple (#1314) removed the `storybook` peer dependency from `@unpunnyfuns/swatchbook-blocks` — a change to the published package's dependency contract, which the pre-1.0 policy bumps `minor` for. The two blocks view/container split changesets are internal-only (public API byte-identical) and stay `patch`; Changesets takes the max level, so this makes the next release **v0.69.0** instead of v0.68.1.

The auto-generated Version Packages PR (#1318) will regenerate once this lands.

Milestone: Maintenance

Closes #1321

Plan impact: none
