### PR TITLE
feat(blocks): mount the snapshot's CSS from SwatchbookProvider

### DIFF
--- a/.changeset/provider-mounts-css.md
+++ b/.changeset/provider-mounts-css.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+SwatchbookProvider mounts the snapshot's CSS by default; opt out with mountCss={false}

--- a/apps/docs/src/content/docs/guides/rendering-blocks-standalone.mdx
+++ b/apps/docs/src/content/docs/guides/rendering-blocks-standalone.mdx
@@ -35,19 +35,11 @@ Wire it in as a pre-step of the app build. Node 24 executes TypeScript directly,
 
 ## Mount it
 
-Two steps at runtime, and both matter. First, apply the snapshot's CSS: `SwatchbookProvider` does not mount it. `wire.css` carries the per-tuple custom-property blocks every block visual reads through `var()`; skip this step and those properties are never defined. Core's `ensureStyleElement` is an idempotent injector built for exactly this; call it once at module level.
-
-Second, wrap the blocks in the provider:
+Wrap the blocks in the provider; it mounts `wire.css` itself, so the per-tuple custom-property blocks every block visual reads through `var()` are defined with no further wiring ([Token CSS](/reference/blocks/provider#token-css) covers the opt-out).
 
 ```tsx title="src/TokenDocs.tsx"
 import { ColorPalette, SwatchbookProvider, TokenTable } from '@unpunnyfuns/swatchbook-blocks';
-import {
-  ensureStyleElement,
-  SWATCHBOOK_STYLE_ELEMENT_ID,
-} from '@unpunnyfuns/swatchbook-core/style-element';
 import wire from './tokens-snapshot.json';
-
-ensureStyleElement(SWATCHBOOK_STYLE_ELEMENT_ID, wire.css);
 
 export function TokenDocs() {
   return (

--- a/apps/docs/src/content/docs/reference/blocks/provider.mdx
+++ b/apps/docs/src/content/docs/reference/blocks/provider.mdx
@@ -6,13 +6,7 @@ title: Provider
 
 ```tsx
 import { SwatchbookProvider, ColorPalette } from '@unpunnyfuns/swatchbook-blocks';
-import {
-  ensureStyleElement,
-  SWATCHBOOK_STYLE_ELEMENT_ID,
-} from '@unpunnyfuns/swatchbook-core/style-element';
 import wire from './tokens-snapshot.json';
-
-ensureStyleElement(SWATCHBOOK_STYLE_ELEMENT_ID, wire.css);
 
 export function TokenDocs() {
   return (
@@ -23,7 +17,7 @@ export function TokenDocs() {
 }
 ```
 
-`wire` is a `SnapshotForWire`, produced by core's `snapshotForWire(project, css)` and typically written to a JSON file at build time; [Rendering blocks standalone](/reference/core#rendering-blocks-standalone) has the full build-script walkthrough. The `ensureStyleElement` line mounts the snapshot's emitted CSS; see [Token CSS](#token-css).
+`wire` is a `SnapshotForWire`, produced by core's `snapshotForWire(project, css)` and typically written to a JSON file at build time; [Rendering blocks standalone](/reference/core#rendering-blocks-standalone) has the full build-script walkthrough.
 
 ## Props
 
@@ -37,6 +31,7 @@ interface SwatchbookProviderProps {
   axes?: Record<string, string>;
   defaultAxes?: Record<string, string>;
   presenters?: PresenterRegistry;
+  mountCss?: boolean;
   children: ReactNode;
 }
 ```
@@ -47,6 +42,7 @@ interface SwatchbookProviderProps {
 | `axes`        | no       | Controlled active tuple. The host owns the selection and re-renders the provider with a new value to flip it. Mutually exclusive with `defaultAxes`; when both are passed, `axes` wins.                                           |
 | `defaultAxes` | no       | Uncontrolled initial tuple. The provider owns the selection from then on; descendants flip it with `useSetAxes()`.                                                                                                                |
 | `presenters`  | no       | Per-`$type` overrides merged over the built-in registry; a type left out keeps the built-in. See [Presenter registry](/reference/blocks/presenters).                                                                              |
+| `mountCss`    | no       | Whether the provider mounts the snapshot's emitted CSS into `document.head` (default `true`). Pass `false` when the host places the stylesheet itself. See [Token CSS](#token-css).                                               |
 
 ## Axis control
 
@@ -69,11 +65,9 @@ The provider wraps its children in a `<div>` carrying one `data-<prefix>-<axis>=
 
 ### Token CSS
 
-The wire snapshot's `css` field carries the emitted stylesheet, but the provider does not mount it. Who does depends on the host:
+The wire snapshot's `css` field carries the emitted stylesheet. The provider mounts it into `document.head` through a managed style element, deduplicated and updated in place, so descendant blocks' `var()` reads resolve without further wiring. `mountCss={false}` opts out for hosts that place the stylesheet themselves: SSR frameworks, shadow roots, or the Storybook addon, which injects its own combined stylesheet into the preview document. Blocks rendered with no provider at all (the [host-fed path](#host-integration)) self-mount the ambient source's CSS through the same managed style element.
 
-- Inside Storybook, the addon injects the stylesheet into the preview document itself.
-- Standalone, apply `wire.css` once yourself. Core's `ensureStyleElement` (from the `/style-element` subpath, as in the example above) is the shared idempotent injector; a plain `<style>` element works too.
-- Blocks rendered with no provider at all (the [host-fed path](#host-integration)) self-mount the ambient source's CSS through the same managed style element, deduplicated and updated in place.
+The managed element is a single shared ID: two providers with different snapshots on one page last-write-wins each other's CSS (same-snapshot providers are fine; the mount is idempotent). A page hosting genuinely different projects should pass `mountCss={false}` and manage stylesheets itself.
 
 Block chrome (the `--swatchbook-*` surface variables and per-block styles) ships in the package's own stylesheet, imported by the bundle entry; it needs no separate wiring.
 

--- a/apps/docs/src/content/docs/reference/core.mdx
+++ b/apps/docs/src/content/docs/reference/core.mdx
@@ -121,7 +121,7 @@ import wire from './tokens-snapshot.json';
 </SwatchbookProvider>;
 ```
 
-`axes` (controlled: the host drives the tuple and re-renders the provider on change) and `defaultAxes` (uncontrolled: the provider owns the tuple, flipped through `useSetAxes()`) are mutually exclusive. The provider does not mount the snapshot's CSS; apply `wire.css` once yourself, per [Token CSS](/reference/blocks/provider#token-css). See [Provider](/reference/blocks/provider) for the full provider API.
+`axes` (controlled: the host drives the tuple and re-renders the provider on change) and `defaultAxes` (uncontrolled: the provider owns the tuple, flipped through `useSetAxes()`) are mutually exclusive. The provider mounts the snapshot's CSS by default; [Token CSS](/reference/blocks/provider#token-css) covers the `mountCss={false}` opt-out. See [Provider](/reference/blocks/provider) for the full provider API.
 
 A Storybook-hosted render doesn't need any of this: the addon's preview decorator assembles the wire snapshot and mounts the provider automatically. The pattern above is for consumers rendering blocks with no addon and no Storybook channel in the page at all. The integration seam for a different host to feed the same blocks is [`@unpunnyfuns/swatchbook-blocks/host`](/reference/blocks/provider#host-integration)'s `registerProjectSource` / `useProjectSource`, which is what the addon itself uses to push Storybook's channel data in.
 

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -269,8 +269,12 @@ const themedDecorator: Decorator = (Story, context) => {
     [live],
   );
 
+  // `mountCss={false}`: the addon already injects the token CSS plus its
+  // iframe chrome rules through its own style element (`ensureStylesheet`
+  // above); letting the provider mount the snapshot's CSS too would
+  // duplicate every custom-property block.
   return (
-    <SwatchbookProvider snapshot={wire} axes={tuple}>
+    <SwatchbookProvider snapshot={wire} axes={tuple} mountCss={false}>
       <ThemeContext.Provider value={themeName}>
         <AxesContext.Provider value={tuple}>
           <div

--- a/packages/blocks/src/provider.tsx
+++ b/packages/blocks/src/provider.tsx
@@ -1,6 +1,10 @@
-import { createContext, useContext, useMemo, useState } from 'react';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
 import type { ReactElement, ReactNode } from 'react';
 import type { SnapshotForWire } from '@unpunnyfuns/swatchbook-core/snapshot-for-wire';
+import {
+  ensureStyleElement,
+  SWATCHBOOK_STYLE_ELEMENT_ID,
+} from '@unpunnyfuns/swatchbook-core/style-element';
 import { tupleToName } from '@unpunnyfuns/swatchbook-core/themes';
 import { SwatchbookContext, useOptionalSwatchbookData } from '#/contexts.ts';
 import type { ProjectSnapshot } from '#/contexts.ts';
@@ -24,6 +28,15 @@ export interface SwatchbookProviderProps {
   defaultAxes?: Record<string, string> | undefined;
   /** Overrides merged over {@link DEFAULT_PRESENTERS} for this subtree. */
   presenters?: PresenterRegistry | undefined;
+  /**
+   * Mount the snapshot's emitted CSS into `document.head` through the shared
+   * managed style element (default `true`). Pass `false` when the host places
+   * the stylesheet itself: SSR frameworks, shadow roots, the Storybook addon
+   * (which injects its own combined stylesheet). The element is shared by ID,
+   * so a page hosting providers with different snapshots should opt out and
+   * manage stylesheets itself; same-snapshot providers are idempotent.
+   */
+  mountCss?: boolean | undefined;
   children: ReactNode;
 }
 
@@ -63,11 +76,19 @@ export function SwatchbookProvider({
   axes,
   defaultAxes,
   presenters,
+  mountCss = true,
   children,
 }: SwatchbookProviderProps): ReactElement {
   const [internalAxes, setInternalAxes] = useState<Record<string, string>>(
     () => defaultAxes ?? snapshot.defaultTuple,
   );
+  // Effect, not render-time, so SSR renders never touch the DOM. The
+  // element is deliberately left in place on unmount: it is shared and
+  // idempotent, matching the host-fed fallback path's semantics.
+  useEffect(() => {
+    if (!mountCss) return;
+    ensureStyleElement(SWATCHBOOK_STYLE_ELEMENT_ID, snapshot.css);
+  }, [mountCss, snapshot.css]);
   const controlled = axes !== undefined;
   const activeAxes = controlled ? axes : internalAxes;
   const value = useMemo(() => assemble(snapshot, activeAxes), [snapshot, activeAxes]);

--- a/packages/blocks/test/provider-standalone.browser.test.tsx
+++ b/packages/blocks/test/provider-standalone.browser.test.tsx
@@ -1,10 +1,17 @@
 import { cleanup, render, screen } from '@testing-library/react';
 import { afterEach, expect, it } from 'vitest';
 import { userEvent } from 'vitest/browser';
+import { SWATCHBOOK_STYLE_ELEMENT_ID } from '@unpunnyfuns/swatchbook-core/style-element';
 import { ColorPalette, SwatchbookProvider, useSetAxes } from '#/index.ts';
 import { makeWireSnapshot } from './_wire-helpers.ts';
 
 afterEach(() => cleanup());
+
+// The managed style element is shared and persists across tests in this
+// file; start each CSS-mounting test from a clean slate.
+function removeManagedStyleElement(): void {
+  document.getElementById(SWATCHBOOK_STYLE_ELEMENT_ID)?.remove();
+}
 
 it('renders resolved tokens from a wire snapshot with no addon or channel', () => {
   render(
@@ -49,4 +56,46 @@ it('an uncontrolled provider flips its tuple through useSetAxes', async () => {
   );
   await userEvent.click(screen.getByRole('button'));
   expect(document.querySelector('[data-sb-mode="Dark"]')).not.toBeNull();
+});
+
+it('mounts the snapshot css into the managed style element by default', () => {
+  removeManagedStyleElement();
+  render(
+    <SwatchbookProvider snapshot={makeWireSnapshot({ css: ':root { --sb-x: 1; }' })}>
+      <span />
+    </SwatchbookProvider>,
+  );
+  const style = document.getElementById(SWATCHBOOK_STYLE_ELEMENT_ID);
+  expect(style).not.toBeNull();
+  expect(style?.textContent).toBe(':root { --sb-x: 1; }');
+});
+
+it('mounts nothing when mountCss is false', () => {
+  removeManagedStyleElement();
+  render(
+    <SwatchbookProvider
+      snapshot={makeWireSnapshot({ css: ':root { --sb-x: 1; }' })}
+      mountCss={false}
+    >
+      <span />
+    </SwatchbookProvider>,
+  );
+  expect(document.getElementById(SWATCHBOOK_STYLE_ELEMENT_ID)).toBeNull();
+});
+
+it('updates the style element in place when a re-render changes the snapshot css', () => {
+  removeManagedStyleElement();
+  const { rerender } = render(
+    <SwatchbookProvider snapshot={makeWireSnapshot({ css: ':root { --sb-x: 1; }' })}>
+      <span />
+    </SwatchbookProvider>,
+  );
+  rerender(
+    <SwatchbookProvider snapshot={makeWireSnapshot({ css: ':root { --sb-x: 2; }' })}>
+      <span />
+    </SwatchbookProvider>,
+  );
+  expect(document.getElementById(SWATCHBOOK_STYLE_ELEMENT_ID)?.textContent).toBe(
+    ':root { --sb-x: 2; }',
+  );
 });


### PR DESCRIPTION
`SwatchbookProvider` now mounts `snapshot.css` into `document.head` by default, through the same shared managed style element the host-fed fallback path uses (idempotent, updated in place, SSR-safe via effect). New `mountCss?: boolean` prop (default `true`) opts out for hosts that place the stylesheet themselves; the addon's decorator passes `mountCss={false}` since it injects its own combined stylesheet (token CSS + iframe chrome rules).

This closes the standalone gap where a bare `<SwatchbookProvider snapshot={wire}>` rendered blocks against undefined custom properties unless the consumer wired `ensureStyleElement` by hand.

Documented edge: the managed element is one shared ID, so providers with *different* snapshots on one page last-write-wins each other's CSS; such pages opt out and manage stylesheets themselves (same-snapshot providers are idempotent).

Docs updated to the new behavior: the provider page's Token CSS section, the standalone guide's Mount-it step (the `ensureStyleElement` ceremony is gone from both examples), and core's standalone section.

Changeset: blocks minor + addon patch; rides the pending 2.0.

## Verification

Browser tests 12/12 direct (three new cases: default mount, `mountCss={false}`, in-place update on css change); blocks+addon gauntlet 11/11 tasks (741 blocks tests); docs build clean.

Milestone: Maintenance

Closes #1422

Plan impact: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `SwatchbookProvider` now mounts snapshot CSS automatically by default.
  * Added `mountCss={false}` to disable automatic CSS mounting when styles are managed externally.
  * Managed styles update in place when the snapshot changes.

* **Bug Fixes**
  * Prevented duplicate CSS injection in the addon.

* **Documentation**
  * Updated rendering guides and provider references to explain the new CSS behavior and opt-out option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->