### PR TITLE
ci: prepare release plumbing for the 1.0.0-alpha channel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -291,6 +291,25 @@ jobs:
 
           echo "All six fixed-group packages confirmed at v$version."
 
+          # During pre-release mode the fixed group must land on the `alpha`
+          # dist-tag, never `latest`. Changesets does this automatically; assert
+          # it so a future change to the publish step can't silently ship a
+          # prerelease as `latest` and clobber the stable line for `npm install`.
+          if [ -f .changeset/pre.json ]; then
+            latest_on_npm=$(npm view @unpunnyfuns/swatchbook-core dist-tags.latest --registry "$NPM_REGISTRY" 2>/dev/null || true)
+            # An empty result means the query failed, not that 'latest' is safe —
+            # fail loudly rather than let a network blip read as a clean pass.
+            if [ -z "$latest_on_npm" ]; then
+              echo "Could not read the 'latest' dist-tag — cannot verify the prerelease didn't leak onto it." >&2
+              exit 1
+            fi
+            if [ "$latest_on_npm" = "$version" ]; then
+              echo "Prerelease $version leaked onto the 'latest' dist-tag — expected 'alpha'." >&2
+              exit 1
+            fi
+            echo "Confirmed: 'latest' still points at $latest_on_npm, not the prerelease $version."
+          fi
+
       # Tag + release the fixed group. `changeset publish` tags only locally on
       # the runner; before the #1065 prepare/publish split the changesets action
       # pushed those tags and cut releases for us, and that side-effect was lost

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,13 @@ jobs:
             # badge would otherwise land on whichever package this loop emits
             # last. addon is the package consumers install, so it gets the badge.
             latest="--latest=false"
-            [ "$pkg" = "addon" ] && latest="--latest"
+            # Only the stable line owns the "Latest" badge. While in Changesets
+            # pre-release mode (.changeset/pre.json present) every publish is a
+            # prerelease, so no release takes the badge — it stays on the last
+            # stable (0.69.1) until `pre exit` removes pre.json at 1.0.0.
+            if [ "$pkg" = "addon" ] && [ ! -f .changeset/pre.json ]; then
+              latest="--latest"
+            fi
             gh release create "$tag" \
               --target "$GITHUB_SHA" \
               --title "$tag" \

--- a/scripts/snapshot-docs-version.mjs
+++ b/scripts/snapshot-docs-version.mjs
@@ -11,6 +11,10 @@
 // Runs from the root `version` script (after `changeset version` has bumped
 // workspace package.json versions), so the snapshot lands in the same
 // "Version Packages" PR that Changesets opens.
+//
+// Prerelease versions (e.g. `1.0.0-alpha.N`) skip snapshotting entirely — see
+// `snapshotPlan` — so the stable snapshot on `/` stays frozen while a prerelease
+// channel is open; only `/next/` (the live `docs/` tree) moves.
 
 import { existsSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { spawnSync } from 'node:child_process';
@@ -20,49 +24,73 @@ import { fileURLToPath } from 'node:url';
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(here, '..');
 
-const next = JSON.parse(
-  readFileSync(join(repoRoot, 'packages/core/package.json'), 'utf8'),
-).version;
-
-const match = next.match(/^(\d+)\.(\d+)\.(\d+)/);
-if (!match) {
-  console.error(`[snapshot-docs] unexpected core version: ${next}`);
-  process.exit(1);
+/**
+ * Decide what the docs snapshot step should do for a given core version.
+ * Prerelease versions (e.g. `1.0.0-alpha.3`) skip snapshotting: during a
+ * prerelease channel the stable snapshot on `/` stays frozen and only
+ * `/next/` (the live `docs/` tree) moves. Non-prerelease versions snapshot
+ * under `version-<major>.<minor>`.
+ */
+export function snapshotPlan(version) {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)(-[0-9A-Za-z.-]+)?$/);
+  if (!match) return { action: 'error', message: `unexpected core version: ${version}` };
+  if (match[4])
+    return { action: 'skip', message: `prerelease ${version} — docs snapshot left unchanged` };
+  return { action: 'snapshot', series: `${match[1]}.${match[2]}` };
 }
-const [, major, minor] = match;
-const series = `${major}.${minor}`;
 
