### PR TITLE
docs: add conceptual ordering diagrams to the concepts pages

### DIFF
--- a/.changeset/concept-diagrams.md
+++ b/.changeset/concept-diagrams.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-core": patch
+---
+
+docs: add theme-reactive concept diagrams for ingestion order, graph queries, axis flips, and snapshot consumers

--- a/apps/docs/docs/concepts/axes.mdx
+++ b/apps/docs/docs/concepts/axes.mdx
@@ -4,6 +4,8 @@ title: Axes
 sidebar_position: 5
 ---
 
+import AxisFlipDiagram from '@site/src/components/diagrams/AxisFlipDiagram';
+
 # Axes
 
 An **axis** is one independent dimension of your theming model: `mode`, `brand`, `density`, `contrast`, whatever fits your system. Each axis has a set of named **contexts** (one of which is the default), and at any moment exactly one context is selected per axis.
@@ -19,6 +21,10 @@ The canonical representation of "what theme is active" is a **tuple**: one conte
 ```
 
 Every resolved token, every CSS selector, every panel readout keys on this tuple. The composed string (`"Dark · Brand A"`) exists for display.
+
+A flip is a selection, not a rebuild: every value it applies was computed when the project loaded.
+
+<AxisFlipDiagram />
 
 ## Data attributes
 

--- a/apps/docs/docs/concepts/token-pipeline.mdx
+++ b/apps/docs/docs/concepts/token-pipeline.mdx
@@ -4,6 +4,7 @@ title: The token pipeline
 sidebar_position: 6
 ---
 
+import BuildQueryDiagram from '@site/src/components/diagrams/BuildQueryDiagram';
 import IngestionDiagram from '@site/src/components/diagrams/IngestionDiagram';
 
 # The token pipeline
@@ -23,6 +24,14 @@ import { tokenGraph, defaultTuple, axes, diagnostics, css } from 'virtual:swatch
 "Virtual" means there's no file on disk. Vite asks the plugin to materialize the module on each preview build, and the plugin does this by calling `loadProject(config, cwd)` from `@unpunnyfuns/swatchbook-core` and serializing the result into ESM exports.
 
 Nothing written to disk. Edit your config or a token file, Vite notices, the plugin re-runs `loadProject`, preview sees fresh values over HMR.
+
+## Build once, query fast
+
+Parsing DTCG sources, resolving alias chains, and working out which axes affect which token is the expensive part. All of it happens once, at load, and the results are folded into a walkable token graph inside the snapshot.
+
+<BuildQueryDiagram />
+
+Everything interactive reads from that graph: token tables, alias inspectors, the switcher's repaints. Those queries are lookups, not resolution, so they stay fast regardless of how many axes or aliases a system declares. The display side never reaches back into parsing.
 
 ## HMR
 

--- a/apps/docs/docs/concepts/token-pipeline.mdx
+++ b/apps/docs/docs/concepts/token-pipeline.mdx
@@ -6,6 +6,7 @@ sidebar_position: 6
 
 import BuildQueryDiagram from '@site/src/components/diagrams/BuildQueryDiagram';
 import IngestionDiagram from '@site/src/components/diagrams/IngestionDiagram';
+import SnapshotConsumersDiagram from '@site/src/components/diagrams/SnapshotConsumersDiagram';
 
 # The token pipeline
 
@@ -46,6 +47,8 @@ See [consuming the active theme](../guides/consuming-the-active-theme.mdx) for h
 The virtual module lives inside Vite's module graph: the Storybook preview resolves it, consumer apps (Next.js, a Vite SPA, Remix) don't. For production, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources; its plugin ecosystem (`plugin-css`, `plugin-js`, `plugin-tailwind`, `plugin-swift`, `plugin-sass`, …) covers downstream platforms. When both pipelines run, [align their options](../guides/sharing-terrazzo-options.mdx) so what swatchbook shows matches what your apps ship.
 
 ## Where the same property holds
+
+<SnapshotConsumersDiagram />
 
 - **Storybook preview**: the primary case.
 - **Docs site blocks outside Storybook**: the blocks package works outside Storybook given a `ProjectSnapshot` through `SwatchbookProvider`. This docs site does that: a small build step computes the snapshot JSON once and ships it as a regular import.

--- a/apps/docs/docs/concepts/token-pipeline.mdx
+++ b/apps/docs/docs/concepts/token-pipeline.mdx
@@ -4,9 +4,13 @@ title: The token pipeline
 sidebar_position: 6
 ---
 
+import IngestionDiagram from '@site/src/components/diagrams/IngestionDiagram';
+
 # The token pipeline
 
 Swatchbook doesn't require a separate token build step. Tokens flow into the preview through a Vite virtual module the addon publishes at dev-server start, updated via HMR on every source file change. No generated CSS in your repo, no `predev` script, no config to keep in sync.
+
+<IngestionDiagram />
 
 ## A virtual module, not a build artifact
 
@@ -16,24 +20,7 @@ The addon's Vite plugin publishes a virtual ESM module named `virtual:swatchbook
 import { tokenGraph, defaultTuple, axes, diagnostics, css } from 'virtual:swatchbook/tokens';
 ```
 
-"Virtual" means there's no file on disk. Vite asks the plugin to materialize the module on each preview build, and the plugin does this by calling `loadProject(config, cwd)` from `@unpunnyfuns/swatchbook-core` and serializing the result into ESM exports:
-
-```
-swatchbook.config.ts               ← your config
-       ↓
- Vite plugin buildStart
-       ↓
- loadProject(config, cwd)          ← parses DTCG, builds token graph, emits CSS
-       ↓
- Project snapshot
-       ↓
- Vite plugin load('virtual:swatchbook/tokens')
-       ↓
- export const tokenGraph = { … }
- export const defaultTuple = { … }
- export const axes = [ … ]
- export const css = '…'            ← preview decorator injects as <style>
-```
+"Virtual" means there's no file on disk. Vite asks the plugin to materialize the module on each preview build, and the plugin does this by calling `loadProject(config, cwd)` from `@unpunnyfuns/swatchbook-core` and serializing the result into ESM exports.
 
 Nothing written to disk. Edit your config or a token file, Vite notices, the plugin re-runs `loadProject`, preview sees fresh values over HMR.
 

--- a/apps/docs/src/components/diagrams/AxisFlipDiagram.tsx
+++ b/apps/docs/src/components/diagrams/AxisFlipDiagram.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react';
+import styles from './diagrams.module.css';
+
+const STEPS: ReadonlyArray<{ x: number; label: string; sub: string }> = [
+  { x: 8, label: 'Pick a context', sub: 'mode: Dark' },
+  { x: 200, label: 'Tuple updates', sub: 'one context per axis' },
+  { x: 392, label: 'Values apply', sub: 'precomputed at load' },
+  { x: 584, label: 'Preview repaints', sub: 'nothing is rebuilt' },
+];
+
+/** What flipping an axis actually does: selection among precomputed values, not a rebuild. */
+export default function AxisFlipDiagram(): ReactNode {
+  return (
+    <div className={styles.scroller}>
+      <svg
+        className={styles.diagram}
+        viewBox="0 0 760 164"
+        role="img"
+        aria-labelledby="axis-flip-diagram-title"
+      >
+        <title id="axis-flip-diagram-title">
+          Flipping an axis picks a context, updates the active tuple, applies values that were
+          precomputed at load, and repaints the preview. Nothing is rebuilt.
+        </title>
+        <defs>
+          <marker
+            id="axis-flip-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" className={styles.arrowhead} />
+          </marker>
+        </defs>
+        {STEPS.map((step) => (
+          <g key={step.label}>
+            <rect className={styles.node} x={step.x} y="56" width="164" height="56" rx="6" />
+            <text className={styles.label} x={step.x + 82} y="80">
+              {step.label}
+            </text>
+            <text className={styles.labelSmall} x={step.x + 82} y="98">
+              {step.sub}
+            </text>
+          </g>
+        ))}
+        {[172, 364, 556].map((x) => (
+          <line
+            key={x}
+            className={styles.edge}
+            x1={x}
+            y1="84"
+            x2={x + 25}
+            y2="84"
+            markerEnd="url(#axis-flip-arrow)"
+          />
+        ))}
+        <text className={styles.labelSmall} x="380" y="148">
+          a flip selects among values that already exist
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/apps/docs/src/components/diagrams/BuildQueryDiagram.tsx
+++ b/apps/docs/src/components/diagrams/BuildQueryDiagram.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from 'react';
+import styles from './diagrams.module.css';
+
+const LOAD_STEPS = ['Parse sources', 'Resolve aliases', 'Index axis effects'];
+const QUERIES = ['value at this tuple?', 'what does this alias?', 'which axes vary this?'];
+
+/** Why the token graph exists: expensive work once at load, instant lookups at display. */
+export default function BuildQueryDiagram(): ReactNode {
+  return (
+    <div className={styles.scroller}>
+      <svg
+        className={styles.diagram}
+        viewBox="0 0 760 300"
+        role="img"
+        aria-labelledby="build-query-diagram-title"
+      >
+        <title id="build-query-diagram-title">
+          At load time, sources are parsed, aliases resolved, and axis effects indexed into the
+          token graph, once. At display time, blocks query the graph for values, aliases, and
+          variance and get instant answers; nothing on the display side reaches back into
+          parsing.
+        </title>
+        <defs>
+          <marker
+            id="build-query-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" className={styles.arrowhead} />
+          </marker>
+        </defs>
+        <rect className={styles.zone} x="8" y="40" width="300" height="220" rx="8" />
+        <rect className={styles.zone} x="452" y="40" width="300" height="220" rx="8" />
+        <text className={styles.zoneTitle} x="158" y="64">
+          At load: once
+        </text>
+        <text className={styles.zoneTitle} x="602" y="64">
+          At display: constantly
+        </text>
+        <line className={styles.barrier} x1="380" y1="40" x2="380" y2="118" />
+        <line className={styles.barrier} x1="380" y1="182" x2="380" y2="260" />
+        {LOAD_STEPS.map((label, i) => (
+          <g key={label}>
+            <rect className={styles.node} x="58" y={78 + i * 52} width="200" height="36" rx="6" />
+            <text className={styles.label} x="158" y={101 + i * 52}>
+              {label}
+            </text>
+          </g>
+        ))}
+        {[114, 166].map((y) => (
+          <line
+            key={y}
+            className={styles.edge}
+            x1="158"
+            y1={y}
+            x2="158"
+            y2={y + 14}
+            markerEnd="url(#build-query-arrow)"
+          />
+        ))}
+        <line
+          className={styles.edge}
+          x1="258"
+          y1="149"
+          x2="316"
+          y2="150"
+          markerEnd="url(#build-query-arrow)"
+        />
+        <rect className={styles.nodeAccent} x="325" y="124" width="110" height="52" rx="6" />
+        <text className={styles.label} x="380" y="154">
+          Token graph
+        </text>
+        {QUERIES.map((label, i) => (
+          <g key={label}>
+            <line
+              className={styles.edge}
+              x1="435"
+              y1="150"
+              x2="487"
+              y2={96 + i * 52}
+              markerEnd="url(#build-query-arrow)"
+            />
+            <rect className={styles.node} x="496" y={78 + i * 52} width="224" height="36" rx="6" />
+            <text className={styles.label} x="608" y={101 + i * 52}>
+              {label}
+            </text>
+          </g>
+        ))}
+        <text className={styles.labelSmall} x="158" y="282">
+          expensive work, done once
+        </text>
+        <text className={styles.labelSmall} x="602" y="282">
+          instant answers, every render
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/apps/docs/src/components/diagrams/IngestionDiagram.tsx
+++ b/apps/docs/src/components/diagrams/IngestionDiagram.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+import styles from './diagrams.module.css';
+
+const STAGES: ReadonlyArray<{ x: number; label: string; sub?: string }> = [
+  { x: 8, label: 'Token sources', sub: 'DTCG files' },
+  { x: 160, label: 'Parse' },
+  { x: 312, label: 'Build graph' },
+  { x: 464, label: 'Snapshot' },
+  { x: 616, label: 'Preview', sub: 'CSS vars + blocks' },
+];
+
+/** Order of operations from token files on disk to a live preview, drawn as one loop. */
+export default function IngestionDiagram(): ReactNode {
+  return (
+    <div className={styles.scroller}>
+      <svg
+        className={styles.diagram}
+        viewBox="0 0 760 204"
+        role="img"
+        aria-labelledby="ingestion-diagram-title"
+      >
+        <title id="ingestion-diagram-title">
+          Token source files are parsed, built into a graph, snapshotted, and shown in the
+          preview as CSS variables and doc blocks. Saving a source file re-runs the whole
+          pipeline in memory.
+        </title>
+        <defs>
+          <marker
+            id="ingestion-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" className={styles.arrowhead} />
+          </marker>
+          <marker
+            id="ingestion-arrow-accent"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" className={styles.arrowheadAccent} />
+          </marker>
+        </defs>
+        <text className={styles.labelSmall} x="380" y="38">
+          runs in memory; nothing is written to disk
+        </text>
+        {STAGES.map((stage) => (
+          <g key={stage.label}>
+            <rect className={styles.node} x={stage.x} y="64" width="136" height="56" rx="6" />
+            <text className={styles.label} x={stage.x + 68} y={stage.sub ? 88 : 96}>
+              {stage.label}
+            </text>
+            {stage.sub ? (
+              <text className={styles.labelSmall} x={stage.x + 68} y="106">
+                {stage.sub}
+              </text>
+            ) : null}
+          </g>
+        ))}
+        {[144, 296, 448, 600].map((x) => (
+          <line
+            key={x}
+            className={styles.edge}
+            x1={x}
+            y1="92"
+            x2={x + 13}
+            y2="92"
+            markerEnd="url(#ingestion-arrow)"
+          />
+        ))}
+        <path
+          className={styles.edgeAccent}
+          d="M684 120 V172 H76 V124"
+          markerEnd="url(#ingestion-arrow-accent)"
+        />
+        <text className={styles.labelSmall} x="380" y="190">
+          saving a source file re-runs the pipeline
+        </text>
+      </svg>
+    </div>
+  );
+}

--- a/apps/docs/src/components/diagrams/SnapshotConsumersDiagram.tsx
+++ b/apps/docs/src/components/diagrams/SnapshotConsumersDiagram.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from 'react';
+import styles from './diagrams.module.css';
+
+const CONSUMERS: ReadonlyArray<{ y: number; label: string; sub: string }> = [
+  { y: 20, label: 'Storybook preview', sub: 'the addon' },
+  { y: 80, label: 'Docs-site blocks', sub: 'outside Storybook' },
+  { y: 140, label: 'MCP server', sub: 'AI agents' },
+];
+
+/** One project snapshot, three independent consumers. */
+export default function SnapshotConsumersDiagram(): ReactNode {
+  return (
+    <div className={styles.scroller}>
+      <svg
+        className={styles.diagram}
+        viewBox="0 0 760 208"
+        role="img"
+        aria-labelledby="snapshot-consumers-diagram-title"
+      >
+        <title id="snapshot-consumers-diagram-title">
+          One project snapshot feeds the Storybook preview, doc blocks outside Storybook, and
+          the MCP server.
+        </title>
+        <defs>
+          <marker
+            id="snapshot-consumers-arrow"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="7"
+            markerHeight="7"
+            orient="auto-start-reverse"
+          >
+            <path d="M0 0 L10 5 L0 10 z" className={styles.arrowhead} />
+          </marker>
+        </defs>
+        <rect className={styles.nodeAccent} x="80" y="78" width="170" height="52" rx="6" />
+        <text className={styles.label} x="165" y="99">
+          Project snapshot
+        </text>
+        <text className={styles.labelSmall} x="165" y="117">
+          computed once
+        </text>
+        {CONSUMERS.map((consumer) => (
+          <g key={consumer.label}>
+            <line
+              className={styles.edge}
+              x1="250"
+              y1="104"
+              x2="461"
+              y2={consumer.y + 24}
+              markerEnd="url(#snapshot-consumers-arrow)"
+            />
+            <rect className={styles.node} x="470" y={consumer.y} width="210" height="48" rx="6" />
+            <text className={styles.label} x="575" y={consumer.y + 20}>
+              {consumer.label}
+            </text>
+            <text className={styles.labelSmall} x="575" y={consumer.y + 38}>
+              {consumer.sub}
+            </text>
+          </g>
+        ))}
+      </svg>
+    </div>
+  );
+}

--- a/apps/docs/src/components/diagrams/diagrams.module.css
+++ b/apps/docs/src/components/diagrams/diagrams.module.css
@@ -1,0 +1,81 @@
+/*
+ * Shared styling for the concept diagrams. Every visual property binds to a
+ * semantic --sb-* custom property so the diagrams repaint with the swatchbook
+ * switcher (mode, a11y, typeface) and Docusaurus color mode. No fills or
+ * strokes may appear as SVG presentation attributes in the components.
+ */
+
+.scroller {
+  overflow-x: auto;
+  margin-block: 1.5rem;
+}
+
+.diagram {
+  display: block;
+  inline-size: 100%;
+  min-inline-size: 560px;
+  max-inline-size: 760px;
+  font-family: var(--sb-font-family-base);
+}
+
+.node {
+  fill: var(--sb-color-surface-raised);
+  stroke: var(--sb-color-code-border);
+  stroke-width: 1.5;
+}
+
+.nodeAccent {
+  fill: var(--sb-color-surface-default);
+  stroke: var(--sb-color-primary-default);
+  stroke-width: 1.5;
+}
+
+.edge {
+  fill: none;
+  stroke: var(--sb-color-text-muted);
+  stroke-width: 1.5;
+}
+
+.edgeAccent {
+  fill: none;
+  stroke: var(--sb-color-primary-default);
+  stroke-width: 1.5;
+  stroke-dasharray: 6 4;
+}
+
+.arrowhead {
+  fill: var(--sb-color-text-muted);
+}
+
+.arrowheadAccent {
+  fill: var(--sb-color-primary-default);
+}
+
+.label {
+  fill: var(--sb-color-text-default);
+  font-size: 14px;
+  text-anchor: middle;
+}
+
+.labelSmall {
+  fill: var(--sb-color-text-muted);
+  font-size: 12px;
+  text-anchor: middle;
+}
+
+.zone {
+  fill: var(--sb-color-surface-muted);
+}
+
+.zoneTitle {
+  fill: var(--sb-color-text-heading);
+  font-size: 12px;
+  font-weight: 600;
+  text-anchor: middle;
+}
+
+.barrier {
+  stroke: var(--sb-color-code-border);
+  stroke-width: 1;
+  stroke-dasharray: 4 4;
+}


### PR DESCRIPTION
Four hand-authored SVG diagrams as React components under apps/docs/src/components/diagrams/, styled entirely via semantic --sb-* custom properties so they repaint with the swatchbook switcher (mode, a11y, typeface) and Docusaurus color mode:

- Ingestion order on the token-pipeline page (replaces the ASCII chain; its implementation detail stays on developers/architecture)
- Build once, query fast: new section showing load-time work vs. display-time graph queries
- Snapshot consumers fan-out in the "Where the same property holds" section
- Axis flip order on the axes page

Conceptual register only: stage names, no function names. Patch changeset included per the docs-only rule. Visually verified in a live browser: light/dark, typeface and a11y axis flips, and 400px-viewport scroll containment on both pages.

Milestone: Maintenance

Closes #1327

Plan impact: none