### PR TITLE
ci: assert the npm trusted-publishing floor instead of ad-hoc upgrading

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,9 +211,21 @@ jobs:
           # to npm with the OIDC token.
           registry-url: https://registry.npmjs.org
 
-      # Node 24 ships npm 10.x; trusted publishing needs >= 11.5.1.
-      - name: Upgrade npm for trusted publishing
-        run: npm install --global npm@latest
+      # Trusted publishing needs npm >= 11.5.1. Node 24 bundles npm 11.x, so
+      # no upgrade happens here — an ad-hoc `npm install -g` is an unpinned
+      # supply-chain surface in the one job holding the OIDC id-token (zizmor
+      # adhoc-packages). Assert the floor instead and fail loudly if a runner
+      # ever serves an npm below it (early 24.x bundled 11.3.0).
+      - name: Assert npm supports trusted publishing
+        run: |
+          set -e
+          need=11.5.1
+          have=$(npm --version)
+          if [ "$(printf '%s\n' "$need" "$have" | sort -V | head -n1)" != "$need" ]; then
+            echo "npm $have < $need (trusted publishing minimum). Bump node-version to a newer 24.x." >&2
+            exit 1
+          fi
+          echo "npm $have >= $need — trusted publishing supported."
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
Fixes code-scanning alert 24 (zizmor adhoc-packages) at the root: the publish job ran an unpinned `npm install --global npm@latest` inside the one job that holds the OIDC id-token. The step's premise is stale — Node 24 has bundled npm 11.x since v24.0.0 (current 24.x bundles 11.16.0, past the 11.5.1 trusted-publishing minimum) — so the upgrade is dropped rather than pinned.

In its place, a guard asserts `npm --version` >= 11.5.1 and fails loudly with a pointed message if a stale toolcache ever serves an early 24.x (which bundled 11.3.0), instead of letting `pnpm run release` fail cryptically mid-publish.

Workflow-only change; no changeset.

Milestone: Maintenance

Closes #1334

Plan impact: none