### PR TITLE
ci: run PR workflows on the edited event so stacked PRs get checks after retarget

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `edited` covers stacked-PR base retargets, which fire no default type
+    # (issue #1336); see ci.yml for the full rationale.
+    types: [opened, synchronize, reopened, edited]
 
 # Cancel superseded PR runs — Chromatic is billed per snapshot, so stacking
 # runs on rapid pushes wastes quota. Main runs complete so the baseline is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # `edited` covers stacked PRs: when the base branch's own PR merges,
+    # GitHub retargets the stacked PR to main via an `edited` event, and the
+    # default types never start a run for its head SHA — required checks sit
+    # Expected forever (issue #1336). Title/body edits also re-run; the
+    # concurrency group below cancels superseded runs.
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
   # riding along on every PR is a cheap, arguably-better-coverage side effect.
   pull_request:
     branches: [main]
+    # `edited` covers stacked-PR base retargets, which fire no default type
+    # (issue #1336); see ci.yml for the full rationale.
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
When a stacked PR's base branch merges, GitHub retargets the PR to main via an `edited` pull_request event. ci.yml, chromatic.yml, and security.yml filtered `pull_request: branches: [main]` with the default types (opened, synchronize, reopened), so no run ever started for the retargeted head SHA and required checks sat Expected forever (seen on the fork-diagram PR; workaround was close/reopen).

Adds `types: [opened, synchronize, reopened, edited]` to all three. Title/body edits now also trigger runs; each workflow's per-ref concurrency group cancels superseded PR runs, so the cost is bounded. CodeQL default setup is GitHub-managed and unaffected either way.

Workflow-only change; no changeset.

Milestone: Maintenance

Closes #1336

Plan impact: none