### PR TITLE
refactor(storybook): add #storybook import alias and adopt it across stories

### DIFF
--- a/.changeset/storybook-import-alias-doc.md
+++ b/.changeset/storybook-import-alias-doc.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+docs: note the #storybook subpath-import option in the stories guide

--- a/apps/docs/docs/guides/displaying-tokens-as-stories.mdx
+++ b/apps/docs/docs/guides/displaying-tokens-as-stories.mdx
@@ -22,6 +22,8 @@ export default meta;
 export const Palette = meta.story({ args: { filter: 'color.**' } });
 ```
 
+> The `../../../.storybook/` climb shortens to `#storybook/preview` if you add `"#storybook/*": "./.storybook/*"` to your `package.json` `imports` — `#storybook` then denotes your `.storybook/` folder, the same subpath scheme as `#/*` → `./src/*`.
+
 The sidebar tree comes from the `title`. Each export is a real story: controllable, testable, snapshot-able.
 
 ## What becomes a control, and what does not

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,8 +1,3 @@
-// Aliasing scheme: the story files import this module via a deep relative
-// path (`../../.storybook/preview.tsx`). A `#storybook/*` subpath import —
-// `"#storybook/*": "./.storybook/*"` in package.json#imports, parallel to the
-// existing `"#/*": "./src/*"` — would let them write `#storybook/preview.tsx`
-// instead, dropping the `../../` climb. Not wired yet; see issue #1284.
 import addonA11y from '@storybook/addon-a11y';
 import addonDocs from '@storybook/addon-docs';
 import { definePreview } from '@storybook/react-vite';

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -1,3 +1,8 @@
+// Aliasing scheme: the story files import this module via a deep relative
+// path (`../../.storybook/preview.tsx`). A `#storybook/*` subpath import —
+// `"#storybook/*": "./.storybook/*"` in package.json#imports, parallel to the
+// existing `"#/*": "./src/*"` — would let them write `#storybook/preview.tsx`
+// instead, dropping the `../../` climb. Not wired yet; see issue #1284.
 import addonA11y from '@storybook/addon-a11y';
 import addonDocs from '@storybook/addon-docs';
 import { definePreview } from '@storybook/react-vite';

