### PR TITLE
fix(core): prefer listing previewValue over raw primitives in formatTokenValue

### DIFF
--- a/.changeset/format-token-value-preview-precedence.md
+++ b/.changeset/format-token-value-preview-precedence.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': patch
+---
+
+formatTokenValue now prefers the listing previewValue over the raw primitive for non-color tokens (fontWeight, opacity, string fontFamily)

--- a/packages/core/src/token-value-css.ts
+++ b/packages/core/src/token-value-css.ts
@@ -33,9 +33,10 @@ export function formatSubColor(raw: unknown, format: ColorFormat): string {
 
 /**
  * Single-line display string for any DTCG token `$value`. Prefers
- * plugin-css's `previewValue` from the Token Listing; for color
- * tokens only when the toolbar format is hex (other formats route
- * through local colorjs.io).
+ * plugin-css's `previewValue` from the Token Listing for non-color tokens
+ * (and for color when the toolbar format is hex); other color formats route
+ * through local colorjs.io. A raw primitive `$value` is the fallback only
+ * when no `previewValue` is present.
  */
 export function formatTokenValue(
   value: unknown,
@@ -44,15 +45,16 @@ export function formatTokenValue(
   listing?: SlimListedToken,
 ): string {
   if (value == null) return '';
-  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-    return String(value);
-  }
 
   const preview = listing?.previewValue;
   if (preview !== undefined) {
     const previewStr = typeof preview === 'string' ? cleanFloatNoise(preview) : String(preview);
     if ($type !== 'color') return previewStr;
     if (colorFormat === 'hex') return previewStr;
+  }
+
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return String(value);
   }
 
   switch ($type) {

--- a/packages/core/test/token-value-css.test.ts
+++ b/packages/core/test/token-value-css.test.ts
@@ -7,3 +7,47 @@ it('formats a dimension object', () => {
 it('formats a color token value', () => {
   expect(formatTokenValue({ hex: '#3b82f6' }, 'color', 'hex')).toBe('#3b82f6');
 });
+
+it('prefers the previewValue over a raw fontWeight primitive', () => {
+  expect(formatTokenValue(700, 'fontWeight', 'hex', { names: {}, previewValue: 'bold' })).toBe(
+    'bold',
+  );
+});
+
+it('prefers the previewValue over a raw opacity number', () => {
+  expect(formatTokenValue(0.5, 'number', 'hex', { names: {}, previewValue: '50%' })).toBe('50%');
+});
+
+it('prefers the previewValue over a single-string fontFamily', () => {
+  expect(
+    formatTokenValue('Geist', 'fontFamily', 'hex', {
+      names: {},
+      previewValue: 'Geist, sans-serif',
+    }),
+  ).toBe('Geist, sans-serif');
+});
+
+it('falls back to the raw primitive when there is no listing', () => {
+  expect(formatTokenValue(700, 'fontWeight', 'hex')).toBe('700');
+});
+
+it('returns the previewValue for a color token on the hex format', () => {
+  expect(
+    formatTokenValue({ hex: '#3b82f6' }, 'color', 'hex', { names: {}, previewValue: '#3b82f6' }),
+  ).toBe('#3b82f6');
+});
+
+it('ignores the previewValue for a color token on a non-hex format', () => {
+  const result = formatTokenValue(
+    { colorSpace: 'srgb', components: [0.23, 0.51, 0.96] },
+    'color',
+    'rgb',
+    { names: {}, previewValue: '#3b82f6' },
+  );
+  expect(result).not.toBe('#3b82f6');
+  expect(result).toMatch(/^rgb\(/);
+});
+
+it('returns an empty string for a null value', () => {
+  expect(formatTokenValue(null, 'fontWeight', 'hex')).toBe('');
+});


### PR DESCRIPTION
`formatTokenValue` short-circuited primitive `$value`s with `String(value)` **before** consulting the listing `previewValue`, so primitive-valued tokens (fontWeight, opacity/number, single-string fontFamily) never got the authoritative plugin-css preview string even when the listing had one.

Reordered so `previewValue` is consulted first (for non-color tokens, and for color when the format is hex), with the raw-primitive path as the fallback only when no preview is present. The color special-casing is unchanged: color `$value` is an object, so color still falls through to `formatColor` on non-hex formats.

Part 2 of #1415 (the presenter-tier follow-ups); part 1 (typed `$value`) is a separate PR.

## Visual impact

This changes displayed strings in the preview tables for the affected primitive types wherever the listing preview differs from the raw value. The **Chromatic run on this PR is the visual gate** — review its diffs (expect fontWeight/opacity/fontFamily rows in TokenTable and friends).

## Verification

7 new unit tests (each with a preview that differs from the raw value, so non-vacuous), covering the primitive-with-preview cases, the no-listing fallback, both color paths, and null. Core + blocks gauntlet green.

Changeset: core patch.

Milestone: Maintenance

Closes #1433

Plan impact: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token value formatting to prefer configured preview values for non-color tokens.
  * Color tokens now use preview values for hexadecimal output while preserving formatted color output for other formats.
  * Added fallback handling for raw primitive values and null inputs.

* **Tests**
  * Added coverage for preview precedence across font, opacity, and color token types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->