### PR TITLE
feat(addon): forward presenter overrides through swatchbookAddon({ presenters })

### DIFF
--- a/.changeset/addon-presenter-wiring.md
+++ b/.changeset/addon-presenter-wiring.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+swatchbookAddon({ presenters }) registers presenter overrides for stories and MDX blocks alike

--- a/apps/docs/src/content/docs/guides/creating-custom-presenters.mdx
+++ b/apps/docs/src/content/docs/guides/creating-custom-presenters.mdx
@@ -81,7 +81,21 @@ Every per-type block reads its visual through `usePresenter`, so the override re
 
 ## Register it inside Storybook
 
-The addon mounts `SwatchbookProvider` itself, so there is no `presenters` prop to reach. Wrap the content whose presenters you want to swap in the raw context, inside the story or MDX body:
+Pass the overrides to `swatchbookAddon({ presenters })` in the preview config. One registration covers both story renders and provider-less MDX doc blocks: the addon forwards the presenters into the ambient registry that every built-in block consults.
+
+```ts
+import { definePreview } from '@storybook/react-vite';
+import swatchbookAddon from '@unpunnyfuns/swatchbook-addon';
+import { DualSurfaceSwatch } from './DualSurfaceSwatch';
+
+export default definePreview({ addons: [swatchbookAddon({ presenters: { color: DualSurfaceSwatch } })] });
+```
+
+The merge is partial and per-`$type`, matching the `presenters` prop: `color` renders `DualSurfaceSwatch`, every other type keeps its built-in.
+
+### Override within one subtree
+
+To swap presenters for one region of a story or MDX body rather than the whole preview, wrap that region in the raw context:
 
 ```tsx
 import { ColorPalette, mergePresenters, PresenterContext } from '@unpunnyfuns/swatchbook-blocks';
@@ -92,7 +106,7 @@ import { DualSurfaceSwatch } from './DualSurfaceSwatch';
 </PresenterContext.Provider>;
 ```
 
-This is the same context `SwatchbookProvider` populates, and `usePresenter` reads the nearest provider. The wrapper sits under the addon's, so the override applies to everything inside it and nothing outside. `mergePresenters` fills the unlisted types with the built-ins, exactly as the `presenters` prop does.
+This is the same context `SwatchbookProvider` populates, and `usePresenter` reads the nearest provider. The wrapper sits under the addon's, so the override applies to everything inside it and nothing outside, and wins over an ambient registration from the factory. `mergePresenters` fills the unlisted types with the built-ins, exactly as the `presenters` prop does.
 
 ## Embedding directly
 

