### PR TITLE
feat(integrations): add skipTailwindImport to the Tailwind integration

### DIFF
--- a/.changeset/tailwind-skip-import.md
+++ b/.changeset/tailwind-skip-import.md
@@ -2,4 +2,4 @@
 '@unpunnyfuns/swatchbook-integrations': minor
 ---
 
-Add `skipTailwindImport` to the Tailwind integration for previews that already compile Tailwind
+`skipTailwindImport` emits the Tailwind `@theme` block without the integration's own `@import`

--- a/.changeset/tailwind-skip-import.md
+++ b/.changeset/tailwind-skip-import.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-integrations': minor
+---
+
+Add `skipTailwindImport` to the Tailwind integration for previews that already compile Tailwind

--- a/apps/docs/src/content/docs/guides/integrations/tailwind.mdx
+++ b/apps/docs/src/content/docs/guides/integrations/tailwind.mdx
@@ -116,6 +116,16 @@ Tailwind scale names are keys; each entry is `[tailwindEntryName, dtcgPath]`.
 
 or have the preview decorator mirror a `.dark` class through the [DOM-observation path](/guides/consuming-the-active-theme#dom-observation-for-everything-else).
 
+**A preview that already compiles Tailwind gets two compilations.** The virtual module emits `@import 'tailwindcss'` so it works as a preview's only Tailwind entry point. Where the preview already imports Tailwind against its own `@theme`, the second import compiles Tailwind again: a duplicate preflight, plus a second copy of every utility both passes generate, with source order rather than intent deciding which copy applies.
+
+`skipTailwindImport` emits the `@theme` block on its own:
+
+```ts
+tailwindIntegration({ skipTailwindImport: true });
+```
+
+Layering the second import is not a substitute. A preview that already emits into `@layer theme / base / utilities` puts both copies in the same layers, where source order still decides. `source(none)` does stop the duplicate scan, but it also stops the integration's own `bg-*` / `p-*` scales from generating at all.
+
 ## What this doesn't do
 
 - Doesn't produce production CSS. Run Tailwind's CLI / Vite plugin against your own `@theme` source for that.

--- a/packages/integrations/src/tailwind.ts
+++ b/packages/integrations/src/tailwind.ts
@@ -23,6 +23,17 @@ export interface TailwindIntegrationOptions {
    * `font`. Works for any DTCG project without a configuration step.
    */
   roles?: TailwindRoleMap;
+  /**
+   * Omit the `@import 'tailwindcss'` line, emitting the `@theme` block alone.
+   * Set this when the preview already compiles Tailwind against its own
+   * stylesheet: a second import compiles Tailwind twice in the same preview,
+   * duplicating preflight and any utility both passes generate, where source
+   * order rather than intent decides which copy wins.
+   *
+   * Leave unset when swatchbook's virtual module is the preview's only
+   * Tailwind entry point, which is the common case.
+   */
+  skipTailwindImport?: boolean;
 }
 
 /**
@@ -78,7 +89,10 @@ export default function tailwindIntegration(
     name: 'tailwind',
     virtualModule: {
       virtualId,
-      render: (project) => renderTailwindTheme(project, userRoles ?? deriveRoles(project)),
+      render: (project) =>
+        renderTailwindTheme(project, userRoles ?? deriveRoles(project), {
+          skipTailwindImport: options.skipTailwindImport === true,
+        }),
       // Tailwind's `@theme` block is a global stylesheet — exactly the
       // kind of payload the addon should auto-inject into the preview,
       // so consumers don't hand-write a second `import` line after
@@ -88,7 +102,11 @@ export default function tailwindIntegration(
   };
 }
 
-function renderTailwindTheme(project: Project, roles: TailwindRoleMap): string {
+function renderTailwindTheme(
+  project: Project,
+  roles: TailwindRoleMap,
+  { skipTailwindImport }: { skipTailwindImport: boolean },
+): string {
   const prefix = project.config.cssVarPrefix ?? '';
   const varPrefix = prefix ? `${prefix}-` : '';
 
@@ -108,7 +126,7 @@ function renderTailwindTheme(project: Project, roles: TailwindRoleMap): string {
   return [
     '/* Synthesized by @unpunnyfuns/swatchbook-integrations/tailwind for preview.',
     ' * Served via `virtual:swatchbook/tailwind.css` — rebuilt on token changes. */',
-    "@import 'tailwindcss';",
+    ...(skipTailwindImport ? [] : ["@import 'tailwindcss';"]),
     '',
     '@theme {',
     ...entries,

--- a/packages/integrations/test/tailwind.test.ts
+++ b/packages/integrations/test/tailwind.test.ts
@@ -22,6 +22,12 @@ function render(p: Project, options?: Parameters<typeof tailwindIntegration>[0])
   return out;
 }
 
