### PR TITLE
docs: trim the #storybook alias aside to a single line

### DIFF
--- a/.changeset/simplify-storybook-alias-aside.md
+++ b/.changeset/simplify-storybook-alias-aside.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": patch
+---
+
+docs: trim the #storybook alias aside in the stories guide to a single line

--- a/apps/docs/docs/guides/displaying-tokens-as-stories.mdx
+++ b/apps/docs/docs/guides/displaying-tokens-as-stories.mdx
@@ -22,7 +22,7 @@ export default meta;
 export const Palette = meta.story({ args: { filter: 'color.**' } });
 ```
 
-> The `../../../.storybook/` climb shortens to `#storybook/preview` if you add `"#storybook/*": "./.storybook/*"` to your `package.json` `imports` — `#storybook` then denotes your `.storybook/` folder, the same subpath scheme as `#/*` → `./src/*`.
+> `#storybook` points to the `.storybook/` folder.
 
 The sidebar tree comes from the `title`. Each export is a real story: controllable, testable, snapshot-able.
 


### PR DESCRIPTION
The `#storybook` aside added in #1324 over-explained (the package.json setup, the parallel to `#/*`, etc.). Reduces it to one line:

> `#storybook` points to the `.storybook/` folder.

Docs-only; `patch` changeset so it reaches the stable snapshot.

Milestone: Maintenance

Closes #1325

Plan impact: none
