### PR TITLE
docs: surface the 1.0.0-alpha channel with an announcement bar

### DIFF
--- a/apps/docs/docusaurus.config.ts
+++ b/apps/docs/docusaurus.config.ts
@@ -96,6 +96,12 @@ const config: Config = {
   ],
 
   themeConfig: {
+    announcementBar: {
+      id: 'v1-0-0-alpha',
+      content:
+        'swatchbook <code>1.0.0-alpha</code> is on npm under the <code>alpha</code> dist-tag. The <a href="/swatchbook/next/">Next docs</a> track it; the default docs below cover the stable 0.69 line.',
+      isCloseable: true,
+    },
     colorMode: {
       respectPrefersColorScheme: true,
     },


### PR DESCRIPTION
Adds a site-wide Docusaurus `announcementBar`: the alpha is on npm under the `alpha` dist-tag and the Next docs track it; the default docs cover the stable 0.69 line. Shows on both `/` and `/next/` since it's `themeConfig`, not versioned content.

Addresses the gap that a published alpha had no signal on the docs site. Does not touch the versioning model (still 0.69 at `/`, Next at `/next/`); the docs-versioning rework stays deferred to the 1.0.0 cut. The `announcementBar.id` (`v1-0-0-alpha`) can be bumped later to re-show it after edits.

No changeset: the docs app is private and, in pre-mode, the frozen snapshot wouldn't rebuild from one anyway. Deploys via the docs workflow on merge.

Milestone: Maintenance
Closes #1351
Plan impact: none; surfaces the already-decided alpha channel in the docs UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dismissible announcement banner to the documentation site highlighting the 1.0.0-alpha release and linking to the Next documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->