### PR TITLE
test: de-flake ConsumerOutput clipboard-copy interaction tests

### DIFF
--- a/apps/storybook/src/stories/token-detail/ConsumerOutput.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/ConsumerOutput.stories.tsx
@@ -1,5 +1,5 @@
 import { ConsumerOutput } from '@unpunnyfuns/swatchbook-blocks';
-import { expect, userEvent, waitFor } from 'storybook/test';
+import { expect, waitFor } from 'storybook/test';
 import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -33,77 +33,5 @@ export const RendersPathAndCssRows = meta.story({
     const cssEl = canvasElement.querySelector('[data-testid="consumer-output-css"]');
     expect(pathEl?.textContent).toBe('color.accent.bg');
     expect(cssEl?.textContent).toBe('var(--sb-color-accent-bg)');
-  },
-});
-
-export const CopyPathWritesToClipboard = meta.story({
-  args: { path: 'color.accent.bg' },
-  play: async ({ canvasElement }) => {
-    const writes: string[] = [];
-    const originalClipboard = navigator.clipboard;
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: (text: string) => {
-          writes.push(text);
-          return Promise.resolve();
-        },
-      },
-    });
-    try {
-      const btn = await waitFor(() => {
-        const el = canvasElement.querySelector<HTMLElement>(
-          '[data-testid="consumer-output-path-copy"]',
-        );
-        if (!el) throw new Error('copy button not rendered');
-        return el;
-      });
-      await userEvent.click(btn);
-      await waitFor(() => {
-        if (writes.length === 0) throw new Error('clipboard not written');
-      });
-      expect(writes).toEqual(['color.accent.bg']);
-    } finally {
-      Object.defineProperty(navigator, 'clipboard', {
-        configurable: true,
-        value: originalClipboard,
-      });
-    }
-  },
-});
-
-export const CopyCssWritesToClipboard = meta.story({
-  args: { path: 'color.accent.bg' },
-  play: async ({ canvasElement }) => {
-    const writes: string[] = [];
-    const originalClipboard = navigator.clipboard;
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: (text: string) => {
-          writes.push(text);
-          return Promise.resolve();
-        },
-      },
-    });
-    try {
-      const btn = await waitFor(() => {
-        const el = canvasElement.querySelector<HTMLElement>(
-          '[data-testid="consumer-output-css-copy"]',
-        );
-        if (!el) throw new Error('copy button not rendered');
-        return el;
-      });
-      await userEvent.click(btn);
-      await waitFor(() => {
-        if (writes.length === 0) throw new Error('clipboard not written');
-      });
-      expect(writes).toEqual(['var(--sb-color-accent-bg)']);
-    } finally {
-      Object.defineProperty(navigator, 'clipboard', {
-        configurable: true,
-        value: originalClipboard,
-      });
-    }
   },
 });

--- a/packages/blocks/test/consumer-output-view.browser.test.tsx
+++ b/packages/blocks/test/consumer-output-view.browser.test.tsx
@@ -22,6 +22,23 @@ afterEach(() => {
   cleanup();
 });
 
+// Headless Chromium denies the clipboard-write permission, so
+// `navigator.clipboard.writeText` rejects regardless of the click. Its
+// `writeText` isn't spyable, so stub the whole `clipboard` object. `clipboard`
+// is an inherited accessor on `Navigator.prototype`; restore by descriptor
+// (deleting the own stub when there was no own property) so nothing is left
+// shadowing that accessor for later tests.
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  const restore = () => {
+    if (original) Object.defineProperty(navigator, 'clipboard', original);
+    else Reflect.deleteProperty(navigator, 'clipboard');
+  };
+  return { writeText, restore };
+}
+
 it('renders Path + CSS rows with no extra platforms', () => {
   setup();
   expect(screen.getByTestId('consumer-output-path').textContent).toBe('color.accent.bg');
@@ -51,16 +68,9 @@ it('renders nothing when hasToken is false', () => {
 });
 
 it('toggles the copy button feedback to "Copied" when clicked, using local state', async () => {
-  // Headless Chromium denies the clipboard-write permission outright, so
-  // `navigator.clipboard.writeText` rejects regardless of the click. Stub it
-  // to isolate what this test actually checks: the View's own local
-  // `copied` state toggle, not the browser's clipboard permission model.
-  const originalClipboard = navigator.clipboard;
-  Object.defineProperty(navigator, 'clipboard', {
-    value: { writeText: vi.fn().mockResolvedValue(undefined) },
-    configurable: true,
-  });
-
+  // Stub the clipboard so the click resolves, isolating what this test checks:
+  // the View's own local `copied` state toggle, not the permission model.
+  const { restore } = stubClipboard();
   try {
     setup();
     const button = screen.getByTestId('consumer-output-path-copy');
@@ -68,49 +78,28 @@ it('toggles the copy button feedback to "Copied" when clicked, using local state
     await userEvent.click(button);
     await expect.poll(() => button.textContent).toBe('Copied');
   } finally {
-    Object.defineProperty(navigator, 'clipboard', {
-      value: originalClipboard,
-      configurable: true,
-    });
+    restore();
   }
 });
 
 it('copies the token path when the path copy button is clicked', async () => {
-  const originalClipboard = navigator.clipboard;
-  const writeText = vi.fn().mockResolvedValue(undefined);
-  Object.defineProperty(navigator, 'clipboard', {
-    value: { writeText },
-    configurable: true,
-  });
-
+  const { writeText, restore } = stubClipboard();
   try {
     setup();
     await userEvent.click(screen.getByTestId('consumer-output-path-copy'));
     await expect.poll(() => writeText.mock.calls).toEqual([['color.accent.bg']]);
   } finally {
-    Object.defineProperty(navigator, 'clipboard', {
-      value: originalClipboard,
-      configurable: true,
-    });
+    restore();
   }
 });
 
 it('copies the CSS variable when the CSS copy button is clicked', async () => {
-  const originalClipboard = navigator.clipboard;
-  const writeText = vi.fn().mockResolvedValue(undefined);
-  Object.defineProperty(navigator, 'clipboard', {
-    value: { writeText },
-    configurable: true,
-  });
-
+  const { writeText, restore } = stubClipboard();
   try {
     setup();
     await userEvent.click(screen.getByTestId('consumer-output-css-copy'));
     await expect.poll(() => writeText.mock.calls).toEqual([['var(--sb-color-accent-bg)']]);
   } finally {
-    Object.defineProperty(navigator, 'clipboard', {
-      value: originalClipboard,
-      configurable: true,
-    });
+    restore();
   }
 });

--- a/packages/blocks/test/consumer-output-view.browser.test.tsx
+++ b/packages/blocks/test/consumer-output-view.browser.test.tsx
@@ -74,3 +74,43 @@ it('toggles the copy button feedback to "Copied" when clicked, using local state
     });
   }
 });
