### PR TITLE
ci: use client-id over the deprecated app-id for the release app token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,10 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          # `client-id`, not the deprecated `app-id`. GitHub's App JWT accepts
+          # either the App ID or the Client ID as the issuer, so the existing
+          # numeric RELEASE_APP_ID secret still authenticates here unchanged.
+          client-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write


### PR DESCRIPTION
`actions/create-github-app-token` deprecated `app-id` in favor of `client-id` (a warning on the release `prepare` job). Switches the input to `client-id`.

GitHub's App JWT issuer accepts either the App ID or the Client ID, so the existing numeric `RELEASE_APP_ID` secret still authenticates unchanged: no secret update needed. A one-line comment records why. Fails loudly and reverts in one line if it ever misbehaves.

Milestone: Maintenance
Closes #1348
Plan impact: none; CI hygiene.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release automation to use the current GitHub App authentication input.
  * Adjusted related workflow comments for accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->