### PR TITLE
chore: document the docs link convention for CodeRabbit

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+reviews:
+  path_instructions:
+    - path: apps/docs/src/content/docs/**/*.{md,mdx}
+      instructions: >-
+        Links between docs pages use extensionless, root-absolute slugs
+        (`/reference/config`, `/guides/quickstart`) by convention. This is
+        intentional: do NOT suggest adding a `.mdx`/`.md` extension, and do NOT
+        suggest converting them to relative paths. A build-time rehype plugin
+        (`apps/docs/src/plugins/rehype-base-links.mjs`) rewrites these
+        markdown-authored links to carry the site's `/swatchbook` base, so an
+        unprefixed root-absolute slug is correct and resolves on the deployed
+        site.
+
+        In JSX/MDX component props (for example `<LinkCard href="...">`), the
+        `/swatchbook/` base is carried by hand, because the rehype plugin only
+        rewrites markdown-syntax links, not JSX attribute values. Do NOT flag a
+        hand-prefixed absolute href in a JSX prop as needing a relative or
+        source-slug form.


### PR DESCRIPTION
Milestone: Maintenance
Closes #1387
Plan impact: none — review-tooling config, no product or docs-content change.

Adds a `.coderabbit.yaml` `path_instructions` entry for `apps/docs/src/content/docs/**` documenting the docs link convention, so CodeRabbit stops raising it as a finding on every docs PR:

- Internal links use extensionless, root-absolute slugs (`/reference/config`), rewritten to carry the `/swatchbook` base at build time by `rehypeBaseLinks`. Not `.mdx`-suffixed, not relative.
- JSX/MDX component props (e.g. `<LinkCard href>`) hand-carry the `/swatchbook/` base, since the rehype plugin only rewrites markdown-syntax links.

This recurred across #1378–#1382 as the one consistently-declined finding. Validated the file parses as YAML.

No changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation authoring guidance for internal links.
  * Clarified preferred extensionless, root-absolute link formats and exceptions for JSX/MDX component properties.
  * Added editor support for validating the documentation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->