-const versionedDocsRoot = join(repoRoot, 'apps/docs/versioned_docs');
-const versionedSidebarsRoot = join(repoRoot, 'apps/docs/versioned_sidebars');
-const versionsJsonPath = join(repoRoot, 'apps/docs/versions.json');
+function main() {
+  const next = JSON.parse(
+    readFileSync(join(repoRoot, 'packages/core/package.json'), 'utf8'),
+  ).version;
 
-// Drop every existing versioned_docs/ snapshot and matching sidebar file —
-// docusaurus docs:version below will write the current release's snapshot
-// fresh. Pre-1.0 single-stable policy: only the just-built snapshot survives
-// on disk. Idempotent + safe to re-run.
-if (existsSync(versionedDocsRoot)) {
-  for (const entry of readdirSync(versionedDocsRoot)) {
-    if (entry.startsWith('version-')) {
-      rmSync(join(versionedDocsRoot, entry), { recursive: true, force: true });
+  const plan = snapshotPlan(next);
+  if (plan.action === 'error') {
+    console.error(`[snapshot-docs] ${plan.message}`);
+    process.exit(1);
+  }
+  if (plan.action === 'skip') {
+    console.log(`[snapshot-docs] ${plan.message}`);
+    process.exit(0);
+  }
+  const series = plan.series;
+
+  const versionedDocsRoot = join(repoRoot, 'apps/docs/versioned_docs');
+  const versionedSidebarsRoot = join(repoRoot, 'apps/docs/versioned_sidebars');
+  const versionsJsonPath = join(repoRoot, 'apps/docs/versions.json');
+
+  // Drop every existing versioned_docs/ snapshot and matching sidebar file —
+  // docusaurus docs:version below will write the current release's snapshot
+  // fresh. Pre-1.0 single-stable policy: only the just-built snapshot survives
+  // on disk. Idempotent + safe to re-run.
+  if (existsSync(versionedDocsRoot)) {
+    for (const entry of readdirSync(versionedDocsRoot)) {
+      if (entry.startsWith('version-')) {
+        rmSync(join(versionedDocsRoot, entry), { recursive: true, force: true });
+      }
     }
   }
-}
-if (existsSync(versionedSidebarsRoot)) {
-  for (const entry of readdirSync(versionedSidebarsRoot)) {
-    if (entry.startsWith('version-') && entry.endsWith('-sidebars.json')) {
-      rmSync(join(versionedSidebarsRoot, entry), { force: true });
+  if (existsSync(versionedSidebarsRoot)) {
+    for (const entry of readdirSync(versionedSidebarsRoot)) {
+      if (entry.startsWith('version-') && entry.endsWith('-sidebars.json')) {
+        rmSync(join(versionedSidebarsRoot, entry), { force: true });
+      }
     }
   }
-}
-// Reset versions.json so `docusaurus docs:version` writes a clean single-entry
-// list. Without the reset it would prepend, accumulating prior entries that
-// no longer have snapshots on disk.
-writeFileSync(versionsJsonPath, '[]\n');
+  // Reset versions.json so `docusaurus docs:version` writes a clean single-entry
+  // list. Without the reset it would prepend, accumulating prior entries that
+  // no longer have snapshots on disk.
+  writeFileSync(versionsJsonPath, '[]\n');
 
-console.log(`[snapshot-docs] snapshotting docs for ${series} (release ${next})`);
-const result = spawnSync(
-  'pnpm',
-  ['--filter', '@unpunnyfuns/swatchbook-docs', 'exec', 'docusaurus', 'docs:version', series],
-  { cwd: repoRoot, stdio: 'inherit' },
-);
-process.exit(result.status ?? 1);
+  console.log(`[snapshot-docs] snapshotting docs for ${series} (release ${next})`);
+  const result = spawnSync(
+    'pnpm',
+    ['--filter', '@unpunnyfuns/swatchbook-docs', 'exec', 'docusaurus', 'docs:version', series],
+    { cwd: repoRoot, stdio: 'inherit' },
+  );
+  process.exit(result.status ?? 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}


### PR DESCRIPTION
Prepares the release plumbing for a `1.0.0-alpha.N` prerelease channel, ahead of entering Changesets pre-release mode. Three release-tooling changes, all keyed off `.changeset/pre.json` (present only while pre-mode is active):

- **Docs snapshot skips prereleases** — `snapshot-docs-version.mjs` gets an exported `snapshotPlan()` that no-ops the docusaurus snapshot on prerelease versions, so the stable snapshot on `/` stays frozen during the alpha and only `/next/` moves.
- **Latest badge stays on the stable line** — `release.yml` gates the GitHub-release `--latest` badge on the absence of `.changeset/pre.json`, so alpha publishes never steal the badge from 0.69.1. It returns to `addon` automatically at `pre exit`.
- **Guard against a `latest` dist-tag leak** — a pre-mode assertion fails the publish if a prerelease reaches npm's `latest`, and fails loudly if it can't read the tag.

Existing `npm install` users are unaffected: `latest` stays at 0.69.1 throughout.

Milestone: Release
Closes #1338
Plan impact: Phase A (channel entry) of the 1.0.0-alpha effort. Entering pre-release mode and cutting `1.0.0-alpha.0` follows in a separate PR once this merges.