### PR TITLE
ci: deploy docs on release, not every push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,15 @@ on:
     branches: [main]
     paths:
       - 'apps/docs/**'
+      # docs.yml builds and embeds the reference Storybook, so a story-only
+      # change to apps/storybook must also refresh the hosted site.
+      - 'apps/storybook/**'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit SHA or ref to build and deploy. Defaults to the triggering commit.
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -42,6 +50,10 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
+          # A release dispatch passes the published commit SHA so the built
+          # docs match the release; a push or bare manual run falls back to
+          # the triggering commit.
+          ref: ${{ inputs.ref || github.sha }}
           # Don't write the GITHUB_TOKEN into .git/config of the checked-out
           # tree. The deploy-pages step uses actions/upload-pages-artifact
           # which would otherwise ship the token in the artifact

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,16 @@
 name: Docs
 
+# Deploy on a docs-only push to main (immediate, for typo and link fixes),
+# or when the release workflow publishes a new version (dispatched from
+# release.yml's publish job). This keeps the live site tracking the
+# published version rather than every push to main (#1414): a code change
+# that lands on main without a release no longer redeploys the docs.
+# workflow_dispatch also covers a manual redeploy.
 on:
   push:
     branches: [main]
+    paths:
+      - 'apps/docs/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,6 +195,10 @@ jobs:
       # npm trusted publishing: the OIDC token is exchanged for a short-lived
       # publish token — no NPM_TOKEN secret. Also covers provenance.
       id-token: write
+      # `actions: write` so the final step can dispatch the Docs workflow
+      # after a real publish. workflow_dispatch is exempt from the
+      # GITHUB_TOKEN-does-not-trigger-workflows rule, so no App token is needed.
+      actions: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -364,3 +368,12 @@ jobs:
               "$latest"
             echo "  ✓ released $tag"
           done
+
+      # Deploy the docs for the just-published version. docs.yml no longer
+      # runs on every push to main (only docs-only changes); a real release
+      # refreshes the site through this dispatch so the live docs track the
+      # published version (#1414).
+      - name: Deploy the docs for the published release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run docs.yml --ref main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,4 +376,7 @@ jobs:
       - name: Deploy the docs for the published release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run docs.yml --ref main
+        # Dispatch on main (workflow_dispatch needs a branch ref) but pass the
+        # published commit SHA so docs.yml checks that out and the live docs
+        # match the release, even if main has advanced since publish started.
+        run: gh workflow run docs.yml --ref main -f ref="$GITHUB_SHA"


### PR DESCRIPTION
Gates the docs deploy on releases instead of every push to `main`, so the live site tracks the published version. Approach A from the issue.

## Change

- **`docs.yml`** now triggers on:
  - `push: [main]` filtered to `paths: ['apps/docs/**']` — a docs-only edit (typo, link) still deploys immediately.
  - `workflow_dispatch` — manual redeploy, and the dispatch target below.
  - A code change landing on `main` without a release no longer redeploys the docs.
- **`release.yml`** — the gated `publish` job (which runs only on a real publish, behind the `release` environment approval) gains `actions: write` and a final step: `gh workflow run docs.yml --ref main`. So a published release refreshes the site.

## Why this shape

- The `publish` job is gated (`if: should-publish == 'true'`), so a plain `workflow_run: completed` would fire on every prepare-only run (i.e. every push) and defeat the purpose. Dispatching from `publish` itself fires only on an actual publish.
- `workflow_dispatch` is exempt from the "`GITHUB_TOKEN` can't trigger workflows" rule (unlike push/release events), so `github.token` + `actions: write` is enough. No App-token minting needed.

## Not included

Docs versioning stays parked (decided on the issue: revisit at 3.0). This is timing-only.

Milestone: Maintenance

Closes #1414

Plan impact: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Docs can now deploy on `main` only when relevant documentation (or storybook updates) changes.
  * After a package release is published, the release process now automatically triggers a docs deployment for the matching published version.
  * Improved workflow messaging and input handling to ensure the correct commit is used for manual runs and release-triggered deploys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->