### PR TITLE
chore: clear zizmor + dependabot security findings

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -219,7 +219,7 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
 
@@ -205,7 +205,7 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           # Cache deliberately disabled during publish: Actions cache

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           run_install: false
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           cache: pnpm

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ overrides:
   '@babel/core': ^7.29.6
   webpack-dev-server: 5.2.5
   http-proxy-middleware: ^3.0.6
+  websocket-driver: ^0.7.5
 
 importers:
 
@@ -9070,8 +9071,8 @@ packages:
       webpack:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -15288,7 +15289,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -18352,7 +18353,7 @@ snapshots:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 14.0.0
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   sort-css-media-queries@2.2.0: {}
 
@@ -19152,7 +19153,7 @@ snapshots:
       '@rspack/core': 1.7.11
       webpack: 5.106.2(@swc/core@1.15.26)(esbuild@0.28.1)
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,3 +52,5 @@ overrides:
   # dev-server proxy, and no workspace sets one — so it is dead here. Pinned to
   # the minimum patched major (not v4) to stay closest to wds's expected API.
   http-proxy-middleware: ^3.0.6
+  # GHSA-xv26-6w52-cph6 (critical) + GHSA-mp7j-qc5w-4988 (#1368), via webpack-dev-server -> sockjs
+  websocket-driver: ^0.7.5


### PR DESCRIPTION
## Summary

Clears the two security-surface findings the repo was flagging.

### Zizmor — 7x `ref-version-mismatch`
`actions/setup-node` is hash-pinned to `48b55a0…` (the `v6.4.0` release commit) across 7 workflow spots, but commented `# v6`. The floating `v6` tag has since moved to a newer commit, so the bare `# v6` comment no longer matches the pinned SHA — zizmor's `ref-version-mismatch`. Made the comment exact (`# v6.4.0`) everywhere. **No functional change** — same pinned commit; verified `v6.4.0` resolves to the pinned SHA.

### Dependabot — `websocket-driver` (critical + medium)
`websocket-driver@0.7.4` is vulnerable to GHSA-xv26-6w52-cph6 (critical, message corruption via protocol length headers) and GHSA-mp7j-qc5w-4988 (medium, resource-limit bypass), both fixed in 0.7.5. It reaches us transitively via `webpack-dev-server → sockjs` (the Docusaurus docs dev server) — the same chain as the existing `uuid` override. Added a pnpm override forcing `^0.7.5`; now resolves to 0.7.5.

## Verification

- `pnpm install --frozen-lockfile` clean (lockfile consistent).
- Workflow edits are comment-only; CI's zizmor + docs-build jobs exercise both changes.

## Milestone
Maintenance

Closes #1368

## Plan impact
None. Most of these overrides trace to the Docusaurus dev-server chain; #1234 (Starlight migration) would retire much of this wall.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened build, documentation, release, and security automation by pinning the Node.js setup action to a specific version.
  * Updated a transitive WebSocket dependency to a secure pinned version addressing published security advisories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->