+
+it('copies the token path when the path copy button is clicked', async () => {
+  const originalClipboard = navigator.clipboard;
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+
+  try {
+    setup();
+    await userEvent.click(screen.getByTestId('consumer-output-path-copy'));
+    await expect.poll(() => writeText).toHaveBeenCalledWith('color.accent.bg');
+  } finally {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+  }
+});
+
+it('copies the CSS variable when the CSS copy button is clicked', async () => {
+  const originalClipboard = navigator.clipboard;
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText },
+    configurable: true,
+  });
+
+  try {
+    setup();
+    await userEvent.click(screen.getByTestId('consumer-output-css-copy'));
+    await expect.poll(() => writeText).toHaveBeenCalledWith('var(--sb-color-accent-bg)');
+  } finally {
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+  }
+});

--- a/packages/blocks/test/consumer-output-view.browser.test.tsx
+++ b/packages/blocks/test/consumer-output-view.browser.test.tsx
@@ -86,7 +86,7 @@ it('copies the token path when the path copy button is clicked', async () => {
   try {
     setup();
     await userEvent.click(screen.getByTestId('consumer-output-path-copy'));
-    await expect.poll(() => writeText).toHaveBeenCalledWith('color.accent.bg');
+    await expect.poll(() => writeText.mock.calls).toEqual([['color.accent.bg']]);
   } finally {
     Object.defineProperty(navigator, 'clipboard', {
       value: originalClipboard,
@@ -106,7 +106,7 @@ it('copies the CSS variable when the CSS copy button is clicked', async () => {
   try {
     setup();
     await userEvent.click(screen.getByTestId('consumer-output-css-copy'));
-    await expect.poll(() => writeText).toHaveBeenCalledWith('var(--sb-color-accent-bg)');
+    await expect.poll(() => writeText.mock.calls).toEqual([['var(--sb-color-accent-bg)']]);
   } finally {
     Object.defineProperty(navigator, 'clipboard', {
       value: originalClipboard,


### PR DESCRIPTION
Milestone: Maintenance
Closes #1370
Plan impact: none.

The `CopyCssWritesToClipboard` (and identical `CopyPathWritesToClipboard`) stories swapped the entire `navigator.clipboard` global for a stub and read a side-channel `writes[]` array inside their play functions, restoring in a play-local `try/finally`. Headless CI Chromium denies the clipboard-write permission, so the stub is load-bearing; but mutating the shared global inside story plays isn't isolated the way a vitest `afterEach` is, so it races under addon-vitest and flakes.

- Moved the exact-value coverage into the isolated browser test `packages/blocks/test/consumer-output-view.browser.test.tsx`, which already stubs the clipboard safely (whole-object stub + `try/finally`, `afterEach(cleanup)`, real Chromium/Firefox). Two new cases assert the copy buttons call `writeText` with exactly `['color.accent.bg']` and `['var(--sb-color-accent-bg)']` — the exact call list, matching (and slightly strengthening) what the removed stories checked.
- Removed the two racy play-stories from `ConsumerOutput.stories.tsx`; `Color`, `Space`, and `RendersPathAndCssRows` stay.

The identical pattern in `TokenUsageSnippet.stories.tsx` is tracked separately as #1390.

Verified: blocks build + test suite green, the new browser-test file run repeatedly (10+ consecutive runs, zero failures), storybook test suite green with the two stories gone, lint/typecheck clean.

Test-only, no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added browser coverage to verify clipboard writing for token path and corresponding CSS variable values.
  * Improved clipboard stubbing to avoid inherited-accessor issues and ensured the original clipboard implementation is restored after each test.
  * Removed redundant Storybook stories that duplicated clipboard-behavior verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->