### PR TITLE
feat(core): carry the originating rule id on Diagnostic.label

### DIFF
--- a/.changeset/diagnostic-label.md
+++ b/.changeset/diagnostic-label.md
@@ -1,0 +1,5 @@
+---
+'@unpunnyfuns/swatchbook-core': minor
+---
+
+`Diagnostic.label` carries the originating lint rule id, and the Diagnostics block shows it

--- a/apps/docs/src/content/docs/reference/diagnostics.mdx
+++ b/apps/docs/src/content/docs/reference/diagnostics.mdx
@@ -14,6 +14,7 @@ swatchbook surfaces load-time and runtime problems as `Diagnostic` entries on `P
 interface Diagnostic {
   severity: 'error' | 'warn' | 'info';
   group: string;
+  label?: string;
   message: string;
   filename?: string;
   line?: number;
@@ -23,6 +24,8 @@ interface Diagnostic {
 `severity` follows the usual gradient. `error` means something downstream cannot be done correctly (e.g. an alias target that doesn't exist, so the walker has nothing to resolve to). `warn` means the load completed but a piece of input was dropped, partial, or structurally suspect. `info` is informational and rarely fires.
 
 `group` is namespaced by feature area (`swatchbook/<area>`). It's stable across releases, so consumers can filter on it.
+
+`label` narrows the origin within `group`. Lint diagnostics carry the rule id, so a `lint` diagnostic labelled `core/valid-color` names the rule your Terrazzo lint config keys on to configure or switch it off. Other groups carry a subsystem name, and it is absent where Terrazzo emits none.
 
 `filename` / `line` are present when the parser knows the authoring source location. Token-tree diagnostics usually carry them; configuration diagnostics generally don't.
 

--- a/packages/blocks/src/Diagnostics.tsx
+++ b/packages/blocks/src/Diagnostics.tsx
@@ -101,9 +101,9 @@ export function DiagnosticsView({
                 </span>
                 <div>
                   <div>{d.message}</div>
-                  {(d.group || d.filename) && (
+                  {(d.group || d.label || d.filename) && (
                     <div className="sb-diagnostics__meta">
-                      {[d.group, d.filename, d.line ? `:${d.line}` : '']
+                      {[d.group, d.label, d.filename, d.line ? `:${d.line}` : '']
                         .filter(Boolean)
                         .join(' · ')}
                     </div>

--- a/packages/blocks/test/diagnostics-view.browser.test.tsx
+++ b/packages/blocks/test/diagnostics-view.browser.test.tsx
@@ -21,6 +21,26 @@ it('renders rows and auto-expands on errors, from plain props', () => {
   expect(details?.hasAttribute('open')).toBe(true);
 });
 
+it('shows the rule id in the meta line so a reader knows which rule to configure', () => {
+  render(
+    <DiagnosticsView
+      diagnostics={[
+        {
+          severity: 'error',
+          group: 'lint',
+          label: 'core/valid-color',
+          message: 'Migrate to the new object format',
+          filename: '/tokens/color.json',
+          line: 3,
+        },
+      ]}
+      cssVarPrefix="sb"
+      activeAxes={{}}
+    />,
+  );
+  screen.getByText('lint · core/valid-color · /tokens/color.json · :3');
+});
+
 it('honors the caption override', () => {
   render(<DiagnosticsView diagnostics={[]} cssVarPrefix="sb" activeAxes={{}} caption="Health" />);
   screen.getByText('Health');

--- a/packages/core/src/diagnostics.ts
+++ b/packages/core/src/diagnostics.ts
@@ -40,6 +40,7 @@ export function toDiagnostics(logger: BufferedLogger): Diagnostic[] {
       group: entry.group,
       message: entry.message,
     };
+    if (entry.label) diagnostic.label = entry.label;
     if (entry.filename) diagnostic.filename = entry.filename.pathname;
     const loc = entry.node?.loc?.start;
     if (loc) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -346,6 +346,12 @@ export interface Diagnostic {
   severity: DiagnosticSeverity;
   /** Source group from Terrazzo (parser, resolver, plugin, …). */
   group: string;
+  /**
+   * Originating rule or subsystem within `group`. Lint diagnostics carry the
+   * rule id, which is the key `lintOptions.rules` takes, so this is what tells
+   * a reader which rule to configure. Absent when Terrazzo emits no label.
+   */
+  label?: string;
   message: string;
   filename?: string;
   line?: number;

--- a/packages/core/test/diagnostics-lint-label.test.ts
+++ b/packages/core/test/diagnostics-lint-label.test.ts
@@ -1,0 +1,19 @@
+/**
+ * End-to-end companion to `diagnostics-to-diagnostics.test.ts`: that file pins
+ * the projection in isolation, this one pins that a real lint diagnostic
+ * reaches `Project.diagnostics` carrying the rule id a consumer needs in order
+ * to configure or silence it.
+ */
+import { resolve } from 'node:path';
+import { expect, it } from 'vitest';
+import { loadProject } from '#/load.ts';
+
+const fixtureCwd = resolve(import.meta.dirname, 'fixtures/css-options-legacyhex');
+
+it('surfaces the lint rule id on diagnostics produced by a real load', async () => {
+  const project = await loadProject({ tokens: ['tokens/*.json'] }, fixtureCwd);
+  const lint = project.diagnostics.filter((d) => d.group === 'lint');
+
+  expect(lint.length).toBeGreaterThan(0);
+  expect(lint.some((d) => d.label === 'core/valid-color')).toBe(true);
+});

--- a/packages/core/test/diagnostics-to-diagnostics.test.ts
+++ b/packages/core/test/diagnostics-to-diagnostics.test.ts
@@ -61,12 +61,25 @@ it('attaches line when the entry carries a node loc', () => {
   expect(diag?.line).toBe(42);
 });
 
-it('omits filename / line when absent', () => {
+it('carries the entry label, which is the lint rule id consumers configure', () => {
+  const logger = new BufferedLogger();
+  logger.error(
+    entry({
+      group: 'lint',
+      label: 'core/valid-color',
+      message: 'Migrate to the new object format',
+    }),
+  );
+  expect(toDiagnostics(logger)[0]?.label).toBe('core/valid-color');
+});
+
+it('omits filename / line / label when absent', () => {
   const logger = new BufferedLogger();
   logger.error(entry({ group: 'g', message: 'bare' }));
   const diag = toDiagnostics(logger)[0];
   expect(diag).not.toHaveProperty('filename');
   expect(diag).not.toHaveProperty('line');
+  expect(diag).not.toHaveProperty('label');
 });
 
 it('returns an empty array when the buffer is empty', () => {


### PR DESCRIPTION
## Summary

Adds `label` to `Diagnostic`, carrying the rule or subsystem a diagnostic came from, and renders it in the Diagnostics block's meta line.

## Full description

`toDiagnostics` mapped `severity`, `group`, `message`, `filename`, and `line`, dropping Terrazzo's `entry.label`. For lint diagnostics that label is the rule id, so a reader saw:

> Migrate to the new object format, e.g. "#ff0000" → { "colorSpace": "srgb", "components": [1, 0, 0] }

under `group: 'lint'` with nothing naming `core/valid-color`. There was no way to work out which rule to configure or switch off short of matching the message text against Terrazzo's rule source.

`label` is populated for other groups too (`parser:init`, plugin names), so the block's meta line now reads `lint · core/valid-color · tokens/color.json · :3` rather than `lint · tokens/color.json · :3`.

Additive and optional: diagnostics from entries with no label are unchanged, and the field is absent rather than empty.

### Tests

`diagnostics-to-diagnostics.test.ts` pins the projection in isolation, including that the field stays absent when the entry carries no label. `diagnostics-lint-label.test.ts` is the end-to-end companion: it loads a fixture with a legacy hex color and asserts a real `lint` diagnostic arrives labelled `core/valid-color`, which is the claim that actually matters to a consumer. A browser-mode view test covers the rendered meta line.

Core: 64 files / 327 tests. Blocks browser-mode suites are covered by CI.

Closes #1466