--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -8,7 +8,8 @@
     "node": ">=24.14.0"
   },
   "imports": {
-    "#/*": "./src/*"
+    "#/*": "./src/*",
+    "#storybook/*": "./.storybook/*"
   },
   "scripts": {
     "storybook": "storybook dev -p 6006 --no-open",

--- a/apps/storybook/src/stories/BlockAssertions.stories.tsx
+++ b/apps/storybook/src/stories/BlockAssertions.stories.tsx
@@ -14,7 +14,7 @@ import {
 } from '@unpunnyfuns/swatchbook-blocks';
 import { diagnostics } from 'virtual:swatchbook/tokens';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 function DiagnosticsProbe() {
   const errors = diagnostics.filter((d) => d.severity === 'error').length;

--- a/apps/storybook/src/stories/BorderPreview.stories.tsx
+++ b/apps/storybook/src/stories/BorderPreview.stories.tsx
@@ -1,6 +1,6 @@
 import { BorderPreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/BorderPreview',

--- a/apps/storybook/src/stories/BorderSample.stories.tsx
+++ b/apps/storybook/src/stories/BorderSample.stories.tsx
@@ -1,5 +1,5 @@
 import { BorderSample } from '@unpunnyfuns/swatchbook-blocks';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/Samples/BorderSample',

--- a/apps/storybook/src/stories/Button.stories.tsx
+++ b/apps/storybook/src/stories/Button.stories.tsx
@@ -1,4 +1,4 @@
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 import { Button } from '../components/Button.tsx';
 
 const meta = preview.meta({

--- a/apps/storybook/src/stories/Card.stories.tsx
+++ b/apps/storybook/src/stories/Card.stories.tsx
@@ -1,4 +1,4 @@
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 import { Card } from '../components/Card.tsx';
 
 const meta = preview.meta({

--- a/apps/storybook/src/stories/ColorFormat.stories.tsx
+++ b/apps/storybook/src/stories/ColorFormat.stories.tsx
@@ -1,6 +1,6 @@
 import { TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Tests/ColorFormat',

--- a/apps/storybook/src/stories/ColorPalette.stories.tsx
+++ b/apps/storybook/src/stories/ColorPalette.stories.tsx
@@ -1,6 +1,6 @@
 import { ColorPalette } from '@unpunnyfuns/swatchbook-blocks';
 import { waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/ColorPalette',

--- a/apps/storybook/src/stories/ColorTable.stories.tsx
+++ b/apps/storybook/src/stories/ColorTable.stories.tsx
@@ -1,6 +1,6 @@
 import { ColorTable } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, userEvent, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/ColorTable',

--- a/apps/storybook/src/stories/CssInJsCard.stories.tsx
+++ b/apps/storybook/src/stories/CssInJsCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 import { CssInJsCard } from '../components/CssInJsCard.tsx';
 
 const meta = preview.meta({

--- a/apps/storybook/src/stories/DimensionBar.stories.tsx
+++ b/apps/storybook/src/stories/DimensionBar.stories.tsx
@@ -1,5 +1,5 @@
 import { DimensionBar } from '@unpunnyfuns/swatchbook-blocks';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/Samples/DimensionBar',

--- a/apps/storybook/src/stories/DimensionScale.stories.tsx
+++ b/apps/storybook/src/stories/DimensionScale.stories.tsx
@@ -1,6 +1,6 @@
 import { DimensionScale } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/DimensionScale',

--- a/apps/storybook/src/stories/GradientPalette.stories.tsx
+++ b/apps/storybook/src/stories/GradientPalette.stories.tsx
@@ -1,6 +1,6 @@
 import { GradientPalette } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/GradientPalette',

--- a/apps/storybook/src/stories/Input.stories.tsx
+++ b/apps/storybook/src/stories/Input.stories.tsx
@@ -1,4 +1,4 @@
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 import { Input } from '../components/Input.tsx';
 
 const meta = preview.meta({

--- a/apps/storybook/src/stories/MotionPreview.stories.tsx
+++ b/apps/storybook/src/stories/MotionPreview.stories.tsx
@@ -1,6 +1,6 @@
 import { MotionPreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/MotionPreview',

--- a/apps/storybook/src/stories/MotionSample.stories.tsx
+++ b/apps/storybook/src/stories/MotionSample.stories.tsx
@@ -1,5 +1,5 @@
 import { MotionSample } from '@unpunnyfuns/swatchbook-blocks';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/Samples/MotionSample',

--- a/apps/storybook/src/stories/OpacityScale.stories.tsx
+++ b/apps/storybook/src/stories/OpacityScale.stories.tsx
@@ -1,6 +1,6 @@
 import { OpacityScale } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/OpacityScale',

--- a/apps/storybook/src/stories/Presets.stories.tsx
+++ b/apps/storybook/src/stories/Presets.stories.tsx
@@ -1,5 +1,5 @@
 import { waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 import { Button } from '../components/Button.tsx';
 import { Card } from '../components/Card.tsx';
 

--- a/apps/storybook/src/stories/ShadowPreview.stories.tsx
+++ b/apps/storybook/src/stories/ShadowPreview.stories.tsx
@@ -1,6 +1,6 @@
 import { ShadowPreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/ShadowPreview',

--- a/apps/storybook/src/stories/ShadowSample.stories.tsx
+++ b/apps/storybook/src/stories/ShadowSample.stories.tsx
@@ -1,5 +1,5 @@
 import { ShadowSample } from '@unpunnyfuns/swatchbook-blocks';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/Samples/ShadowSample',

--- a/apps/storybook/src/stories/TailwindCard.stories.tsx
+++ b/apps/storybook/src/stories/TailwindCard.stories.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 import { TailwindCard } from '../components/TailwindCard.tsx';
 
 const meta = preview.meta({

--- a/apps/storybook/src/stories/ThemeSwitch.stories.tsx
+++ b/apps/storybook/src/stories/ThemeSwitch.stories.tsx
@@ -1,5 +1,5 @@
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 import { Button } from '../components/Button.tsx';
 import { Card } from '../components/Card.tsx';
 

--- a/apps/storybook/src/stories/TokenDetail.stories.tsx
+++ b/apps/storybook/src/stories/TokenDetail.stories.tsx
@@ -1,6 +1,6 @@
 import { TokenDetail } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/TokenDetail',

--- a/apps/storybook/src/stories/TokenNavigator.stories.tsx
+++ b/apps/storybook/src/stories/TokenNavigator.stories.tsx
@@ -2,7 +2,7 @@ import { SwatchbookProvider, TokenNavigator } from '@unpunnyfuns/swatchbook-bloc
 import type { ProjectSnapshot, VirtualTokenShape } from '@unpunnyfuns/swatchbook-blocks';
 import { useState } from 'react';
 import { expect, userEvent, waitFor, within } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/TokenNavigator',

--- a/apps/storybook/src/stories/TokenTable.stories.tsx
+++ b/apps/storybook/src/stories/TokenTable.stories.tsx
@@ -1,6 +1,6 @@
 import { TokenTable } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, userEvent, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/TokenTable',

--- a/apps/storybook/src/stories/Toolbar.stories.tsx
+++ b/apps/storybook/src/stories/Toolbar.stories.tsx
@@ -23,7 +23,7 @@ import type { SwitcherAxis, SwitcherPreset } from '@unpunnyfuns/swatchbook-addon
 import { useState } from 'react';
 import type { ReactElement } from 'react';
 import { expect, userEvent, within } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const FIXTURE_AXES: SwitcherAxis[] = [
   {

--- a/apps/storybook/src/stories/TypographyScale.stories.tsx
+++ b/apps/storybook/src/stories/TypographyScale.stories.tsx
@@ -1,6 +1,6 @@
 import { TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Blocks/TypographyScale',

--- a/apps/storybook/src/stories/UseToken.stories.tsx
+++ b/apps/storybook/src/stories/UseToken.stories.tsx
@@ -1,6 +1,6 @@
 import { useToken } from '@unpunnyfuns/swatchbook-addon/hooks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 function TokenProbe({ path }: { path: string }) {
   const info = useToken(path);

--- a/apps/storybook/src/stories/UseTokenUpdates.stories.tsx
+++ b/apps/storybook/src/stories/UseTokenUpdates.stories.tsx
@@ -1,6 +1,6 @@
 import { useToken } from '@unpunnyfuns/swatchbook-addon/hooks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 function Probe() {
   const surface = useToken('color.surface.default');

--- a/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasChain.stories.tsx
@@ -1,6 +1,6 @@
 import { AliasChain } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/AliasChain',

--- a/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AliasedBy.stories.tsx
@@ -1,6 +1,6 @@
 import { AliasedBy } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/AliasedBy',

--- a/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/AxisVariance.stories.tsx
@@ -1,6 +1,6 @@
 import { AxisVariance } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/AxisVariance',

--- a/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositeBreakdown.stories.tsx
@@ -1,6 +1,6 @@
 import { CompositeBreakdown } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/CompositeBreakdown',

--- a/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/CompositePreview.stories.tsx
@@ -1,6 +1,6 @@
 import { CompositePreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/CompositePreview',

--- a/apps/storybook/src/stories/token-detail/ConsumerOutput.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/ConsumerOutput.stories.tsx
@@ -1,6 +1,6 @@
 import { ConsumerOutput } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, userEvent, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/ConsumerOutput',

--- a/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenHeader.stories.tsx
@@ -1,6 +1,6 @@
 import { TokenHeader } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/TokenHeader',

--- a/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
@@ -1,6 +1,6 @@
 import { TokenUsageSnippet } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, userEvent, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
   title: 'Internals/TokenDetail/TokenUsageSnippet',

--- a/apps/storybook/src/stories/tokens/Borders.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Borders.stories.tsx
@@ -1,6 +1,6 @@
 import { BorderPreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Composite layer ($type: border).
 const meta = preview.meta({

--- a/apps/storybook/src/stories/tokens/Colors.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Colors.stories.tsx
@@ -1,6 +1,6 @@
 import { ColorPalette, ColorTable } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Catalog stories for $type: color. The swatch-grid views use <ColorPalette>
 // (Palette = the primitive ramps, Semantic = the role tier), mirroring the

--- a/apps/storybook/src/stories/tokens/Dimensions.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Dimensions.stories.tsx
@@ -1,6 +1,6 @@
 import { DimensionScale } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Primitive layer ($type: dimension). `visual` chooses length | radius | size.
 const meta = preview.meta({

--- a/apps/storybook/src/stories/tokens/FontFamily.stories.tsx
+++ b/apps/storybook/src/stories/tokens/FontFamily.stories.tsx
@@ -1,6 +1,6 @@
 import { FontFamilyPreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Primitive layer ($type: fontFamily).
 const meta = preview.meta({

--- a/apps/storybook/src/stories/tokens/FontWeight.stories.tsx
+++ b/apps/storybook/src/stories/tokens/FontWeight.stories.tsx
@@ -1,6 +1,6 @@
 import { FontWeightScale } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Primitive layer ($type: fontWeight).
 const meta = preview.meta({

--- a/apps/storybook/src/stories/tokens/Gradients.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Gradients.stories.tsx
@@ -1,6 +1,6 @@
 import { GradientPalette } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Composite layer ($type: gradient).
 const meta = preview.meta({

--- a/apps/storybook/src/stories/tokens/Motion.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Motion.stories.tsx
@@ -1,6 +1,6 @@
 import { MotionPreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Composite ($type: transition) + primitives ($type: duration, cubicBezier).
 // Respects prefers-reduced-motion. disableSnapshot avoids animated-frame churn

--- a/apps/storybook/src/stories/tokens/Overview.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Overview.stories.tsx
@@ -1,6 +1,6 @@
 import { TokenNavigator } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Cross-type catalog: the whole token graph as a searchable tree. Heavy DOM,
 // so chromatic.delay lets it settle before capture; a11y off here, scoped onto

--- a/apps/storybook/src/stories/tokens/Shadows.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Shadows.stories.tsx
@@ -1,6 +1,6 @@
 import { ShadowPreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Composite layer ($type: shadow).
 const meta = preview.meta({

--- a/apps/storybook/src/stories/tokens/StrokeStyles.stories.tsx
+++ b/apps/storybook/src/stories/tokens/StrokeStyles.stories.tsx
@@ -1,6 +1,6 @@
 import { StrokeStylePreview } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Primitive layer ($type: strokeStyle).
 const meta = preview.meta({

--- a/apps/storybook/src/stories/tokens/Typography.stories.tsx
+++ b/apps/storybook/src/stories/tokens/Typography.stories.tsx
@@ -1,6 +1,6 @@
 import { TypographyScale } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, waitFor } from 'storybook/test';
-import preview from '../../../.storybook/preview.tsx';
+import preview from '#storybook/preview.tsx';
 
 // Composite layer ($type: typography). Each token renders as a sample line
 // using all its composed sub-values (fontFamily/fontSize/fontWeight/


### PR DESCRIPTION
Implements the `#storybook` import alias for the reference Storybook and adopts it everywhere.

Every story file imported the preview via a deep relative path — `../../.storybook/preview.tsx` (top-level stories) or `../../../.storybook/preview.tsx` (nested `token-detail/`, `tokens/`). Adding `"#storybook/*": "./.storybook/*"` to `apps/storybook/package.json#imports` (parallel to the existing `"#/*": "./src/*"`) collapses both to a depth-independent `#storybook/preview.tsx`.

## Changes
- `apps/storybook/package.json` — new `#storybook/*` subpath import entry.
- 47 story files migrated to `import preview from '#storybook/preview.tsx'` (no more `../../` / `../../../` climbing; depth-independent).
- Docs: a one-line aside in the "Displaying tokens as stories" guide points consumers at the same option (with a `patch` changeset so it reaches the stable docs snapshot).

Verified across all three resolution surfaces: `tsc` typecheck, oxlint, and the apps/storybook story tests (Vite/Vitest runtime) — full gauntlet green (37/37).

Milestone: Maintenance

Closes #1284

Plan impact: none
