### PR TITLE
fix(blocks): stop SwatchbookProvider's element generating a layout box

### DIFF
--- a/.changeset/provider-contents.md
+++ b/.changeset/provider-contents.md
@@ -1,0 +1,6 @@
+---
+'@unpunnyfuns/swatchbook-blocks': minor
+'@unpunnyfuns/swatchbook-addon': minor
+---
+
+SwatchbookProvider's element generates no layout box, and the preview decorator no longer adds one of its own

--- a/apps/storybook/src/stories/DecoratorLayout.stories.tsx
+++ b/apps/storybook/src/stories/DecoratorLayout.stories.tsx
@@ -28,11 +28,14 @@ export default meta;
  * latter two also cover `SwatchbookProvider`'s host element, which sits between
  * the wrapper and the container.
  *
- * The play function can't verify `layout` itself. The vitest harness renders
- * into a bare div appended to `body` — no `#storybook-root`, no `sb-main-*`
- * class — so the parameter is inert here and the four stories are identical to
- * it. They diverge only in the real preview iframe, where Chromatic snapshots
- * them; #1451 tracks asserting that in CI.
+ * These run in two environments with different containers, so every assertion
+ * is computed against `canvasElement`'s *content* box rather than its border
+ * box. Under vitest the container is a bare div appended to `body`, with no
+ * `#storybook-root` and no `sb-main-*` class, so `layout` is inert and padding
+ * is zero. Chromatic runs the same play functions in the real preview iframe,
+ * where the container is the story root and carries Storybook's own padding:
+ * `centered` puts 1rem on it, which a border-box height check reads as 32px of
+ * phantom decorator spacing.
  */
 function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
   const probe = canvasElement.querySelector<HTMLElement>('[data-testid="layout-probe"]');
@@ -50,6 +53,12 @@ function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
     box.left + Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.borderLeftWidth);
   const contentTop =
     box.top + Number.parseFloat(style.paddingTop) + Number.parseFloat(style.borderTopWidth);
+  const contentHeight =
+    box.height -
+    Number.parseFloat(style.paddingTop) -
+    Number.parseFloat(style.paddingBottom) -
+    Number.parseFloat(style.borderTopWidth) -
+    Number.parseFloat(style.borderBottomWidth);
 
   const probeBox = probe.getBoundingClientRect();
   expect(probeBox.left, 'decorator must not inset the story horizontally').toBeCloseTo(
@@ -57,7 +66,7 @@ function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
     1,
   );
   expect(probeBox.top, 'decorator must not inset the story vertically').toBeCloseTo(contentTop, 1);
-  expect(box.height, 'decorator must not add height around the story').toBeCloseTo(
+  expect(contentHeight, 'decorator must not add height around the story').toBeCloseTo(
     probeBox.height,
     1,
   );

--- a/apps/storybook/src/stories/DecoratorLayout.stories.tsx
+++ b/apps/storybook/src/stories/DecoratorLayout.stories.tsx
@@ -23,18 +23,26 @@ export default meta;
  * #storybook-root`). The addon's decorator renders inside that root, so any box
  * it contributes stacks on top rather than replacing it.
  *
- * The assertion is that the probe sits flush against its container and the
- * container is no taller than the probe: true for every `layout` value, because
- * it measures only what the decorator adds, not what Storybook does.
+ * Three assertions, narrowest first: the decorator's own wrapper generates no
+ * box at all, and the chain as a whole adds neither inset nor height. The
+ * latter two also cover `SwatchbookProvider`'s host element, which sits between
+ * the wrapper and the container.
  *
- * Note the play function can't verify `layout` itself. The vitest harness
- * renders into a bare div appended to `body` — no `#storybook-root`, no
- * `sb-main-*` class — so the parameter is inert here. The four stories still
- * differ in the real preview iframe, which is where Chromatic snapshots them.
+ * The play function can't verify `layout` itself. The vitest harness renders
+ * into a bare div appended to `body` — no `#storybook-root`, no `sb-main-*`
+ * class — so the parameter is inert here and the four stories are identical to
+ * it. They diverge only in the real preview iframe, where Chromatic snapshots
+ * them; #1451 tracks asserting that in CI.
  */
 function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
   const probe = canvasElement.querySelector<HTMLElement>('[data-testid="layout-probe"]');
   if (!probe) throw new Error('layout-probe missing');
+  const wrapper = probe.parentElement;
+  if (!wrapper) throw new Error('decorator wrapper missing');
+
+  expect(wrapper.getClientRects().length, 'the axis-attribute wrapper must generate no box').toBe(
+    0,
+  );
 
   const style = getComputedStyle(canvasElement);
   const box = canvasElement.getBoundingClientRect();
@@ -55,21 +63,25 @@ function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
   );
 }
 