+const themeEntriesOf = (css: string) =>
+  css
+    .split('\n')
+    .filter((line) => line.startsWith('  --'))
+    .join('\n');
+
 it('integration exposes virtual:swatchbook/tailwind.css by default', () => {
   const integration = tailwindIntegration();
   expect(integration.name).toBe('tailwind');
@@ -49,6 +55,20 @@ it('drops the dash when cssVarPrefix is empty', async () => {
   const css = render(bare);
   expect(css).toContain('--color-surface-default: var(--color-surface-default);');
   expect(css).not.toContain('--sb-');
+});
+
+it('omits the tailwindcss import under skipTailwindImport, keeping the theme intact', () => {
+  const css = render(project, { skipTailwindImport: true });
+  expect(css).not.toContain('tailwindcss');
+  expect(css).toMatch(/^\/\* Synthesized by @unpunnyfuns\/swatchbook-integrations\/tailwind/);
+  expect(css).toContain('@theme {');
+  expect(css).toContain('--color-sb-surface-default: var(--sb-color-surface-default);');
+});
+
+it('emits identical theme entries with and without the import', () => {
+  expect(themeEntriesOf(render(project, { skipTailwindImport: true }))).toBe(
+    themeEntriesOf(render(project)),
+  );
 });
 
 it('accepts a custom role map replacing the derived default', () => {


### PR DESCRIPTION
## Summary

Adds `skipTailwindImport` to `tailwindIntegration()`, emitting the `@theme` block without the integration's own `@import 'tailwindcss'`.

## Full description

The virtual module opens with `@import 'tailwindcss'` so it works as a preview's only Tailwind entry point, which is the common case. In a Storybook that already compiles Tailwind against its own `@theme`, that second import compiles Tailwind again in the same preview: a duplicate preflight, plus a second copy of every utility both passes generate.

The reporter measured it on one tree with the integration as the only variable. Preview CSS grew 9.85%, preflight rule groups doubled from 11 to 22, and 14 utilities were emitted twice (`rounded`, `border`, `border-t/r/b/l`, `shadow`, `shadow-2xs/sm/md/2xl`, `ring`, `inset-shadow-xs`, `text-shadow-sm`). No classes or variables were lost. Each duplicate happened to resolve to the intended copy by emission order, so a reordered import would have silently flipped those 14 to stock Tailwind geometry with nothing failing.

```ts
tailwindIntegration({ skipTailwindImport: true });
```

Default is unchanged: absent the flag the import is still emitted, and the `@theme` entries are byte-identical either way (pinned by a test).

Layering the second import is not an alternative, and the guide now says so: a preview already emitting into `@layer theme / base / utilities` puts both copies in the same layers, where source order still decides. `source(none)` stops the duplicate scan but also stops the integration's own `bg-*` / `p-*` scales generating, which defeats the integration.

An opt-out flag was chosen over splitting into a second virtual module. The reporter asked for the outcome rather than a specific API shape, and a second public virtual ID would need supporting indefinitely while making `autoInject` ambiguous.

Closes #1460