--- a/apps/docs/src/content/docs/reference/addon.mdx
+++ b/apps/docs/src/content/docs/reference/addon.mdx
@@ -48,6 +48,18 @@ export default definePreview({
 });
 ```
 
+### Factory options
+
+`swatchbookAddon(options?)` accepts a `presenters` option, a `PresenterRegistry` merged over the built-ins per `$type`. One registration reaches every built-in block in both story renders and provider-less MDX doc blocks:
+
+```ts
+export default definePreview({
+  addons: [swatchbookAddon({ presenters: { color: DualSurfaceSwatch } })],
+});
+```
+
+This is distinct from the preset `AddonOptions` passed in `main.ts` (`config` / `configPath` / `integrations`). See [Creating custom presenters](/guides/creating-custom-presenters) for the presenter contract and [Presenter registry](/reference/blocks/presenters#overriding-a-presenter) for the full override precedence.
+
 ## What it registers
 
 - **Preview decorator**: reads the active axis tuple, writes one `data-<prefix>-<axis>="<context>"` attribute per axis on `<html>` + story wrapper, mounts the per-theme CSS, emits `INIT_EVENT` to the manager. The prefix follows `cssVarPrefix` (default `swatch`).

--- a/apps/docs/src/content/docs/reference/blocks/presenters.mdx
+++ b/apps/docs/src/content/docs/reference/blocks/presenters.mdx
@@ -98,7 +98,18 @@ export function TokenDocs(): ReactElement {
 
 `ColorPalette` now renders `MyColorSwatch` for every color row; every other `$type` keeps its built-in. The merge is per-`$type`, not per-block: there's no mechanism to override a presenter for one block while leaving another block's use of that same type on the built-in.
 
-The prop is a convenience over two exported pieces. `mergePresenters(overrides?: PresenterRegistry): PresenterRegistry` returns `DEFAULT_PRESENTERS` with the overrides merged in per `$type`, and `PresenterContext` is the React context (`Context<PresenterRegistry>`, defaulting to `DEFAULT_PRESENTERS`) that every `usePresenter` call reads; `SwatchbookProvider` provides the merged result through it. When no provider is yours to configure, inside Storybook where the addon mounts it, wrap the affected subtree in `PresenterContext.Provider` with a merged registry: [Creating custom presenters](/guides/creating-custom-presenters#register-it-inside-storybook) walks through it.
+The prop is a convenience over two exported pieces. `mergePresenters(overrides?: PresenterRegistry): PresenterRegistry` returns `DEFAULT_PRESENTERS` with the overrides merged in per `$type`, and `PresenterContext` is the React context (`Context<PresenterRegistry>`, defaulting to `DEFAULT_PRESENTERS`) that every `usePresenter` call reads; `SwatchbookProvider` provides the merged result through it. Inside Storybook the addon mounts the provider, so the primary route is `swatchbookAddon({ presenters })`, which registers the overrides for every block including provider-less MDX doc blocks; to scope an override to one subtree instead, wrap it in `PresenterContext.Provider` with a merged registry. [Creating custom presenters](/guides/creating-custom-presenters#register-it-inside-storybook) walks through both.
+
+### Precedence
+
+`usePresenter` resolves a `$type` against the first registry that supplies it, in this order:
+
+1. `SwatchbookProvider`'s `presenters` prop.
+2. A `PresenterContext.Provider` wrap.
+3. The ambient registry set by `registerPresenters`, host-registered, e.g. via `swatchbookAddon({ presenters })`.
+4. `DEFAULT_PRESENTERS`.
+
+`registerPresenters(overrides?: PresenterRegistry)` lives on `@unpunnyfuns/swatchbook-blocks/host` and is what `swatchbookAddon({ presenters })` calls at preview-init; it seeds the provider-less fallback that MDX doc blocks read, while an explicit provider or context override still wins for its own subtree.
 
 ## Options bag
 

--- a/packages/addon/src/index.ts
+++ b/packages/addon/src/index.ts
@@ -2,9 +2,22 @@
 // major-bump checklist in CLAUDE.md; the import set is pinned by
 // storybook-internal-surface.test.ts.
 import { definePreviewAddon } from 'storybook/internal/csf';
+import { registerPresenters } from '@unpunnyfuns/swatchbook-blocks/host';
+import type { PresenterRegistry } from '@unpunnyfuns/swatchbook-blocks';
 import * as previewExports from '#/preview.tsx';
 
 export type { AddonOptions } from '#/options.ts';
+
+/** Options for the {@link swatchbookAddon} CSF preview factory. */
+export interface SwatchbookAddonOptions {
+  /**
+   * Presenter overrides applied to every built-in block, in both story
+   * renders and provider-less MDX doc blocks. Merged over the built-ins per
+   * `$type`. A `SwatchbookProvider presenters` prop or a local
+   * `PresenterContext.Provider` still wins for its own subtree.
+   */
+  presenters?: PresenterRegistry;
+}
 
 /**
  * Typed shapes for the `parameters.swatchbook.*` / `globals.swatchbook*`
@@ -48,7 +61,12 @@ export type { ColorFormat } from '@unpunnyfuns/swatchbook-blocks';
  * CSF Next factory. Consumers call this inside
  * `definePreview({ addons: [swatchbookAddon()] })` so the preview annotations
  * (decorator, globalTypes, initialGlobals) are added to the preview bundle.
+ * Pass `{ presenters }` to register presenter overrides for every built-in
+ * block, in both story renders and provider-less MDX doc blocks.
  */
-export default function swatchbookAddon(): ReturnType<typeof definePreviewAddon> {
+export default function swatchbookAddon(
+  options?: SwatchbookAddonOptions,
+): ReturnType<typeof definePreviewAddon> {
+  if (options?.presenters) registerPresenters(options.presenters);
   return definePreviewAddon(previewExports);
 }

--- a/packages/addon/test/addon-presenter-wiring.browser.test.tsx
+++ b/packages/addon/test/addon-presenter-wiring.browser.test.tsx
@@ -1,0 +1,25 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import { afterEach, expect, it } from 'vitest';
+import { DEFAULT_PRESENTERS, usePresenter } from '@unpunnyfuns/swatchbook-blocks';
+import { registerPresenters } from '@unpunnyfuns/swatchbook-blocks/host';
+import swatchbookAddon from '#/index.ts';
+
+const Custom = () => <i>custom</i>;
+
+// The ambient registry is module-global; reset to the built-ins after each
+// so the factory registration in one test does not leak into the next.
+afterEach(() => {
+  cleanup();
+  registerPresenters();
+});
+
+it('forwards factory presenters into the ambient registry for provider-less blocks', () => {
+  expect(usePresenterOutsideProvider()).toBe(DEFAULT_PRESENTERS.color);
+  swatchbookAddon({ presenters: { color: Custom } });
+  expect(usePresenterOutsideProvider()).toBe(Custom);
+});
+
+function usePresenterOutsideProvider() {
+  const { result } = renderHook(() => usePresenter('color'));
+  return result.current;
+}

--- a/packages/addon/test/virtual-stub.ts
+++ b/packages/addon/test/virtual-stub.ts
@@ -23,6 +23,7 @@ export const diagnostics = [] as const;
 export const css = '';
 export const cssVarPrefix = 'sb';
 export const defaultColorFormat = 'hex';
+export const indicators: Record<string, boolean> = {};
 export const listing = {};
 export const defaultTuple: Record<string, string> = { mode: 'Light' };
 export const tokenGraph: TokenGraph = {

--- a/packages/blocks/src/host.ts
+++ b/packages/blocks/src/host.ts
@@ -118,3 +118,11 @@ function getServerSnapshot(): ProjectSource {
 export function useProjectSource(): ProjectSource {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
+
+/**
+ * Host adapter API. Register the ambient presenter registry consulted by
+ * provider-less blocks (MDX doc blocks, autodocs). A host calls this once at
+ * preview-init; an explicit `SwatchbookProvider presenters` prop or a local
+ * `PresenterContext.Provider` still wins for its own subtree.
+ */
+export { registerPresenters } from '#/presenters/registry.ts';

--- a/packages/blocks/src/presenters/registry.ts
+++ b/packages/blocks/src/presenters/registry.ts
@@ -39,7 +39,32 @@ export function mergePresenters(overrides?: PresenterRegistry): PresenterRegistr
 /** The active merged registry for the subtree. */
 export const PresenterContext = createContext<PresenterRegistry>(DEFAULT_PRESENTERS);
 
+let ambientPresenters: PresenterRegistry = DEFAULT_PRESENTERS;
+
+/**
+ * Set the ambient presenter registry consulted by blocks that render with
+ * no `SwatchbookProvider` or `PresenterContext.Provider` above them (MDX
+ * doc blocks, autodocs). A host registers this once at preview-init; it is
+ * NOT reactive, so register before first render. Passing no argument (or
+ * `undefined`) resets to the built-ins. An explicit provider/context
+ * override still wins for its subtree; this only fills the provider-less
+ * gap.
+ */
+export function registerPresenters(overrides?: PresenterRegistry): void {
+  ambientPresenters = mergePresenters(overrides);
+}
+
+/** The ambient registry for the provider-less fallback. */
+export function getAmbientPresenters(): PresenterRegistry {
+  return ambientPresenters;
+}
+
 /** The presenter for `type`, or `undefined` if none is registered. */
 export function usePresenter(type: TokenType): PresenterComponent | undefined {
-  return useContext(PresenterContext)[type];
+  const ctx = useContext(PresenterContext);
+  // An explicit provider/context override replaces the default reference, so
+  // identity distinguishes "no override present" (fall to ambient) from
+  // "override present" (honor it).
+  const registry = ctx === DEFAULT_PRESENTERS ? ambientPresenters : ctx;
+  return registry[type];
 }

--- a/packages/blocks/test/ambient-presenters.browser.test.tsx
+++ b/packages/blocks/test/ambient-presenters.browser.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, renderHook } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, expect, it } from 'vitest';
+import {
+  DEFAULT_PRESENTERS,
+  mergePresenters,
+  PresenterContext,
+  SwatchbookProvider,
+  usePresenter,
+} from '#/index.ts';
+import { registerPresenters } from '#/presenters/registry.ts';
+import { makeWireSnapshot } from './_wire-helpers.ts';
+
+const Custom = () => <i>custom</i>;
+const Other = () => <i>other</i>;
+
+// The ambient registry is module-global and leaks across tests; reset to the
+// built-ins after each so no test inherits a prior registration.
+afterEach(() => {
+  cleanup();
+  registerPresenters();
+});
+
+it('resolves the built-in with no provider and no registration', () => {
+  const { result } = renderHook(() => usePresenter('color'));
+  expect(result.current).toBe(DEFAULT_PRESENTERS.color);
+});
+
+it('resolves an ambient registration with no provider (the MDX path)', () => {
+  registerPresenters({ color: Custom });
+  const { result } = renderHook(() => usePresenter('color'));
+  expect(result.current).toBe(Custom);
+});
+
+it('resolves the ambient registration inside a provider with no presenters prop', () => {
+  registerPresenters({ color: Custom });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SwatchbookProvider snapshot={makeWireSnapshot()}>{children}</SwatchbookProvider>
+  );
+  const { result } = renderHook(() => usePresenter('color'), { wrapper });
+  expect(result.current).toBe(Custom);
+});
+
+it('honors a provider presenters prop over the ambient registration', () => {
+  registerPresenters({ color: Custom });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <SwatchbookProvider snapshot={makeWireSnapshot()} presenters={{ color: Other }}>
+      {children}
+    </SwatchbookProvider>
+  );
+  const { result } = renderHook(() => usePresenter('color'), { wrapper });
+  expect(result.current).toBe(Other);
+});
+
+it('honors a manual PresenterContext.Provider over the ambient registration', () => {
+  registerPresenters({ color: Custom });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <PresenterContext.Provider value={mergePresenters({ color: Other })}>
+      {children}
+    </PresenterContext.Provider>
+  );
+  const { result } = renderHook(() => usePresenter('color'), { wrapper });
+  expect(result.current).toBe(Other);
+});
+
+it('resets to the built-in when registerPresenters is called with no argument', () => {
+  registerPresenters({ color: Custom });
+  registerPresenters();
+  const { result } = renderHook(() => usePresenter('color'));
+  expect(result.current).toBe(DEFAULT_PRESENTERS.color);
+});


### PR DESCRIPTION
Gives the addon a first-class presenter-override path: `swatchbookAddon({ presenters })` registers custom presenters that every built-in block honors, in both story-decorator renders **and** provider-less MDX doc blocks. Closes the gap the custom-presenters guide had to work around with a manual `PresenterContext.Provider` wrap.

## Mechanism

Presenters are static config, not per-render state, so they don't belong in the dynamic `/host` channel path. Instead:

- **blocks** gains a module-level ambient presenter registry (mirroring the existing `/host` `registerProjectSource` seam). `registerPresenters(overrides?)` sets it; `usePresenter` falls through to it **only when the `PresenterContext` value is the default reference** (i.e. no provider/context override is present). Since `mergePresenters(undefined)` returns the same `DEFAULT_PRESENTERS` reference, a story-decorator provider mounted without a `presenters` prop transparently honors the ambient registry too, so one registration covers both surfaces with no decorator change.
- **addon**: `swatchbookAddon({ presenters })` calls `registerPresenters` at preview-init. `registerPresenters` is exported from `@unpunnyfuns/swatchbook-blocks/host` (host-wiring seam, kept off the main consumer surface like `registerProjectSource`).

## Precedence

`SwatchbookProvider presenters` prop → `PresenterContext.Provider` wrap → ambient `registerPresenters` → `DEFAULT_PRESENTERS`. Explicit provider/context overrides still win per subtree; the ambient registry only fills the provider-less gap.

## Docs

The custom-presenters guide now leads with `swatchbookAddon({ presenters })` as the recommended route and reframes the context wrap as a subtree escape hatch; the presenters reference gains a precedence list; the addon reference documents the factory option (distinct from preset `AddonOptions`).

## Verification

blocks 6 new cases (all four precedence levels + reset) × 2 engines, addon 1 case × 2 engines, all green; full blocks+addon gate + docs build pass. `test:storybook` (CI-only) exercises the live decorator story path.

Changeset: blocks minor + addon minor; rides the pending 2.0.

Milestone: Maintenance

Closes #1421

Plan impact: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering custom presenter overrides through the Swatchbook addon.
  * Presenter overrides now apply to both Storybook stories and provider-less MDX blocks.
  * Added ambient presenter registration for host integrations.
  * Explicit provider and context overrides take precedence over ambient presenters and built-in defaults.

* **Documentation**
  * Expanded guides and reference documentation with presenter registration, scoping, merging, and precedence details.

* **Tests**
  * Added coverage for ambient presenter resolution, addon wiring, override priority, and reset behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->