### PR TITLE
feat(core): type RealisedToken $value per $type via a TokenValue mapped type

### DIFF
--- a/.changeset/typed-token-value.md
+++ b/.changeset/typed-token-value.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+RealisedToken<T>['$value'] is now typed per $type via a TokenValue<T> mapped type

--- a/packages/blocks/src/border-preview/BorderSample.tsx
+++ b/packages/blocks/src/border-preview/BorderSample.tsx
@@ -27,12 +27,11 @@ export function BorderSampleView({ cssVar }: BorderSampleViewProps): ReactElemen
  * color branch emits a display-only JSON string that the browser would
  * reject as a border color.
  */
-function borderValueToCss(value: unknown, colorFormat: ColorFormat): string {
+function borderValueToCss(value: BorderValue, colorFormat: ColorFormat): string {
   if (!value || typeof value !== 'object') return '';
-  const b = value as BorderValue;
-  const width = formatLength(b.width);
-  const style = typeof b.style === 'string' ? b.style : 'solid';
-  const color = formatColor(b.color, cssColorFormat(colorFormat)).value;
+  const width = formatLength(value.width);
+  const style = typeof value.style === 'string' ? value.style : 'solid';
+  const color = formatColor(value.color, cssColorFormat(colorFormat)).value;
   return [width, style, color].join(' ');
 }
 

--- a/packages/blocks/src/motion-preview/MotionSample.tsx
+++ b/packages/blocks/src/motion-preview/MotionSample.tsx
@@ -2,6 +2,7 @@ import type { ReactElement } from 'react';
 import './MotionSample.css';
 import clsx from 'clsx';
 import { useEffect, useState } from 'react';
+import type { TransitionValue } from '#/internal/composite-types.ts';
 import { usePrefersReducedMotion } from '#/internal/prefers-reduced-motion.ts';
 import type { PresenterProps } from '#/presenters/types.ts';
 
@@ -96,10 +97,7 @@ export function resolveMotionSpec(
   if (!token) return null;
   const type = token.$type;
   if (type === 'transition') {
-    const v = (token.$value ?? {}) as {
-      duration?: unknown;
-      timingFunction?: unknown;
-    };
+    const v = (token.$value ?? {}) as TransitionValue;
     return {
       durationMs: asDuration(v.duration, themeTokens, DEFAULT_DURATION_MS),
       easing: asEasing(v.timingFunction, themeTokens, DEFAULT_EASING),

--- a/packages/blocks/src/presenters/GradientSwatch.tsx
+++ b/packages/blocks/src/presenters/GradientSwatch.tsx
@@ -36,7 +36,7 @@ function gradientValueToCss(stops: readonly GradientStop[], colorFormat: ColorFo
  * matches the direction the standalone block previously hard-coded.
  */
 export function GradientSwatch({ token, cssVar, colorFormat }: GradientSwatchProps): ReactElement {
-  const stops = Array.isArray(token.$value) ? (token.$value as GradientStop[]) : [];
+  const stops = Array.isArray(token.$value) ? token.$value : [];
   const background = cssVar
     ? `linear-gradient(90deg, ${cssVar})`
     : gradientValueToCss(stops, colorFormat);

--- a/packages/blocks/src/presenters/TypeSpecimen.tsx
+++ b/packages/blocks/src/presenters/TypeSpecimen.tsx
@@ -53,7 +53,7 @@ function describeValue(value: TypographyValue): string {
 export function TypeSpecimen({ token, cssVar: _cssVar, options }: TypeSpecimenProps): ReactElement {
   const rawSample = options?.['sample'];
   const sample = typeof rawSample === 'string' ? rawSample : DEFAULT_SAMPLE;
-  const value = (token.$value ?? {}) as TypographyValue;
+  const value = token.$value ?? {};
   // Terrazzo emits typography sub-properties (font-family/size/weight/
   // line-height) as individual custom properties, never a composite `font`
   // shorthand var. `font: var(--sb-typography-<name>)` references an

--- a/packages/core/src/token-value-types.ts
+++ b/packages/core/src/token-value-types.ts
@@ -1,10 +1,11 @@
 /**
- * Typed envelopes for DTCG 2025.10 composite `$value` shapes — one per
- * `$type` the packages that render tokens consume. Sub-values stay
- * `unknown` because each may be a primitive (number / string), a
- * sub-value alias (string in `{token.path}` form, post-resolution
- * flattened to a string), or a nested composite. The win over
- * `Record<string, unknown>` isn't value-level narrowing — it's that
+ * Typed envelopes for DTCG 2025.10 composite `$value` shapes, one per
+ * `$type` the packages that render tokens consume. `RealisedToken`'s
+ * top-level `$value` is typed per `$type` via the `TokenValue<T>` mapped
+ * type below; sub-values stay `unknown` because each may be a primitive
+ * (number / string), a sub-value alias (string in `{token.path}` form,
+ * post-resolution flattened to a string), or a nested composite. The win
+ * over `Record<string, unknown>` isn't value-level narrowing: it's that
  * typo-ing a key (`fontFamlly`) becomes a compile error.
  *
  * The DTCG spec is the source of truth for the keys; this file
@@ -60,6 +61,12 @@ export interface GradientStop {
   position?: unknown;
 }
 
+/** `dimension` / `duration` object form per DTCG 2025.10 (`{ value, unit }`). */
+export interface DimensionValue {
+  value?: unknown;
+  unit?: unknown;
+}
+
 /**
  * `color.$value` per DTCG 2025.10 §8.1. Either the explicit
  * `colorSpace + components` form, or the legacy `hex` short-form
@@ -103,13 +110,48 @@ export type TokenType =
   | 'cubicBezier';
 
 /**
+ * The realised top-level `$value` shape per `$type`. Narrows the envelope a
+ * presenter reads without re-casting; sub-values stay `unknown` (a sub-value
+ * may be a primitive, a resolved alias string, or a nested composite), same
+ * as the envelopes themselves.
+ */
+export type TokenValue<T extends TokenType> = T extends 'color'
+  ? ColorValue
+  : T extends 'gradient'
+    ? GradientStop[]
+    : T extends 'shadow'
+      ? ShadowLayer | ShadowLayer[]
+      : T extends 'border'
+        ? BorderValue
+        : T extends 'transition'
+          ? TransitionValue
+          : T extends 'typography'
+            ? TypographyValue
+            : T extends 'strokeStyle'
+              ? string | DashedStrokeStyleValue
+              : T extends 'fontFamily'
+                ? string | string[]
+                : T extends 'fontWeight'
+                  ? number | string
+                  : T extends 'number'
+                    ? number
+                    : T extends 'cubicBezier'
+                      ? number[]
+                      : T extends 'dimension' | 'duration'
+                        ? string | number | DimensionValue
+                        : unknown;
+
+/**
  * A fully-realised token: concrete `$value` (aliases already resolved, no
- * graph lookup), plus DTCG metadata a presenter may show. The presenter tier
- * consumes this; resolution is the caller's job.
+ * graph lookup), typed per `$type` via `TokenValue<T>`, plus DTCG metadata a
+ * presenter may show. The presenter tier consumes this; resolution is the
+ * caller's job. Typing `$value` per `$type` lets a presenter holding a
+ * concrete `RealisedToken<T>` read the envelope without re-casting, and makes
+ * a wrong-shape literal a compile error.
  */
 export interface RealisedToken<T extends TokenType = TokenType> {
   $type: T;
-  $value: unknown;
+  $value: TokenValue<T>;
   $description?: string;
   $deprecated?: string | boolean;
 }

--- a/packages/core/src/token-value-types.ts
+++ b/packages/core/src/token-value-types.ts
@@ -148,10 +148,16 @@ export type TokenValue<T extends TokenType> = T extends 'color'
  * caller's job. Typing `$value` per `$type` lets a presenter holding a
  * concrete `RealisedToken<T>` read the envelope without re-casting, and makes
  * a wrong-shape literal a compile error.
+ *
+ * Distributive over `T`, so the default `RealisedToken` (T = `TokenType`) is a
+ * discriminated union that couples each `$type` to its own `$value` rather than
+ * pairing an arbitrary `$type` with an arbitrary envelope.
  */
-export interface RealisedToken<T extends TokenType = TokenType> {
-  $type: T;
-  $value: TokenValue<T>;
-  $description?: string;
-  $deprecated?: string | boolean;
-}
+export type RealisedToken<T extends TokenType = TokenType> = T extends TokenType
+  ? {
+      $type: T;
+      $value: TokenValue<T>;
+      $description?: string;
+      $deprecated?: string | boolean;
+    }
+  : never;

--- a/packages/core/test/token-value-types.test-d.ts
+++ b/packages/core/test/token-value-types.test-d.ts
@@ -1,11 +1,14 @@
 import { expectTypeOf, it } from 'vitest';
 import type {
+  BorderValue,
   ColorValue,
+  DashedStrokeStyleValue,
   DimensionValue,
   GradientStop,
   RealisedToken,
   ShadowLayer,
   TokenType,
+  TransitionValue,
   TypographyValue,
 } from '#/token-value-types.ts';
 
@@ -25,6 +28,17 @@ it('RealisedToken $value is typed per $type', () => {
     string | number | DimensionValue
   >();
   expectTypeOf<RealisedToken<'fontFamily'>['$value']>().toEqualTypeOf<string | string[]>();
+  expectTypeOf<RealisedToken<'border'>['$value']>().toEqualTypeOf<BorderValue>();
+  expectTypeOf<RealisedToken<'transition'>['$value']>().toEqualTypeOf<TransitionValue>();
+  expectTypeOf<RealisedToken<'strokeStyle'>['$value']>().toEqualTypeOf<
+    string | DashedStrokeStyleValue
+  >();
+  expectTypeOf<RealisedToken<'fontWeight'>['$value']>().toEqualTypeOf<number | string>();
+  expectTypeOf<RealisedToken<'number'>['$value']>().toEqualTypeOf<number>();
+  expectTypeOf<RealisedToken<'duration'>['$value']>().toEqualTypeOf<
+    string | number | DimensionValue
+  >();
+  expectTypeOf<RealisedToken<'cubicBezier'>['$value']>().toEqualTypeOf<number[]>();
 });
 
 it('a concrete RealisedToken accepts a matching $value and rejects a wrong shape', () => {
@@ -33,4 +47,13 @@ it('a concrete RealisedToken accepts a matching $value and rejects a wrong shape
   // @ts-expect-error a number is not a valid typography $value
   const bad: RealisedToken<'typography'> = { $type: 'typography', $value: 42 };
   void bad;
+});
+
+it('the default RealisedToken couples each $type to its own $value', () => {
+  // A matching pair compiles (assignable to the union's `color` member).
+  const ok: RealisedToken = { $type: 'color', $value: { hex: '#3b82f6' } };
+  void ok;
+  // @ts-expect-error 'color' does not pair with a numeric $value in the coupled union
+  const mismatch: RealisedToken = { $type: 'color', $value: 42 };
+  void mismatch;
 });

--- a/packages/core/test/token-value-types.test-d.ts
+++ b/packages/core/test/token-value-types.test-d.ts
@@ -1,9 +1,36 @@
 import { expectTypeOf, it } from 'vitest';
-import type { RealisedToken, ShadowLayer, TokenType } from '#/token-value-types.ts';
+import type {
+  ColorValue,
+  DimensionValue,
+  GradientStop,
+  RealisedToken,
+  ShadowLayer,
+  TokenType,
+  TypographyValue,
+} from '#/token-value-types.ts';
 
 it('RealisedToken narrows $type and carries realised value + metadata', () => {
   const t: RealisedToken<'shadow'> = { $type: 'shadow', $value: [], $description: 'x' };
   expectTypeOf(t.$type).toEqualTypeOf<'shadow'>();
   expectTypeOf<ShadowLayer>().toHaveProperty('offsetX');
   expectTypeOf<TokenType>().toMatchTypeOf<string>();
+});
+
+it('RealisedToken $value is typed per $type', () => {
+  expectTypeOf<RealisedToken<'gradient'>['$value']>().toEqualTypeOf<GradientStop[]>();
+  expectTypeOf<RealisedToken<'typography'>['$value']>().toEqualTypeOf<TypographyValue>();
+  expectTypeOf<RealisedToken<'color'>['$value']>().toEqualTypeOf<ColorValue>();
+  expectTypeOf<RealisedToken<'shadow'>['$value']>().toEqualTypeOf<ShadowLayer | ShadowLayer[]>();
+  expectTypeOf<RealisedToken<'dimension'>['$value']>().toEqualTypeOf<
+    string | number | DimensionValue
+  >();
+  expectTypeOf<RealisedToken<'fontFamily'>['$value']>().toEqualTypeOf<string | string[]>();
+});
+
+it('a concrete RealisedToken accepts a matching $value and rejects a wrong shape', () => {
+  const t: RealisedToken<'typography'> = { $type: 'typography', $value: { fontSize: '16px' } };
+  expectTypeOf(t.$value).toEqualTypeOf<TypographyValue>();
+  // @ts-expect-error a number is not a valid typography $value
+  const bad: RealisedToken<'typography'> = { $type: 'typography', $value: 42 };
+  void bad;
 });


### PR DESCRIPTION
`RealisedToken<T>['$value']` was `unknown`; it is now typed per `$type` via a new exported `TokenValue<T>` mapped type, so a presenter holding a concrete `RealisedToken<T>` reads the right envelope without re-casting. The **top-level** shape is typed; sub-values stay `unknown` (a sub-value may be a primitive, a resolved alias string, or a nested composite), consistent with the existing envelope philosophy. A wrong-shape `$value` literal for a concrete `T` is now a compile error.

Part 1 of #1415 (the presenter-tier follow-ups); part 2 (the previewValue precedence fix) landed in #1432.

## What changed

- New `DimensionValue` envelope (`{ value, unit }`, DTCG 2025.10) and the `TokenValue<T>` mapped type covering every `TokenType` (color→ColorValue, gradient→GradientStop[], shadow→ShadowLayer|ShadowLayer[], typography→TypographyValue, border→BorderValue, transition→TransitionValue, strokeStyle→string|DashedStrokeStyleValue, fontFamily→string|string[], fontWeight→number|string, number→number, cubicBezier→number[], dimension/duration→string|number|DimensionValue).
- `RealisedToken<T>['$value']` retyped to `TokenValue<T>`.
- Dropped the now-redundant envelope casts in `GradientSwatch`, `TypeSpecimen`, `BorderSample`, and swapped `MotionSample`'s inline structural cast to the named `TransitionValue`. Kept the casts that operate on raw `unknown` from resolved data (the query blocks `ShadowPreview`/`GradientPalette`/`BorderPreview`, `CompositeBreakdown`, and `ShadowSample`'s `unknown[]` normalizer), since the mapped type doesn't reach those.
- Extended the `.test-d.ts` type tests (per-`$type` `$value` assertions + a `@ts-expect-error` wrong-shape case).

No runtime behavior change.

## Verification

Full gauntlet (format/lint/typecheck/test) green across core, blocks, addon, and storybook (20/20 turbo tasks), including the `.test-d.ts` type tests and the storybook typecheck.

Changeset: core minor.

Milestone: Maintenance

Closes #1415

Plan impact: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved token type accuracy so `RealisedToken['$value']` is inferred from each token’s `$type`.
  * Added support for structured `dimension` and `duration` values using `{ value, unit }`.
* **Bug Fixes**
  * Improved type safety across token previews (border, motion, gradient, and typography) by tightening `$value` handling.
  * Preview parsing now more directly uses strongly-typed `BorderValue`, `TransitionValue`, and gradient stop arrays, reducing incorrect casts.
* **Tests**
  * Expanded type-level coverage to verify correct `$type`/`$value` pairings and rejection of invalid shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->