### PR TITLE
test(storybook): cover the decorator's layout neutrality across layout values

### DIFF
--- a/apps/storybook/src/stories/DecoratorLayout.stories.tsx
+++ b/apps/storybook/src/stories/DecoratorLayout.stories.tsx
@@ -28,11 +28,14 @@ export default meta;
  * latter two also cover `SwatchbookProvider`'s host element, which sits between
  * the wrapper and the container.
  *
- * The play function can't verify `layout` itself. The vitest harness renders
- * into a bare div appended to `body` — no `#storybook-root`, no `sb-main-*`
- * class — so the parameter is inert here and the four stories are identical to
- * it. They diverge only in the real preview iframe, where Chromatic snapshots
- * them; #1451 tracks asserting that in CI.
+ * These run in two environments with different containers, so every assertion
+ * is computed against `canvasElement`'s *content* box rather than its border
+ * box. Under vitest the container is a bare div appended to `body`, with no
+ * `#storybook-root` and no `sb-main-*` class, so `layout` is inert and padding
+ * is zero. Chromatic runs the same play functions in the real preview iframe,
+ * where the container is the story root and carries Storybook's own padding:
+ * `centered` puts 1rem on it, which a border-box height check reads as 32px of
+ * phantom decorator spacing.
  */
 function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
   const probe = canvasElement.querySelector<HTMLElement>('[data-testid="layout-probe"]');
@@ -50,6 +53,12 @@ function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
     box.left + Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.borderLeftWidth);
   const contentTop =
     box.top + Number.parseFloat(style.paddingTop) + Number.parseFloat(style.borderTopWidth);
+  const contentHeight =
+    box.height -
+    Number.parseFloat(style.paddingTop) -
+    Number.parseFloat(style.paddingBottom) -
+    Number.parseFloat(style.borderTopWidth) -
+    Number.parseFloat(style.borderBottomWidth);
 
   const probeBox = probe.getBoundingClientRect();
   expect(probeBox.left, 'decorator must not inset the story horizontally').toBeCloseTo(
@@ -57,7 +66,7 @@ function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
     1,
   );
   expect(probeBox.top, 'decorator must not inset the story vertically').toBeCloseTo(contentTop, 1);
-  expect(box.height, 'decorator must not add height around the story').toBeCloseTo(
+  expect(contentHeight, 'decorator must not add height around the story').toBeCloseTo(
     probeBox.height,
     1,
   );

--- a/apps/storybook/src/stories/DecoratorLayout.stories.tsx
+++ b/apps/storybook/src/stories/DecoratorLayout.stories.tsx
@@ -23,18 +23,26 @@ export default meta;
  * #storybook-root`). The addon's decorator renders inside that root, so any box
  * it contributes stacks on top rather than replacing it.
  *
- * The assertion is that the probe sits flush against its container and the
- * container is no taller than the probe: true for every `layout` value, because
- * it measures only what the decorator adds, not what Storybook does.
+ * Three assertions, narrowest first: the decorator's own wrapper generates no
+ * box at all, and the chain as a whole adds neither inset nor height. The
+ * latter two also cover `SwatchbookProvider`'s host element, which sits between
+ * the wrapper and the container.
  *
- * Note the play function can't verify `layout` itself. The vitest harness
- * renders into a bare div appended to `body` — no `#storybook-root`, no
- * `sb-main-*` class — so the parameter is inert here. The four stories still
- * differ in the real preview iframe, which is where Chromatic snapshots them.
+ * The play function can't verify `layout` itself. The vitest harness renders
+ * into a bare div appended to `body` — no `#storybook-root`, no `sb-main-*`
+ * class — so the parameter is inert here and the four stories are identical to
+ * it. They diverge only in the real preview iframe, where Chromatic snapshots
+ * them; #1451 tracks asserting that in CI.
  */
 function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
   const probe = canvasElement.querySelector<HTMLElement>('[data-testid="layout-probe"]');
   if (!probe) throw new Error('layout-probe missing');
+  const wrapper = probe.parentElement;
+  if (!wrapper) throw new Error('decorator wrapper missing');
+
+  expect(wrapper.getClientRects().length, 'the axis-attribute wrapper must generate no box').toBe(
+    0,
+  );
 
   const style = getComputedStyle(canvasElement);
   const box = canvasElement.getBoundingClientRect();
@@ -55,21 +63,25 @@ function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
   );
 }
 
