### PR TITLE
docs: link the swatchbook-example starter from the README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ If your stories already style with swatchbook's token CSS variables, they pick u
 
 **Documentation** · [unpunnyfuns.github.io/swatchbook](https://unpunnyfuns.github.io/swatchbook/)
 **Live Storybook** · [/storybook](https://unpunnyfuns.github.io/swatchbook/storybook/)
+**Starter project** · [swatchbook-example](https://github.com/unpunnyfuns/swatchbook-example)
 
 ## Install
 

--- a/apps/docs/src/content/docs/guides/quickstart.mdx
+++ b/apps/docs/src/content/docs/guides/quickstart.mdx
@@ -117,3 +117,4 @@ Also worth a look:
 - [Blocks reference](/reference/blocks): every block's full prop list.
 - [Axes reference](/concepts/axes): the runtime model behind the toolbar.
 - [Live Storybook](/storybook/): the addon running against a real multi-axis fixture.
+- [Starter project](https://github.com/unpunnyfuns/swatchbook-example): a working Storybook setup wired to published tokens, ready to clone or use as a template.

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -30,4 +30,5 @@ import ScreenshotGallery from '#/components/ScreenshotGallery.tsx';
 	<LinkCard title="Reference" href="/swatchbook/reference/addon/" description="Packages, blocks, config, diagnostics." />
 	<LinkCard title="Concepts" href="/swatchbook/concepts/" description="The mental model: axes and tuples, the token graph, the pipeline." />
 	<LinkCard title="Developers" href="/swatchbook/developers/" description="Architecture and contributor notes." />
+	<LinkCard title="Starter project" href="https://github.com/unpunnyfuns/swatchbook-example" description="A working Storybook setup you can clone or use as a template to start your own." />
 </CardGrid>


### PR DESCRIPTION
Links the standalone consumer example (https://github.com/unpunnyfuns/swatchbook-example) so people have a working Storybook setup to clone or use as a template.

- Root README: a `Starter project` entry in the header link block.
- Docs landing: a `Starter project` card in the "Where to go next" grid.
- Quickstart: a bullet in "Where to next".

Framed as an easy starting point (its regression-testing use stays internal).

Milestone: Maintenance

Closes #1436

Plan impact: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a Starter project link to the README.
  - Added Starter project resources to the quickstart guide and documentation homepage.
  - The starter project provides a cloneable Storybook setup with published tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->