### PR TITLE
docs(docs): resolve CodeRabbit accuracy findings from the overhaul PRs

### DIFF
--- a/apps/docs/src/content/docs/concepts/axes.mdx
+++ b/apps/docs/src/content/docs/concepts/axes.mdx
@@ -6,7 +6,7 @@ import AxisFlipDiagram from '#/components/diagrams/AxisFlipDiagram.tsx';
 
 An **axis** is one independent dimension of your theming model: `mode`, `brand`, `density`, `contrast`, whatever fits your system. Each axis has a set of named **contexts** (one of which is the default), and at any moment exactly one context is selected per axis.
 
-The axis shape is the alternative to a flat string-ID model (`"light"`, `"dark"`, `"brand-a-dark-compact"`). Flat IDs have to name every combination, and the count multiplies: one dimension becomes two, two become four. Modelling each dimension independently keeps that counting out of theme names; contexts compose at runtime instead. If your system has exactly one dimension and no plans for more, [`@storybook/addon-themes`](https://storybook.js.org/addons/@storybook/addon-themes)' single-string-ID model is simpler and a better fit.
+The axis shape is the alternative to a flat string-ID model (`"light"`, `"dark"`, `"brand-a-dark-compact"`). Flat IDs have to name every combination, and the count multiplies: with two contexts each, one dimension is two names, two dimensions four. Modelling each dimension independently keeps that counting out of theme names; contexts compose at runtime instead. If your system has exactly one dimension and no plans for more, [`@storybook/addon-themes`](https://storybook.js.org/addons/@storybook/addon-themes)' single-string-ID model is simpler and a better fit.
 
 ## Tuples, not strings
 

--- a/apps/docs/src/content/docs/concepts/index.mdx
+++ b/apps/docs/src/content/docs/concepts/index.mdx
@@ -15,7 +15,7 @@ The package contains two things:
 - **Doc blocks.** React components for MDX: `TokenDetail`, `TokenTable`, `TokenNavigator`, `ColorPalette`, `TypographyScale`, and per-type previews for motion, shadow, border, gradient, stroke style.
 - **A toolbar theme switcher.** One dropdown per modifier axis in your DTCG resolver. Flip mode, brand, contrast, density (whatever your system has) and tokens repaint live.
 
-Stories that already style with CSS variables pick up the switcher's flips without further wiring.
+Stories that already style with swatchbook's token CSS variables pick up the switcher's flips without further wiring.
 
 :::tip[Try it here]
 The yinyang icon in the top-right of this page drives the same switcher against this docs site's own tokens. Flip **mode**, **a11y**, or **typeface** to see.

--- a/apps/docs/src/content/docs/concepts/token-pipeline.mdx
+++ b/apps/docs/src/content/docs/concepts/token-pipeline.mdx
@@ -20,7 +20,7 @@ import { tokenGraph, defaultTuple, axes, diagnostics, css } from 'virtual:swatch
 
 "Virtual" means there's no file on disk. Vite asks the plugin to materialize the module on each preview build, and the plugin does this by calling `loadProject(config, cwd)` from `@unpunnyfuns/swatchbook-core` and serializing the result into ESM exports.
 
-Edit your config or a token file, Vite notices, the plugin re-runs `loadProject`, and the preview sees fresh values over HMR.
+Edit a token or resolver file, Vite notices, the plugin re-runs `loadProject`, and the preview sees fresh values over HMR.
 
 ## Build once, query fast
 
@@ -53,4 +53,4 @@ The virtual module lives inside Vite's module graph: the Storybook preview resol
 ## Sharp edges
 
 - **Vite is required.** The addon bundles the plugin for Storybook's Vite integration. Webpack-based Storybook setups don't get the virtual module materialized; they would fall back to a pre-built snapshot or switch to the Vite builder. Storybook 10's default is Vite, so this only bites older setups.
-- The virtual module's addon-internal status and the dir-level `fs.watch` that keeps atomic-save editors working are covered under [Sharp corners](/developers/sharp-corners).
+- The virtual module's addon-internal status and the directory-level `fs.watch` that keeps atomic-save editors working are covered under [Sharp corners](/developers/sharp-corners).

--- a/apps/docs/src/content/docs/developers/architecture.mdx
+++ b/apps/docs/src/content/docs/developers/architecture.mdx
@@ -82,7 +82,7 @@ The `Project` snapshot passed to `render` carries everything: axes, `tokenGraph`
 
 ## Data flow: static build path
 
-The simpler of the two flows, used by the docs site, emitted CSS for consumers, and the MCP server at startup.
+The simpler of the two flows, used by the docs site build, the CSS emitted for consumers, and the MCP server at startup.
 
 ```
 tokens/resolver.json

--- a/apps/docs/src/content/docs/reference/addon.mdx
+++ b/apps/docs/src/content/docs/reference/addon.mdx
@@ -2,7 +2,7 @@
 title: Addon
 ---
 
-Wiring swatchbook into Storybook is this package's job. It loads your config at build time through `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, and at preview time registers a decorator, a manager toolbar, and the `useToken` hook. The MDX doc blocks live in `@unpunnyfuns/swatchbook-blocks`, which this package depends on and re-exports; importing either package's name gets you the blocks.
+Wiring swatchbook into Storybook is this package's job. It loads your config at build time through `@unpunnyfuns/swatchbook-core`, exposes the resolved graph as a virtual module, and at preview time registers a decorator and a manager toolbar, and exposes the `useToken` hook. The MDX doc blocks live in `@unpunnyfuns/swatchbook-blocks`, which this package depends on and re-exports; importing either package's name gets you the blocks.
 
 ## Install
 
@@ -10,7 +10,7 @@ Wiring swatchbook into Storybook is this package's job. It loads your config at 
 npm install -D @unpunnyfuns/swatchbook-addon @unpunnyfuns/swatchbook-core
 ```
 
-This gives you the toolbar, preview decorator, and the `useToken()` hook. The addon depends on `@unpunnyfuns/swatchbook-blocks` and re-exports its full surface (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `Diagnostics`, `SwatchbookProvider`, block-side hooks), so no separate install is needed inside a Storybook that already registers the addon; import from either package's name and both resolve to the same module. Install `@unpunnyfuns/swatchbook-blocks` directly only for a non-Storybook consumer of the blocks. See the [authoring guide](/guides/authoring-doc-stories) for MDX composition patterns.
+This gives you the toolbar, preview decorator, and the `useToken()` hook. The addon depends on `@unpunnyfuns/swatchbook-blocks` and re-exports its full surface (`TokenTable`, `ColorPalette`, `TokenDetail`, `TokenNavigator`, `Diagnostics`, `SwatchbookProvider`, block-side hooks), so no separate install is needed inside a Storybook that already registers the addon; import from either package's name for the same re-exported surface. Install `@unpunnyfuns/swatchbook-blocks` directly only for a non-Storybook consumer of the blocks. See the [authoring guide](/guides/authoring-doc-stories) for MDX composition patterns.
 
 Peer requirements: Storybook 10.1+ on the Vite builder, React 18+.
 

--- a/apps/docs/src/content/docs/reference/blocks/index.mdx
+++ b/apps/docs/src/content/docs/reference/blocks/index.mdx
@@ -2,7 +2,7 @@
 title: Blocks
 ---
 
-The MDX-embeddable doc blocks for token reference pages live in `@unpunnyfuns/swatchbook-blocks`. Each block reads the active token graph from the addon's virtual module and re-renders when the toolbar flips an axis.
+The MDX-embeddable doc blocks for token reference pages live in `@unpunnyfuns/swatchbook-blocks`. Each block reads the active token graph from a `SwatchbookProvider` and re-renders when the toolbar flips an axis.
 
 ## Install
 

--- a/apps/docs/src/content/docs/reference/core.mdx
+++ b/apps/docs/src/content/docs/reference/core.mdx
@@ -345,7 +345,7 @@ See the [Integrations guide](/guides/integrations) for factories that build thes
 
 ### `Diagnostic`
 
-One load-time warning or error on `Project.diagnostics`. See the [Diagnostics reference](/reference/diagnostics) for the interface shape and the full catalog by group.
+One load-time diagnostic (`error`, `warn`, or `info`) on `Project.diagnostics`. See the [Diagnostics reference](/reference/diagnostics) for the interface shape and the full catalog by group.
 
 ### `DiagnosticSeverity`
 

--- a/apps/docs/src/content/docs/reference/switcher.mdx
+++ b/apps/docs/src/content/docs/reference/switcher.mdx
@@ -142,7 +142,7 @@ The Storybook addon's manager toolbar imports this directly to avoid carrying a 
 
 The component is pure: it reads its inputs, draws the menu, and calls back when the user clicks. It never touches `localStorage` / `sessionStorage`, the DOM outside its own subtree, or the router. Applying a change, and persisting it across reloads, is the host's policy. Two common shapes for applying it:
 
-- **Attribute on `<html>`**: set `data-<prefix>-<axis>` on `document.documentElement` per change. Pairs with `cssVarPrefix` from `loadProject` so emitted CSS targets the same selectors. The Storybook addon and the docs-site switcher both use this.
+- **Attribute on `<html>`**: set `data-<prefix>-<axis>` on `document.documentElement` per change. Pairs with `cssVarPrefix` from `loadProject` so emitted CSS targets the same selectors. The Storybook addon and the docs-site switcher both use this, though the docs-site switcher drives `mode` through Starlight's `data-theme` instead.
 - **Class on `<body>`**: toggle `theme-<value>` on `document.body.classList`. Useful if the project's stylesheet uses class-based scoping instead of attribute selectors.
 
 For persistence, the Storybook addon piggybacks on Storybook's globals API; the docs-site switcher syncs with the site's own light/dark theme (Starlight's `data-theme` + `starlight-theme` `localStorage` key) for `mode` and persists the rest via a separate `localStorage` key.


### PR DESCRIPTION
Milestone: Maintenance
Closes #1385
Plan impact: none — docs-site accuracy corrections, no design intent change.

Batches the valid CodeRabbit review comments left on #1380, #1381, and #1382 into one pass. All are small prose accuracy nits, verified against the source:

- **addon**: `useToken` is exposed via re-export, not "registered" at preview time; the addon and blocks "expose the same re-exported surface" rather than "resolve to the same module".
- **blocks/index**: each block reads the active graph from a `SwatchbookProvider`, not the addon's internal virtual module directly (matches the standalone-usage section on the same page).
- **core**: `Project.diagnostics` entries carry `error`, `warn`, or `info` — the summary said only warning/error (`DiagnosticSeverity` is `'error' | 'warn' | 'info'`).
- **switcher**: noted that the docs-site switcher drives `mode` through Starlight's `data-theme`, an exception to the per-axis `data-<prefix>-<axis>` strategy.
- **concepts/axes**: the flat-ID combination count ("one dimension becomes two, two become four") holds for two contexts per dimension — qualified.
- **concepts**: scoped the live-repaint claim to swatchbook's token CSS variables, not arbitrary ones.
- **token-pipeline**: the HMR watcher watches token and resolver sources, not the config file (verified in `packages/addon/src/virtual/plugin.ts`); "dir-level" → "directory-level".
- **architecture**: fixed a garbled sentence in the static-build-flow description.

Declined the `.mdx`-extension and source-slug link suggestions: they contradict the repo's extensionless-root-absolute link convention (rewritten at build time by `rehypeBaseLinks`), and the flagged landing LinkCard already uses the correct hand-prefixed JSX href.

Verified: docs build (29 pages), format/lint clean.

Docs-only, no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how axis contexts scale and combine at runtime.
  * Explained how token CSS variables power theme switching in stories.
  * Documented refreshed preview values during token and resolver edits.
  * Improved addon installation, exports, and `useToken()` guidance.
  * Clarified token graph access and re-rendering for embedded blocks.
  * Expanded diagnostic severity documentation to include `info`.
  * Clarified theme-state propagation differences between Storybook and the docs site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->