### PR TITLE
chore: exempt trivial storybook Default stories from CodeRabbit's doc-comment rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,3 +17,14 @@ reviews:
         rewrites markdown-syntax links, not JSX attribute values. Do NOT flag a
         hand-prefixed absolute href in a JSX prop as needing a relative or
         source-slug form.
+    - path: apps/storybook/src/**/*.stories.tsx
+      instructions: >-
+        Storybook story exports (`export const X = meta.story(...)`) are exempt
+        from the "exported constants need a `/** */` doc comment" rule. A story
+        that renders the component with its meta defaults and carries no `play`
+        function or assertions is self-evident from its name and the meta it
+        inherits, so a doc comment would only restate it: do NOT flag such
+        stories (for example a `Default` story) as needing documentation. Only
+        stories that verify non-obvious behavior (a `play` function with
+        assertions) warrant a `/** */` comment, and it should state what the
+        story verifies, not that it renders the component.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -20,11 +20,14 @@ reviews:
     - path: apps/storybook/src/**/*.stories.tsx
       instructions: >-
         Storybook story exports (`export const X = meta.story(...)`) are exempt
-        from the "exported constants need a `/** */` doc comment" rule. A story
-        that renders the component with its meta defaults and carries no `play`
-        function or assertions is self-evident from its name and the meta it
-        inherits, so a doc comment would only restate it: do NOT flag such
-        stories (for example a `Default` story) as needing documentation. Only
-        stories that verify non-obvious behavior (a `play` function with
-        assertions) warrant a `/** */` comment, and it should state what the
-        story verifies, not that it renders the component.
+        from the "exported constants need a `/** */` doc comment" rule when the
+        story is self-evident: its behavior is fully conveyed by its name, the
+        meta it inherits, and any plain `args` it sets, and it has no `play`
+        function or assertions. Do NOT flag such stories as needing
+        documentation, whether they inherit the meta defaults (a `Default`
+        story) or set straightforward `args` (for example `meta.story({ args: {
+        visual: 'radius' } })`). A story does warrant a `/** */` comment when it
+        does something the name and args do not convey: a `play` function with
+        assertions, or a custom `render`/decorator composing a non-obvious
+        scenario. In that case the comment should state what the story verifies
+        or sets up, not that it renders the component.


### PR DESCRIPTION
Adds a `.coderabbit.yaml` path instruction for `apps/storybook/src/**/*.stories.tsx`: trivial `Default` story exports (render the component with meta defaults, no `play` or assertions) are self-evident from the name and inherited meta, so they don't need a `/** */` comment. Only behavior-verifying stories (a `play` function with assertions) warrant one, stating what they verify.

Codifies the convention surfaced in #1429's review so the reviewer stops flagging it.

Milestone: Maintenance

Closes #1430

Plan impact: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Storybook code review guidance for exported story files.
  * Self-explanatory stories that don’t use a `play` function and don’t include assertions no longer require documentation comments.
  * Stories with `play`-based checks or non-obvious setup (e.g., custom rendering/decoration) should include comments describing what the story verifies or configures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->