+/** `padded` puts 1rem on `body`; the decorator must not add a second inset inside the root. */
 export const Padded = meta.story({
   parameters: { layout: 'padded' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
 });
 
+/** `centered` puts 1rem on the story root and centres it with `margin: auto`. */
 export const Centered = meta.story({
   parameters: { layout: 'centered' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
 });
 
+/** `fullscreen` zeroes both, so any box the decorator adds is the only spacing present. */
 export const Fullscreen = meta.story({
   parameters: { layout: 'fullscreen' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
 });
 
+/** No layout class at all: the baseline the other three are measured against. */
 export const NoLayout = meta.story({
   parameters: { layout: 'none' },
   play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),

--- a/apps/storybook/src/stories/DecoratorLayout.stories.tsx
+++ b/apps/storybook/src/stories/DecoratorLayout.stories.tsx
@@ -1,0 +1,76 @@
+import { expect } from 'storybook/test';
+import preview from '#storybook/preview.tsx';
+
+/**
+ * Fixed-height, auto-width block. Any box the addon's decorator chain
+ * contributes shows up as an inset between this and the story container.
+ */
+function LayoutProbe() {
+  return <div data-testid="layout-probe" style={{ height: 24, background: '#0066cc' }} />;
+}
+
+const meta = preview.meta({
+  title: 'Tests/DecoratorLayout',
+  tags: ['!manifest', '!dev'],
+  component: LayoutProbe,
+});
+
+export default meta;
+
+/**
+ * Storybook owns story spacing through the `layout` parameter, applied to
+ * `body` (`.sb-main-padded`) or the story root (`.sb-main-centered
+ * #storybook-root`). The addon's decorator renders inside that root, so any box
+ * it contributes stacks on top rather than replacing it.
+ *
+ * The assertion is that the probe sits flush against its container and the
+ * container is no taller than the probe: true for every `layout` value, because
+ * it measures only what the decorator adds, not what Storybook does.
+ *
+ * Note the play function can't verify `layout` itself. The vitest harness
+ * renders into a bare div appended to `body` — no `#storybook-root`, no
+ * `sb-main-*` class — so the parameter is inert here. The four stories still
+ * differ in the real preview iframe, which is where Chromatic snapshots them.
+ */
+function expectDecoratorAddsNoBox(canvasElement: HTMLElement) {
+  const probe = canvasElement.querySelector<HTMLElement>('[data-testid="layout-probe"]');
+  if (!probe) throw new Error('layout-probe missing');
+
+  const style = getComputedStyle(canvasElement);
+  const box = canvasElement.getBoundingClientRect();
+  const contentLeft =
+    box.left + Number.parseFloat(style.paddingLeft) + Number.parseFloat(style.borderLeftWidth);
+  const contentTop =
+    box.top + Number.parseFloat(style.paddingTop) + Number.parseFloat(style.borderTopWidth);
+
+  const probeBox = probe.getBoundingClientRect();
+  expect(probeBox.left, 'decorator must not inset the story horizontally').toBeCloseTo(
+    contentLeft,
+    1,
+  );
+  expect(probeBox.top, 'decorator must not inset the story vertically').toBeCloseTo(contentTop, 1);
+  expect(box.height, 'decorator must not add height around the story').toBeCloseTo(
+    probeBox.height,
+    1,
+  );
+}
+
+export const Padded = meta.story({
+  parameters: { layout: 'padded' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});
+
+export const Centered = meta.story({
+  parameters: { layout: 'centered' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});
+
+export const Fullscreen = meta.story({
+  parameters: { layout: 'fullscreen' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});
+
+export const NoLayout = meta.story({
+  parameters: { layout: 'none' },
+  play: ({ canvasElement }) => expectDecoratorAddsNoBox(canvasElement),
+});

--- a/packages/addon/src/preview.tsx
+++ b/packages/addon/src/preview.tsx
@@ -229,15 +229,6 @@ const themedDecorator: Decorator = (Story, context) => {
   // mount-time theme.
   const announcement = useThemeAnnouncement(themeName);
 
-  const wrapperAttrs: Record<string, string> = {};
-  for (const axis of virtualAxes) {
-    const value = tuple[axis.name];
-    if (value !== undefined) wrapperAttrs[dataAttr(cssVarPrefix, axis.name)] = value;
-  }
-  forEachPinnedAxis((name, value) => {
-    wrapperAttrs[dataAttr(cssVarPrefix, name)] = value;
-  });
-
   // Read token data from the live ambient project source (seeded from the
   // virtual module at init, updated in place on each dev-time HMR token
   // save) rather than the static virtual-module exports, so blocks
@@ -274,20 +265,16 @@ const themedDecorator: Decorator = (Story, context) => {
   // above); letting the provider mount the snapshot's CSS too would
   // duplicate every custom-property block.
   //
-  // The attribute wrapper has to exist but must generate no box. It's the only
-  // per-story scope for the axis attributes; <html> can't stand in for it,
-  // holding a single tuple while docs mode renders several stories with
-  // different per-story overrides. Storybook's `layout` parameter owns story
-  // spacing (`.sb-main-padded`, `.sb-main-centered #storybook-root`), and a box
-  // here would stack on top of it rather than replace it. `display: contents`
-  // removes the box without affecting selector matching.
+  // The provider's own element carries the per-story axis attributes, so the
+  // decorator adds no element of its own. <html> can't stand in for it: it
+  // holds a single tuple, while docs mode renders several stories with
+  // different per-story overrides. Pinned axes are build-time constants and
+  // stay on <html> alone (`setRootAxes`), since no story can vary them.
   return (
     <SwatchbookProvider snapshot={wire} axes={tuple} mountCss={false}>
       <ThemeContext.Provider value={themeName}>
         <AxesContext.Provider value={tuple}>
-          <div {...wrapperAttrs} style={{ display: 'contents' }}>
-            <Story />
-          </div>
+          <Story />
           <div role="status" aria-live="polite" style={SR_ONLY_STYLE}>
             {announcement}
           </div>

--- a/packages/blocks/src/internal/provider.css
+++ b/packages/blocks/src/internal/provider.css
@@ -1,0 +1,10 @@
+/*
+ * The provider's element exists only to carry the axis data-attributes that
+ * descendant blocks resolve their CSS vars against. `display: contents` keeps
+ * it out of layout: hosts position the subtree themselves, and a box here
+ * would sit between the host's container and the content it laid out.
+ */
+
+.sb-provider {
+  display: contents;
+}

--- a/packages/blocks/src/provider.tsx
+++ b/packages/blocks/src/provider.tsx
@@ -12,6 +12,7 @@ import { perAxisAttrs } from '#/internal/data-attr.ts';
 import { mergePresenters, PresenterContext } from '#/presenters/registry.ts';
 import type { PresenterRegistry } from '#/presenters/types.ts';
 import '#/internal/chrome-base.css';
+import '#/internal/provider.css';
 import '#/internal/internal-tokens.css';
 import '#/internal/internal-dimensions.css';
 import '#/internal/internal-typography.css';
@@ -102,8 +103,12 @@ export function SwatchbookProvider({
   // every story in a light card regardless of the active theme axis.
   // Axis data-attributes are still the point: descendant blocks' CSS var
   // reads resolve against the nearest matching `[data-<prefix>-<axis>]`.
+  //
+  // The element stays out of layout via `.sb-provider` (`display: contents`):
+  // hosts position the subtree themselves, and a box here would sit between
+  // the host's container and the content it laid out.
   return (
-    <div {...perAxisAttrs(snapshot.cssVarPrefix, activeAxes)}>
+    <div {...perAxisAttrs(snapshot.cssVarPrefix, activeAxes)} className="sb-provider">
       <SwatchbookContext.Provider value={value}>
         <PresenterContext.Provider value={merged}>
           <SetAxesContext.Provider value={setAxes}>{children}</SetAxesContext.Provider>


### PR DESCRIPTION
## Summary

Collapses two axis-attribute wrappers into one, and stops that one generating a box.

## Full description

The preview decorator and `SwatchbookProvider` each rendered a div carrying axis data-attributes:

```
story < div (addon wrapper, display: contents) < div (provider, display: block) < #storybook-root
```

The attribute sets overlapped. The addon built `wrapperAttrs` from `virtualAxes` plus `forEachPinnedAxis`; the provider got `perAxisAttrs(prefix, activeAxes)` over the same tuple. The only addition was the pinned axes, and `setRootAxes` already writes those to `<html>` — they're build-time constants, so no story can vary them and a per-story copy buys nothing.

The decorator's wrapper is therefore removed outright, and the provider's element gets `display: contents`. Measured in the built Storybook under `layout: centered`:

```
probe < DIV.sb-provider (contents, 0 client rects, data-sb-mode="Light") < #storybook-root
```

One node, no box, still flush with the root's content box, root content height 24 against a 24px probe.

This is the half of the #1443 review feedback that the padding fix left open: the decorator stopped contributing a box, but the provider's div still did, so a story root was never a direct child of `#storybook-root`.

### Minor, not patch

`SwatchbookProvider`'s rendered output is public API. The element is unstyled and exposes no `className` or `style` prop, so it's untargetable except structurally, but it does stop generating a block box for anyone using blocks outside Storybook.

### Note on the stylesheet

`display: contents` comes from `.sb-provider` in `internal/provider.css` rather than an inline style. `no-inline-static-styles.test.ts` bans static inline literals in blocks, and caught the first attempt.

### Verification

- `turbo run format:check lint typecheck test`: 39/39 tasks
- blocks 757 tests, addon 73, `test:storybook` 195
- The addon browser test asserting `story.parentElement` carries `data-sb-mode` still passes, now resolving to the provider's element rather than the removed wrapper

Closes #1453

### Chromatic capture geometry changes

Every story re-baselines, and the diffs read as "component got bigger" without being one. The layout is unchanged: `#storybook-root` measures 1384x42 both before and after locally. What moves is what Chromatic captures.

```
before:  #storybook-root(1384x42) > DIV(block, 1384x42)               > BUTTON(133x42)
after:   #storybook-root(1384x42) > DIV.sb-provider(contents, 0 rects) > BUTTON(133x42)
```

Chromatic sizes the capture from the story root's child element. A `display: contents` child has zero client rects, so it falls through to the story's own content. On the Button story that's baseline `1169x42` (the root at Chromatic's 1200px viewport, less 16px body padding each side) against `134x42` (the button's own box). The image is then scaled, which is why it reads as a size change.

The practical consequence is that captures are now content-tight rather than full-width, so snapshots no longer watch the space around a component. Accepted deliberately; baselines have been re-approved.
