### PR TITLE
perf(blocks): virtualize TokenTable rows to bound theme-switch cost by viewport

### DIFF
--- a/.changeset/virtualize-token-table.md
+++ b/.changeset/virtualize-token-table.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-blocks": minor
+---
+
+Virtualize TokenTable rows so theme-switch cost tracks viewport size, not token count.

--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -56,6 +56,7 @@
     "format:check": "oxfmt --check -c ../../.oxfmtrc.json src test"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "3.14.5",
     "@unpunnyfuns/swatchbook-core": "workspace:*",
     "clsx": "^2.1.1",
     "colorjs.io": "^0.6.1"

--- a/packages/blocks/src/TokenTable.tsx
+++ b/packages/blocks/src/TokenTable.tsx
@@ -1,7 +1,8 @@
 import { fuzzyFilter } from '@unpunnyfuns/swatchbook-core/fuzzy';
+import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import cx from 'clsx';
 import type { ReactElement } from 'react';
-import { useCallback, useDeferredValue, useMemo } from 'react';
+import { useCallback, useDeferredValue, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import './TokenTable.css';
 import { useColorFormat } from '#/contexts.ts';
 import { CopyButton } from '#/internal/CopyButton.tsx';
@@ -174,6 +175,40 @@ export function TokenTableView({
     return fuzzyFilter(rows, deferredQuery, (row) => `${row.path} ${row.type} ${row.value}`);
   }, [rows, deferredQuery, searchable]);
 
+  const VIRTUALIZE_THRESHOLD = 50;
+  const scrollParentRef = useRef<HTMLTableSectionElement>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const virtualize = typeof window !== 'undefined' && visibleRows.length >= VIRTUALIZE_THRESHOLD;
+
+  useLayoutEffect(() => {
+    if (!virtualize) return;
+    const el = scrollParentRef.current;
+    if (!el) return;
+    const update = () => setScrollMargin(el.getBoundingClientRect().top + window.scrollY);
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(document.body);
+    window.addEventListener('resize', update);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', update);
+    };
+  }, [virtualize]);
+
+  const virtualizer = useWindowVirtualizer({
+    count: virtualize ? visibleRows.length : 0,
+    estimateSize: () => 40,
+    overscan: 8,
+    scrollMargin,
+  });
+  const virtualItems = virtualize ? virtualizer.getVirtualItems() : [];
+  const padTop = virtualItems.length > 0 ? (virtualItems[0]?.start ?? 0) - scrollMargin : 0;
+  const padBottom =
+    virtualItems.length > 0
+      ? virtualizer.getTotalSize() -
+        ((virtualItems[virtualItems.length - 1]?.end ?? 0) - scrollMargin)
+      : 0;
+
   const handleRowClick = useCallback(
     (path: string) => {
       if (onSelect) onSelect(path);
@@ -189,6 +224,96 @@ export function TokenTableView({
     `${rows.length} token${rows.length === 1 ? '' : 's'}${
       filter ? ` matching \`${filter}\`` : ''
     }${type ? ` · $type=${type}` : ''}${matchSuffix} · ${activeTheme}`;
+
+  const renderRow = (
+    row: TokenRow,
+    rowIndex: number,
+    measureRef?: (el: HTMLTableRowElement | null) => void,
+  ) => {
+    const token = row.token;
+    return (
+      <tr
+        key={row.path}
+        ref={measureRef}
+        data-index={rowIndex}
+        aria-rowindex={rowIndex + 2}
+        className="sb-token-table__row"
+        onClick={() => handleRowClick(row.path)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleRowClick(row.path);
+          }
+        }}
+        tabIndex={0}
+        aria-haspopup="dialog"
+        aria-label={`Inspect ${row.path}`}
+        data-testid="token-table-row"
+        data-path={row.path}
+      >
+        <td
+          className={cx('sb-token-table__td', 'sb-token-table__path')}
+          data-deprecated={enabledIndicators.deprecation && row.isDeprecated ? 'true' : undefined}
+        >
+          {row.path}
+        </td>
+        <td className="sb-token-table__td">
+          <span className="sb-token-table__value-cell">
+            {row.type && <span className="sb-token-table__type-pill">{row.type}</span>}
+            {row.isColor && (
+              <span
+                className="sb-token-table__swatch"
+                style={{ background: row.cssVar }}
+                aria-hidden
+              />
+            )}
+            <span
+              className="sb-token-table__value-text"
+              title={row.value}
+              data-testid="token-table-value"
+            >
+              {row.value}
+            </span>
+            {row.outOfGamut && (
+              <span
+                title="Out of sRGB gamut for this format"
+                aria-label="out of gamut"
+                className="sb-token-table__gamut-warn"
+              >
+                ⚠
+              </span>
+            )}
+            <span
+              className="sb-token-table__copy-wrap"
+              onClick={(e) => e.stopPropagation()}
+              onKeyDown={(e) => e.stopPropagation()}
+              role="presentation"
+            >
+              <CopyButton
+                value={row.value}
+                label={`Copy value ${row.value}`}
+                className="sb-token-table__copy"
+              />
+            </span>
+          </span>
+        </td>
+        <td className="sb-token-table__td sb-token-table__refs">
+          {token && (
+            <RowIndicators
+              path={row.path}
+              token={token}
+              root={undefined}
+              variance={row.variance}
+              colorFormat={colorFormat}
+              canReference={(p) => validPaths.has(p)}
+              onReferenceClick={(p) => setSelectedPath(p)}
+              enabled={enabledIndicators}
+            />
+          )}
+        </td>
+      </tr>
+    );
+  };
 
   if (rows.length === 0) {
     return (
@@ -220,10 +345,10 @@ export function TokenTableView({
             : ''}
         </span>
       )}
-      <table className="sb-token-table__table">
+      <table className="sb-token-table__table" aria-rowcount={visibleRows.length + 1}>
         <caption className="sb-token-table__caption">{captionText}</caption>
         <thead>
-          <tr>
+          <tr aria-rowindex={1}>
             <th className={cx('sb-token-table__th', 'sb-token-table__th--path')}>Path</th>
             <th className={cx('sb-token-table__th', 'sb-token-table__th--value')}>Value</th>
             <th className="sb-token-table__th sb-token-table__th--refs">
@@ -231,7 +356,7 @@ export function TokenTableView({
             </th>
           </tr>
         </thead>
-        <tbody>
+        <tbody ref={scrollParentRef}>
           {visibleRows.length === 0 && (
             <tr>
               <td colSpan={3} className="sb-token-table__td sb-token-table__empty-row">
@@ -239,90 +364,23 @@ export function TokenTableView({
               </td>
             </tr>
           )}
-          {visibleRows.map((row) => {
-            const token = row.token;
-            return (
-              <tr
-                key={row.path}
-                className="sb-token-table__row"
-                onClick={() => handleRowClick(row.path)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    handleRowClick(row.path);
-                  }
-                }}
-                tabIndex={0}
-                aria-haspopup="dialog"
-                aria-label={`Inspect ${row.path}`}
-                data-testid="token-table-row"
-                data-path={row.path}
-              >
-                <td
-                  className={cx('sb-token-table__td', 'sb-token-table__path')}
-                  data-deprecated={
-                    enabledIndicators.deprecation && row.isDeprecated ? 'true' : undefined
-                  }
-                >
-                  {row.path}
-                </td>
-                <td className="sb-token-table__td">
-                  <span className="sb-token-table__value-cell">
-                    {row.type && <span className="sb-token-table__type-pill">{row.type}</span>}
-                    {row.isColor && (
-                      <span
-                        className="sb-token-table__swatch"
-                        style={{ background: row.cssVar }}
-                        aria-hidden
-                      />
-                    )}
-                    <span
-                      className="sb-token-table__value-text"
-                      title={row.value}
-                      data-testid="token-table-value"
-                    >
-                      {row.value}
-                    </span>
-                    {row.outOfGamut && (
-                      <span
-                        title="Out of sRGB gamut for this format"
-                        aria-label="out of gamut"
-                        className="sb-token-table__gamut-warn"
-                      >
-                        ⚠
-                      </span>
-                    )}
-                    <span
-                      className="sb-token-table__copy-wrap"
-                      onClick={(e) => e.stopPropagation()}
-                      onKeyDown={(e) => e.stopPropagation()}
-                      role="presentation"
-                    >
-                      <CopyButton
-                        value={row.value}
-                        label={`Copy value ${row.value}`}
-                        className="sb-token-table__copy"
-                      />
-                    </span>
-                  </span>
-                </td>
-                <td className="sb-token-table__td sb-token-table__refs">
-                  {token && (
-                    <RowIndicators
-                      path={row.path}
-                      token={token}
-                      root={undefined}
-                      variance={row.variance}
-                      colorFormat={colorFormat}
-                      canReference={(p) => validPaths.has(p)}
-                      onReferenceClick={(p) => setSelectedPath(p)}
-                      enabled={enabledIndicators}
-                    />
-                  )}
-                </td>
-              </tr>
-            );
-          })}
+          {!virtualize && visibleRows.map((row, i) => renderRow(row, i))}
+          {virtualize && padTop > 0 && (
+            <tr aria-hidden="true" style={{ height: padTop }}>
+              <td colSpan={3} />
+            </tr>
+          )}
+          {virtualize &&
+            virtualItems.map((vi) => {
+              const row = visibleRows[vi.index];
+              if (!row) return null;
+              return renderRow(row, vi.index, virtualizer.measureElement);
+            })}
+          {virtualize && padBottom > 0 && (
+            <tr aria-hidden="true" style={{ height: padBottom }}>
+              <td colSpan={3} />
+            </tr>
+          )}
         </tbody>
       </table>
 

--- a/packages/blocks/test/token-table-virtualization.browser.test.tsx
+++ b/packages/blocks/test/token-table-virtualization.browser.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { SwatchbookProvider, TokenTable } from '#/index.ts';
+import type { ProjectSnapshot } from '#/index.ts';
+import { makeResolveAt } from './_snapshot-helpers.ts';
+
+function bigSnapshot(count: number): ProjectSnapshot {
+  const tokens: Record<string, { $type: string; $value: { hex: string } }> = {};
+  for (let i = 0; i < count; i++) {
+    tokens[`color.gen.p${i}`] = { $type: 'color', $value: { hex: '#3b82f6' } };
+  }
+  const snap: ProjectSnapshot = {
+    axes: [{ name: 'theme', contexts: ['Light'], default: 'Light', source: 'synthetic' }],
+    defaultTuple: { theme: 'Light' },
+    activeTheme: 'Light',
+    activeAxes: { theme: 'Light' },
+    cssVarPrefix: 'sb',
+    diagnostics: [],
+    css: '',
+  };
+  snap.resolveAt = makeResolveAt(tokens);
+  return snap;
+}
+
+afterEach(() => cleanup());
+
+it('mounts only a bounded window of rows for a large table', async () => {
+  render(
+    <SwatchbookProvider value={bigSnapshot(1000)}>
+      <TokenTable searchable={false} />
+    </SwatchbookProvider>,
+  );
+  await screen.findAllByTestId('token-table-row');
+  const mounted = screen.getAllByTestId('token-table-row').length;
+  expect(mounted).toBeGreaterThan(0);
+  expect(mounted).toBeLessThan(60);
+});
+
+it('reveals later rows on scroll and unmounts earlier ones', async () => {
+  render(
+    <SwatchbookProvider value={bigSnapshot(1000)}>
+      <TokenTable searchable={false} />
+    </SwatchbookProvider>,
+  );
+  await screen.findAllByTestId('token-table-row');
+  expect(screen.queryByText('color.gen.p0')).not.toBeNull();
+  window.scrollTo(0, 20000);
+  window.dispatchEvent(new Event('scroll'));
+  await new Promise((r) => setTimeout(r, 100));
+  const paths = screen.getAllByTestId('token-table-row').map((el) => el.getAttribute('data-path'));
+  expect(paths).not.toContain('color.gen.p0');
+  expect(paths.length).toBeGreaterThan(0);
+});
+
+it('renders every row and no spacer for a small table', async () => {
+  render(
+    <SwatchbookProvider value={bigSnapshot(20)}>
+      <TokenTable searchable={false} />
+    </SwatchbookProvider>,
+  );
+  await screen.findAllByTestId('token-table-row');
+  expect(screen.getAllByTestId('token-table-row').length).toBe(20);
+  expect(document.querySelector('tr[aria-hidden="true"]')).toBeNull();
+  const table = screen.getByRole('table');
+  expect(table.getAttribute('aria-rowcount')).toBe('21');
+  expect(screen.getAllByTestId('token-table-row')[0]?.getAttribute('aria-rowindex')).toBe('2');
+});
+
+it('exposes the full row count and true row indices despite windowing', async () => {
+  render(
+    <SwatchbookProvider value={bigSnapshot(1000)}>
+      <TokenTable searchable={false} />
+    </SwatchbookProvider>,
+  );
+  const table = await screen.findByRole('table');
+  expect(table.getAttribute('aria-rowcount')).toBe('1001');
+  const firstRow = screen.getAllByTestId('token-table-row')[0];
+  expect(firstRow?.getAttribute('aria-rowindex')).toBe('2');
+});
+
+it('can reach and mount the final row when scrolled to the bottom', async () => {
+  render(
+    <SwatchbookProvider value={bigSnapshot(1000)}>
+      <TokenTable searchable={false} />
+    </SwatchbookProvider>,
+  );
+  await screen.findAllByTestId('token-table-row');
+  window.scrollTo(0, document.body.scrollHeight);
+  window.dispatchEvent(new Event('scroll'));
+  await new Promise((r) => setTimeout(r, 150));
+  const paths = screen.getAllByTestId('token-table-row').map((el) => el.getAttribute('data-path'));
+  expect(paths).toContain('color.gen.p999');
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -273,6 +273,9 @@ importers:
 
   packages/blocks:
     dependencies:
+      '@tanstack/react-virtual':
+        specifier: 3.14.5
+        version: 3.14.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@unpunnyfuns/swatchbook-core':
         specifier: workspace:*
         version: link:../core
@@ -4105,6 +4108,15 @@ packages:
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-virtual@3.14.5':
+    resolution: {integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.17.3':
+    resolution: {integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==}
 
   '@terrazzo/cli@2.3.0':
     resolution: {integrity: sha512-xq90WI53j7O24Xi1n9KmEPQKjbnEfu6yrC87CWiHNy3Ww1EFxo9tC1EwEZQ8D5vlViak5j0+Gfl452miOphfKw==}
@@ -13383,6 +13395,14 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
       vite: 8.0.16(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(terser@5.46.1)(yaml@2.9.0)
+
+  '@tanstack/react-virtual@3.14.5(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/virtual-core@3.17.3': {}
 
   '@terrazzo/cli@2.3.0(@types/node@25.6.0)(esbuild@0.28.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.46.1)':
     dependencies:


### PR DESCRIPTION
Window-virtualizes `TokenTableView` so a theme switch re-renders only the rows in the viewport, not every token.

## Why

Measured root cause (issue #1340): a theme switch on a sizable set blocks the main thread ~2s, >90% of it React re-rendering every non-virtualized row. On a 5,003-token dashboard, TokenTable mounted 5,008 `<tr>` / ~71k DOM elements and reconciled all of them per flip. A prototype of this change took the same switch to ~200ms (>10x), with rendered rows dropping 5,008 → 33.

## What

- Above a 50-row threshold, `TokenTableView` renders only the viewport window of real `<tr>`s (via `@tanstack/react-virtual`'s `useWindowVirtualizer`), bracketed by top/bottom spacer rows sized from measured offsets. Below the threshold, the plain table renders unchanged.
- `aria-rowcount` on the table and `aria-rowindex` on every row (header included) preserve the true row set for assistive tech despite windowing.
- Window (page-flow) virtualization, so it feels native in docs pages and works in canvas stories; `scrollMargin` is measured from the `<tbody>` start. A `typeof window` guard degrades to the plain table in non-browser renders.

Phase 1 of the blocks-virtualization effort. TokenNavigator (tree + keyboard nav) gets its own follow-up; its expanded/Overview surface stays unvirtualized until then. Known follow-ups: focus restoration when a focused row unmounts on scroll; a `useRowVirtualizer` extraction.

Verified in real Chromium + Firefox: windowed row count is bounded (<60 for 1,000 rows), scrolling unmounts the top row and reaches the last, search composes, the below-threshold path renders all rows, and the a11y attributes track the full set. Full suite 631/631.

Milestone: Maintenance
Closes #1340
Plan impact: implements the approved TokenTable-virtualization design (phase 1).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved performance for large token tables by rendering only rows visible in the viewport.
  * Added smooth scrolling support to access rows throughout large tables.
  * Preserved row counts and accessibility information during virtualization.

* **Bug Fixes**
  * Small token tables continue to render all rows normally without unnecessary virtualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->