### PR TITLE
docs(docs): move withAxes reference into a Creating story variants guide

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
           items: [
             'guides/quickstart',
             'guides/authoring-doc-stories',
+            'guides/creating-story-variants',
             'guides/consuming-the-active-theme',
             {
               label: 'Integrations',
@@ -76,7 +77,6 @@ export default defineConfig({
               ],
             },
             'reference/diagnostics',
-            'reference/with-axes',
           ],
         },
         {
@@ -120,5 +120,6 @@ export default defineConfig({
     '/concepts/overview': '/swatchbook/concepts/',
     '/concepts/concepts': '/swatchbook/concepts/',
     '/reference/integrations': '/swatchbook/guides/integrations/',
+    '/reference/with-axes': '/swatchbook/guides/creating-story-variants/',
   },
 });

--- a/apps/docs/src/content/docs/guides/creating-story-variants.mdx
+++ b/apps/docs/src/content/docs/guides/creating-story-variants.mdx
@@ -1,11 +1,12 @@
 ---
-title: withAxes
+title: Creating story variants
 ---
 
-`withAxes` produces the input for a story's `.extend()`, pinning a variant to a
-chosen axis tuple so its full test (render, play, and a11y) runs under that
-tuple. The addon generates one test per story export, so each variant is its own
-test. Import it from the addon's `testing` subpath:
+A story variant pins a base story to a chosen axis tuple, so it renders and runs
+its full test (render, play, and a11y) under that tuple instead of whatever the
+toolbar has selected. The `withAxes` helper produces the input for the variant's
+`.extend()`; the addon generates one test per story export, so each variant is
+its own test. Import it from the addon's `testing` subpath:
 
 ```ts
 import { withAxes } from '@unpunnyfuns/swatchbook-addon/testing';

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -53,7 +53,7 @@ Returns `{ value, cssVar, type?, description? }`. `cssVar` is stable across them
 
 ## Testing
 
-Author axis coverage for tests with [`withAxes`](https://unpunnyfuns.github.io/swatchbook/reference/with-axes) from the `testing` subpath.
+Author axis coverage for tests with [`withAxes`](https://unpunnyfuns.github.io/swatchbook/guides/creating-story-variants) from the `testing` subpath.
 
 ## Credits
 


### PR DESCRIPTION
Milestone: Maintenance
Closes #1383
Plan impact: none — docs-site reorganisation, no design intent change.

The `reference/with-axes` page reads as a guide, not an API entry: it opens on a workflow (pin a story variant to an axis tuple, get one test per variant) and its substantive sections are task advice ("Choosing what to cover", "Hiding a variant from the sidebar"). It was the odd page in a Reference section framed as "grouped by kind (Packages / Blocks)", fitting neither and titled after a symbol.

- Moved to `guides/creating-story-variants` and retitled "Creating story variants"; the page opens with what a variant is before introducing the `withAxes` helper.
- Redirect from `/reference/with-axes`; the addon README link updated.
- Sidebar: dropped from Reference, added to Guides after the authoring guide.

Verified: docs build, format/lint clean, new page and redirect stub present, no stale slug references.

Docs-only, no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the “withAxes” content under the Guides section as “Creating story variants.”
  * Clarified how story variants run tests against specific axis combinations and how `withAxes` supports this workflow.
  * Updated documentation links and added a redirect from the previous reference page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->