+/** `padded` puts 1rem on `body`; the decorator must not add a second inset inside the root. */
 export const Padded = meta.story({
   parameters: { layout: 'padded' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
 });
 
+/** `centered` puts 1rem on the story root and centres it with `margin: auto`. */
 export const Centered = meta.story({
   parameters: { layout: 'centered' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
 });
 
+/** `fullscreen` zeroes both, so any box the decorator adds is the only spacing present. */
 export const Fullscreen = meta.story({
   parameters: { layout: 'fullscreen' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
 });
 
+/** No layout class at all: the baseline the other three are measured against. */
 export const NoLayout = meta.story({
   parameters: { layout: 'none' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),

--- a/apps/storybook/src/stories/DecoratorLayout.stories.tsx
+++ b/apps/storybook/src/stories/DecoratorLayout.stories.tsx
@@ -1,0 +1,76 @@
+import { expect } from 'storybook/test';
+import preview from '#storybook/preview.tsx';
+
+/**
+ * Fixed-height, auto-width block. Any box the addon's decorator chain
+ * contributes shows up as an inset between this and the story container.
+ */
+function LayoutProbe() {
+  return <div data-testid="layout-probe" style={{ height: 24, background: '#0066cc' }} />;
+}
+
+const meta = preview.meta({
+  title: 'Tests/DecoratorLayout',
+  tags: ['!manifest', '!dev'],
+  component: LayoutProbe,
+});
+
+export default meta;
+
+/**
+ * Storybook owns story spacing through the `layout` parameter, applied to
+ * `body` (`.sb-main-padded`) or the story root (`.sb-main-centered
+ * #storybook-root`). The addon's decorator renders inside that root, so any box
+ * it contributes stacks on top rather than replacing it.
+ *
+ * The assertion is that the probe sits flush against its container and the
+ * container is no taller than the probe: true for every `layout` value, because
+ * it measures only what the decorator adds, not what Storybook does.
+ *
+ * Note the play function can't verify `layout` itself. The vitest harness
+ * renders into a bare div appended to `body` — no `#storybook-root`, no
+ * `sb-main-*` class — so the parameter is inert here. The four stories still
+ * differ in the real preview iframe, which is where Chromatic snapshots them.
+ */
+function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
+  const probe = canvasElement.querySelector<HTMLElement>('[data-testid="layout-probe"]');
+  if (!probe) throw new Error('layout-probe missing');
+
+  const style = getComputedStyle(canvasElement);
+  const box = canvasElement.getBoundingClientRect();
+  const contentLeft =
+    box.left + Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.borderLeftWidth);
+  const contentTop =
+    box.top + Number.parseFloat(style.paddingTop) + Number.parseFloat(style.borderTopWidth);
+
+  const probeBox = probe.getBoundingClientRect();
+  expect(probeBox.left, 'decorator must not inset the story horizontally').toBeCloseTo(
+    contentLeft,
+    1,
+  );
+  expect(probeBox.top, 'decorator must not inset the story vertically').toBeCloseTo(contentTop, 1);
+  expect(box.height, 'decorator must not add height around the story').toBeCloseTo(
+    probeBox.height,
+    1,
+  );
+}
+
+export const Padded = meta.story({
+  parameters: { layout: 'padded' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});
+
+export const Centered = meta.story({
+  parameters: { layout: 'centered' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});
+
+export const Fullscreen = meta.story({
+  parameters: { layout: 'fullscreen' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});
+
+export const NoLayout = meta.story({
+  parameters: { layout: 'none' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});


### PR DESCRIPTION
## Summary

Stories across every `layout` value, asserting the preview decorator contributes no box of its own.

## Full description

The regression test that shipped with #1443 measures against a synthetic host element in `packages/addon/test/`. It proves the wrapper generates no box, but never touches Storybook's own layout chrome — the thing the padding was interfering with.

These four stories cover `padded`, `centered`, `fullscreen` and `none`. Each asserts the story sits flush with its container's content box on both axes, and that the container is no taller than the story. Measuring the content box rather than per-layout constants means one assertion holds for every value: Storybook's own padding is part of the calculation, the decorator's would not be.

### What these can't do

The play functions can't verify the `layout` parameter itself. The `@storybook/addon-vitest` runner renders each story into a bare div appended to `body`:

```
#storybook-root present: false
document.body.className: ""
ancestor chain: DIV < BODY < HTML
```

No `#storybook-root`, no `sb-main-*` class, so `layout` is inert and all four stories are identical to the runner. They diverge only in the real preview iframe, which is where Chromatic snapshots them — visual-diff coverage rather than assertion coverage. That limitation is documented in the file rather than left to be assumed away, and #1451 tracks closing it with Playwright against a built Storybook.

### Verification

Confirmed these fail against the pre-fix decorator: an early run picked up a stale `packages/addon/dist` still carrying `padding: "1rem"` and all four failed at `left=16` vs `0`. Against the rebuilt addon they pass, with `display: contents` visible in the ancestor chain.

`test:storybook`: 195 tests / 55 files.

Closes #1450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added Storybook coverage for decorator layout behavior.
  * Added scenarios for padded, centered, fullscreen, and no-layout configurations.
  * Verified layouts introduce no unintended spacing or additional container height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->