### PR TITLE
feat(addon): add withAxes for axis-parametrized story tests

### DIFF
--- a/.changeset/axis-parametrized-tests.md
+++ b/.changeset/axis-parametrized-tests.md
@@ -1,0 +1,5 @@
+---
+"@unpunnyfuns/swatchbook-addon": minor
+---
+
+Add `withAxes` (from the `testing` subpath) to run a story's tests under additional axis tuples.

--- a/apps/docs/docs/reference/with-axes.mdx
+++ b/apps/docs/docs/reference/with-axes.mdx
@@ -1,0 +1,61 @@
+---
+id: with-axes
+title: withAxes
+sidebar_position: 8
+---
+
+# `withAxes`
+
+`withAxes` produces the input for a story's `.extend()`, pinning a variant to a
+chosen axis tuple so its full test (render, play, and a11y) runs under that
+tuple. The addon generates one test per story export, so each variant is its own
+test. Import it from the addon's `testing` subpath:
+
+```ts
+import { withAxes } from '@unpunnyfuns/swatchbook-addon/testing';
+
+const meta = preview.meta({ component: ColorTable });
+export default meta;
+
+export const RefBlue = meta.story({ args: { filter: 'color.palette.blue.**' } });
+
+export const RefBlueBrandADark = RefBlue.extend(withAxes('Brand A Dark'));
+export const RefBlueHighContrast = RefBlue.extend(withAxes({ mode: 'Light', contrast: 'High' }));
+```
+
+`'Brand A Dark'` above is an example preset name from the reference app's own
+config, not a value `withAxes` recognizes universally; the presets available to
+you come from your project's `presets` config.
+
+Apply the result through the factory story's `.extend()` at the export site.
+Storybook only generates a test for an export whose right-hand side is a
+`.story()` or `.extend()` call, so `withAxes(...)` must sit inside `.extend()`,
+not stand alone.
+
+## Argument
+
+| Value | Meaning |
+| --- | --- |
+| `Record<string, string>` | A partial axis tuple. Only the axes you name are set; the rest fall back to their defaults at render time. |
+| `string` | A preset name from the project config's `presets`. Resolves to that preset's axes. |
+
+An unknown preset name, an unknown axis key, or an out-of-range axis value throws
+at load, rather than silently running under the default tuple.
+
+## Hiding a variant from the sidebar
+
+Variants are visible sibling stories by default. To keep a variant test-only, add
+a literal `!dev` tag in the `.extend` object and spread the helper for the axes:
+
+```ts
+export const RefBlueHidden = RefBlue.extend({ tags: ['!dev'], ...withAxes({ contrast: 'High' }) });
+```
+
+The tag must be written literally at the call site; it cannot come from the
+helper.
+
+## Choosing what to cover
+
+Axis coverage costs one extra test per variant per story, so opt in where the
+axis changes behavior: a11y-sensitive color and contrast stories gain the most,
+since contrast and readability regressions are axis-specific.

--- a/apps/docs/sidebars.ts
+++ b/apps/docs/sidebars.ts
@@ -53,6 +53,7 @@ const sidebars: SidebarsConfig = {
       ],
     },
     'reference/diagnostics',
+    'reference/with-axes',
   ],
   concepts: [
     'concepts/overview',

--- a/apps/storybook/src/stories/ColorTable.stories.tsx
+++ b/apps/storybook/src/stories/ColorTable.stories.tsx
@@ -1,3 +1,4 @@
+import { withAxes } from '@unpunnyfuns/swatchbook-addon/testing';
 import { ColorTable } from '@unpunnyfuns/swatchbook-blocks';
 import { expect, userEvent, waitFor } from 'storybook/test';
 import preview from '#storybook/preview.tsx';
@@ -45,6 +46,16 @@ export const RefBlue = meta.story({
   parameters: { a11y: { test: 'error' } },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),
 });
