### PR TITLE
fix(docs): keep the switcher trigger icon visible on hover

### DIFF
--- a/apps/docs/src/components/SwatchbookSwitcherButton.css
+++ b/apps/docs/src/components/SwatchbookSwitcherButton.css
@@ -22,7 +22,11 @@
 .sb-docs-switcher__trigger:hover,
 .sb-docs-switcher__trigger[aria-expanded='true'] {
   color: var(--sl-color-text-accent, var(--sl-color-accent));
-  background: var(--sl-color-bg-accent, rgba(0, 0, 0, 0.05));
+  /* Neutral surface, not `--sl-color-bg-accent`: that variable resolves to the
+     same value as `--sl-color-text-accent`, so an accent bg behind the now-accent
+     icon hid it entirely. `--sl-color-gray-6` is Starlight's subtle hover surface
+     and flips with the theme. */
+  background: var(--sl-color-gray-6, rgba(128, 128, 128, 0.12));
 }
 
 .sb-docs-switcher__popover {


### PR DESCRIPTION
Milestone: Maintenance
Closes #1399
Plan impact: none.

Hovering the theme-switcher button in the docs header made its icon disappear. The trigger's hover rule set the icon color and the background to accent variables that resolve to the same value:

```css
color: var(--sl-color-text-accent, …);
background: var(--sl-color-bg-accent, …);   /* == --sl-color-text-accent */
```

So the accent-colored icon sat on an accent-colored fill and vanished (verified live: both resolved to `rgb(14.51% 38.82% 92.16%)`). The color change is fine; only the background was wrong. Swapped it for `--sl-color-gray-6` — Starlight's subtle hover surface, which flips with the theme — so the icon reads against a neutral background in both light and dark.

Verified on the dev server: on hover the background is now the neutral gray while the icon keeps the accent color (distinct values), and the icon is clearly visible.

Docs-only (private `apps/docs`), no changeset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the swatchbook switcher button’s hover and expanded-state background styling for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->