### PR TITLE
docs: tighten and align package READMEs

### DIFF
--- a/.changeset/readme-pass.md
+++ b/.changeset/readme-pass.md
@@ -1,0 +1,10 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+'@unpunnyfuns/swatchbook-addon': patch
+'@unpunnyfuns/swatchbook-blocks': patch
+'@unpunnyfuns/swatchbook-switcher': patch
+'@unpunnyfuns/swatchbook-integrations': patch
+'@unpunnyfuns/swatchbook-mcp': patch
+---
+
+Tighten and align package READMEs so registries show the refreshed copy; no code changes.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Storybook addon and MDX doc blocks for visualising [DTCG design tokens](https:
 
 Built on [Terrazzo](https://terrazzo.app/)'s parser. Your production build runs Terrazzo's CLI against the same DTCG source; swatchbook reads it too, inside Storybook.
 
-If your stories already style with CSS variables, they pick up the toolbar's axis flips automatically. That's mostly what the tool does.
+If your stories already style with swatchbook's token CSS variables, they pick up the toolbar's axis flips automatically.
 
 **Documentation** · [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/)
 **Live Storybook** · [/storybook](https://unpunnyfuns.github.io/swatchbook/storybook/)

--- a/packages/addon/README.md
+++ b/packages/addon/README.md
@@ -25,7 +25,7 @@ addons: [
     options: {
       config: {
         resolver: 'tokens/resolver.json',
-        cssVarPrefix: 'ds',
+        cssVarPrefix: 'sb',
       },
     },
   },

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -39,10 +39,7 @@ Block catalogue, props, and composition patterns live in the [blocks reference](
 
 ## Boundaries
 
-- ✅ Compose multiple blocks per page; each mounts independently.
-- ✅ Render outside Storybook with a hand-built or loaded `ProjectSnapshot`.
-- ❌ Don't import from `virtual:swatchbook/tokens`; it's the addon's internal wiring, not a public API. Use `SwatchbookProvider`.
-- ❌ Don't use `useGlobals` / `useArgs` from `storybook/preview-api` inside custom blocks; those hooks throw in docs context.
+Blocks read from `SwatchbookProvider`, not the addon's internal `virtual:swatchbook/tokens` module; don't import that directly. And `useGlobals` / `useArgs` from `storybook/preview-api` throw in a docs context, so don't call them inside custom blocks.
 
 ## Credits
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -36,23 +36,11 @@ The [config reference](https://unpunnyfuns.github.io/swatchbook/reference/config
 
 ## Browser-safe subpaths
 
-Leaf utilities consumers need without the loader's Node deps live on dedicated subpaths, each tree-shake-clean, no `@terrazzo/parser`, no `node:*` imports:
-
-- `@unpunnyfuns/swatchbook-core/snapshot-for-wire`: `snapshotForWire(project, css)` + `SnapshotForWire` type
-- `@unpunnyfuns/swatchbook-core/themes`: `enumerateThemes({axes, presets, defaultTuple})` + `tupleToName(axes, tuple)` + `ThemeEntry` type
-- `@unpunnyfuns/swatchbook-core/match-path`: `matchPath(path, filter)` glob-style matcher (`*` / `**`)
-- `@unpunnyfuns/swatchbook-core/fuzzy`: uFuzzy-backed token search
-- `@unpunnyfuns/swatchbook-core/css-var`: `cssVarRef(path, prefix)`
-- `@unpunnyfuns/swatchbook-core/data-attr`: `dataAttr(prefix, key)`
-- `@unpunnyfuns/swatchbook-core/style-element`: `ensureStyleElement(id, text)` + `SWATCHBOOK_STYLE_ELEMENT_ID`
+Leaf utilities that don't need the loader's Node deps ship on dedicated, tree-shakeable subpaths (no `@terrazzo/parser`, no `node:*` imports): `/snapshot-for-wire`, `/themes`, `/match-path`, `/fuzzy`, `/css-var`, `/data-attr`, `/style-element`. The [core reference](https://unpunnyfuns.github.io/swatchbook/reference/core) documents each one's exports.
 
 ## Boundaries
 
-- ✅ Build-time use: Node, scripts, SSR, Storybook presets.
-- ✅ Pair with [Terrazzo](https://terrazzo.app/)'s CLI for production artifact emission (CSS / JS / Tailwind / Swift / Sass / …).
-- ✅ Ship `project.tokenGraph` / `project.defaultTokens` / `project.defaultTuple` to the browser via the `snapshot-for-wire` subpath. That's exactly what the addon's preview does.
-- ❌ Don't ship the full `Project` object to the browser. `resolveAt` is a function and `cwd` is a Node-side absolute path; use `snapshotForWire(project, css)` to get a JSON-friendly subset.
-- ❌ Don't reach into `@terrazzo/parser` directly. Stay on the core surface so upgrades don't churn your code.
+`swatchbook-core` is build-time only: Node, scripts, SSR, Storybook presets. Pair it with [Terrazzo](https://terrazzo.app/)'s CLI for production artifact emission (CSS / JS / Tailwind / Swift / Sass). To hand data to the browser, ship the `snapshotForWire(project, css)` subset (the addon's preview does exactly this) rather than the full `Project`, whose `resolveAt` is a function and whose `cwd` is a Node-side absolute path. Stay on the core surface rather than reaching into `@terrazzo/parser` directly, so upgrades don't churn your code.
 
 ## Credits
 

--- a/packages/integrations/README.md
+++ b/packages/integrations/README.md
@@ -1,6 +1,6 @@
 # swatchbook-integrations
 
-Preview-side adapters that let your Storybook stories use [Tailwind v4](./src/tailwind.ts) or a [CSS-in-JS library](./src/css-in-js.ts) against [swatchbook](https://github.com/unpunnyfuns/swatchbook)'s tokens.
+These adapters let your Storybook stories style with [Tailwind v4](./src/tailwind.ts) or a [CSS-in-JS library](./src/css-in-js.ts) against [swatchbook](https://github.com/unpunnyfuns/swatchbook)'s tokens.
 
 Not a replacement for your production build. Integrations are preview-only: they let `bg-sb-surface-default` or `theme.color.accent.bg` resolve correctly inside Storybook; for production artifacts, run [Terrazzo](https://terrazzo.app/)'s CLI against the same DTCG sources.
 
@@ -40,8 +40,11 @@ Per-integration wiring details live in the [Integrations guide](https://unpunnyf
 
 ## Boundaries
 
-- ✅ Preview-side use inside Storybook. Stories that style with utility classes or theme accessors pick up the swatchbook toolbar's axis flips via CSS cascade.
-- ❌ No MUI / Vuetify / Bootstrap SCSS factories. Those need resolved values per named theme; run Terrazzo's CLI with `@terrazzo/plugin-js` for that case.
+Preview-side use inside Storybook only: stories that style with utility classes or theme accessors pick up the toolbar's axis flips via the CSS cascade. There are no MUI / Vuetify / Bootstrap SCSS factories here; those need resolved values per named theme, so run Terrazzo's CLI with `@terrazzo/plugin-js` for that.
+
+## Credits
+
+Token parsing and resolver evaluation come from [Terrazzo](https://terrazzo.app/) by the [Terrazzo team](https://github.com/terrazzoapp) via `@unpunnyfuns/swatchbook-core`.
 
 ## Documentation
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -42,7 +42,7 @@ await server.connect(new StdioServerTransport());
 
 ## Tools
 
-Fourteen read-only tools covering token listing, search, theme resolution, alias chains, color formats + contrast, axis variance, and diagnostics. Full catalogue in the [MCP reference](https://unpunnyfuns.github.io/swatchbook/reference/mcp).
+A set of read-only tools covering token listing, search, theme resolution, alias chains, color formats + contrast, axis variance, and diagnostics. Full catalogue in the [MCP reference](https://unpunnyfuns.github.io/swatchbook/reference/mcp).
 
 ## Credits
 


### PR DESCRIPTION
Milestone: Maintenance
Closes #1392
Plan impact: none.

The package READMEs weren't part of the docs-site overhaul. This is a light pass against the same register and the project's README convention (terse; detailed reference lives on the docs site; link prominently).

- Root: scoped the CSS-variable pickup claim to swatchbook's token variables (the accuracy fix already made in `concepts/index`), and dropped the "That's mostly what the tool does." throwaway.
- mcp: un-hard-coded the "Fourteen tools" count (rot-prone; the docs already stopped stating a number).
- core: condensed the "Browser-safe subpaths" signature list to the subpath names plus a pointer to the core reference, where the full detail lives.
- Dropped the `✅/❌` do/don't ("Boundaries") sections; folded the load-bearing constraints (build-time-only, `snapshotForWire` vs full `Project`, the virtual-module / preview-api hook gotchas, the SCSS-factory scope note) into prose.
- Consistency: standardized the example `cssVarPrefix` to `sb`; added a Credits section to integrations to match the other packages; rewrote the "Preview-side adapters that…" fragment opener.

Cut as a **patch** release so the refreshed READMEs reach npm — READMEs ship with the package and only refresh on publish. Private `packages/tokens` README left as-is (unpublished dogfood, out of the reviewed set).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how token-based styling benefits from toolbar axis flips.
  * Updated Storybook configuration guidance for CSS variable prefixes.
  * Simplified guidance on block boundaries, browser-safe usage, and token delivery.
  * Improved integration documentation for Tailwind, CSS-in-JS, and Storybook-only adapters.
  * Refined MCP tools descriptions and consolidated package README content for clearer registry display.

* **Chores**
  * Published patch-level documentation updates across the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->