+
+/**
+ * Axis coverage for the a11y-enabled RefBlue story: the same small blue-palette
+ * table re-rendered under two curated presets via `.extend`. Each generates its
+ * own render + play + a11y test, so axe runs against dark surfaces and against
+ * high-contrast borders, not only the default light baseline.
+ */
+export const RefBlueBrandADark = RefBlue.extend(withAxes('Brand A Dark'));
+export const RefBlueHighContrast = RefBlue.extend(withAxes('A11y High Contrast'));
+
 export const SortedPerceptually = meta.story({
   args: { sortBy: 'value' },
   play: async ({ canvasElement }) => assertTableRenders(canvasElement),

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -51,6 +51,10 @@ function Card() {
 
 Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across themes; `value` flips with the active tuple. Paths autocomplete from the generated `.swatchbook/tokens.d.ts`.
 
+## Testing
+
+Author axis coverage for tests with [`withAxes`](https://unpunnyfuns.github.io/swatchbook/reference/with-axes) from the `testing` subpath.
+
 ## Credits
 
 Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.

--- a/packages/addon/package.json
+++ b/packages/addon/package.json
@@ -48,6 +48,10 @@
       "types": "./dist/hooks/index.d.mts",
       "import": "./dist/hooks/index.mjs"
     },
+    "./testing": {
+      "types": "./dist/testing.d.mts",
+      "import": "./dist/testing.mjs"
+    },
     "./package.json": "./package.json"
   },
   "imports": {

--- a/packages/addon/src/axis-variant.ts
+++ b/packages/addon/src/axis-variant.ts
@@ -45,7 +45,7 @@ export function assertKnownTuple(
       const known = axes.map((candidate) => candidate.name).join(', ') || '(none)';
       throw new Error(`withAxes: unknown axis "${key}". Known axes: ${known}.`);
     }
-    if (value !== undefined && !axis.contexts.includes(value)) {
+    if (value === undefined || !axis.contexts.includes(value)) {
       throw new Error(
         `withAxes: "${value}" is not a context of axis "${key}". Known contexts: ${axis.contexts.join(', ')}.`,
       );

--- a/packages/addon/src/axis-variant.ts
+++ b/packages/addon/src/axis-variant.ts
@@ -12,18 +12,10 @@ export interface ResolvePreset {
   readonly axes: Partial<Record<string, string>>;
 }
 
-/** Minimal structural view of a CSF-factory story: only the input the helper reads. */
-export interface FactoryStory {
-  readonly input?: { readonly name?: string };
+/** The `.extend()` input `withAxes` produces: a swatchbook axis override, nothing else. */
+export interface AxisVariantInput {
+  parameters: { swatchbook: { axes: Partial<Record<string, string>> } };
 }
-
-/** Options controlling how a generated axis variant behaves. */
-export interface WithAxesOptions {
-  /** Add `!dev` so the variant generates a test but stays out of the sidebar. */
-  hidden?: boolean;
-}
-
-const HIDDEN_TAG = '!dev';
 
 /** Resolve a preset name to its partial axes tuple; throw if no preset carries that name. */
 export function resolvePreset(
@@ -61,44 +53,18 @@ export function assertKnownTuple(
   }
 }
 
-// Compact human label for a raw tuple, e.g. `mode: Dark · brand: Brand A`.
-function tupleLabel(tuple: Partial<Record<string, string>>): string {
-  return Object.entries(tuple)
-    .filter((entry): entry is [string, string] => entry[1] !== undefined)
-    .map(([axis, context]) => `${axis}: ${context}`)
-    .join(' · ');
-}
-
 /**
- * Derive a CSF-factory story variant pinned to a resolved, validated axis
- * tuple. Pure over explicit axes/presets lists so it's testable without the
- * virtual module; the public `withAxes` wrapper injects the addon's virtual
- * exports. Reaches `.extend` through a cast so the public generic need not
- * carry a `.extend` signature (a real `extend<TInput>` is not cleanly
- * assignable to a non-generic structural one).
+ * Build the `.extend()` input that pins a CSF-factory story variant to a
+ * resolved, validated axis tuple. Pure over explicit axes/presets lists so it's
+ * testable without the virtual module; the public `withAxes` wrapper injects the
+ * addon's virtual exports.
  */
-export function buildAxisVariant<TStory extends FactoryStory>(
-  base: TStory,
+export function buildAxisInput(
   axesOrPreset: Readonly<Record<string, string>> | string,
-  options: WithAxesOptions,
   project: { axes: readonly ResolveAxis[]; presets: readonly ResolvePreset[] },
-): TStory {
-  const isPreset = typeof axesOrPreset === 'string';
-  const tuple = isPreset ? resolvePreset(axesOrPreset, project.presets) : axesOrPreset;
+): AxisVariantInput {
+  const tuple =
+    typeof axesOrPreset === 'string' ? resolvePreset(axesOrPreset, project.presets) : axesOrPreset;
   assertKnownTuple(tuple, project.axes);
-
-  const label = isPreset ? axesOrPreset : tupleLabel(tuple);
-  const baseName = base.input?.name;
-  const name = baseName ? `${baseName} (${label})` : label;
-
-  const patch: Record<string, unknown> = {
-    name,
-    parameters: { swatchbook: { axes: tuple } },
-  };
-  if (options.hidden) {
-    patch['tags'] = [HIDDEN_TAG];
-  }
-
-  const extendable = base as unknown as { extend(input: Record<string, unknown>): unknown };
-  return extendable.extend(patch) as TStory;
+  return { parameters: { swatchbook: { axes: tuple } } };
 }

--- a/packages/addon/src/axis-variant.ts
+++ b/packages/addon/src/axis-variant.ts
@@ -1,0 +1,104 @@
+/**
+ * Pure core for `withAxes` (see `#/testing.ts`). Kept free of the
+ * `virtual:swatchbook/tokens` import so the resolution + validation rules are
+ * unit-testable without the virtual module, mirroring `#/tuple-resolve.ts`.
+ */
+
+import type { ResolveAxis } from '#/tuple-resolve.ts';
+
+/** Named axis combination the resolver reads. Structurally satisfied by the addon's virtual `presets` export. */
+export interface ResolvePreset {
+  readonly name: string;
+  readonly axes: Partial<Record<string, string>>;
+}
+
+/** Minimal structural view of a CSF-factory story: only the input the helper reads. */
+export interface FactoryStory {
+  readonly input?: { readonly name?: string };
+}
+
+/** Options controlling how a generated axis variant behaves. */
+export interface WithAxesOptions {
+  /** Add `!dev` so the variant generates a test but stays out of the sidebar. */
+  hidden?: boolean;
+}
+
+const HIDDEN_TAG = '!dev';
+
+/** Resolve a preset name to its partial axes tuple; throw if no preset carries that name. */
+export function resolvePreset(
+  name: string,
+  presets: readonly ResolvePreset[],
+): Partial<Record<string, string>> {
+  const match = presets.find((preset) => preset.name === name);
+  if (!match) {
+    const known = presets.map((preset) => preset.name).join(', ') || '(none)';
+    throw new Error(`withAxes: unknown preset "${name}". Known presets: ${known}.`);
+  }
+  return match.axes;
+}
+
+/**
+ * Throw if any key isn't a known axis or any value isn't one of that axis's
+ * contexts. Stricter than `normalizeTuple`, whose silent fall-back to defaults
+ * would let a typo pass as a green test running the wrong tuple.
+ */
+export function assertKnownTuple(
+  tuple: Partial<Record<string, string>>,
+  axes: readonly ResolveAxis[],
+): void {
+  for (const [key, value] of Object.entries(tuple)) {
+    const axis = axes.find((candidate) => candidate.name === key);
+    if (!axis) {
+      const known = axes.map((candidate) => candidate.name).join(', ') || '(none)';
+      throw new Error(`withAxes: unknown axis "${key}". Known axes: ${known}.`);
+    }
+    if (value !== undefined && !axis.contexts.includes(value)) {
+      throw new Error(
+        `withAxes: "${value}" is not a context of axis "${key}". Known contexts: ${axis.contexts.join(', ')}.`,
+      );
+    }
+  }
+}
+
+// Compact human label for a raw tuple, e.g. `mode: Dark · brand: Brand A`.
+function tupleLabel(tuple: Partial<Record<string, string>>): string {
+  return Object.entries(tuple)
+    .filter((entry): entry is [string, string] => entry[1] !== undefined)
+    .map(([axis, context]) => `${axis}: ${context}`)
+    .join(' · ');
+}
+
+/**
+ * Derive a CSF-factory story variant pinned to a resolved, validated axis
+ * tuple. Pure over explicit axes/presets lists so it's testable without the
+ * virtual module; the public `withAxes` wrapper injects the addon's virtual
+ * exports. Reaches `.extend` through a cast so the public generic need not
+ * carry a `.extend` signature (a real `extend<TInput>` is not cleanly
+ * assignable to a non-generic structural one).
+ */
+export function buildAxisVariant<TStory extends FactoryStory>(
+  base: TStory,
+  axesOrPreset: Readonly<Record<string, string>> | string,
+  options: WithAxesOptions,
+  project: { axes: readonly ResolveAxis[]; presets: readonly ResolvePreset[] },
+): TStory {
+  const isPreset = typeof axesOrPreset === 'string';
+  const tuple = isPreset ? resolvePreset(axesOrPreset, project.presets) : axesOrPreset;
+  assertKnownTuple(tuple, project.axes);
+
+  const label = isPreset ? axesOrPreset : tupleLabel(tuple);
+  const baseName = base.input?.name;
+  const name = baseName ? `${baseName} (${label})` : label;
+
+  const patch: Record<string, unknown> = {
+    name,
+    parameters: { swatchbook: { axes: tuple } },
+  };
+  if (options.hidden) {
+    patch['tags'] = [HIDDEN_TAG];
+  }
+
+  const extendable = base as unknown as { extend(input: Record<string, unknown>): unknown };
+  return extendable.extend(patch) as TStory;
+}

--- a/packages/addon/src/testing.ts
+++ b/packages/addon/src/testing.ts
@@ -1,27 +1,28 @@
 /**
  * Story-authoring helper exported from `@unpunnyfuns/swatchbook-addon/testing`.
- * `withAxes(base, axesOrPreset, options?)` derives a CSF-factory story variant
- * that runs the base story's full test (render + play + a11y) under a different
- * axis tuple. Assign the result to its own named export so `addon-vitest`
- * generates a test for it.
+ * `withAxes(axesOrPreset)` returns the `.extend()` input that runs a CSF-factory
+ * story's full test (render + play + a11y) under a different axis tuple. Apply it
+ * at the export site so addon-vitest generates a test:
+ *
+ *   export const Dark = RefBlue.extend(withAxes('Brand A Dark'));
+ *
+ * To hide a variant from the sidebar while still testing it, add a literal tag:
+ *
+ *   export const Hidden = RefBlue.extend({ tags: ['!dev'], ...withAxes('Brand A Dark') });
  */
 
 import { axes as virtualAxes, presets as virtualPresets } from 'virtual:swatchbook/tokens';
-import { buildAxisVariant } from '#/axis-variant.ts';
-import type { FactoryStory, WithAxesOptions } from '#/axis-variant.ts';
+import { buildAxisInput } from '#/axis-variant.ts';
+import type { AxisVariantInput } from '#/axis-variant.ts';
 
-export type { WithAxesOptions } from '#/axis-variant.ts';
+export type { AxisVariantInput } from '#/axis-variant.ts';
 
 /**
- * Derive an axis variant of a CSF-factory story. Pass a partial tuple
- * (`{ mode: 'Dark' }`) or a preset name (`'Brand A Dark'`); both are validated
- * against the project's axes/presets and throw on a typo. Unlisted axes fall
- * back to their defaults at render time.
+ * Produce the `.extend()` input pinning a story variant to an axis tuple. Pass a
+ * partial tuple (`{ mode: 'Dark' }`) or a preset name (`'Brand A Dark'`); both are
+ * validated against the project's axes/presets and throw on a typo. Unlisted axes
+ * fall back to their defaults at render time.
  */
-export function withAxes<TStory extends FactoryStory>(
-  base: TStory,
-  axes: Readonly<Record<string, string>> | string,
-  options: WithAxesOptions = {},
-): TStory {
-  return buildAxisVariant(base, axes, options, { axes: virtualAxes, presets: virtualPresets });
+export function withAxes(axes: Readonly<Record<string, string>> | string): AxisVariantInput {
+  return buildAxisInput(axes, { axes: virtualAxes, presets: virtualPresets });
 }

--- a/packages/addon/src/testing.ts
+++ b/packages/addon/src/testing.ts
@@ -1,0 +1,27 @@
+/**
+ * Story-authoring helper exported from `@unpunnyfuns/swatchbook-addon/testing`.
+ * `withAxes(base, axesOrPreset, options?)` derives a CSF-factory story variant
+ * that runs the base story's full test (render + play + a11y) under a different
+ * axis tuple. Assign the result to its own named export so `addon-vitest`
+ * generates a test for it.
+ */
+
+import { axes as virtualAxes, presets as virtualPresets } from 'virtual:swatchbook/tokens';
+import { buildAxisVariant } from '#/axis-variant.ts';
+import type { FactoryStory, WithAxesOptions } from '#/axis-variant.ts';
+
+export type { WithAxesOptions } from '#/axis-variant.ts';
+
+/**
+ * Derive an axis variant of a CSF-factory story. Pass a partial tuple
+ * (`{ mode: 'Dark' }`) or a preset name (`'Brand A Dark'`); both are validated
+ * against the project's axes/presets and throw on a typo. Unlisted axes fall
+ * back to their defaults at render time.
+ */
+export function withAxes<TStory extends FactoryStory>(
+  base: TStory,
+  axes: Readonly<Record<string, string>> | string,
+  options: WithAxesOptions = {},
+): TStory {
+  return buildAxisVariant(base, axes, options, { axes: virtualAxes, presets: virtualPresets });
+}

--- a/packages/addon/test/axis-variant.test.ts
+++ b/packages/addon/test/axis-variant.test.ts
@@ -38,6 +38,16 @@ it('assertKnownTuple throws on an out-of-context axis value', () => {
   );
 });
 
+it('assertKnownTuple throws on an explicitly undefined axis value', () => {
+  // Typed callers can't express this under exactOptionalPropertyTypes, but an
+  // untyped JS caller or a malformed preset can pass an explicit `undefined`.
+  // It must fail loud rather than silently resolve the axis to its default.
+  const tuple = { mode: undefined } as unknown as Record<string, string>;
+  expect(() => assertKnownTuple(tuple, AXES)).toThrow(
+    /"undefined" is not a context of axis "mode"/,
+  );
+});
+
 it('buildAxisInput stores a raw partial tuple as-authored on swatchbook.axes', () => {
   expect(buildAxisInput({ mode: 'Dark', brand: 'Brand A' }, PROJECT)).toEqual({
     parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },

--- a/packages/addon/test/axis-variant.test.ts
+++ b/packages/addon/test/axis-variant.test.ts
@@ -1,0 +1,107 @@
+import { expect, it } from 'vitest';
+import { assertKnownTuple, buildAxisVariant, resolvePreset } from '#/axis-variant.ts';
+import type { ResolvePreset } from '#/axis-variant.ts';
+import type { ResolveAxis } from '#/tuple-resolve.ts';
+
+const AXES: readonly ResolveAxis[] = [
+  { name: 'mode', default: 'Light', contexts: ['Light', 'Dark'] },
+  { name: 'brand', default: 'Default', contexts: ['Default', 'Brand A'] },
+  { name: 'contrast', default: 'Normal', contexts: ['Normal', 'High'] },
+];
+
+const PRESETS: readonly ResolvePreset[] = [
+  { name: 'Brand A Dark', axes: { mode: 'Dark', brand: 'Brand A' } },
+  { name: 'A11y High Contrast', axes: { mode: 'Light', contrast: 'High' } },
+];
+
+const PROJECT = { axes: AXES, presets: PRESETS };
+
+// A fake CSF-factory story: `extend` records its patch so we can assert it
+// without Storybook. `input.name` drives the display-name branch.
+function fakeStory(name?: string) {
+  return {
+    input: name === undefined ? {} : { name },
+    extend(patch: Record<string, unknown>) {
+      return { extended: patch };
+    },
+  };
+}
+
+it('resolvePreset returns the named preset axes', () => {
+  expect(resolvePreset('Brand A Dark', PRESETS)).toEqual({ mode: 'Dark', brand: 'Brand A' });
+});
+
+it('resolvePreset throws on an unknown preset name and lists known ones', () => {
+  expect(() => resolvePreset('Nope', PRESETS)).toThrow(/unknown preset "Nope".*Brand A Dark/s);
+});
+
+it('assertKnownTuple accepts a valid partial tuple', () => {
+  expect(() => assertKnownTuple({ mode: 'Dark' }, AXES)).not.toThrow();
+});
+
+it('assertKnownTuple throws on an unknown axis key', () => {
+  expect(() => assertKnownTuple({ mdoe: 'Dark' }, AXES)).toThrow(/unknown axis "mdoe"/);
+});
+
+it('assertKnownTuple throws on an out-of-context axis value', () => {
+  expect(() => assertKnownTuple({ brand: 'Brnd A' }, AXES)).toThrow(
+    /"Brnd A" is not a context of axis "brand"/,
+  );
+});
+
+it('buildAxisVariant stores a raw partial tuple as-authored on swatchbook.axes', () => {
+  const out = buildAxisVariant(fakeStory(), { mode: 'Dark', brand: 'Brand A' }, {}, PROJECT) as {
+    extended: Record<string, unknown>;
+  };
+  expect(out.extended.parameters).toEqual({
+    swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } },
+  });
+});
+
+it('buildAxisVariant resolves a preset name to its tuple', () => {
+  const out = buildAxisVariant(fakeStory(), 'A11y High Contrast', {}, PROJECT) as {
+    extended: Record<string, unknown>;
+  };
+  expect(out.extended.parameters).toEqual({
+    swatchbook: { axes: { mode: 'Light', contrast: 'High' } },
+  });
+});
+
+it('buildAxisVariant labels a preset variant with the preset name', () => {
+  const out = buildAxisVariant(fakeStory(), 'Brand A Dark', {}, PROJECT) as {
+    extended: { name: string };
+  };
+  expect(out.extended.name).toBe('Brand A Dark');
+});
+
+it('buildAxisVariant labels a raw-tuple variant with axis: context joined by a middle dot', () => {
+  const out = buildAxisVariant(fakeStory(), { mode: 'Dark', brand: 'Brand A' }, {}, PROJECT) as {
+    extended: { name: string };
+  };
+  expect(out.extended.name).toBe('mode: Dark · brand: Brand A');
+});
+
+it('buildAxisVariant prefixes the base name when the base story sets one', () => {
+  const out = buildAxisVariant(fakeStory('Full table'), 'Brand A Dark', {}, PROJECT) as {
+    extended: { name: string };
+  };
+  expect(out.extended.name).toBe('Full table (Brand A Dark)');
+});
+
+it('buildAxisVariant adds a !dev tag only when hidden is set', () => {
+  const shown = buildAxisVariant(fakeStory(), 'Brand A Dark', {}, PROJECT) as {
+    extended: Record<string, unknown>;
+  };
+  expect('tags' in shown.extended).toBe(false);
+
+  const hidden = buildAxisVariant(fakeStory(), 'Brand A Dark', { hidden: true }, PROJECT) as {
+    extended: { tags: string[] };
+  };
+  expect(hidden.extended.tags).toEqual(['!dev']);
+});
+
+it('buildAxisVariant throws before extending on an invalid tuple', () => {
+  expect(() => buildAxisVariant(fakeStory(), { mode: 'Sepia' }, {}, PROJECT)).toThrow(
+    /"Sepia" is not a context of axis "mode"/,
+  );
+});

--- a/packages/addon/test/axis-variant.test.ts
+++ b/packages/addon/test/axis-variant.test.ts
@@ -1,5 +1,5 @@
 import { expect, it } from 'vitest';
-import { assertKnownTuple, buildAxisVariant, resolvePreset } from '#/axis-variant.ts';
+import { assertKnownTuple, buildAxisInput, resolvePreset } from '#/axis-variant.ts';
 import type { ResolvePreset } from '#/axis-variant.ts';
 import type { ResolveAxis } from '#/tuple-resolve.ts';
 
@@ -15,17 +15,6 @@ const PRESETS: readonly ResolvePreset[] = [
 ];
 
 const PROJECT = { axes: AXES, presets: PRESETS };
-
-// A fake CSF-factory story: `extend` records its patch so we can assert it
-// without Storybook. `input.name` drives the display-name branch.
-function fakeStory(name?: string) {
-  return {
-    input: name === undefined ? {} : { name },
-    extend(patch: Record<string, unknown>) {
-      return { extended: patch };
-    },
-  };
-}
 
 it('resolvePreset returns the named preset axes', () => {
   expect(resolvePreset('Brand A Dark', PRESETS)).toEqual({ mode: 'Dark', brand: 'Brand A' });
@@ -49,59 +38,20 @@ it('assertKnownTuple throws on an out-of-context axis value', () => {
   );
 });
 
-it('buildAxisVariant stores a raw partial tuple as-authored on swatchbook.axes', () => {
-  const out = buildAxisVariant(fakeStory(), { mode: 'Dark', brand: 'Brand A' }, {}, PROJECT) as {
-    extended: Record<string, unknown>;
-  };
-  expect(out.extended.parameters).toEqual({
-    swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } },
+it('buildAxisInput stores a raw partial tuple as-authored on swatchbook.axes', () => {
+  expect(buildAxisInput({ mode: 'Dark', brand: 'Brand A' }, PROJECT)).toEqual({
+    parameters: { swatchbook: { axes: { mode: 'Dark', brand: 'Brand A' } } },
   });
 });
 
-it('buildAxisVariant resolves a preset name to its tuple', () => {
-  const out = buildAxisVariant(fakeStory(), 'A11y High Contrast', {}, PROJECT) as {
-    extended: Record<string, unknown>;
-  };
-  expect(out.extended.parameters).toEqual({
-    swatchbook: { axes: { mode: 'Light', contrast: 'High' } },
+it('buildAxisInput resolves a preset name to its tuple', () => {
+  expect(buildAxisInput('A11y High Contrast', PROJECT)).toEqual({
+    parameters: { swatchbook: { axes: { mode: 'Light', contrast: 'High' } } },
   });
 });
 
-it('buildAxisVariant labels a preset variant with the preset name', () => {
-  const out = buildAxisVariant(fakeStory(), 'Brand A Dark', {}, PROJECT) as {
-    extended: { name: string };
-  };
-  expect(out.extended.name).toBe('Brand A Dark');
-});
-
-it('buildAxisVariant labels a raw-tuple variant with axis: context joined by a middle dot', () => {
-  const out = buildAxisVariant(fakeStory(), { mode: 'Dark', brand: 'Brand A' }, {}, PROJECT) as {
-    extended: { name: string };
-  };
-  expect(out.extended.name).toBe('mode: Dark · brand: Brand A');
-});
-
-it('buildAxisVariant prefixes the base name when the base story sets one', () => {
-  const out = buildAxisVariant(fakeStory('Full table'), 'Brand A Dark', {}, PROJECT) as {
-    extended: { name: string };
-  };
-  expect(out.extended.name).toBe('Full table (Brand A Dark)');
-});
-
-it('buildAxisVariant adds a !dev tag only when hidden is set', () => {
-  const shown = buildAxisVariant(fakeStory(), 'Brand A Dark', {}, PROJECT) as {
-    extended: Record<string, unknown>;
-  };
-  expect('tags' in shown.extended).toBe(false);
-
-  const hidden = buildAxisVariant(fakeStory(), 'Brand A Dark', { hidden: true }, PROJECT) as {
-    extended: { tags: string[] };
-  };
-  expect(hidden.extended.tags).toEqual(['!dev']);
-});
-
-it('buildAxisVariant throws before extending on an invalid tuple', () => {
-  expect(() => buildAxisVariant(fakeStory(), { mode: 'Sepia' }, {}, PROJECT)).toThrow(
+it('buildAxisInput throws before returning on an invalid tuple', () => {
+  expect(() => buildAxisInput({ mode: 'Sepia' }, PROJECT)).toThrow(
     /"Sepia" is not a context of axis "mode"/,
   );
 });

--- a/packages/addon/tsdown.config.ts
+++ b/packages/addon/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'src/preview.tsx',
     'src/manager.tsx',
     'src/hooks/index.ts',
+    'src/testing.ts',
   ],
   format: 'esm',
   dts: true,


### PR DESCRIPTION
## Summary

Adds `withAxes`, published from `@unpunnyfuns/swatchbook-addon/testing`, so a story can run its full test (render + play + a11y) under axis tuples beyond the config default. Storybook Test previously exercised every story only at the default tuple, so Dark mode / Brand A / High contrast were never covered in CI. Coverage is opt-in and additive: a story you don't touch stays at one test.

`withAxes(axesOrPreset)` returns the input for a CSF-factory story's `.extend()`. Author usage:

```ts
export const RefBlueBrandADark   = RefBlue.extend(withAxes('Brand A Dark'));
export const RefBlueHighContrast = RefBlue.extend(withAxes({ mode: 'Light', contrast: 'High' }));
```

The helper returns the `.extend()` input (not a wrapped story) because addon-vitest's test generation is a static csf-tools transform that only recognizes a story export whose right-hand side is a literal `.story()`/`.extend()` member-call; a free `withAxes(Story, ...)` call generates zero tests silently. A partial tuple or a preset name is accepted, and an unknown preset name / axis key / out-of-range value throws at load rather than silently running under the default tuple. To keep a variant test-only, add a literal tag: `Base.extend({ tags: ['!dev'], ...withAxes('X') })`.

Dogfooded on `ColorTable`'s a11y-enabled `RefBlue` story: two variants generate tests and pass axe under both presets.

## Milestone
Maintenance

Closes #1362

## Plan impact
None. Additive public surface (new `./testing` subpath); no change to existing APIs or the axis-resolution path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `withAxes` testing helper (new `testing` entry point) to generate story variants pinned to specific axis tuples or named presets.
  * Added new ColorTable derived stories to run accessibility checks under additional curated visual presets.
* **Documentation**
  * Added reference documentation for `withAxes`, updated the docs navigation, and expanded README guidance for axis-based test coverage and variant visibility.
* **Tests**
  * Added unit tests covering preset resolution, tuple/axis validation, and generated test inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->