### PR TITLE
test(blocks): cover CopyButton copy in isolation; drop the racy snippet-copy story

### DIFF
--- a/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
+++ b/apps/storybook/src/stories/token-detail/TokenUsageSnippet.stories.tsx
@@ -1,5 +1,5 @@
 import { TokenUsageSnippet } from '@unpunnyfuns/swatchbook-blocks';
-import { expect, userEvent, waitFor } from 'storybook/test';
+import { expect, waitFor } from 'storybook/test';
 import preview from '#storybook/preview.tsx';
 
 const meta = preview.meta({
@@ -24,39 +24,5 @@ export const RendersSnippetAndCssVar = meta.story({
       return el;
     });
     expect(snippet.textContent).toBe('color: var(--sb-color-accent-bg);');
-  },
-});
-
-export const CopySnippetWritesToClipboard = meta.story({
-  args: { path: 'color.accent.bg' },
-  play: async ({ canvasElement }) => {
-    const writes: string[] = [];
-    const originalClipboard = navigator.clipboard;
-    Object.defineProperty(navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: (text: string) => {
-          writes.push(text);
-          return Promise.resolve();
-        },
-      },
-    });
-    try {
-      const btn = await waitFor(() => {
-        const el = canvasElement.querySelector<HTMLElement>('.sb-token-detail__snippet-row button');
-        if (!el) throw new Error('copy button not rendered');
-        return el;
-      });
-      await userEvent.click(btn);
-      await waitFor(() => {
-        if (writes.length === 0) throw new Error('clipboard not written');
-      });
-      expect(writes).toEqual(['color: var(--sb-color-accent-bg);']);
-    } finally {
-      Object.defineProperty(navigator, 'clipboard', {
-        configurable: true,
-        value: originalClipboard,
-      });
-    }
   },
 });

--- a/packages/blocks/test/copy-button.browser.test.tsx
+++ b/packages/blocks/test/copy-button.browser.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { userEvent } from 'vitest/browser';
+import { afterEach, expect, it, vi } from 'vitest';
+import { CopyButton } from '#/internal/CopyButton.tsx';
+
+afterEach(() => {
+  cleanup();
+});
+
+// Headless Chromium denies the clipboard-write permission, so
+// `navigator.clipboard.writeText` rejects regardless of the click. Its
+// `writeText` isn't spyable, so stub the whole `clipboard` object. `clipboard`
+// is an inherited accessor on `Navigator.prototype`; restore by descriptor
+// (deleting the own stub when there was no own property) so nothing is left
+// shadowing that accessor for later tests.
+function stubClipboard() {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+  Object.defineProperty(navigator, 'clipboard', { value: { writeText }, configurable: true });
+  const restore = () => {
+    if (original) Object.defineProperty(navigator, 'clipboard', original);
+    else Reflect.deleteProperty(navigator, 'clipboard');
+  };
+  return { writeText, restore };
+}
+
+it('writes the exact value to the clipboard when clicked', async () => {
+  const { writeText, restore } = stubClipboard();
+  try {
+    render(<CopyButton value="color: var(--sb-color-accent-bg);" />);
+    await userEvent.click(screen.getByRole('button'));
+    await expect.poll(() => writeText.mock.calls).toEqual([['color: var(--sb-color-accent-bg);']]);
+  } finally {
+    restore();
+  }
+});
+
+it('toggles the visible "Copied" affordance when clicked', async () => {
+  const { restore } = stubClipboard();
+  try {
+    render(<CopyButton value="color: var(--sb-color-accent-bg);" />);
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('data-copied')).toBeNull();
+    await userEvent.click(button);
+    await expect.poll(() => button.getAttribute('data-copied')).toBe('true');
+  } finally {
+    restore();
+  }
+});


### PR DESCRIPTION
The `CopySnippetWritesToClipboard` story stubbed the shared `navigator.clipboard` global inside its `play` and read a side-channel `writes[]` array, the same racy pattern that made `CopyCssWritesToClipboard` flaky (#1370). Same treatment as #1370: relocate the copied-value assertion into an isolated blocks browser test and drop the global-mutating story.

- New `packages/blocks/test/copy-button.browser.test.tsx` tests the reusable `CopyButton` directly: clicking writes the exact `value` to the clipboard, and the "Copied" affordance toggles. Reuses the verbatim clipboard-stub-by-descriptor pattern from `consumer-output-view.browser.test.tsx` (restore by descriptor so nothing shadows the inherited accessor for later tests), with `try/finally` so the global is always restored.
- Removed `CopySnippetWritesToClipboard` (and its now-unused `userEvent` import) from `TokenUsageSnippet.stories.tsx`. The snippet-string derivation stays covered by the `RendersSnippetAndCssVar` story, which mutates nothing.

Test-only; apps/storybook is changeset-ignored, so no changeset.

## Verification

New test 4/4 (2 cases × chromium/firefox); `test:storybook` green with the racy story gone (54 files, 191 tests); blocks + storybook lint/typecheck/format clean.

Milestone: Maintenance

Closes #1390

Plan impact: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added browser coverage for copying values to the clipboard.
  * Added verification that the button displays a “Copied” state after use.
  * Improved clipboard test isolation and reliability.
* **Chores**
  * Removed an outdated Storybook interaction story for the copy button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->