### PR TITLE
chore(addon): typecheck the test directory

### DIFF
--- a/packages/addon/src/virtual/plugin.ts
+++ b/packages/addon/src/virtual/plugin.ts
@@ -272,7 +272,7 @@ export function swatchbookTokensPlugin({
  */
 export function collectWatchPaths(
   config: Config,
-  project: Project | undefined,
+  project: Pick<Project, 'sourceFiles'> | undefined,
   cwd: string,
 ): string[] {
   const paths: string[] = [];

--- a/packages/addon/test/virtual-plugin.test.ts
+++ b/packages/addon/test/virtual-plugin.test.ts
@@ -10,15 +10,8 @@ import { collectWatchPaths, swatchbookTokensPlugin } from '#/virtual/plugin.ts';
 
 const CWD = '/project';
 
-function project(sourceFiles: string[]): Project {
-  return {
-    config: {},
-    axes: [],
-    disabledAxes: [],
-    presets: [],
-    sourceFiles,
-    diagnostics: [],
-  } as Project;
+function project(sourceFiles: string[]): Pick<Project, 'sourceFiles'> {
+  return { sourceFiles };
 }
 
 it('uses config.tokens via picomatch.scan base when provided', () => {
@@ -74,9 +67,11 @@ it('excludes the addon virtual IDs from Vite optimizeDeps pre-bundling', () => {
     config: { tokens: ['tokens/**/*.json'] },
     cwd: '/project',
   });
+  // `config` is an ObjectHook whose function form declares a ConfigPluginContext
+  // `this`; the hook body ignores it, so a bare receiver satisfies the type.
   const configResult =
     typeof plugin.config === 'function'
-      ? plugin.config({}, { command: 'serve', mode: 'development' })
+      ? plugin.config.call(undefined as never, {}, { command: 'serve', mode: 'development' })
       : undefined;
   const exclude =
     configResult && 'optimizeDeps' in configResult ? configResult.optimizeDeps?.exclude : undefined;

--- a/packages/addon/tsconfig.json
+++ b/packages/addon/tsconfig.json
@@ -4,5 +4,5 @@
     "types": ["node"],
     "noEmit": false
   },
-  "include": ["src"]
+  "include": ["src", "test", "vitest.config.ts"]
 }


### PR DESCRIPTION
## Summary

The addon's `tsconfig.json` included only `src`, so `tsc --noEmit` never type-checked `test/` — unlike `blocks` / `integrations` / `mcp` / `switcher`, which all include their `test` dir. Addon test files compiled and ran green under vitest (esbuild strips types without a full check), but type errors in them were invisible to CI.

This adds `test` and `vitest.config.ts` to the addon's `include`, matching the sibling packages. Two latent errors surfaced and are fixed:

- `collectWatchPaths` declared a `Project` param but only reads `project.sourceFiles`; narrowed to `Pick<Project, 'sourceFiles'>`, which also makes the test double honest (no `as Project` cast). Addon-internal helper, no external consumers.
- The `config`-hook invocation in `virtual-plugin.test.ts` is now called with a receiver satisfying its `ConfigPluginContext` `this` (the hook body ignores `this`).

No runtime or public-API change; internal-only, so no changeset.

## Milestone
Maintenance

Closes #1364

## Plan impact
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type flexibility for watch-path collection without changing runtime behavior.
  * Continued collecting and de-duplicating paths from configured tokens, project source files, and the resolver.

* **Tests**
  * Simplified test project setup and updated plugin configuration invocation for improved type safety.
  * Expanded TypeScript checking to include tests and test configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->