### PR TITLE
fix(addon): stop the preview decorator padding stories

### DIFF
--- a/.changeset/tough-pugs-repeat.md
+++ b/.changeset/tough-pugs-repeat.md
@@ -2,4 +2,4 @@
 '@unpunnyfuns/swatchbook-addon': patch
 ---
 
-stop the preview decorator padding stories; Storybook's `layout` parameter is the only source of spacing again
+The preview decorator no longer pads stories; Storybook's `layout` parameter is the only source of story spacing

--- a/.changeset/tough-pugs-repeat.md
+++ b/.changeset/tough-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-addon': patch
+---
+
+stop the preview decorator padding stories; Storybook's `layout` parameter is the only source of spacing again

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -273,17 +273,19 @@ const themedDecorator: Decorator = (Story, context) => {
   // iframe chrome rules through its own style element (`ensureStylesheet`
   // above); letting the provider mount the snapshot's CSS too would
   // duplicate every custom-property block.
+  //
+  // The attribute wrapper has to exist but must generate no box. It's the only
+  // per-story scope for the axis attributes; <html> can't stand in for it,
+  // holding a single tuple while docs mode renders several stories with
+  // different per-story overrides. Storybook's `layout` parameter owns story
+  // spacing (`.sb-main-padded`, `.sb-main-centered #storybook-root`), and a box
+  // here would stack on top of it rather than replace it. `display: contents`
+  // removes the box without affecting selector matching.
   return (
     <SwatchbookProvider snapshot={wire} axes={tuple} mountCss={false}>
       <ThemeContext.Provider value={themeName}>
         <AxesContext.Provider value={tuple}>
-          <div
-            {...wrapperAttrs}
-            style={{
-              padding: '1rem',
-              minHeight: '100%',
-            }}
-          >
+          <div {...wrapperAttrs} style={{ display: 'contents' }}>
             <Story />
           </div>
           <div role="status" aria-live="polite" style={SR_ONLY_STYLE}>

--- a/packages/addon/test/decorator-layout.browser.test.tsx
+++ b/packages/addon/test/decorator-layout.browser.test.tsx
@@ -17,7 +17,7 @@ afterEach(cleanup);
 // Mount the decorator around a fixed-size story inside a host whose height
 // is content-driven, so any box the wrapper contributes shows up as extra
 // height on the host.
-function mount() {
+function mount(parameters: Record<string, unknown> = {}) {
   const host = document.createElement('div');
   host.style.width = '200px';
   document.body.appendChild(host);
@@ -25,7 +25,7 @@ function mount() {
   function Decorated() {
     return themedDecorator(() => <div data-testid="story" style={{ height: '10px' }} />, {
       globals: {},
-      parameters: {},
+      parameters,
     } as never);
   }
 
@@ -46,11 +46,13 @@ it('wraps the story without contributing a box, so the host layout is the only s
   expect(hostBox.height).toBe(storyBox.height);
 });
 
-it('keeps the axis attributes on an ancestor of the story so per-story overrides still scope', () => {
-  const { story } = mount();
+// `parentElement`, not `closest()`: SwatchbookProvider mounts its own
+// attribute div further out carrying the same tuple, so a walk up the tree
+// would still find a match with the decorator's own attributes missing.
+// A non-default context proves the per-story override reaches the wrapper
+// rather than the axis defaulting into place.
+it('puts the axis attributes on the wrapper directly around the story so per-story overrides scope', () => {
+  const { story } = mount({ swatchbook: { axes: { mode: 'Dark' } } });
 
-  const scope = story.closest('[data-sb-mode]');
-
-  expect(scope).not.toBeNull();
-  expect(scope?.getAttribute('data-sb-mode')).toBe('Light');
+  expect(story.parentElement?.getAttribute('data-sb-mode')).toBe('Dark');
 });

--- a/packages/addon/test/decorator-layout.browser.test.tsx
+++ b/packages/addon/test/decorator-layout.browser.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render } from '@testing-library/react';
+import type { Decorator } from '@storybook/react-vite';
+import { afterEach, expect, it } from 'vitest';
+import { decorators } from '#/preview.tsx';
+
+// Real geometry in a real browser is the whole point here: the bug this
+// guards against (#1443) is the decorator's wrapper contributing a box of
+// its own, which only shows up as measured layout.
+function themedDecorator(...args: Parameters<Decorator>): ReturnType<Decorator> {
+  const [first] = decorators as Decorator[];
+  if (!first) throw new Error('the addon preview exports no decorator');
+  return first(...args);
+}
+
+afterEach(cleanup);
+
+// Mount the decorator around a fixed-size story inside a host whose height
+// is content-driven, so any box the wrapper contributes shows up as extra
+// height on the host.
+function mount() {
+  const host = document.createElement('div');
+  host.style.width = '200px';
+  document.body.appendChild(host);
+
+  function Decorated() {
+    return themedDecorator(() => <div data-testid="story" style={{ height: '10px' }} />, {
+      globals: {},
+      parameters: {},
+    } as never);
+  }
+
+  render(<Decorated />, { container: host });
+  const story = host.querySelector('[data-testid="story"]') as HTMLElement;
+  return { host, story };
+}
+
+it('wraps the story without contributing a box, so the host layout is the only source of spacing', () => {
+  const { host, story } = mount();
+
+  const hostBox = host.getBoundingClientRect();
+  const storyBox = story.getBoundingClientRect();
+
+  expect(storyBox.left).toBe(hostBox.left);
+  expect(storyBox.top).toBe(hostBox.top);
+  expect(storyBox.width).toBe(hostBox.width);
+  expect(hostBox.height).toBe(storyBox.height);
+});
+
+it('keeps the axis attributes on an ancestor of the story so per-story overrides still scope', () => {
+  const { story } = mount();
+
+  const scope = story.closest('[data-sb-mode]');
+
+  expect(scope).not.toBeNull();
+  expect(scope?.getAttribute('data-sb-mode')).toBe('Light');
+});


### PR DESCRIPTION
## Summary

The preview decorator wrapped every story in a div with `padding: 1rem`, shifting stories in any project that installs the addon.

## Full description

Storybook implements the `layout` parameter as host-level CSS on `body` / `#storybook-root`:

```css
.sb-show-main.sb-main-padded                   { padding: 1rem }
.sb-show-main.sb-main-centered #storybook-root { padding: 1rem; margin: auto }
.sb-show-main.sb-main-fullscreen               { padding: 0 }
```

The decorator's axis-attribute wrapper sits *inside* `#storybook-root`, so its own padding stacked on those rules rather than overriding them. `padded` (the default) rendered at 2rem, and `fullscreen` got 1rem when the consumer explicitly asked for zero.

The wrapper element is load-bearing: it carries `data-<prefix>-<axis>`, the only per-story scope for `parameters.swatchbook.axes` overrides, since `<html>` holds a single tuple while docs mode renders several stories at once. So the element keeps its place in the tree and gets `display: contents`, which removes the box without affecting selector matching. `minHeight: 100%` goes with it; the wrapper paints no background, so the iframe surface still comes from the `html, body` chrome rules.

Test asserts geometry rather than computed style: it measures the host box collapsing onto the story box, so any future wrapper geometry fails the test instead of pinning `display: contents` as the implementation. Fails at a 16px offset before the change, in both Chromium and Firefox.

### Reviewer note

Chromatic will report a diff on essentially every story in the reference Storybook. The baselines were captured with the extra 1rem, so the shift is the fix landing and needs a bulk re-approval.

Closes #1443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Removed unintended preview padding and minimum-height spacing from stories.
  - Storybook’s `layout` setting now solely controls story spacing.
  - Preserved story-level layout axis overrides without adding an extra layout box.

- **Tests**
  - Added browser coverage to verify sizing, layout behavior, attribute scoping, and missing decorator handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->